### PR TITLE
Fix unbound recursion with const var field in script

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -455,6 +455,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             diagnosticsForFirstDeclarator.Add(ErrorCode.ERR_ImplicitlyTypedVariableMultipleDeclarator, typeSyntax.Location);
                         }
+                        else if (this.IsConst && this.ContainingType.IsScriptClass)
+                        {
+                            // For const var in script, we won't try to bind the initializer (case below), as it can lead to an unbound recursion
+                            type = null;
+                        }
                         else
                         {
                             fieldsBeingBound = new ConsList<FieldSymbol>(this, fieldsBeingBound);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -1358,6 +1358,26 @@ goto Label;");
                 );
         }
 
+        [Fact]
+        [WorkItem(17779, "https://github.com/dotnet/roslyn/issues/17779")]
+        public void TestScriptWithConstVar()
+        {
+            var script = CreateCompilation(
+                source: @"string F() => null; const var x = F();",
+                parseOptions: TestOptions.Script,
+                options: TestOptions.DebugExe,
+                references: new MetadataReference[] { TaskFacadeAssembly(), MscorlibRef_v20 });
+
+            script.VerifyDiagnostics(
+                // (1,27): error CS0822: Implicitly-typed variables cannot be constant
+                // string F() => null; const var x = F();
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableCannotBeConst, "var").WithLocation(1, 27),
+                // (1,35): error CS0120: An object reference is required for the non-static field, method, or property 'F()'
+                // string F() => null; const var x = F();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("F()").WithLocation(1, 35)
+                );
+        }
+
         private static MemberAccessExpressionSyntax ErrorTestsGetNode(SyntaxTree syntaxTree)
         {
             var node1 = (CompilationUnitSyntax)syntaxTree.GetRoot();

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -33,28 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         }
 
         [Fact]
