### PR TITLE
Include impl assemblies in debugger packages

### DIFF
--- a/src/Tools/GenerateSdkPackages/engine.nuspec
+++ b/src/Tools/GenerateSdkPackages/engine.nuspec
@@ -17,8 +17,9 @@
     <tags>VSSDK</tags>
   </metadata>
   <files>
-    <file src="$debuggerPath$\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\net20" />
-    <file src="$debuggerPath$\v4.5\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\net45" />
-    <file src="$debuggerPath$\portable\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\netstandard1.3" />
+    <file src="$debuggerPath$\ref\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\net20" />
+    <file src="$debuggerPath$\ref\v4.5\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\net45" />
+    <file src="$debuggerPath$\ref\portable\Microsoft.VisualStudio.Debugger.Engine.dll" target="ref\netstandard1.3" />
+    <file src="$debuggerPath$\lib\net45\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\net45" />
   </files>
 </package>

--- a/src/Tools/GenerateSdkPackages/make-all.ps1
+++ b/src/Tools/GenerateSdkPackages/make-all.ps1
@@ -28,10 +28,14 @@ function Package-Normal() {
 # The debugger DLLs have a more complex structure and it's easier to special case
 # copying them over.
 function Copy-Debugger() { 
-    $refRootPath = [IO.Path]::GetFullPath((Join-Path $dropPath "..\..\Debugger\ReferenceDLL"))
-    $debuggerDllPath = Join-Path $dllPath "debugger"
-    Create-Directory $debuggerDllPath
-    Copy-Item -re -fo "$refRootPath\*" $debuggerDllPath
+    $debuggerRefDir = Join-Path $dllPath "debugger\ref"
+    $debuggerImplDir = Join-Path $dllPath "debugger\lib\net45"
+    Create-Directory $debuggerRefDir
+    Create-Directory $debuggerImplDir
+    
+    Copy-Item -re -fo (Join-Path $dropPath "..\..\Debugger\ReferenceDLL\*") $debuggerRefDir
+    Copy-Item -re -fo (Join-Path $dropPath "..\..\Debugger\IDE\Microsoft.VisualStudio.Debugger.Engine.dll") $debuggerImplDir
+    Copy-Item -re -fo (Join-Path $dropPath "Microsoft.VisualStudio.Debugger.Metadata.dll") $debuggerImplDir
 }
 
 # Used to package debugger nugets

--- a/src/Tools/GenerateSdkPackages/metadata.nuspec
+++ b/src/Tools/GenerateSdkPackages/metadata.nuspec
@@ -17,7 +17,8 @@
     <tags>VSSDK</tags>
   </metadata>
   <files>
-    <file src="$debuggerPath$\v2.0\Microsoft.VisualStudio.Debugger.Metadata.dll" target="ref\net20" />
-    <file src="$debuggerPath$\portable\Microsoft.VisualStudio.Debugger.Metadata.dll" target="ref\netstandard1.3" />
+    <file src="$debuggerPath$\ref\v2.0\Microsoft.VisualStudio.Debugger.Metadata.dll" target="ref\net20" />
+    <file src="$debuggerPath$\ref\portable\Microsoft.VisualStudio.Debugger.Metadata.dll" target="ref\netstandard1.3" />
+    <file src="$debuggerPath$\lib\net45\Microsoft.VisualStudio.Debugger.Metadata.dll" target="lib\net45" />
   </files>
 </package>


### PR DESCRIPTION
Turns out some of EE tests depend on the implementation. Long term we should perhaps refactor them to avoid that, but for now we need the implementation assemblies deployed when running tests.