### PR TITLE
Move LambdaRewriter MakeFrames into Analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             LanguageVersion languageVersion,
             DocumentationMode documentationMode,
             SourceCodeKind kind,
-            IEnumerable<string> preprocessorSymbols,
+            ImmutableArray<string> preprocessorSymbols,
             IReadOnlyDictionary<string, string> features)
             : base(kind, documentationMode)
         {

--- a/src/Compilers/CSharp/Portable/Compiler/TypeCompilationState.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/TypeCompilationState.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public readonly CSharpCompilation Compilation;
 
-        public LambdaFrame StaticLambdaFrame;
+        public ClosureEnvironment StaticLambdaFrame;
 
         /// <summary>
         /// A graph of method->method references for this(...) constructor initializers.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _isThis = isThisParameter;
         }
 
-        public static LambdaCapturedVariable Create(LambdaFrame frame, Symbol captured, ref int uniqueId)
+        public static LambdaCapturedVariable Create(ClosureEnvironment frame, Symbol captured, ref int uniqueId)
         {
             Debug.Assert(captured is LocalSymbol || captured is ParameterSymbol);
 
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)local != null)
             {
                 // if we're capturing a generic frame pointer, construct it with the new frame's type parameters
-                var lambdaFrame = local.Type.OriginalDefinition as LambdaFrame;
+                var lambdaFrame = local.Type.OriginalDefinition as ClosureEnvironment;
                 if ((object)lambdaFrame != null)
                 {
                     // lambdaFrame may have less generic type parameters than frame, so trim them down (the first N will always match)

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaFrame.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaFrame.cs
@@ -1,44 +1,58 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
     /// A class that represents the set of variables in a scope that have been
-    /// captured by lambdas within that scope.
+    /// captured by nested functions within that scope.
     /// </summary>
-    internal sealed class LambdaFrame : SynthesizedContainer, ISynthesizedMethodBodyImplementationSymbol
+    internal sealed class ClosureEnvironment : SynthesizedContainer, ISynthesizedMethodBodyImplementationSymbol
     {
-        private readonly TypeKind _typeKind;
         private readonly MethodSymbol _topLevelMethod;
-        private readonly MethodSymbol _containingMethod;
-        private readonly MethodSymbol _constructor;
-        private readonly MethodSymbol _staticConstructor;
-        private readonly FieldSymbol _singletonCache;
         internal readonly SyntaxNode ScopeSyntaxOpt;
         internal readonly int ClosureOrdinal;
+        /// <summary>
+        /// The closest method/lambda that this frame is originally from. Null if nongeneric static closure.
+        /// Useful because this frame's type parameters are constructed from this method and all methods containing this method.
+        /// </summary>
+        internal readonly MethodSymbol OriginalContainingMethodOpt;
+        internal readonly FieldSymbol SingletonCache;
+        internal readonly MethodSymbol StaticConstructor;
+        public readonly IEnumerable<Symbol> CapturedVariables;
 
-        internal LambdaFrame(MethodSymbol topLevelMethod, MethodSymbol containingMethod, bool isStruct, SyntaxNode scopeSyntaxOpt, DebugId methodId, DebugId closureId)
+        public override TypeKind TypeKind { get; }
+        internal override MethodSymbol Constructor { get; }
+
+        internal ClosureEnvironment(
+            IEnumerable<Symbol> capturedVariables,
+            MethodSymbol topLevelMethod,
+            MethodSymbol containingMethod,
+            bool isStruct,
+            SyntaxNode scopeSyntaxOpt,
+            DebugId methodId,
+            DebugId closureId)
             : base(MakeName(scopeSyntaxOpt, methodId, closureId), containingMethod)
         {
-            _typeKind = isStruct ? TypeKind.Struct : TypeKind.Class;
+            CapturedVariables = capturedVariables;
+            TypeKind = isStruct ? TypeKind.Struct : TypeKind.Class;
             _topLevelMethod = topLevelMethod;
-            _containingMethod = containingMethod;
-            _constructor = isStruct ? null : new LambdaFrameConstructor(this);
+            OriginalContainingMethodOpt = containingMethod;
+            Constructor = isStruct ? null : new LambdaFrameConstructor(this);
             this.ClosureOrdinal = closureId.Ordinal;
 
             // static lambdas technically have the class scope so the scope syntax is null 
             if (scopeSyntaxOpt == null)
             {
-                _staticConstructor = new SynthesizedStaticConstructor(this);
+                StaticConstructor = new SynthesizedStaticConstructor(this);
                 var cacheVariableName = GeneratedNames.MakeCachedFrameInstanceFieldName();
-                _singletonCache = new SynthesizedLambdaCacheFieldSymbol(this, this, cacheVariableName, topLevelMethod, isReadOnly: true, isStatic: true);
+                SingletonCache = new SynthesizedLambdaCacheFieldSymbol(this, this, cacheVariableName, topLevelMethod, isReadOnly: true, isStatic: true);
             }
 
             AssertIsClosureScopeSyntax(scopeSyntaxOpt);
@@ -77,69 +91,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.UnexpectedValue(syntaxOpt.Kind());
         }
 
-        public override TypeKind TypeKind
-        {
-            get { return _typeKind; }
-        }
-
-        internal override MethodSymbol Constructor
-        {
-            get { return _constructor; }
-        }
-
-        internal MethodSymbol StaticConstructor
-        {
-            get { return _staticConstructor; }
-        }
-
-        /// <summary>
-        /// The closest method/lambda that this frame is originally from. Null if nongeneric static closure.
-        /// Useful because this frame's type parameters are constructed from this method and all methods containing this method.
-        /// </summary>
-        internal MethodSymbol ContainingMethod
-        {
-            get { return _containingMethod; }
-        }
-
         public override ImmutableArray<Symbol> GetMembers()
         {
             var members = base.GetMembers();
-            if ((object)_staticConstructor != null)
+            if ((object)StaticConstructor != null)
             {
-                members = ImmutableArray.Create<Symbol>(_staticConstructor, _singletonCache).AddRange(members);
+                members = ImmutableArray.Create<Symbol>(StaticConstructor, SingletonCache).AddRange(members);
             }
 
             return members;
         }
 
-        internal FieldSymbol SingletonCache
-        {
-            get { return _singletonCache; }
-        }
-
         // display classes for static lambdas do not have any data and can be serialized.
-        internal override bool IsSerializable
-        {
-            get { return (object)_singletonCache != null; }
-        }
+        internal override bool IsSerializable => (object)SingletonCache != null;
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _topLevelMethod.ContainingSymbol; }
-        }
+        public override Symbol ContainingSymbol => _topLevelMethod.ContainingSymbol;
 
-        bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency
-        {
-            get
-            {
-                // the lambda method contains user code from the lambda:
-                return true;
-            }
-        }
+        // The lambda method contains user code from the lambda
+        bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency => true;
 
-        IMethodSymbol ISynthesizedMethodBodyImplementationSymbol.Method
-        {
-            get { return _topLevelMethod; }
-        }
+        IMethodSymbol ISynthesizedMethodBodyImplementationSymbol.Method => _topLevelMethod;
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaFrameConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaFrameConstructor.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed class LambdaFrameConstructor : SynthesizedInstanceConstructor, ISynthesizedMethodBodyImplementationSymbol
     {
-        internal LambdaFrameConstructor(LambdaFrame frame)
+        internal LambdaFrameConstructor(ClosureEnvironment frame)
             : base(frame)
         {
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         _framePointers.TryGetValue(synthesizedLambda.ContainingType, out _innermostFramePointer);
                     }
 
-                    var containerAsFrame = synthesizedLambda.ContainingType as LambdaFrame;
+                    var containerAsFrame = synthesizedLambda.ContainingType as ClosureEnvironment;
 
                     // Includes type parameters from the containing type iff
                     // the containing type is a frame. If it is a frame then
@@ -201,11 +201,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // will always be a LambdaFrame, it's always a capture frame
                     var frameType = (NamedTypeSymbol)loweredSymbol.Parameters[i].Type.OriginalDefinition;
 
-                    Debug.Assert(frameType is LambdaFrame);
+                    Debug.Assert(frameType is ClosureEnvironment);
 
                     if (frameType.Arity > 0)
                     {
-                        var typeParameters = ((LambdaFrame)frameType).ConstructedFromTypeParameters;
+                        var typeParameters = ((ClosureEnvironment)frameType).ConstructedFromTypeParameters;
                         Debug.Assert(typeParameters.Length == frameType.Arity);
                         var subst = this.TypeMap.SubstituteTypeParameters(typeParameters);
                         frameType = frameType.Construct(subst);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// have captured variables.  The result of this analysis is left in <see cref="_analysis"/>.
     /// 
     /// Then we make a frame, or compiler-generated class, represented by an instance of
-    /// <see cref="LambdaFrame"/> for each scope with captured variables.  The generated frames are kept
+    /// <see cref="ClosureEnvironment"/> for each scope with captured variables.  The generated frames are kept
     /// in <see cref="_frames"/>.  Each frame is given a single field for each captured
     /// variable in the corresponding scope.  These are maintained in <see cref="MethodToClassRewriter.proxies"/>.
     /// 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // lambda frame for static lambdas. 
         // initialized lazily and could be null if there are no static lambdas
-        private LambdaFrame _lazyStaticLambdaFrame;
+        private ClosureEnvironment _lazyStaticLambdaFrame;
 
         // A mapping from every lambda parameter to its corresponding method's parameter.
         private readonly Dictionary<ParameterSymbol, ParameterSymbol> _parameterMap = new Dictionary<ParameterSymbol, ParameterSymbol>();
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly Dictionary<LocalFunctionSymbol, MappedLocalFunction> _localFunctionMap = new Dictionary<LocalFunctionSymbol, MappedLocalFunction>();
 
         // for each block with lifted (captured) variables, the corresponding frame type
-        private readonly Dictionary<BoundNode, LambdaFrame> _frames = new Dictionary<BoundNode, LambdaFrame>();
+        private readonly Dictionary<BoundNode, ClosureEnvironment> _frames = new Dictionary<BoundNode, ClosureEnvironment>();
 
         // the current set of frame pointers in scope.  Each is either a local variable (where introduced),
         // or the "this" parameter when at the top level.  Keys in this map are never constructed types.
@@ -187,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             _assignLocals = assignLocals;
             _currentTypeParameters = method.TypeParameters;
             _currentLambdaBodyTypeMap = TypeMap.Empty;
-            _innermostFramePointer = _currentFrameThis = thisParameterOpt;
+            _innermostFramePointer = null;
+            _currentFrameThis = thisParameterOpt;
             _framePointers[thisType] = thisParameterOpt;
             _seenBaseCall = method.MethodKind != MethodKind.Constructor; // only used for ctors
             _synthesizedFieldNameIdDispenser = 1;
@@ -243,7 +244,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(((object)thisParameter == null) || (thisParameter.Type == thisType));
             Debug.Assert(compilationState.ModuleBuilderOpt != null);
 
-            var analysis = Analysis.Analyze(loweredBody, method, diagnostics);
+            var analysis = Analysis.Analyze(
+                loweredBody,
+                method,
+                methodOrdinal,
+                substitutedSourceMethod,
+                slotAllocatorOpt,
+                compilationState,
+                closureDebugInfoBuilder,
+                diagnostics);
 
             CheckLocalsDefined(loweredBody);
             var rewriter = new LambdaRewriter(
@@ -259,8 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics,
                 assignLocals);
 
-            analysis.ComputeLambdaScopesAndFrameCaptures(thisParameter);
-            rewriter.MakeFrames(closureDebugInfoBuilder);
+            rewriter.SynthesizeClosureEnvironments();
 
             // First, lower everything but references (calls, delegate conversions)
             // to local functions
@@ -333,161 +341,47 @@ namespace Microsoft.CodeAnalysis.CSharp
         static partial void CheckLocalsDefined(BoundNode node);
 
         /// <summary>
-        /// Create the frame types.
+        /// Adds <see cref="ClosureEnvironment"/> synthesized types to the compilation state
+        /// and creates hoisted fields for all locals captured by the environments.
         /// </summary>
-        private void MakeFrames(ArrayBuilder<ClosureDebugInfo> closureDebugInfo)
+        private void SynthesizeClosureEnvironments()
         {
-            Analysis.VisitClosures(_analysis.ScopeTree, (scope, closure) =>
+            Analysis.VisitScopeTree(_analysis.ScopeTree, scope =>
             {
-                var capturedVars = closure.CapturedVariables;
-                MethodSymbol closureSymbol = closure.OriginalMethodSymbol;
-                bool canTakeRefParams = _analysis.CanTakeRefParameters(closureSymbol);
-
-                if (canTakeRefParams && OnlyCapturesThis(closure, scope))
+                if (scope.DeclaredEnvironments.Count > 0)
                 {
-                    return;
-                }
+                    Debug.Assert(!_frames.ContainsKey(scope.BoundNode));
+                    // At the moment, all variables declared in the same
+                    // scope always get assigned to the same environment
+                    Debug.Assert(scope.DeclaredEnvironments.Count == 1);
 
-                foreach (var captured in capturedVars)
-                {
-                    var declarationScope = Analysis.GetVariableDeclarationScope(scope, captured);
-                    if (declarationScope == null)
+                    var env = scope.DeclaredEnvironments[0];
+
+                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(ContainingType, env);
+                    if (env.Constructor != null)
                     {
-                        continue;
+                        AddSynthesizedMethod(
+                            env.Constructor,
+                            FlowAnalysisPass.AppendImplicitReturn(
+                                MethodCompiler.BindMethodBody(env.Constructor, CompilationState, null),
+                                env.Constructor));
                     }
 
-                    // If this is a local function that can take ref params, skip
-                    // frame creation for local function calls. This is semantically
-                    // important because otherwise we may create a struct frame which
-                    // is empty, which crashes in emit.
-                    // This is not valid for lambdas or local functions which can't take
-                    // take ref params since they will be lowered into their own frames.
-                    if (canTakeRefParams && captured.Kind == SymbolKind.Method)
+                    foreach (var captured in env.CapturedVariables)
                     {
-                        continue;
-                    }
+                        Debug.Assert(!proxies.ContainsKey(captured));
 
-                    LambdaFrame frame = GetFrameForScope(declarationScope, closureDebugInfo);
-
-                    if (captured.Kind != SymbolKind.Method && !proxies.ContainsKey(captured))
-                    {
-                        var hoistedField = LambdaCapturedVariable.Create(frame, captured, ref _synthesizedFieldNameIdDispenser);
+                        var hoistedField = LambdaCapturedVariable.Create(env, captured, ref _synthesizedFieldNameIdDispenser);
                         proxies.Add(captured, new CapturedToFrameSymbolReplacement(hoistedField, isReusable: false));
-                        CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, hoistedField);
+                        CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(env, hoistedField);
                     }
+
+                    _frames.Add(scope.BoundNode, env);
                 }
             });
         }
 
-        private SmallDictionary<Analysis.Closure, bool> _onlyCapturesThisMemoTable;
-        /// <summary>
-        /// Helper for determining whether a local function transitively
-        /// only captures this (only captures this or other local functions
-        /// which only capture this).
-        /// </summary>
-        private bool OnlyCapturesThis(
-            Analysis.Closure closure,
-            Analysis.Scope scope,
-            PooledHashSet<LocalFunctionSymbol> localFuncsInProgress = null)
-        {
-            Debug.Assert(closure != null);
-            Debug.Assert(scope != null);
-
-            bool result = false;
-            if (_onlyCapturesThisMemoTable?.TryGetValue(closure, out result) == true)
-            {
-                return result;
-            }
-
-            result = true;
-            foreach (var captured in closure.CapturedVariables)
-            {
-                var param = captured as ParameterSymbol;
-                if (param != null && param.IsThis)
-                {
-                    continue;
-                }
-
-                var localFunc = captured as LocalFunctionSymbol;
-                if (localFunc != null)
-                {
-                    bool freePool = false;
-                    if (localFuncsInProgress == null)
-                    {
-                        localFuncsInProgress = PooledHashSet<LocalFunctionSymbol>.GetInstance();
-                        freePool = true;
-                    }
-                    else if (localFuncsInProgress.Contains(localFunc))
-                    {
-                        continue;
-                    }
-
-                    localFuncsInProgress.Add(localFunc);
-                    var (found, foundScope) = Analysis.GetVisibleClosure(scope, localFunc);
-                    bool transitivelyTrue = OnlyCapturesThis(found, foundScope, localFuncsInProgress);
-
-                    if (freePool)
-                    {
-                        localFuncsInProgress.Free();
-                        localFuncsInProgress = null;
-                    }
-
-                    if (transitivelyTrue)
-                    {
-                        continue;
-                    }
-                }
-
-                result = false;
-                break;
-            }
-
-            if (_onlyCapturesThisMemoTable == null)
-            {
-                _onlyCapturesThisMemoTable = new SmallDictionary<Analysis.Closure, bool>();
-            }
-
-            _onlyCapturesThisMemoTable[closure] = result;
-            return result;
-        }
-
-        private LambdaFrame GetFrameForScope(Analysis.Scope scope, ArrayBuilder<ClosureDebugInfo> closureDebugInfo)
-        {
-            var scopeBoundNode = scope.BoundNode;
-            LambdaFrame frame;
-            if (!_frames.TryGetValue(scopeBoundNode, out frame))
-            {
-                var syntax = scopeBoundNode.Syntax;
-                Debug.Assert(syntax != null);
-
-                DebugId methodId = GetTopLevelMethodId();
-                DebugId closureId = GetClosureId(syntax, closureDebugInfo);
-
-                var canBeStruct = !_analysis.ScopesThatCantBeStructs.Contains(scopeBoundNode);
-
-                var containingMethod = scope.ContainingClosureOpt?.OriginalMethodSymbol ?? _topLevelMethod;
-                if (_substitutedSourceMethod != null && containingMethod == _topLevelMethod)
-                {
-                    containingMethod = _substitutedSourceMethod;
-                }
-                frame = new LambdaFrame(_topLevelMethod, containingMethod, canBeStruct, syntax, methodId, closureId);
-                _frames.Add(scopeBoundNode, frame);
-
-                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(ContainingType, frame);
-                if (frame.Constructor != null)
-                {
-                    AddSynthesizedMethod(
-                        frame.Constructor,
-                        FlowAnalysisPass.AppendImplicitReturn(
-                            MethodCompiler.BindMethodBody(frame.Constructor, CompilationState, null),
-                            frame.Constructor));
-                }
-            }
-
-            return frame;
-        }
-
-        private LambdaFrame GetStaticFrame(DiagnosticBag diagnostics, IBoundLambdaOrFunction lambda)
+        private ClosureEnvironment GetStaticFrame(DiagnosticBag diagnostics, IBoundLambdaOrFunction lambda)
         {
             if (_lazyStaticLambdaFrame == null)
             {
@@ -506,13 +400,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        methodId = GetTopLevelMethodId();
+                        methodId = _analysis.GetTopLevelMethodId();
                     }
 
                     DebugId closureId = default(DebugId);
                     // using _topLevelMethod as containing member because the static frame does not have generic parameters, except for the top level method's
                     var containingMethod = isNonGeneric ? null : (_substitutedSourceMethod ?? _topLevelMethod);
-                    _lazyStaticLambdaFrame = new LambdaFrame(_topLevelMethod, containingMethod, isStruct: false, scopeSyntaxOpt: null, methodId: methodId, closureId: closureId);
+                    _lazyStaticLambdaFrame = new ClosureEnvironment(
+                        SpecializedCollections.EmptyEnumerable<Symbol>(),
+                        _topLevelMethod,
+                        containingMethod,
+                        isStruct: false,
+                        scopeSyntaxOpt: null,
+                        methodId: methodId,
+                        closureId: closureId);
 
                     // non-generic static lambdas can share the frame
                     if (isNonGeneric)
@@ -632,7 +533,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="frame">The frame for the translated node</param>
         /// <param name="F">A function that computes the translation of the node.  It receives lists of added statements and added symbols</param>
         /// <returns>The translated statement, as returned from F</returns>
-        private BoundNode IntroduceFrame(BoundNode node, LambdaFrame frame, Func<ArrayBuilder<BoundExpression>, ArrayBuilder<LocalSymbol>, BoundNode> F)
+        private BoundNode IntroduceFrame(BoundNode node, ClosureEnvironment frame, Func<ArrayBuilder<BoundExpression>, ArrayBuilder<LocalSymbol>, BoundNode> F)
         {
             var frameTypeParameters = ImmutableArray.Create(StaticCast<TypeSymbol>.From(_currentTypeParameters).SelectAsArray(TypeMap.TypeSymbolAsTypeWithModifiers), 0, frame.Arity);
             NamedTypeSymbol frameType = frame.ConstructIfGeneric(frameTypeParameters);
@@ -646,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var prologue = ArrayBuilder<BoundExpression>.GetInstance();
 
-            if (frame.Constructor != null)
+            if ((object)frame.Constructor != null)
             {
                 MethodSymbol constructor = frame.Constructor.AsMember(frameType);
                 Debug.Assert(frameType == constructor.ContainingType);
@@ -675,20 +576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundExpression left = new BoundFieldAccess(syntax, new BoundLocal(syntax, framePointer, null, frameType), frameParent, null);
                     BoundExpression right = FrameOfType(syntax, frameParent.Type as NamedTypeSymbol);
                     BoundExpression assignment = new BoundAssignmentOperator(syntax, left, right, left.Type);
-
-                    if (_currentMethod.MethodKind == MethodKind.Constructor && capturedFrame.Type == _currentMethod.ContainingType && !_seenBaseCall)
-                    {
-                        // Containing method is a constructor 
-                        // Initialization statement for the "this" proxy must be inserted
-                        // after the constructor initializer statement block
-                        // This insertion will be done by the delegate F
-                        Debug.Assert(_thisProxyInitDeferred == null);
-                        _thisProxyInitDeferred = assignment;
-                    }
-                    else
-                    {
-                        prologue.Add(assignment);
-                    }
+                    prologue.Add(assignment);
 
                     if (CompilationState.Emitting)
                     {
@@ -702,15 +590,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Capture any parameters of this block.  This would typically occur
             // at the top level of a method or lambda with captured parameters.
-            // TODO: speed up the following by computing it in analysis.
-            var scope = Analysis.GetScopeWithMatchingBoundNode(_analysis.ScopeTree, node);
-            foreach (var variable in scope.DeclaredVariables)
+            foreach (var variable in frame.CapturedVariables)
             {
                 InitVariableProxy(syntax, variable, framePointer, prologue);
             }
 
             Symbol oldInnermostFramePointer = _innermostFramePointer;
-            _innermostFramePointer = framePointer;
+            if (!framePointer.Type.IsValueType)
+            {
+                _innermostFramePointer = framePointer;
+            }
             var addedLocals = ArrayBuilder<LocalSymbol>.GetInstance();
             addedLocals.Add(framePointer);
             _framePointers.Add(frame, framePointer);
@@ -775,7 +664,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var left = proxy.Replacement(syntax, frameType1 => new BoundLocal(syntax, framePointer, null, framePointer.Type));
                 var assignToProxy = new BoundAssignmentOperator(syntax, left, value, value.Type);
-                prologue.Add(assignToProxy);
+                if (_currentMethod.MethodKind == MethodKind.Constructor &&
+                    symbol == _currentMethod.ThisParameter &&
+                    !_seenBaseCall)
+                {
+                    // Containing method is a constructor 
+                    // Initialization statement for the "this" proxy must be inserted
+                    // after the constructor initializer statement block
+                    Debug.Assert(_thisProxyInitDeferred == null);
+                    _thisProxyInitDeferred = assignToProxy;
+                }
+                else
+                {
+                    prologue.Add(assignToProxy);
+                }
             }
         }
 
@@ -826,7 +728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out NamedTypeSymbol constructedFrame)
         {
             var translatedLambdaContainer = synthesizedMethod.ContainingType;
-            var containerAsFrame = translatedLambdaContainer as LambdaFrame;
+            var containerAsFrame = translatedLambdaContainer as ClosureEnvironment;
 
             // All of _currentTypeParameters might not be preserved here due to recursively calling upwards in the chain of local functions/lambdas
             Debug.Assert((typeArgumentsOpt.IsDefault && !originalMethod.IsGenericMethod) || (typeArgumentsOpt.Length == originalMethod.Arity));
@@ -915,17 +817,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Check if we need to init the 'this' proxy in a ctor call
             if (!_seenBaseCall)
             {
-                _seenBaseCall = _currentMethod == _topLevelMethod && node.IsConstructorInitializer();
-                if (_seenBaseCall && _thisProxyInitDeferred != null)
+                if (_currentMethod == _topLevelMethod && node.IsConstructorInitializer())
                 {
-                    // Insert the this proxy assignment after the ctor call.
-                    // Create bound sequence: { ctor call, thisProxyInitDeferred }
-                    return new BoundSequence(
-                        syntax: node.Syntax,
-                        locals: ImmutableArray<LocalSymbol>.Empty,
-                        sideEffects: ImmutableArray.Create<BoundExpression>(rewritten),
-                        value: _thisProxyInitDeferred,
-                        type: rewritten.Type);
+                    _seenBaseCall = true;
+                    if (_thisProxyInitDeferred != null)
+                    {
+                        // Insert the this proxy assignment after the ctor call.
+                        // Create bound sequence: { ctor call, thisProxyInitDeferred }
+                        return new BoundSequence(
+                            syntax: node.Syntax,
+                            locals: ImmutableArray<LocalSymbol>.Empty,
+                            sideEffects: ImmutableArray.Create<BoundExpression>(rewritten),
+                            value: _thisProxyInitDeferred,
+                            type: rewritten.Type);
+                    }
                 }
             }
 
@@ -961,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBlock(BoundBlock node)
         {
-            LambdaFrame frame;
+            ClosureEnvironment frame;
             // Test if this frame has captured variables and requires the introduction of a closure class.
             if (_frames.TryGetValue(node, out frame))
             {
@@ -1019,7 +924,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)
         {
             // Test if this frame has captured variables and requires the introduction of a closure class.
-            LambdaFrame frame;
+            ClosureEnvironment frame;
             if (_frames.TryGetValue(node, out frame))
             {
                 return IntroduceFrame(node, frame, (ArrayBuilder<BoundExpression> prologue, ArrayBuilder<LocalSymbol> newLocals) =>
@@ -1086,7 +991,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSequence(BoundSequence node)
         {
-            LambdaFrame frame;
+            ClosureEnvironment frame;
             // Test if this frame has captured variables and requires the introduction of a closure class.
             if (_frames.TryGetValue(node, out frame))
             {
@@ -1103,7 +1008,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitStatementList(BoundStatementList node)
         {
-            LambdaFrame frame;
+            ClosureEnvironment frame;
             // Test if this frame has captured variables and requires the introduction of a closure class.
             // That can occur for a BoundStatementList if it is the body of a method with captured parameters.
             if (_frames.TryGetValue(node, out frame))
@@ -1129,7 +1034,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
         {
-            LambdaFrame frame;
+            ClosureEnvironment frame;
             // Test if this frame has captured variables and requires the introduction of a closure class.
             if (_frames.TryGetValue(node, out frame))
             {
@@ -1200,7 +1105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ClosureKind closureKind;
             NamedTypeSymbol translatedLambdaContainer;
-            LambdaFrame containerAsFrame;
+            ClosureEnvironment containerAsFrame;
             BoundNode lambdaScope;
             DebugId topLevelMethodId;
             DebugId lambdaId;
@@ -1214,32 +1119,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 out lambdaId);
 
             return new BoundNoOpStatement(node.Syntax, NoOpStatementFlavor.Default);
-        }
-
-        private DebugId GetTopLevelMethodId()
-        {
-            return slotAllocatorOpt?.MethodId ?? new DebugId(_topLevelMethodOrdinal, CompilationState.ModuleBuilderOpt.CurrentGenerationOrdinal);
-        }
-
-        private DebugId GetClosureId(SyntaxNode syntax, ArrayBuilder<ClosureDebugInfo> closureDebugInfo)
-        {
-            Debug.Assert(syntax != null);
-
-            DebugId closureId;
-            DebugId previousClosureId;
-            if (slotAllocatorOpt != null && slotAllocatorOpt.TryGetPreviousClosure(syntax, out previousClosureId))
-            {
-                closureId = previousClosureId;
-            }
-            else
-            {
-                closureId = new DebugId(closureDebugInfo.Count, CompilationState.ModuleBuilderOpt.CurrentGenerationOrdinal);
-            }
-
-            int syntaxOffset = _topLevelMethod.CalculateLocalSyntaxOffset(syntax.SpanStart, syntax.SyntaxTree);
-            closureDebugInfo.Add(new ClosureDebugInfo(syntaxOffset, closureId));
-
-            return closureId;
         }
 
         private DebugId GetLambdaId(SyntaxNode syntax, ClosureKind closureKind, int closureOrdinal)
@@ -1299,19 +1178,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             IBoundLambdaOrFunction node,
             out ClosureKind closureKind,
             out NamedTypeSymbol translatedLambdaContainer,
-            out LambdaFrame containerAsFrame,
+            out ClosureEnvironment containerAsFrame,
             out BoundNode lambdaScope,
             out DebugId topLevelMethodId,
             out DebugId lambdaId)
         {
-            ImmutableArray<TypeSymbol> structClosures;
+            Analysis.Closure closure = Analysis.GetClosureInTree(_analysis.ScopeTree, node.Symbol);
+
+            var structClosures = closure.CapturedEnvironments
+                .Where(env => env.IsStructType()).AsImmutable();
             int closureOrdinal;
-            if (_analysis.LambdaScopes.TryGetValue(node.Symbol, out lambdaScope))
+            if (closure.ContainingEnvironmentOpt != null)
             {
-                containerAsFrame = _frames[lambdaScope];
-                structClosures = _analysis.CanTakeRefParameters(node.Symbol)
-                    ? GetStructClosures(containerAsFrame, lambdaScope)
-                    : default(ImmutableArray<TypeSymbol>);
+                containerAsFrame = closure.ContainingEnvironmentOpt;
 
                 if (containerAsFrame?.IsValueType == true)
                 {
@@ -1327,9 +1206,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureKind = ClosureKind.General;
                     translatedLambdaContainer = containerAsFrame;
                     closureOrdinal = containerAsFrame.ClosureOrdinal;
+                    // Find the scope of the containing environment
+                    BoundNode tmpScope = null;
+                    Analysis.VisitScopeTree(_analysis.ScopeTree, scope =>
+                    {
+                        if (scope.DeclaredEnvironments.Contains(closure.ContainingEnvironmentOpt))
+                        {
+                            tmpScope = scope.BoundNode;
+                        }
+                    });
+                    Debug.Assert(tmpScope != null);
+                    lambdaScope = tmpScope;
                 }
             }
-            else if (Analysis.GetClosureInTree(_analysis.ScopeTree, node.Symbol).CapturedVariables.Count == 0)
+            else if (closure.CapturedVariables.Count == 0)
             {
                 if (_analysis.MethodsConvertedToDelegates.Contains(node.Symbol))
                 {
@@ -1344,28 +1234,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureKind = ClosureKind.Static;
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
-                structClosures = default;
+                lambdaScope = null;
             }
             else
             {
-                // GetStructClosures is currently overly aggressive in gathering
-                // closures since the only information it has at this point is
-                // NeedsParentFrame, which doesn't say what exactly is needed from
-                // the parent frame. If `this` is captured, that's enough to mark
-                // NeedsParentFrame for the current closure, so we need to gather
-                // struct closures for all intermediate frames, even if they only
-                // strictly need `this`.
-                if (_analysis.CanTakeRefParameters(node.Symbol))
-                {
-                    lambdaScope = Analysis.GetScopeParent(_analysis.ScopeTree, node.Body)?.BoundNode;
-                    _ = _frames.TryGetValue(lambdaScope, out containerAsFrame);
-                    structClosures = GetStructClosures(containerAsFrame, lambdaScope);
-                }
-                else
-                {
-                    structClosures = default;
-                }
-
+                lambdaScope = null;
                 containerAsFrame = null;
                 translatedLambdaContainer = _topLevelMethod.ContainingType;
                 closureKind = ClosureKind.ThisOnly;
@@ -1373,7 +1246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Move the body of the lambda to a freshly generated synthetic method on its frame.
-            topLevelMethodId = GetTopLevelMethodId();
+            topLevelMethodId = _analysis.GetTopLevelMethodId();
             lambdaId = GetLambdaId(node.Syntax, closureKind, closureOrdinal);
 
             var synthesizedMethod = new SynthesizedLambdaMethod(translatedLambdaContainer, structClosures, closureKind, _topLevelMethod, topLevelMethodId, node, lambdaId);
@@ -1411,7 +1284,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 _currentFrameThis = synthesizedMethod.ThisParameter;
-                _innermostFramePointer = null;
                 _framePointers.TryGetValue(translatedLambdaContainer, out _innermostFramePointer);
             }
 
@@ -1433,52 +1305,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             _addedStatements = oldAddedStatements;
 
             return synthesizedMethod;
-        }
-
-        /// <summary>
-        /// Builds a list of all the struct-based closure environments that will
-        /// need to be passed as arguments to the method.
-        /// </summary>
-        private ImmutableArray<TypeSymbol> GetStructClosures(LambdaFrame containerAsFrame, BoundNode lambdaScope)
-        {
-            var structClosureParamBuilder = ArrayBuilder<TypeSymbol>.GetInstance();
-            while (containerAsFrame?.IsValueType == true ||
-                   _analysis.NeedsParentFrame.Contains(lambdaScope))
-            {
-                if (containerAsFrame?.IsValueType == true)
-                {
-                    structClosureParamBuilder.Add(containerAsFrame);
-                }
-                if (_analysis.NeedsParentFrame.Contains(lambdaScope)
-                    && FindParentFrame(ref containerAsFrame, ref lambdaScope))
-                {
-                    continue;
-                }
-
-                // can happen when scope no longer needs parent frame, or we're at the outermost level and the "parent frame" is top level "this".
-                break;
-            }
-
-            // Reverse it because we're going from inner to outer, and parameters are in order of outer to inner
-            structClosureParamBuilder.ReverseContents();
-            return structClosureParamBuilder.ToImmutableAndFree();
-
-            bool FindParentFrame(ref LambdaFrame container, ref BoundNode scope)
-            {
-                while (true)
-                {
-                    scope = Analysis.GetScopeParent(_analysis.ScopeTree, scope)?.BoundNode;
-                    if (scope == null)
-                    {
-                        return false;
-                    }
-
-                    if (_frames.TryGetValue(scope, out container))
-                    {
-                        return true;
-                    }
-                }
-            }
         }
 
         private void AddSynthesizedMethod(MethodSymbol method, BoundStatement body)
@@ -1512,7 +1338,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ClosureKind closureKind;
             NamedTypeSymbol translatedLambdaContainer;
-            LambdaFrame containerAsFrame;
+            ClosureEnvironment containerAsFrame;
             BoundNode lambdaScope;
             DebugId topLevelMethodId;
             DebugId lambdaId;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class SynthesizedLambdaMethod : SynthesizedMethodBaseSymbol, ISynthesizedMethodBodyImplementationSymbol
     {
         private readonly MethodSymbol _topLevelMethod;
-        private readonly ImmutableArray<TypeSymbol> _structClosures;
+        private readonly ImmutableArray<NamedTypeSymbol> _structEnvironments;
 
         internal SynthesizedLambdaMethod(
             NamedTypeSymbol containingType,
-            ImmutableArray<TypeSymbol> structClosures,
+            ImmutableArray<ClosureEnvironment> structEnvironments,
             ClosureKind closureKind,
             MethodSymbol topLevelMethod,
             DebugId topLevelMethodId,
@@ -43,15 +43,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeMap typeMap;
             ImmutableArray<TypeParameterSymbol> typeParameters;
             ImmutableArray<TypeParameterSymbol> constructedFromTypeParameters;
-            LambdaFrame lambdaFrame;
+            ClosureEnvironment lambdaFrame;
 
-            lambdaFrame = this.ContainingType as LambdaFrame;
+            lambdaFrame = this.ContainingType as ClosureEnvironment;
             switch (closureKind)
             {
                 case ClosureKind.Singleton: // all type parameters on method (except the top level method's)
                 case ClosureKind.General: // only lambda's type parameters on method (rest on class)
                     Debug.Assert(lambdaFrame != null);
-                    typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, out constructedFromTypeParameters, lambdaFrame.ContainingMethod);
+                    typeMap = lambdaFrame.TypeMap.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, out constructedFromTypeParameters, lambdaFrame.OriginalContainingMethodOpt);
                     break;
                 case ClosureKind.ThisOnly: // all type parameters on method
                 case ClosureKind.Static:
@@ -62,28 +62,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                     throw ExceptionUtilities.UnexpectedValue(closureKind);
             }
 
-            if (!structClosures.IsDefaultOrEmpty && typeParameters.Length != 0)
+            if (!structEnvironments.IsDefaultOrEmpty && typeParameters.Length != 0)
             {
-                var constructedStructClosures = ArrayBuilder<TypeSymbol>.GetInstance();
-                foreach (var closure in structClosures)
+                var constructedStructClosures = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+                foreach (var env in structEnvironments)
                 {
-                    var frame = (LambdaFrame)closure;
                     NamedTypeSymbol constructed;
-                    if (frame.Arity == 0)
+                    if (env.Arity == 0)
                     {
-                        constructed = frame;
+                        constructed = env;
                     }
                     else
                     {
-                        var originals = frame.ConstructedFromTypeParameters;
+                        var originals = env.ConstructedFromTypeParameters;
                         var newArgs = typeMap.SubstituteTypeParameters(originals);
-                        constructed = frame.Construct(newArgs);
+                        constructed = env.Construct(newArgs);
                     }
                     constructedStructClosures.Add(constructed);
                 }
-                structClosures = constructedStructClosures.ToImmutableAndFree();
+                _structEnvironments = constructedStructClosures.ToImmutableAndFree();
             }
-            _structClosures = structClosures;
+            else
+            {
+                _structEnvironments = ImmutableArray<NamedTypeSymbol>.CastUp(structEnvironments);
+            }
 
             AssignTypeMapAndTypeParameters(typeMap, typeParameters);
         }
@@ -125,8 +127,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // UNDONE: names from the delegate. Does it really matter?
         protected override ImmutableArray<ParameterSymbol> BaseMethodParameters => this.BaseMethod.Parameters;
 
-        protected override ImmutableArray<TypeSymbol> ExtraSynthesizedRefParameters => _structClosures;
-        internal int ExtraSynthesizedParameterCount => this._structClosures.IsDefault ? 0 : this._structClosures.Length;
+        protected override ImmutableArray<TypeSymbol> ExtraSynthesizedRefParameters
+            => ImmutableArray<TypeSymbol>.CastUp(_structEnvironments);
+        internal int ExtraSynthesizedParameterCount => this._structEnvironments.IsDefault ? 0 : this._structEnvironments.Length;
 
         internal override bool GenerateDebugInfo => !this.IsAsync;
         internal override bool IsExpressionBodied => false;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -1015,17 +1015,17 @@ class Program
 {
   // Code size      131 (0x83)
   .maxstack  3
-  .locals init (Program.<>c__DisplayClass1_2<T> V_0, //CS$<>8__locals0
-                Program.<>c__DisplayClass1_1<T> V_1, //CS$<>8__locals1
+  .locals init (Program.<>c__DisplayClass1_1<T> V_0, //CS$<>8__locals0
+                Program.<>c__DisplayClass1_2<T> V_1, //CS$<>8__locals1
                 T V_2)
-  IL_0000:  newobj     ""Program.<>c__DisplayClass1_2<T>..ctor()""
+  IL_0000:  newobj     ""Program.<>c__DisplayClass1_1<T>..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  ldarg.0
-  IL_0008:  stfld      ""Program.<>c__DisplayClass1_0<T> Program.<>c__DisplayClass1_2<T>.CS$<>8__locals1""
+  IL_0008:  stfld      ""Program.<>c__DisplayClass1_0<T> Program.<>c__DisplayClass1_1<T>.CS$<>8__locals1""
   IL_000d:  ldloc.0
   IL_000e:  ldstr      ""y""
-  IL_0013:  stfld      ""string Program.<>c__DisplayClass1_2<T>.y""
+  IL_0013:  stfld      ""string Program.<>c__DisplayClass1_1<T>.y""
   .try
   {
     IL_0018:  ldstr      ""xy""
@@ -1041,17 +1041,17 @@ class Program
     IL_002c:  ldc.i4.0
     IL_002d:  br.s       IL_005d
     IL_002f:  unbox.any  ""T""
-    IL_0034:  newobj     ""Program.<>c__DisplayClass1_1<T>..ctor()""
+    IL_0034:  newobj     ""Program.<>c__DisplayClass1_2<T>..ctor()""
     IL_0039:  stloc.1
     IL_003a:  ldloc.1
     IL_003b:  ldloc.0
-    IL_003c:  stfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_1<T>.CS$<>8__locals2""
+    IL_003c:  stfld      ""Program.<>c__DisplayClass1_1<T> Program.<>c__DisplayClass1_2<T>.CS$<>8__locals2""
     IL_0041:  stloc.2
     IL_0042:  ldloc.1
     IL_0043:  ldloc.2
-    IL_0044:  stfld      ""T Program.<>c__DisplayClass1_1<T>.e""
+    IL_0044:  stfld      ""T Program.<>c__DisplayClass1_2<T>.e""
     IL_0049:  ldloc.1
-    IL_004a:  ldftn      ""bool Program.<>c__DisplayClass1_1<T>.<F>b__1()""
+    IL_004a:  ldftn      ""bool Program.<>c__DisplayClass1_2<T>.<F>b__1()""
     IL_0050:  newobj     ""System.Func<bool>..ctor(object, System.IntPtr)""
     IL_0055:  callvirt   ""bool System.Func<bool>.Invoke()""
     IL_005a:  ldc.i4.0
@@ -1064,8 +1064,8 @@ class Program
     IL_0065:  ldarg.0
     IL_0066:  ldfld      ""string Program.<>c__DisplayClass1_0<T>.x""
     IL_006b:  ldloc.1
-    IL_006c:  ldfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_1<T>.CS$<>8__locals2""
-    IL_0071:  ldfld      ""string Program.<>c__DisplayClass1_2<T>.y""
+    IL_006c:  ldfld      ""Program.<>c__DisplayClass1_1<T> Program.<>c__DisplayClass1_2<T>.CS$<>8__locals2""
+    IL_0071:  ldfld      ""string Program.<>c__DisplayClass1_1<T>.y""
     IL_0076:  call       ""string string.Concat(string, string, string)""
     IL_007b:  call       ""void System.Console.Write(string)""
     IL_0080:  leave.s    IL_0082
@@ -3646,12 +3646,12 @@ public static class Program
 {
   // Code size       89 (0x59)
   .maxstack  2
-  .locals init (Program.c1.<>c__DisplayClass1_1 V_0) //CS$<>8__locals0
-  IL_0000:  newobj     ""Program.c1.<>c__DisplayClass1_1..ctor()""
+  .locals init (Program.c1.<>c__DisplayClass1_0 V_0) //CS$<>8__locals0
+  IL_0000:  newobj     ""Program.c1.<>c__DisplayClass1_0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  ldarg.0
-  IL_0008:  stfld      ""Program.c1 Program.c1.<>c__DisplayClass1_1.<>4__this""
+  IL_0008:  stfld      ""Program.c1 Program.c1.<>c__DisplayClass1_0.<>4__this""
   IL_000d:  ldarg.0
   IL_000e:  call       ""bool Program.c1.T()""
   IL_0013:  brfalse.s  IL_002e
@@ -3664,12 +3664,12 @@ public static class Program
   IL_002d:  ret
   IL_002e:  ldloc.0
   IL_002f:  ldc.i4.s   42
-  IL_0031:  stfld      ""int Program.c1.<>c__DisplayClass1_1.aaa""
+  IL_0031:  stfld      ""int Program.c1.<>c__DisplayClass1_0.aaa""
   IL_0036:  ldarg.0
   IL_0037:  call       ""bool Program.c1.T()""
   IL_003c:  brfalse.s  IL_0057
   IL_003e:  ldloc.0
-  IL_003f:  ldftn      ""bool Program.c1.<>c__DisplayClass1_1.<Test>b__2(int)""
+  IL_003f:  ldftn      ""bool Program.c1.<>c__DisplayClass1_0.<Test>b__2(int)""
   IL_0045:  newobj     ""System.Func<int, bool>..ctor(object, System.IntPtr)""
   IL_004a:  ldc.i4.s   42
   IL_004c:  callvirt   ""bool System.Func<int, bool>.Invoke(int)""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -76,6 +76,28 @@ class C
 }", expectedOutput: 
 @"0
 1");
+            verifier.VerifyIL("C.M()", @"
+{
+  // Code size       46 (0x2e)
+  .maxstack  2
+  .locals init (C.<>c__DisplayClass2_0 V_0) //CS$<>8__locals0
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldarg.0
+  IL_0003:  stfld      ""C C.<>c__DisplayClass2_0.<>4__this""
+  IL_0008:  ldloca.s   V_0
+  IL_000a:  ldc.i4.0
+  IL_000b:  stfld      ""int C.<>c__DisplayClass2_0.var1""
+  IL_0010:  ldarg.0
+  IL_0011:  ldfld      ""int C._x""
+  IL_0016:  call       ""void System.Console.WriteLine(int)""
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       ""void C.<M>g__L12_0(ref C.<>c__DisplayClass2_0)""
+  IL_0022:  ldarg.0
+  IL_0023:  ldfld      ""int C._x""
+  IL_0028:  call       ""void System.Console.WriteLine(int)""
+  IL_002d:  ret
+}");
+
             // L1
             verifier.VerifyIL("C.<M>g__L12_0(ref C.<>c__DisplayClass2_0)", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -271,8 +271,8 @@ class C
 
             // no new synthesized members generated (with #1 in names):
             diff1.VerifySynthesizedMembers(
-                "C: {<>c__DisplayClass0_0}",
-                "C.<>c__DisplayClass0_0: {a, <>4__this, <F>b__0}");
+                "C.<>c__DisplayClass0_0: {<>4__this, a, <F>b__0}",
+                "C: {<>c__DisplayClass0_0}");
 
             var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -1128,11 +1128,11 @@ class C
         </encLocalSlotMap>
         <encLambdaMap>
           <methodOrdinal>1</methodOrdinal>
-          <closure offset=""102"" />
           <closure offset=""41"" />
-          <lambda offset=""149"" closure=""0"" />
-          <lambda offset=""73"" closure=""1"" />
-          <lambda offset=""87"" closure=""1"" />
+          <closure offset=""102"" />
+          <lambda offset=""149"" closure=""1"" />
+          <lambda offset=""73"" closure=""0"" />
+          <lambda offset=""87"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -2948,12 +2948,12 @@ class Student : Person { public double GPA; }
         </encLocalSlotMap>
         <encLambdaMap>
           <methodOrdinal>2</methodOrdinal>
-          <closure offset=""383"" />
           <closure offset=""0"" />
-          <lambda offset=""109"" closure=""0"" />
-          <lambda offset=""202"" closure=""0"" />
-          <lambda offset=""295"" closure=""0"" />
-          <lambda offset=""383"" closure=""1"" />
+          <closure offset=""383"" />
+          <lambda offset=""109"" closure=""1"" />
+          <lambda offset=""202"" closure=""1"" />
+          <lambda offset=""295"" closure=""1"" />
+          <lambda offset=""383"" closure=""0"" />
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>

--- a/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ImmutableArrayExtensions.cs
@@ -9,24 +9,10 @@ namespace Roslyn.Utilities
     internal static class ImmutableArrayExtensions
     {
         internal static ImmutableArray<T> ToImmutableArrayOrEmpty<T>(this IEnumerable<T> items)
-        {
-            if (items == null)
-            {
-                return ImmutableArray.Create<T>();
-            }
-
-            return ImmutableArray.CreateRange<T>(items);
-        }
+            => items == null ? ImmutableArray<T>.Empty : ImmutableArray.CreateRange(items);
 
         internal static ImmutableArray<T> ToImmutableArrayOrEmpty<T>(this ImmutableArray<T> items)
-        {
-            if (items.IsDefault)
-            {
-                return ImmutableArray.Create<T>();
-            }
-
-            return items;
-        }
+            => items.IsDefault ? ImmutableArray<T>.Empty : items;
 
         // same as Array.BinarySearch but the ability to pass arbitrary value to the comparer without allocation
         internal static int BinarySearch<TElement, TValue>(this ImmutableArray<TElement> array, TValue value, Func<TElement, TValue, int> comparer)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -1312,7 +1312,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 MakeDeclaredInterfacesInPart(syntaxRef.SyntaxTree, syntaxRef.GetVisualBasicSyntax(), interfaces, basesBeingResolved, diagnostics)
             Next
 
-            Return interfaces.InInsertionOrder.AsImmutable
+            Return interfaces.AsImmutable
         End Function
 
         Private Function GetInheritsLocation(base As NamedTypeSymbol) As Location

--- a/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicParseOptions.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             languageVersion As LanguageVersion,
             documentationMode As DocumentationMode,
             kind As SourceCodeKind,
-            preprocessorSymbols As IEnumerable(Of KeyValuePair(Of String, Object)),
+            preprocessorSymbols As ImmutableArray(Of KeyValuePair(Of String, Object)),
             features As ImmutableDictionary(Of String, String))
 
             MyBase.New(kind, documentationMode)


### PR DESCRIPTION
This PR is dependent on https://github.com/dotnet/roslyn/pull/21088.

This is part of the effort to move as much logic from LambdaRewriter
into Analysis as possible. The more logic there is in the Rewriter, the
more difficult it is to find calculation problems until the last
possible moment, and it's also very difficult to calculate useful
information for later analysis passes, like the final debug and closure
IDs for each environment.