### PR TITLE
Use explicit casts rather than `as`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3627,7 +3627,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // 4. A delegate type.
                 else if (argument.Type.TypeKind == TypeKind.Delegate)
                 {
-                    var sourceDelegate = argument.Type as NamedTypeSymbol;
+                    var sourceDelegate = (NamedTypeSymbol)argument.Type;
                     MethodGroup methodGroup = MethodGroup.GetInstance();
                     try
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (state.clauses.IsEmpty() && state.selectOrGroup.Kind() == SyntaxKind.SelectClause)
             {
-                var select = state.selectOrGroup as SelectClauseSyntax;
+                var select = (SelectClauseSyntax)state.selectOrGroup;
                 BoundCall invocation;
                 if (join.Into == null)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (parent.Kind() == SyntaxKind.JoinClause)
                 {
-                    var join = parent as JoinClauseSyntax;
+                    var join = (JoinClauseSyntax)parent;
                     if (join.LeftExpression.Span.Contains(node.Span) && join.Identifier.ValueText == node.Identifier.ValueText) return true;
                 }
             }
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (parent.Kind() == SyntaxKind.JoinClause)
                 {
-                    var join = parent as JoinClauseSyntax;
+                    var join = (JoinClauseSyntax)parent;
                     if (join.RightExpression.Span.Contains(node.Span)) return true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ExitPointsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ExitPointsWalker.cs
@@ -127,13 +127,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (pending.Branch.Kind)
                 {
                     case BoundKind.GotoStatement:
-                        if (_labelsInside.Contains(((pending.Branch) as BoundGotoStatement).Label)) continue;
+                        if (_labelsInside.Contains(((BoundGotoStatement)pending.Branch).Label)) continue;
                         break;
                     case BoundKind.BreakStatement:
-                        if (_labelsInside.Contains(((pending.Branch) as BoundBreakStatement).Label)) continue;
+                        if (_labelsInside.Contains(((BoundBreakStatement)pending.Branch).Label)) continue;
                         break;
                     case BoundKind.ContinueStatement:
-                        if (_labelsInside.Contains(((pending.Branch) as BoundContinueStatement).Label)) continue;
+                        if (_labelsInside.Contains(((BoundContinueStatement)pending.Branch).Label)) continue;
                         break;
                     case BoundKind.YieldBreakStatement:
                     case BoundKind.ReturnStatement:

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -197,26 +197,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (expr1.Kind)
             {
                 case BoundKind.Local:
-                    var local1 = expr1 as BoundLocal;
-                    var local2 = expr2 as BoundLocal;
+                    var local1 = (BoundLocal)expr1;
+                    var local2 = (BoundLocal)expr2;
                     return local1.LocalSymbol == local2.LocalSymbol;
                 case BoundKind.FieldAccess:
-                    var field1 = expr1 as BoundFieldAccess;
-                    var field2 = expr2 as BoundFieldAccess;
+                    var field1 = (BoundFieldAccess)expr1;
+                    var field2 = (BoundFieldAccess)expr2;
                     return field1.FieldSymbol == field2.FieldSymbol &&
                         (field1.FieldSymbol.IsStatic || IsSameLocalOrField(field1.ReceiverOpt, field2.ReceiverOpt));
                 case BoundKind.EventAccess:
-                    var event1 = expr1 as BoundEventAccess;
-                    var event2 = expr2 as BoundEventAccess;
+                    var event1 = (BoundEventAccess)expr1;
+                    var event2 = (BoundEventAccess)expr2;
                     return event1.EventSymbol == event2.EventSymbol &&
                         (event1.EventSymbol.IsStatic || IsSameLocalOrField(event1.ReceiverOpt, event2.ReceiverOpt));
                 case BoundKind.Parameter:
-                    var param1 = expr1 as BoundParameter;
-                    var param2 = expr2 as BoundParameter;
+                    var param1 = (BoundParameter)expr1;
+                    var param2 = (BoundParameter)expr2;
                     return param1.ParameterSymbol == param2.ParameterSymbol;
                 case BoundKind.RangeVariable:
-                    var rangeVar1 = expr1 as BoundRangeVariable;
-                    var rangeVar2 = expr2 as BoundRangeVariable;
+                    var rangeVar1 = (BoundRangeVariable)expr1;
+                    var rangeVar2 = (BoundRangeVariable)expr2;
                     return rangeVar1.RangeVariableSymbol == rangeVar2.RangeVariableSymbol;
                 case BoundKind.ThisReference:
                 case BoundKind.PreviousSubmissionReference:

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Add a field: T current
             _currentField = F.StateMachineField(_elementType, GeneratedNames.MakeIteratorCurrentFieldName());
 
-            // if it is an enumerable, and either Environment.CurrentManagedThreadId or System.Thread are available
+            // if it is an enumerable, and either Environment.CurrentManagedThreadId or Thread.ManagedThreadId are available
             // add a field: int initialThreadId
             bool addInitialThreadId =
                    _isEnumerable &&

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -269,28 +269,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Property(WellKnownMember member)
         {
-            var propertySym = WellKnownMember(member) as PropertySymbol;
-            //if (propertySym == null) return BoundBadExpression
-            Binder.ReportUseSiteDiagnostics(propertySym, Diagnostics, Syntax);
-            Debug.Assert(propertySym.IsStatic);
-            return Call(null, propertySym.GetMethod);
+            return Property(null, member);
         }
 
-        public BoundExpression Property(BoundExpression receiver, WellKnownMember member)
+        public BoundExpression Property(BoundExpression receiverOpt, WellKnownMember member)
         {
-            var propertySym = WellKnownMember(member) as PropertySymbol;
-            Debug.Assert(!propertySym.IsStatic);
-            Debug.Assert(receiver.Type.GetMembers(propertySym.Name).OfType<PropertySymbol>().Single() == propertySym);
-            //if (propertySym == null) return BoundBadExpression
+            var propertySym = (PropertySymbol)WellKnownMember(member);
+            Debug.Assert(receiverOpt == null ||
+                receiverOpt.Type.GetMembers(propertySym.Name).OfType<PropertySymbol>().Single() == propertySym);
             Binder.ReportUseSiteDiagnostics(propertySym, Diagnostics, Syntax);
-            Debug.Assert(!propertySym.IsStatic);
-            return Call(receiver, propertySym.GetMethod);
+            return Property(receiverOpt, propertySym);
         }
 
-        public BoundExpression Property(BoundExpression receiver, PropertySymbol property)
+        public BoundExpression Property(BoundExpression receiverOpt, PropertySymbol property)
         {
-            Debug.Assert(!property.IsStatic);
-            return Call(receiver, property.GetMethod); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
+            Debug.Assert((receiverOpt == null) == property.IsStatic);
+            return Call(receiverOpt, property.GetMethod); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
         }
 
         public NamedTypeSymbol SpecialType(SpecialType st)
@@ -601,7 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)method == null)
             {
-                return new BoundBadExpression(Syntax, default(LookupResultKind), ImmutableArray<Symbol>.Empty, args.AsImmutableOrNull(), receiver);
+                return new BoundBadExpression(Syntax, default(LookupResultKind), ImmutableArray<Symbol>.Empty, args.AsImmutable(), receiver);
             }
 
             return Call(null, method, args);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -374,8 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if ((object)other != null)
                     {
-                        if (nts is SourceNamedTypeSymbol && other is SourceNamedTypeSymbol &&
-                            (nts as SourceNamedTypeSymbol).IsPartial && (other as SourceNamedTypeSymbol).IsPartial)
+                        if ((nts as SourceNamedTypeSymbol)?.IsPartial == true && (other as SourceNamedTypeSymbol)?.IsPartial == true)
                         {
                             diagnostics.Add(ErrorCode.ERR_PartialTypeKindConflict, symbol.Locations[0], symbol);
                         }

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpPragmaWarningStateMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpPragmaWarningStateMap.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 if (d.Kind() == SyntaxKind.PragmaWarningDirectiveTrivia)
                 {
-                    var w = d as PragmaWarningDirectiveTriviaSyntax;
+                    var w = (PragmaWarningDirectiveTriviaSyntax)d;
 
                     // Ignore directives with errors (i.e., Unrecognized #pragma directive) and
                     // directives inside disabled code (by #if and #endif)
@@ -83,12 +83,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         var errorId = string.Empty;
                         if (currentErrorCode.Kind() == SyntaxKind.NumericLiteralExpression)
                         {
-                            var token = (currentErrorCode as LiteralExpressionSyntax).Token;
+                            var token = ((LiteralExpressionSyntax)currentErrorCode).Token;
                             errorId = MessageProvider.Instance.GetIdForErrorCode((int)token.Value);
                         }
                         else if (currentErrorCode.Kind() == SyntaxKind.IdentifierName)
                         {
-                            errorId = (currentErrorCode as IdentifierNameSyntax).Identifier.ValueText;
+                            errorId = ((IdentifierNameSyntax)currentErrorCode).Identifier.ValueText;
                         }
 
                         if (!string.IsNullOrWhiteSpace(errorId))


### PR DESCRIPTION
Use explicit casts rather than `as` in several places where the cast will not fail.