### PR TITLE
EnC and EE cleanup

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
@@ -183,16 +183,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             awaiterSlotCount = maxAwaiterSlotIndex + 1;
         }
 
-        protected override ImmutableArray<EncLocalInfo> TryGetLocalSlotMapFromMetadata(MethodDefinitionHandle handle, EditAndContinueMethodDebugInformation debugInfo)
+        protected override ImmutableArray<EncLocalInfo> GetLocalSlotMapFromMetadata(StandaloneSignatureHandle handle, EditAndContinueMethodDebugInformation debugInfo)
         {
-            ImmutableArray<LocalInfo<TypeSymbol>> slotMetadata;
-            if (!_metadataDecoder.TryGetLocals(handle, out slotMetadata))
-            {
-                return default(ImmutableArray<EncLocalInfo>);
-            }
+            Debug.Assert(!handle.IsNil);
 
-            var result = CreateLocalSlotMap(debugInfo, slotMetadata);
-            Debug.Assert(result.Length == slotMetadata.Length);
+            var localInfos = _metadataDecoder.GetLocalsOrThrow(handle);
+            var result = CreateLocalSlotMap(debugInfo, localInfos);
+            Debug.Assert(result.Length == localInfos.Length);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -384,6 +384,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///   the "value" parameter for a property setter,
         ///   the parameters on indexer accessor methods (not on the indexer itself),
         ///   methods in anonymous types,
+        ///   anonymous functions
         /// </summary>
         public virtual bool IsImplicitlyDeclared
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinuePdbTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinuePdbTests.cs
@@ -40,11 +40,11 @@ public class C
 
     void G()
     {
-        Func<int> H1 = <N:0>() => 1</N:0>;
+        Func<int> <N:4>H1</N:4> = <N:0>() => 1</N:0>;
 
-        Action H2 = <N:1>() =>
+        Action <N:5>H2</N:5> = <N:1>() =>
         {
-            Func<int> H3 = <N:2>() => 3</N:2>;
+            Func<int> <N:6>H3</N:6> = <N:2>() => 3</N:2>;
 
         }</N:1>;
     }
@@ -69,12 +69,12 @@ public class C
 
     void G()
     {
-        Func<int> H1 = <N:0>() => 1</N:0>;
+        Func<int> <N:4>H1</N:4> = <N:0>() => 1</N:0>;
 
-        Action H2 = <N:1>() =>
+        Action <N:5>H2</N:5> = <N:1>() =>
         {
-            Func<int> H3 = <N:2>() => 3</N:2>;
-            Func<int> H4 = <N:3>() => 4</N:3>;
+            Func<int> <N:6>H3</N:6> = <N:2>() => 3</N:2>;
+            Func<int> <N:7>H4</N:7> = <N:3>() => 4</N:3>;
         }</N:1>;
     }
 
@@ -102,10 +102,10 @@ public class C
     {
         
 
-        Action H2 = <N:1>() =>
+        Action <N:5>H2</N:5> = <N:1>() =>
         {
             
-            Func<int> H4 = <N:3>() => 4</N:3>;
+            Func<int> <N:7>H4</N:7> = <N:3>() => 4</N:3>;
         }</N:1>;
     }
 
@@ -184,7 +184,7 @@ public class C
             diff1.VerifyPdb(Enumerable.Range(0x06000001, 20), @"
 <symbols>
   <files>
-    <file id=""1"" name=""C:\Enc1.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""D1, 84, C6,  3, AA, 83, C0, CF, 49, E2, 52, 48, BB, 35, 99, 51, 88, 2B, 6C, D6, "" />
+    <file id=""1"" name=""C:\Enc1.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum="" B, 95, CB, 78,  0, AE, C7, 34, 45, D9, FB, 31, E4, 30, A4,  E, FC, EA, 9E, 95, "" />
     <file id=""2"" name=""C:\F\A.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
     <file id=""3"" name=""C:\F\C.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
   </files>
@@ -211,13 +211,13 @@ public class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""43"" document=""1"" />
+        <entry offset=""0x1"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""54"" document=""1"" />
         <entry offset=""0x21"" startLine=""21"" startColumn=""9"" endLine=""25"" endColumn=""17"" document=""1"" />
         <entry offset=""0x41"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x42"">
-        <local name=""H1"" il_index=""2"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
-        <local name=""H2"" il_index=""3"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
+        <local name=""H1"" il_index=""0"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
+        <local name=""H2"" il_index=""1"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
       </scope>
     </method>
     <method token=""0x6000008"">
@@ -225,7 +225,7 @@ public class C
         <forward token=""0x6000002"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""19"" startColumn=""35"" endLine=""19"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x0"" startLine=""19"" startColumn=""46"" endLine=""19"" endColumn=""47"" document=""1"" />
       </sequencePoints>
     </method>
     <method token=""0x6000009"">
@@ -234,13 +234,13 @@ public class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x1"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""47"" document=""1"" />
-        <entry offset=""0x21"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x1"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x21"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""58"" document=""1"" />
         <entry offset=""0x41"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x42"">
-        <local name=""H3"" il_index=""1"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
-        <local name=""H4"" il_index=""2"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
+        <local name=""H3"" il_index=""0"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
+        <local name=""H4"" il_index=""1"" il_start=""0x0"" il_end=""0x42"" attributes=""0"" />
       </scope>
     </method>
     <method token=""0x600000a"">
@@ -248,7 +248,7 @@ public class C
         <forward token=""0x6000002"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""23"" startColumn=""39"" endLine=""23"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x0"" startLine=""23"" startColumn=""50"" endLine=""23"" endColumn=""51"" document=""1"" />
       </sequencePoints>
     </method>
     <method token=""0x600000b"">
@@ -256,7 +256,7 @@ public class C
         <forward token=""0x6000002"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""24"" startColumn=""39"" endLine=""24"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x0"" startLine=""24"" startColumn=""50"" endLine=""24"" endColumn=""51"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -305,7 +305,7 @@ public class C
             diff2.VerifyPdb(Enumerable.Range(0x06000001, 20), @"
 <symbols>
   <files>
-    <file id=""1"" name=""C:\Enc1.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""4D, 14, 76, DE, 68, ED, ED, C1, 88, DF,  C, 85, 1C, 6B, 15, F7, BE, C0, 34, 34, "" />
+    <file id=""1"" name=""C:\Enc1.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""9C, B9, FF, 18,  E, 9F, A4, 22, 93, 85, A8, 5A,  6, 11, 43, 1E, 64, 3E, 88,  6, "" />
     <file id=""2"" name=""C:\F\B.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
     <file id=""3"" name=""C:\F\E.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
   </files>
@@ -341,10 +341,10 @@ public class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""21"" startColumn=""9"" endLine=""25"" endColumn=""17"" document=""1"" />
-        <entry offset=""0x22"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x21"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x23"">
-        <local name=""H2"" il_index=""4"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x22"">
+        <local name=""H2"" il_index=""1"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
       </scope>
     </method>
     <method token=""0x6000009"">
@@ -353,7 +353,7 @@ public class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x1"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x1"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""58"" document=""1"" />
         <entry offset=""0x21"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x22"">
@@ -365,7 +365,7 @@ public class C
         <forward token=""0x6000001"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""24"" startColumn=""39"" endLine=""24"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x0"" startLine=""24"" startColumn=""50"" endLine=""24"" endColumn=""51"" document=""1"" />
       </sequencePoints>
     </method>
     <method token=""0x600000c"">

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/EmitBaselineTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/EmitBaselineTests.cs
@@ -12,9 +12,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
     public class EmitBaselineTests
     {
         [Fact]
-        public void CreateInitialBaseline()
+        public void CreateInitialBaseline_Errors()
         {
-            var provider = new Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation>(_ => default(EditAndContinueMethodDebugInformation));
+            var debugInfoProvider = new Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation>(_ => default);
+            var localSigProvider = new Func<MethodDefinitionHandle, StandaloneSignatureHandle>(_ => default);
             var peModule = ModuleMetadata.CreateFromImage(TestResources.Basic.Members);
             var peReader = peModule.Module.PEReaderOpt;
 
@@ -22,9 +23,14 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
             var mdBytesHandle = GCHandle.Alloc(mdBytes.DangerousGetUnderlyingArray(), GCHandleType.Pinned);
             var mdModule = ModuleMetadata.CreateFromMetadata(mdBytesHandle.AddrOfPinnedObject(), mdBytes.Length);
 
-            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, provider));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider));
             Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null));
