### PR TITLE
Fix vbc on non-English cultures

### DIFF
--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -1,11 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Globalization
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Public Module PredefinedPreprocessorSymbols
 
-        Friend ReadOnly CurrentVersionNumber As Double = Double.Parse(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().GetErrorName())
+        Friend ReadOnly CurrentVersionNumber As Double = Double.Parse(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().GetErrorName(), CultureInfo.InvariantCulture)
 
         ''' <summary>
         ''' Adds predefined preprocessor symbols VBC_VER and TARGET to given list of preprocessor symbols if not included yet.

--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -6,7 +6,11 @@ Imports System.Globalization
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Public Module PredefinedPreprocessorSymbols
 
-        Friend ReadOnly CurrentVersionNumber As Double = Double.Parse(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().GetErrorName(), CultureInfo.InvariantCulture)
+        Friend ReadOnly Property CurrentVersionNumber As Double
+            Get
+                Return Double.Parse(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().GetErrorName(), CultureInfo.InvariantCulture)
+            End Get
+        End Property
 
         ''' <summary>
         ''' Adds predefined preprocessor symbols VBC_VER and TARGET to given list of preprocessor symbols if not included yet.

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Globalization
 Imports System.Linq
 Imports Roslyn.Test.Utilities
 
@@ -84,7 +85,7 @@ Public Class VisualBasicParseOptionsTests
             Max().
             ToDisplayString()
 
-        Assert.Equal(highest, PredefinedPreprocessorSymbols.CurrentVersionNumber.ToString())
+        Assert.Equal(highest, PredefinedPreprocessorSymbols.CurrentVersionNumber.ToString(CultureInfo.InvariantCulture))
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -88,6 +88,21 @@ Public Class VisualBasicParseOptionsTests
         Assert.Equal(highest, PredefinedPreprocessorSymbols.CurrentVersionNumber.ToString(CultureInfo.InvariantCulture))
     End Sub
 
+    <Fact, WorkItem(21094, "https://github.com/dotnet/roslyn/issues/21094")>
+    Public Sub CurrentVersionNumberIsCultureIndependent()
+        Dim currentCulture = CultureInfo.CurrentCulture
+        Try
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture
+            Dim invariantCultureVersion = PredefinedPreprocessorSymbols.CurrentVersionNumber
+            ' cs-CZ uses decimal comma, which can cause issues
+            CultureInfo.CurrentCulture = New CultureInfo("cs-CZ")
+            Dim czechCultureVersion = PredefinedPreprocessorSymbols.CurrentVersionNumber
+            Assert.Equal(invariantCultureVersion, czechCultureVersion)
+        Finally
+            CultureInfo.CurrentCulture = currentCulture
+        End Try
+    End Sub
+
     <Fact>
     Public Sub PredefinedPreprocessorSymbols_Win8()
         Dim options = VisualBasicParseOptions.Default


### PR DESCRIPTION
**Customer scenario**

Do anything that involves the VB compiler on a culture that doesn't use decimal point, such as cs-CZ.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn/issues/21094.

**Workarounds, if any**

Switch the current culture to en-US.

**Risk**

It's a simple one-line change, it should not be risky.

**Performance impact**

Should not be significant, parsing with invariant culture shouldn't be slower than using the current culture.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

How did we miss it? By running CI only with en-US culture.

What tests are we adding to guard against it in the future? No idea.

**How was the bug found?**

I discovered it when trying to run Roslyn tests on my machine with cs-CZ culture.