### PR TITLE
Disable GenerateTypeDialog tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateTypeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateTypeDialog.cs
@@ -21,7 +21,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21154"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void OpenAndCloseDialog()
         {
             SetUpEditor(@"class C
@@ -42,7 +42,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             GenerateTypeDialog.VerifyClosed();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21154"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void CSharpToBasic()
         {
             var vbProj = new ProjectUtils.Project("VBProj");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
@@ -21,7 +21,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21154"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void BasicToCSharp()
         {
             var csProj = new ProjectUtils.Project("CSProj");
@@ -68,7 +68,7 @@ End Class
 }", actualText);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21154"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void SameProject()
         {
             SetUpEditor(@"


### PR DESCRIPTION
They've been hanging the VS integration tests. I think CSharpToBasic or
BasicToCSharp is the culprit (can't remember which I've seen).

Related to https://github.com/dotnet/roslyn/issues/21154