-            Assert.Throws<ArgumentException>(() => EmitBaseline.CreateInitialBaseline(mdModule, provider));
+            Assert.Throws<ArgumentException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider));
+
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider, localSigProvider, true));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null, localSigProvider, true));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, null, true));
+            Assert.NotNull(EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, localSigProvider, true));
         }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -151,14 +151,14 @@ namespace Microsoft.CodeAnalysis.Emit
             out IReadOnlyDictionary<Cci.ITypeReference, int> awaiterMap,
             out int awaiterSlotCount);
 
-        protected abstract ImmutableArray<EncLocalInfo> TryGetLocalSlotMapFromMetadata(MethodDefinitionHandle handle, EditAndContinueMethodDebugInformation debugInfo);
+        protected abstract ImmutableArray<EncLocalInfo> GetLocalSlotMapFromMetadata(StandaloneSignatureHandle handle, EditAndContinueMethodDebugInformation debugInfo);
         protected abstract ITypeSymbol TryGetStateMachineType(EntityHandle methodHandle);
 
         internal VariableSlotAllocator TryCreateVariableSlotAllocator(EmitBaseline baseline, Compilation compilation, IMethodSymbolInternal method, IMethodSymbol topLevelMethod, DiagnosticBag diagnostics)
         {
             // Top-level methods are always included in the semantic edit list. Lambda methods are not.
             MappedMethod mappedMethod;
-            if (!this.mappedMethods.TryGetValue(topLevelMethod, out mappedMethod))
+            if (!mappedMethods.TryGetValue(topLevelMethod, out mappedMethod))
             {
                 return null;
             }
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Emit
             // Handle cases when the previous method doesn't exist.
 
             MethodDefinitionHandle previousHandle;
-            if (!this.TryGetMethodHandle(baseline, (Cci.IMethodDefinition)method, out previousHandle))
+            if (!TryGetMethodHandle(baseline, (Cci.IMethodDefinition)method, out previousHandle))
             {
                 // Unrecognized method. Must have been added in the current compilation.
                 return null;
@@ -227,11 +227,13 @@ namespace Microsoft.CodeAnalysis.Emit
                 // Method has not changed since initial generation. Generate a map
                 // using the local names provided with the initial metadata.
                 EditAndContinueMethodDebugInformation debugInfo;
+                StandaloneSignatureHandle localSignature;
                 try
                 {
                     debugInfo = baseline.DebugInformationProvider(previousHandle);
+                    localSignature = baseline.LocalSignatureProvider(previousHandle);
                 }
-                catch (InvalidDataException)
+                catch (Exception e) when (e is InvalidDataException || e is IOException)
                 {
                     diagnostics.Add(MessageProvider.CreateDiagnostic(
                         MessageProvider.ERR_InvalidDebugInfo,
@@ -292,10 +294,21 @@ namespace Microsoft.CodeAnalysis.Emit
                         }
                     }
 
-                    previousLocals = TryGetLocalSlotMapFromMetadata(previousHandle, debugInfo);
-                    if (previousLocals.IsDefault)
+                    try
                     {
-                        // TODO: Report error that metadata is not supported.
+                        previousLocals = localSignature.IsNil ? ImmutableArray<EncLocalInfo>.Empty : 
+                            GetLocalSlotMapFromMetadata(localSignature, debugInfo);
+                    }
+                    catch (Exception e) when (e is UnsupportedSignatureContent || e is BadImageFormatException || e is IOException)
+                    {
+                        diagnostics.Add(MessageProvider.CreateDiagnostic(
+                            MessageProvider.ERR_InvalidDebugInfo,
+                            method.Locations.First(),
+                            method,
+                            MetadataTokens.GetToken(localSignature),
+                            method.ContainingAssembly
+                        ));
+
                         return null;
                     }
                 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -134,8 +134,6 @@ namespace Microsoft.CodeAnalysis.Emit
 
         internal EmitBaseline GetDelta(EmitBaseline baseline, Compilation compilation, Guid encId, MetadataSizes metadataSizes)
         {
-            var moduleBuilder = (CommonPEModuleBuilder)this.module;
-
             var addedOrChangedMethodsByIndex = new Dictionary<int, AddedOrChangedMethodInfo>();
             foreach (var pair in _addedOrChangedMethods)
             {
@@ -143,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Emit
             }
 
             var previousTableSizes = _previousGeneration.TableEntriesAdded;
-            var deltaTableSizes = this.GetDeltaTableSizes(metadataSizes.RowCounts);
+            var deltaTableSizes = GetDeltaTableSizes(metadataSizes.RowCounts);
             var tableSizes = new int[MetadataTokens.TableCount];
 
             for (int i = 0; i < tableSizes.Length; i++)
@@ -153,11 +151,11 @@ namespace Microsoft.CodeAnalysis.Emit
 
             // If the previous generation is 0 (metadata) get the synthesized members from the current compilation's builder,
             // otherwise members from the current compilation have already been merged into the baseline.
-            var synthesizedMembers = (baseline.Ordinal == 0) ? moduleBuilder.GetSynthesizedMembers() : baseline.SynthesizedMembers;
+            var synthesizedMembers = (baseline.Ordinal == 0) ? module.GetSynthesizedMembers() : baseline.SynthesizedMembers;
 
             return baseline.With(
                 compilation,
-                moduleBuilder,
+                module,
                 baseline.Ordinal + 1,
                 encId,
                 typesAdded: AddRange(_previousGeneration.TypesAdded, _typeDefs.GetAdded()),
@@ -177,10 +175,11 @@ namespace Microsoft.CodeAnalysis.Emit
                 userStringStreamLengthAdded: metadataSizes.GetAlignedHeapSize(HeapIndex.UserString) + _previousGeneration.UserStringStreamLengthAdded,
                 // Guid stream accumulates on the GUID heap unlike other heaps, so the previous generations are already included.
                 guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid],
-                anonymousTypeMap: ((IPEDeltaAssemblyBuilder)moduleBuilder).GetAnonymousTypeMap(),
+                anonymousTypeMap: ((IPEDeltaAssemblyBuilder)module).GetAnonymousTypeMap(),
                 synthesizedMembers: synthesizedMembers,
                 addedOrChangedMethods: AddRange(_previousGeneration.AddedOrChangedMethods, addedOrChangedMethodsByIndex, replace: true),
-                debugInformationProvider: baseline.DebugInformationProvider);
+                debugInformationProvider: baseline.DebugInformationProvider,
+                localSignatureProvider: baseline.LocalSignatureProvider);
         }
 
         private static IReadOnlyDictionary<K, V> AddRange<K, V>(IReadOnlyDictionary<K, V> previous, IReadOnlyDictionary<K, V> current, bool replace = false)

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -662,23 +662,19 @@ namespace Microsoft.CodeAnalysis.Emit
             }
             else
             {
-                localSignatureHandle = default(StandaloneSignatureHandle);
+                localSignatureHandle = default;
             }
 
