### PR TITLE
Fix a couple of infrastructure issues

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -75,6 +75,9 @@
       {RawFileName};
     </AssemblySearchPaths>
 
+    <!-- https://github.com/dotnet/roslyn/issues/21183 -->
+    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
+
     <RoslynNetSdkRootPath>$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\</RoslynNetSdkRootPath> 
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -445,7 +445,7 @@ function Ensure-ProcDump() {
         Remove-Item -Re $filePath -ErrorAction SilentlyContinue
         Create-Directory $outDir 
         $zipFilePath = Join-Path $toolsDir "procdump.zip"
-        Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -outfile $zipFilePath | Out-Null
+        Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -UseBasicParsing -outfile $zipFilePath | Out-Null
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         [IO.Compression.ZipFile]::ExtractToDirectory($zipFilePath, $outDir)
     }

--- a/build/scripts/run_perf.ps1
+++ b/build/scripts/run_perf.ps1
@@ -12,7 +12,7 @@ if ( -not $? )
     exit 1
 }
 
-Invoke-WebRequest -Uri http://dotnetci.blob.core.windows.net/roslyn-perf/cpc.zip -OutFile cpc.zip
+Invoke-WebRequest -Uri http://dotnetci.blob.core.windows.net/roslyn-perf/cpc.zip -OutFile cpc.zip -UseBasicParsing
 [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') | Out-Null
 [IO.Compression.ZipFile]::ExtractToDirectory('cpc.zip', $CPCLocation)
 

--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -156,7 +156,7 @@ try {
     }
 
     Write-Host "Downloading PublishData.json"
-    $publishFileContent = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/roslyn/master/build/config/PublishData.json").Content
+    $publishFileContent = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/roslyn/master/build/config/PublishData.json" -UseBasicParsing).Content
     $data = ConvertFrom-Json $publishFileContent
 
     if ($branchName -ne "" -and $releaseName -ne "") {


### PR DESCRIPTION
Issues addressed:

- Recent VS drops can't build roslyn due to a compat break in the SDK when using netstandard1.6 projects. Used an MSBUild property to suppress the check. 
- Calls to `Invoke-WebRequest` fail if IE hasn't been run on the machine. This broke several of our Microbuild runs. Passing the UseBasicParsing switch now to work around it. 