### PR TITLE
Handle navigation to a doc ID without a corresponding doc

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -997,6 +997,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             var hostDocument = GetHostDocument(documentId);
+            if (hostDocument == null)
+            {
+                // This can happen if the document was temporary and has since been closed/deleted.
+                return base.GetDocumentIdInCurrentContext(documentId);
+            }
+
             var itemId = hostDocument.GetItemId();
             if (itemId == (uint)VSConstants.VSITEMID.Nil)
             {


### PR DESCRIPTION
This is a port of https://github.com/dotnet/roslyn/pull/21126 to dev15.4.x.