-            var method = body.MethodDefinition;
-            if (!method.IsImplicitlyDeclared)
-            {
-                var info = new AddedOrChangedMethodInfo(
-                    body.MethodId,
-                    encInfos.ToImmutable(),
-                    body.LambdaDebugInfo,
-                    body.ClosureDebugInfo,
-                    body.StateMachineTypeName,
-                    body.StateMachineHoistedLocalSlots,
-                    body.StateMachineAwaiterSlots);
+            var info = new AddedOrChangedMethodInfo(
+                body.MethodId,
+                encInfos.ToImmutable(),
+                body.LambdaDebugInfo,
+                body.ClosureDebugInfo,
+                body.StateMachineTypeName,
+                body.StateMachineHoistedLocalSlots,
+                body.StateMachineAwaiterSlots);
 
-                _addedOrChangedMethods.Add(method, info);
-            }
+            _addedOrChangedMethods.Add(body.MethodDefinition, info);
 
             encInfos.Free();
             return localSignatureHandle;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -89,26 +89,10 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <param name="module">The metadata of the module before editing.</param>
         /// <param name="debugInformationProvider">
         /// A function that for a method handle returns Edit and Continue debug information emitted by the compiler into the PDB.
-        /// The function shall throw <see cref="System.IO.InvalidDataException"/> if the debug information can't be read for the specified method.
-        /// This exception is caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// The function shall throw <see cref="InvalidDataException"/> if the debug information can't be read for the specified method.
+        /// This exception and <see cref="IOException"/> are caught and converted to an emit diagnostic. Other exceptions are passed through.
         /// </param>
         /// <returns>An <see cref="EmitBaseline"/> for the module.</returns>