-        [WorkItem(17779, "https://github.com/dotnet/roslyn/issues/17779")]
-        public async Task TestScriptWithConstVar()
-        {
-            try
-            {
-                var script = CSharpScript.Create("string F() => null;").ContinueWith("const var x = F();");
-                await script.RunAsync();
-            }
-            catch (CompilationErrorException ex)
-            {
-                ex.Diagnostics.Verify(
-                    // (1,7): error CS0822: Implicitly-typed variables cannot be constant
-                    // const var x = F();
-                    Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableCannotBeConst, "var").WithLocation(1, 7),
-                    // (1,15): error CS0120: An object reference is required for the non-static field, method, or property 'F()'
-                    // const var x = F();
-                    Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("F()").WithLocation(1, 15)
-                    );
-            }
-        }
-
-        [Fact]
         public void TestCreateScript_CodeIsNull()
         {
             Assert.Throws<ArgumentNullException>(() => CSharpScript.Create((string)null));


### PR DESCRIPTION
**Customer scenario**
Type the following in script:
`string F() => null;`
`const var x = F(); // stack overflow` 

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/17779

**Workarounds, if any**
Don't use `const var`. It's not allowed.

**Root cause analysis:**
When compiling the second submission (while looking for the entry point), we'll make all the members for the submission. When making the member for `x`, we'll also consider making a static initializer for it. We first check that it is `const` (which it is) and then check its type (because of special handling for the `decimal` type, see `IsMetadataConstant`). But to figure out the type of `var`, we need to bind the initializer. Since that involves looking up a member, this will recurse. See the portion of stack below.

```
Microsoft.CodeAnalysis.CSharp.Binder.LookupMembersWithoutInheritance(Microsoft.CodeAnalysis.CSharp.LookupResult result, Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol type, string name, int arity, Microsoft.CodeAnalysis.CSharp.LookupOptions options, Microsoft.CodeAnalysis.CSharp.Binder originalBinder, Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol accessThroughType, bool diagnose, ref System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.DiagnosticInfo> useSiteDiagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbol> basesBeingResolved) Line 664	C#
Microsoft.CodeAnalysis.CSharp.Binder.LookupMembersInSubmissions(Microsoft.CodeAnalysis.CSharp.LookupResult result, Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol submissionClass, string name, int arity, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbol> basesBeingResolved, Microsoft.CodeAnalysis.CSharp.LookupOptions options, Microsoft.CodeAnalysis.CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.DiagnosticInfo> useSiteDiagnostics) Line 280	C#
Microsoft.CodeAnalysis.CSharp.InContainerBinder.LookupSymbolsInSingleBinder(Microsoft.CodeAnalysis.CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbol> basesBeingResolved, Microsoft.CodeAnalysis.CSharp.LookupOptions options, Microsoft.CodeAnalysis.CSharp.Binder originalBinder, bool diagnose, ref System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.DiagnosticInfo> useSiteDiagnostics) Line 214	C#
Microsoft.CodeAnalysis.CSharp.Binder.LookupSymbolsInternal(Microsoft.CodeAnalysis.CSharp.LookupResult result, string name, int arity, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbol> basesBeingResolved, Microsoft.CodeAnalysis.CSharp.LookupOptions options, bool diagnose, ref System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.DiagnosticInfo> useSiteDiagnostics) Line 95	C#
Microsoft.CodeAnalysis.CSharp.Binder.LookupSymbolsWithFallback(Microsoft.CodeAnalysis.CSharp.LookupResult result, string name, int arity, ref System.Collections.Generic.HashSet<Microsoft.CodeAnalysis.DiagnosticInfo> useSiteDiagnostics, Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbol> basesBeingResolved, Microsoft.CodeAnalysis.CSharp.LookupOptions options) Line 61	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindIdentifier(Microsoft.CodeAnalysis.CSharp.Syntax.SimpleNameSyntax node, bool invoked, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 1126	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindInvocationExpression(Microsoft.CodeAnalysis.CSharp.Syntax.InvocationExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 159	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionInternal(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 452	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax node, Microsoft.CodeAnalysis.DiagnosticBag diagnostics, bool invoked, bool indexed) Line 396	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindInferredVariableInitializer(Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax initializer, Microsoft.CodeAnalysis.CSharp.Binder.BindValueKind valueKind, Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode errorSyntax) Line 692	C#
Microsoft.CodeAnalysis.CSharp.Binder.BindInferredVariableInitializer(Microsoft.CodeAnalysis.DiagnosticBag diagnostics, Microsoft.CodeAnalysis.RefKind refKind, Microsoft.CodeAnalysis.CSharp.Syntax.EqualsValueClauseSyntax initializer, Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode errorSyntax) Line 669	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberFieldSymbolFromDeclarator.GetFieldType(Roslyn.Utilities.ConsList<Microsoft.CodeAnalysis.CSharp.Symbols.FieldSymbol> fieldsBeingBound) Line 469	C#
Microsoft.CodeAnalysis.CSharp.Symbols.FieldSymbol.IsMetadataConstant.get() Line 124	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.AddInitializer(ref Microsoft.CodeAnalysis.ArrayBuilder<Microsoft.CodeAnalysis.CSharp.Symbols.FieldOrPropertyInitializer> initializers, ref int aggregateSyntaxLength, Microsoft.CodeAnalysis.CSharp.Symbols.FieldSymbol fieldOpt, Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode node) Line 2657	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.AddNonTypeMembers(Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.MemberDeclarationSyntax> members, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2901	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.AddDeclaredNontypeMembers(Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder builder, Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2327	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.BuildMembersAndInitializers(Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2237	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembersAndInitializers() Line 1262	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.MakeAllMembers(Microsoft.CodeAnalysis.DiagnosticBag diagnostics) Line 2096	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembersByNameSlow() Line 1292	C#
Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol.GetMembers(string name) Line 1160	C#
```

@tmat @dotnet/roslyn-compiler for review. Thanks