### PR TITLE
Fix tests on cs-CZ culture

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("f1945cd6 c19e56b3 c1c78943 ef5ec181 16907a4c a1efc40a 57d48ab1 db7adfc5", StringTextTest.ChecksumToHexQuads(checksum));
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [ConditionalFact(typeof(HasEnglishDefaultEncoding))]
         [WorkItem(5663, "https://github.com/dotnet/roslyn/issues/5663")]
         public void Decode_NonUtf8()
         {

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -47,6 +47,13 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "OS default codepage is not Shift-JIS (932).";
     }
 
+    public class HasEnglishDefaultEncoding : ExecutionCondition
+    {
+        public override bool ShouldSkip => Encoding.GetEncoding(0)?.CodePage != 1252;
+
+        public override string SkipReason => "OS default codepage is not Windows-1252.";
+    }
+
     public class IsEnglishLocal : ExecutionCondition
     {
         public override bool ShouldSkip =>

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -172,7 +172,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     return "null";
                 case string s:
                     if (quoteString)
+                    {
                         return @"""" + s + @"""";
+                    }
                     return s;
                 case IFormattable formattable:
                     return formattable.ToString(null, CultureInfo.InvariantCulture);

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -163,13 +164,26 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+        private static string ConstantToString(object constant, bool quoteString = true)
+        {
+            switch (constant)
+            {
+                case null:
+                    return "null";
+                case string s:
+                    if (quoteString)
+                        return @"""" + s + @"""";
+                    return s;
+                case IFormattable formattable:
+                    return formattable.ToString(null, CultureInfo.InvariantCulture);
+                default:
+                    return constant.ToString();
+            }
+        }
+
         private void LogConstant(object constant, string header = "Constant")
         {
-            var valueStr = constant != null ? constant.ToString() : "null";
-            if (constant is string)
-            {
-                valueStr = @"""" + valueStr + @"""";
-            }
+            string valueStr = ConstantToString(constant);
 
             LogString($"{header}: {valueStr}");
         }
@@ -845,8 +859,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             LogString(nameof(ILiteralExpression));
 
-            object value;
-            if (operation.ConstantValue.HasValue && ((value = operation.ConstantValue.Value) == null ? "null" : value.ToString()) == operation.Text)
+            if (operation.ConstantValue.HasValue && ConstantToString(operation.ConstantValue.Value, quoteString: false) == operation.Text)
             {
                 LogString($" (Text: {operation.Text})");
             }


### PR DESCRIPTION
**Customer scenario**

When I run tests for Roslyn on my machine with cs-CZ culture and Czech default encoding, some tests fail.

**Bugs this fixes:**

None.

**Workarounds, if any**

Switching to the en-US culture fixes some of these issues.

**Risk**

This only changes tests, so risk should be small.

**Performance impact**

This only changes tests, so performance of the compiler won't be affected.

**Is this a regression from a previous update?** No.

**Root cause analysis:**

How did we miss it? By only running tests on en-US culture and English default encoding.

What tests are we adding to guard against it in the future? I don't think tests for tests are necessary.

**How was the bug found?**

By me running `Test.cmd` on my machine.