-        /// <remarks>
-        /// Only the initial baseline is created using this method; subsequent baselines are created
-        /// automatically when emitting the differences in subsequent compilations.
-        /// 
-        /// When an active method (one for which a frame is allocated on a stack) is updated the values of its local variables need to be preserved.
-        /// The mapping of local variable names to their slots in the frame is not included in the metadata and thus needs to be provided by 
-        /// <paramref name="debugInformationProvider"/>.
-        /// 
-        /// The <paramref name="debugInformationProvider"/> is only needed for the initial generation. The mapping for the subsequent generations
-        /// is carried over through <see cref="EmitBaseline"/>. The compiler assigns slots to named local variables (including named temporary variables)
-        /// it the order in which they appear in the source code. This property allows the compiler to reconstruct the local variable mapping 
-        /// for the initial generation. A subsequent generation may add a new variable in between two variables of the previous generation. 
-        /// Since the slots of the previous generation variables need to be preserved the only option is to add these new variables to the end.
-        /// The slot ordering thus no longer matches the syntax ordering. It is therefore necessary to pass <see cref="EmitDifferenceResult.Baseline"/>
-        /// to the next generation (rather than e.g. create new <see cref="EmitBaseline"/>s from scratch based on metadata produced by subsequent compilations).
-        /// </remarks>
         /// <exception cref="ArgumentException"><paramref name="module"/> is not a PE image.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="module"/> is null.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="debugInformationProvider"/> is null.</exception>
@@ -127,27 +111,96 @@ namespace Microsoft.CodeAnalysis.Emit
                 throw new ArgumentException(CodeAnalysisResources.PEImageNotAvailable, nameof(module));
             }
 
