### PR TITLE
Disable BasicLineCommit.CommitOnSave

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -75,7 +75,7 @@ End Module");
             VisualStudio.Editor.Verify.CaretPosition(16);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.LineCommit)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/20991"), Trait(Traits.Feature, Traits.Features.LineCommit)]
         void CommitOnSave()
         {
             VisualStudio.Editor.SetText(@"Module Module1


### PR DESCRIPTION
It's been failing. Tracked by https://github.com/dotnet/roslyn/issues/20991