### PR TITLE
Fix a couple of infrastructure issues

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -69,6 +69,9 @@
       {RawFileName};
     </AssemblySearchPaths>
 
+    <!-- https://github.com/dotnet/roslyn/issues/21183 -->
+    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
+
     <RoslynNetSdkRootPath>$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\</RoslynNetSdkRootPath> 
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>

--- a/build/scripts/run_perf.ps1
+++ b/build/scripts/run_perf.ps1
@@ -12,7 +12,7 @@ if ( -not $? )
     exit 1
 }
 
-Invoke-WebRequest -Uri http://dotnetci.blob.core.windows.net/roslyn-perf/cpc.zip -OutFile cpc.zip
+Invoke-WebRequest -Uri http://dotnetci.blob.core.windows.net/roslyn-perf/cpc.zip -OutFile cpc.zip -UseBasicParsing
 [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') | Out-Null
 [IO.Compression.ZipFile]::ExtractToDirectory('cpc.zip', $CPCLocation)
 


### PR DESCRIPTION
Issues addressed:

- Recent VS drops can't build roslyn due to a compat break in the SDK when using netstandard1.6 projects. Used an MSBUild property to suppress the check. 
- Calls to `Invoke-WebRequest` fail if IE hasn't been run on the machine. This broke several of our Microbuild runs. Passing the UseBasicParsing switch now to work around it. 