+            var hasPortablePdb = module.Module.PEReaderOpt.ReadDebugDirectory().Any(entry => entry.IsPortableCodeView);
+
+            var localSigProvider = new Func<MethodDefinitionHandle, StandaloneSignatureHandle>(methodHandle =>
+            {
+                try
+                {
+                    return module.Module.GetMethodBodyOrThrow(methodHandle)?.LocalSignature ?? default;
+                }
+                catch (Exception e) when (e is BadImageFormatException || e is IOException)
+                {
+                    throw new InvalidDataException(e.Message, e);
+                }
+            });
+
+            return CreateInitialBaseline(module, debugInformationProvider, localSigProvider, hasPortablePdb);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="EmitBaseline"/> from the metadata of the module before editing
+        /// and from a function that maps from a method to an array of local names. 
+        /// </summary>
+        /// <param name="module">The metadata of the module before editing.</param>
+        /// <param name="debugInformationProvider">
+        /// A function that for a method handle returns Edit and Continue debug information emitted by the compiler into the PDB.
+        /// The function shall throw <see cref="InvalidDataException"/> if the debug information can't be read for the specified method.
+        /// This exception and <see cref="IOException"/> are caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// </param>
+        /// <param name="localSignatureProvider">
+        /// A function that for a method handle returns the signature of its local variables.
+        /// The function shall throw <see cref="InvalidDataException"/> if the information can't be read for the specified method.
+        /// This exception and <see cref="IOException"/> are caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// </param>
+        /// <param name="hasPortableDebugInformation">
+        /// True if the baseline PDB is portable.
+        /// </param>
+        /// <returns>An <see cref="EmitBaseline"/> for the module.</returns>
+        /// <remarks>
+        /// Only the initial baseline is created using this method; subsequent baselines are created
+        /// automatically when emitting the differences in subsequent compilations.
+        /// 
+        /// When an active method (one for which a frame is allocated on a stack) is updated the values of its local variables need to be preserved.
+        /// The mapping of local variable names to their slots in the frame is not included in the metadata and thus needs to be provided by 
+        /// <paramref name="debugInformationProvider"/>.
+        /// 
+        /// The <paramref name="debugInformationProvider"/> is only needed for the initial generation. The mapping for the subsequent generations
+        /// is carried over through <see cref="EmitBaseline"/>. The compiler assigns slots to named local variables (including named temporary variables)
+        /// it the order in which they appear in the source code. This property allows the compiler to reconstruct the local variable mapping 
+        /// for the initial generation. A subsequent generation may add a new variable in between two variables of the previous generation. 
+        /// Since the slots of the previous generation variables need to be preserved the only option is to add these new variables to the end.
+        /// The slot ordering thus no longer matches the syntax ordering. It is therefore necessary to pass <see cref="EmitDifferenceResult.Baseline"/>
+        /// to the next generation (rather than e.g. create new <see cref="EmitBaseline"/>s from scratch based on metadata produced by subsequent compilations).
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="module"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="debugInformationProvider"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="localSignatureProvider"/> is null.</exception>
+        /// <exception cref="IOException">Error reading module metadata.</exception>
+        /// <exception cref="BadImageFormatException">Module metadata is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">Module has been disposed.</exception>
+        internal static EmitBaseline CreateInitialBaseline(
+            ModuleMetadata module, 
+            Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider,
+            Func<MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider,
+            bool hasPortableDebugInformation)
+        {
+            if (module == null)
+            {
+                throw new ArgumentNullException(nameof(module));
+            }
+
             if (debugInformationProvider == null)
             {
                 throw new ArgumentNullException(nameof(debugInformationProvider));
             }
 
-            // module has IL as checked above and hence a PE reader:
-            Debug.Assert(module.Module.PEReaderOpt != null);
+            if (localSignatureProvider == null)
+            {
+                throw new ArgumentNullException(nameof(localSignatureProvider));
+            }
 
             var reader = module.MetadataReader;
-            var moduleVersionId = module.GetModuleVersionId();
-            var hasPortablePdb = module.Module.PEReaderOpt.ReadDebugDirectory().Any(entry => entry.IsPortableCodeView);
 
             return new EmitBaseline(
                 null,
                 module,
                 compilation: null,
                 moduleBuilder: null,
-                moduleVersionId: moduleVersionId,
+                moduleVersionId: module.GetModuleVersionId(),
                 ordinal: 0,
-                encId: default(Guid),
-                hasPortablePdb: hasPortablePdb,
+                encId: default,
+                hasPortablePdb: hasPortableDebugInformation,
                 typesAdded: new Dictionary<Cci.ITypeDefinition, int>(),
                 eventsAdded: new Dictionary<Cci.IEventDefinition, int>(),
                 fieldsAdded: new Dictionary<Cci.IFieldDefinition, int>(),
@@ -165,6 +218,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 synthesizedMembers: ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>>.Empty,
                 methodsAddedOrChanged: new Dictionary<int, AddedOrChangedMethodInfo>(),
                 debugInformationProvider: debugInformationProvider,
+                localSignatureProvider: localSignatureProvider,
                 typeToEventMap: CalculateTypeEventMap(reader),
                 typeToPropertyMap: CalculateTypePropertyMap(reader),
                 methodImpls: CalculateMethodImpls(reader));
@@ -220,10 +274,21 @@ namespace Microsoft.CodeAnalysis.Emit
 
         /// <summary>
         /// Reads EnC debug information of a method from the initial baseline PDB.
-        /// The function shall throw <see cref="System.IO.InvalidDataException"/> if the debug information can't be read for the specified method.
-        /// This exception is caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// The function shall throw <see cref="InvalidDataException"/> if the debug information can't be read for the specified method.
+        /// This exception and <see cref="IOException"/> are caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// The function shall return an empty <see cref="EditAndContinueMethodDebugInformation"/> if the method that corresponds to the specified handle
+        /// has no debug information.
         /// </summary>
         internal readonly Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> DebugInformationProvider;
+
+        /// <summary>
+        /// A function that for a method handle returns the signature of its local variables.
+        /// The function shall throw <see cref="InvalidDataException"/> if the information can't be read for the specified method.
+        /// This exception and <see cref="IOException"/> are caught and converted to an emit diagnostic. Other exceptions are passed through.
+        /// The function shall return a nil <see cref="StandaloneSignatureHandle"/> if the method that corresponds to the specified handle
+        /// has no local variables.
+        /// </summary>
+        internal readonly Func<MethodDefinitionHandle, StandaloneSignatureHandle> LocalSignatureProvider;
 
         internal readonly ImmutableArray<int> TableSizes;
         internal readonly IReadOnlyDictionary<int, int> TypeToEventMap;
@@ -258,18 +323,20 @@ namespace Microsoft.CodeAnalysis.Emit
             ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> synthesizedMembers,
             IReadOnlyDictionary<int, AddedOrChangedMethodInfo> methodsAddedOrChanged,
             Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider,
+            Func<MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider,
             IReadOnlyDictionary<int, int> typeToEventMap,
             IReadOnlyDictionary<int, int> typeToPropertyMap,
             IReadOnlyDictionary<MethodImplKey, int> methodImpls)
         {
             Debug.Assert(module != null);
-            Debug.Assert((ordinal == 0) == (encId == default(Guid)));
+            Debug.Assert((ordinal == 0) == (encId == default));
             Debug.Assert((ordinal == 0) == (initialBaseline == null));
             Debug.Assert(encId != module.GetModuleVersionId());
             Debug.Assert(debugInformationProvider != null);
+            Debug.Assert(localSignatureProvider != null);
             Debug.Assert(typeToEventMap != null);
             Debug.Assert(typeToPropertyMap != null);
-            Debug.Assert(moduleVersionId != default(Guid));
+            Debug.Assert(moduleVersionId != default);
             Debug.Assert(moduleVersionId == module.GetModuleVersionId());
             Debug.Assert(synthesizedMembers != null);
 
@@ -289,37 +356,38 @@ namespace Microsoft.CodeAnalysis.Emit
 
             var reader = module.Module.MetadataReader;
 
-            this.InitialBaseline = initialBaseline ?? this;
-            this.OriginalMetadata = module;
-            this.Compilation = compilation;
-            this.PEModuleBuilder = moduleBuilder;
-            this.ModuleVersionId = moduleVersionId;
-            this.Ordinal = ordinal;
-            this.EncId = encId;
-            this.HasPortablePdb = hasPortablePdb;
+            InitialBaseline = initialBaseline ?? this;
+            OriginalMetadata = module;
+            Compilation = compilation;
+            PEModuleBuilder = moduleBuilder;
+            ModuleVersionId = moduleVersionId;
+            Ordinal = ordinal;
+            EncId = encId;
+            HasPortablePdb = hasPortablePdb;
 
-            this.TypesAdded = typesAdded;
-            this.EventsAdded = eventsAdded;
-            this.FieldsAdded = fieldsAdded;
-            this.MethodsAdded = methodsAdded;
-            this.PropertiesAdded = propertiesAdded;
-            this.EventMapAdded = eventMapAdded;
-            this.PropertyMapAdded = propertyMapAdded;
-            this.MethodImplsAdded = methodImplsAdded;
-            this.TableEntriesAdded = tableEntriesAdded;
-            this.BlobStreamLengthAdded = blobStreamLengthAdded;
-            this.StringStreamLengthAdded = stringStreamLengthAdded;
-            this.UserStringStreamLengthAdded = userStringStreamLengthAdded;
-            this.GuidStreamLengthAdded = guidStreamLengthAdded;
+            TypesAdded = typesAdded;
+            EventsAdded = eventsAdded;
+            FieldsAdded = fieldsAdded;
+            MethodsAdded = methodsAdded;
+            PropertiesAdded = propertiesAdded;
+            EventMapAdded = eventMapAdded;
+            PropertyMapAdded = propertyMapAdded;
+            MethodImplsAdded = methodImplsAdded;
+            TableEntriesAdded = tableEntriesAdded;
+            BlobStreamLengthAdded = blobStreamLengthAdded;
+            StringStreamLengthAdded = stringStreamLengthAdded;
+            UserStringStreamLengthAdded = userStringStreamLengthAdded;
+            GuidStreamLengthAdded = guidStreamLengthAdded;
             _anonymousTypeMap = anonymousTypeMap;
-            this.SynthesizedMembers = synthesizedMembers;
-            this.AddedOrChangedMethods = methodsAddedOrChanged;
+            SynthesizedMembers = synthesizedMembers;
+            AddedOrChangedMethods = methodsAddedOrChanged;
 
-            this.DebugInformationProvider = debugInformationProvider;
-            this.TableSizes = CalculateTableSizes(reader, this.TableEntriesAdded);
-            this.TypeToEventMap = typeToEventMap;
-            this.TypeToPropertyMap = typeToPropertyMap;
-            this.MethodImpls = methodImpls;
+            DebugInformationProvider = debugInformationProvider;
+            LocalSignatureProvider = localSignatureProvider;
+            TableSizes = CalculateTableSizes(reader, TableEntriesAdded);
+            TypeToEventMap = typeToEventMap;
+            TypeToPropertyMap = typeToPropertyMap;
+            MethodImpls = methodImpls;
         }
 
         internal EmitBaseline With(
@@ -343,7 +411,8 @@ namespace Microsoft.CodeAnalysis.Emit
             IReadOnlyDictionary<AnonymousTypeKey, AnonymousTypeValue> anonymousTypeMap,
             ImmutableDictionary<Cci.ITypeDefinition, ImmutableArray<Cci.ITypeDefinitionMember>> synthesizedMembers,
             IReadOnlyDictionary<int, AddedOrChangedMethodInfo> addedOrChangedMethods,
-            Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider)
+            Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider,
+            Func<MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider)
         {
             Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap != null);
             Debug.Assert(_anonymousTypeMap == null || anonymousTypeMap.Count >= _anonymousTypeMap.Count);
