### PR TITLE
Handle navigation to a doc ID without a corresponding doc

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -997,6 +997,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             var hostDocument = GetHostDocument(documentId);
+            if (hostDocument == null)
+            {
+                // This can happen if the document was temporary and has since been closed/deleted.
+                return base.GetDocumentIdInCurrentContext(documentId);
+            }
+
             var itemId = hostDocument.GetItemId();
             if (itemId == (uint)VSConstants.VSITEMID.Nil)
             {


### PR DESCRIPTION
The FAR window is hierarchical: declarations are parents and references are children.  Apparently, we follow different codepaths for the two cases.  (I would be interested to learn why.)  The codepaths have the same observed behavior when the file is open, but not if the file is closed.

This is the behavior I'm seeing for TypeScript FAR:

| File               | Decl             | Ref              |
| ------------- | ------------- | ------------- |
| Opened       | Navigate     | Navigate     |
| Closed         | No-op         | Navigate     |
| Deleted       | NRE             | No-op         |

This PR fixes the NRE (and the new behavior is No-op).

It would be cool if decls in closed files worked, but that's a problem for another day.