### PR TITLE
Set the CWD to the user profile dir, instead of current startup proj

### DIFF
--- a/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
                 Commands,
                 contentTypeRegistry,
                 Path.GetDirectoryName(typeof(CSharpVsInteractiveWindowPackage).Assembly.Location),
-                CommonVsUtils.GetWorkingDirectory());
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
         }
 
         protected override FunctionId InteractiveWindowFunctionId

--- a/src/VisualStudio/InteractiveServices/Interactive/CommonVsUtils.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/CommonVsUtils.cs
@@ -18,19 +18,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
     {
         internal const string OutputWindowId = "34e76e81-ee4a-11d0-ae2e-00a0c90fffc3";
 
-        internal static string GetWorkingDirectory()
-        {
-            var startupProject = GetStartupProject();
-            if (startupProject != null)
-            {
-                return Path.GetDirectoryName(startupProject.FullName);
-            }
-            else
-            {
-                return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            }
-        }
-
         internal static string GetFilePath(ITextBuffer textBuffer)
         {
             ITextDocument textDocument;
@@ -93,31 +80,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             }
 
             return null;
-        }
-
-        private static EnvDTE.Project GetStartupProject()
-        {
-            var buildMgr = (IVsSolutionBuildManager)Package.GetGlobalService(typeof(IVsSolutionBuildManager));
-            IVsHierarchy hierarchy;
-            if (buildMgr != null && ErrorHandler.Succeeded(buildMgr.get_StartupProject(out hierarchy)) && hierarchy != null)
-            {
-                return GetProject(hierarchy);
-            }
-
-            return null;
-        }
-
-        internal static EnvDTE.Project GetProject(IVsHierarchy hierarchy)
-        {
-            object project;
-
-            ErrorHandler.ThrowOnFailure(
-                hierarchy.GetProperty(
-                    VSConstants.VSITEMID_ROOT,
-                    (int)__VSHPROPID.VSHPROPID_ExtObject,
-                    out project));
-
-            return project as EnvDTE.Project;
         }
     }
 }

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicVsInteractiveWindowProvider.vb
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicVsInteractiveWindowProvider.vb
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Interactive
                 Commands,
                 contentTypeRegistry,
                 Path.GetDirectoryName(GetType(VisualBasicVsInteractiveWindowPackage).Assembly.Location),
-                CommonVsUtils.GetWorkingDirectory())
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile))
         End Function
 
         Protected Overrides ReadOnly Property InteractiveWindowFunctionId As FunctionId


### PR DESCRIPTION
The Interactive Window used the current startup project's directory to set the initial working directory of the REPL. With Lightweight Solution Load on a project's IVsHierarchy was not always available and we crashed. 

This change uses the user home directory instead. It doesn't make much sense to use the current startup project dir since IW is standalone and doesn't have any relationship with the project. When initializing REPL from a specified project we still correctly use that project's directory.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/410475.