@@ -374,6 +443,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 synthesizedMembers: synthesizedMembers,
                 methodsAddedOrChanged: addedOrChangedMethods,
                 debugInformationProvider: debugInformationProvider,
+                localSignatureProvider: localSignatureProvider,
                 typeToEventMap: TypeToEventMap,
                 typeToPropertyMap: TypeToPropertyMap,
                 methodImpls: MethodImpls);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -43,10 +43,11 @@ namespace Microsoft.CodeAnalysis.Emit
                 stringStreamLengthAdded: baseline.StringStreamLengthAdded,
                 userStringStreamLengthAdded: baseline.UserStringStreamLengthAdded,
                 guidStreamLengthAdded: baseline.GuidStreamLengthAdded,
-                anonymousTypeMap: this.MapAnonymousTypes(baseline.AnonymousTypeMap),
+                anonymousTypeMap: MapAnonymousTypes(baseline.AnonymousTypeMap),
                 synthesizedMembers: mappedSynthesizedMembers,
-                addedOrChangedMethods: this.MapAddedOrChangedMethods(baseline.AddedOrChangedMethods),
-                debugInformationProvider: baseline.DebugInformationProvider);
+                addedOrChangedMethods: MapAddedOrChangedMethods(baseline.AddedOrChangedMethods),
+                debugInformationProvider: baseline.DebugInformationProvider, 
+                localSignatureProvider: baseline.LocalSignatureProvider);
         }
 
         private IReadOnlyDictionary<K, V> MapDefinitions<K, V>(IReadOnlyDictionary<K, V> items)

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -1024,31 +1024,11 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal bool TryGetLocals(MethodDefinitionHandle handle, out ImmutableArray<LocalInfo<TypeSymbol>> localInfo)
+        internal ImmutableArray<LocalInfo<TypeSymbol>> GetLocalsOrThrow(StandaloneSignatureHandle handle)
         {
-            try
-            {
-                Debug.Assert(Module.HasIL);
-                var methodBody = Module.GetMethodBodyOrThrow(handle);
-
-                if (!methodBody.LocalSignature.IsNil)
-                {
-                    var signatureHandle = Module.MetadataReader.GetStandaloneSignature(methodBody.LocalSignature).Signature;
-                    var signatureReader = Module.GetMemoryReaderOrThrow(signatureHandle);
-                    localInfo = DecodeLocalSignatureOrThrow(ref signatureReader);
-                }
-                else
-                {
-                    localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
-                }
-            }
-            catch (Exception e) when (e is UnsupportedSignatureContent || e is BadImageFormatException || e is IOException)
-            {
-                localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
-                return false;
-            }
-
-            return true;
+            var signatureHandle = Module.MetadataReader.GetStandaloneSignature(handle).Signature;
+            var signatureReader = Module.MetadataReader.GetBlobReader(signatureHandle);
+            return DecodeLocalSignatureOrThrow(ref signatureReader);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -3028,7 +3028,7 @@ namespace Microsoft.CodeAnalysis
             // we shouldn't ask for method IL if we don't have PE image
             Debug.Assert(_peReaderOpt != null);
 
-            MethodDefinition method = this.MetadataReader.GetMethodDefinition(methodHandle);
+            MethodDefinition method = MetadataReader.GetMethodDefinition(methodHandle);
             if ((method.ImplAttributes & MethodImplAttributes.CodeTypeMask) != MethodImplAttributes.IL ||
                  method.RelativeVirtualAddress == 0)
             {

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
@@ -168,14 +168,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             awaiterSlotCount = maxAwaiterSlotIndex + 1
         End Sub
 
-        Protected Overrides Function TryGetLocalSlotMapFromMetadata(handle As MethodDefinitionHandle, debugInfo As EditAndContinueMethodDebugInformation) As ImmutableArray(Of EncLocalInfo)
-            Dim slotMetadata As ImmutableArray(Of LocalInfo(Of TypeSymbol)) = Nothing
-            If Not _metadataDecoder.TryGetLocals(handle, slotMetadata) Then
-                Return Nothing
-            End If
+        Protected Overrides Function GetLocalSlotMapFromMetadata(handle As StandaloneSignatureHandle, debugInfo As EditAndContinueMethodDebugInformation) As ImmutableArray(Of EncLocalInfo)
+            Debug.Assert(Not handle.IsNil)
 
-            Dim result = CreateLocalSlotMap(debugInfo, slotMetadata)
-            Debug.Assert(result.Length = slotMetadata.Length)
+            Dim localInfos = _metadataDecoder.GetLocalsOrThrow(handle)
+            Dim result = CreateLocalSlotMap(debugInfo, localInfos)
+            Debug.Assert(result.Length = localInfos.Length)
             Return result
         End Function
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -416,7 +417,7 @@ class C
                     }
                     else
                     {
-                        Marshal.ThrowExceptionForHR(unchecked((int)MetadataUtilities.CORDBG_E_MISSING_METADATA));
+                        Marshal.ThrowExceptionForHR(DkmExceptionUtilities.CORDBG_E_MISSING_METADATA);
                         throw ExceptionUtilities.Unreachable;
                     }
                 };
@@ -443,7 +444,7 @@ class C
             ShouldTryAgain_False(
                 (AssemblyIdentity assemblyIdentity, out uint uSize) =>
                 {
-                    Marshal.ThrowExceptionForHR(unchecked((int)MetadataUtilities.CORDBG_E_MISSING_METADATA));
+                    Marshal.ThrowExceptionForHR(DkmExceptionUtilities.CORDBG_E_MISSING_METADATA);
                     throw ExceptionUtilities.Unreachable;
                 });
         }
@@ -454,7 +455,7 @@ class C
             ShouldTryAgain_False(
                 (AssemblyIdentity assemblyIdentity, out uint uSize) =>
                 {
-                    Marshal.ThrowExceptionForHR(unchecked((int)MetadataUtilities.COR_E_BADIMAGEFORMAT));
+                    Marshal.ThrowExceptionForHR(DkmExceptionUtilities.COR_E_BADIMAGEFORMAT);
                     throw ExceptionUtilities.Unreachable;
                 });
         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmExceptionUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmExceptionUtilities.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Debugging
+{
+    internal static partial class DkmExceptionUtilities
+    {
+        internal const int COR_E_BADIMAGEFORMAT = unchecked((int)0x8007000b);
+        internal const int CORDBG_E_MISSING_METADATA = unchecked((int)0x80131c35);
+
+        internal static bool IsBadOrMissingMetadataException(Exception e)
+        {
+            return e is ObjectDisposedException || 
+                   e.HResult == COR_E_BADIMAGEFORMAT || 
+                   e.HResult == CORDBG_E_MISSING_METADATA;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Clr;
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     // DkmClrNcModuleInstance.GetMetaDataBytesPtr not implemented in Dev14.
                     throw new NotImplementedMetadataException(e);
                 }
-                catch (Exception e) when (MetadataUtilities.IsBadOrMissingMetadataException(e, module.FullName))
+                catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
                 {
                     continue;
                 }
@@ -94,7 +95,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     Debug.Assert(size > 0);
                     block = GetMetadataBlock(ptr, size);
                 }
-                catch (Exception e) when (MetadataUtilities.IsBadOrMissingMetadataException(e, missingAssemblyIdentity.GetDisplayName()))
+                catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
                 {
                     continue;
                 }
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         Debug.Assert(size > 0);
                         reader = new MetadataReader((byte*)ptr, (int)size);
                     }
-                    catch (Exception e) when (MetadataUtilities.IsBadOrMissingMetadataException(e, module.FullName))
+                    catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
                     {
                         continue;
                     }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         metadataBuilder.Add(metadata);
                     }
                 }
-                catch (Exception e) when (IsBadMetadataException(e))
+                catch (BadImageFormatException)
                 {
                     // Ignore modules with "bad" metadata.
                 }
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         }
                     }
                 }
-                catch (Exception e) when (IsBadMetadataException(e))
+                catch (BadImageFormatException)
                 {
                     // Ignore modules with "bad" metadata.
                 }

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.VisualStudio.Debugger;
 using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
 using Microsoft.VisualStudio.Debugger.FunctionResolution;
 using Microsoft.VisualStudio.Debugger.Symbols;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection.Metadata;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
@@ -119,7 +120,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 ptr = module.GetMetaDataBytesPtr(out length);
             }
-            catch (Exception e) when (MetadataUtilities.IsBadOrMissingMetadataException(e, module.FullName))
+            catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
             {
                 return null;
             }

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.csproj
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.csproj
@@ -34,8 +34,8 @@
     <Compile Include="..\..\..\..\Compilers\CSharp\Portable\Syntax\SyntaxKindFacts.cs">
       <Link>CSharp\Compiler\SyntaxKindFacts.cs</Link>
     </Compile>
-    <Compile Include="..\ExpressionCompiler\MetadataUtilities_Exceptions.cs">
-      <Link>ExpressionCompiler\MetadataUtilities_Exceptions.cs</Link>
+    <Compile Include="..\ExpressionCompiler\DkmExceptionUtilities.cs">
+      <Link>ExpressionCompiler\DkmExceptionUtilities.cs</Link>
     </Compile>
     <VsdConfigXml Include="CSharp\FunctionResolver.vsdconfigxml" />
     <VsdConfigXml Include="VisualBasic\FunctionResolver.vsdconfigxml" />


### PR DESCRIPTION
Preparation for further work in EnC to avoid locking files in obj directory during debugging. 

 - Clean up Concord exception utilities
The future work is gonna use Concord APIs and can reuse some of the helpers we have in EEs today.

 - Avoid dependency on IL stream in EnC local slot mapping
Currently we read local signatures from IL stream during EnC. This change refactors the code to allow reading the tokens from PDBs, so that we can use debugger APIs that give us just the metadata blob (no IL stream).






