### PR TITLE
Make RunCsc/Vbc scripts respect DOTNET_HOST_PATH

### DIFF
--- a/build/NuGetAdditionalFiles/RunCsc
+++ b/build/NuGetAdditionalFiles/RunCsc
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+set -e
+set -u
+
 THISDIR=$(dirname $0)
 
-dotnet $THISDIR/csc.dll "$@"
+# The expression ${VAR:+TEXT} expands to:
+#  If VAR is null or empty => empty string
+#  If VAR is non-empty => TEXT
+# Do this expression to make sure HOST_PATH ends with a slash,
+#  but if it's unset, have it be completely empty (look up dotnet in PATH)
+HOST_PATH=${DOTNET_HOST_PATH:+${DOTNET_HOST_PATH-}/}
+
+exec ${HOST_PATH}dotnet $THISDIR/csc.dll "$@"

--- a/build/NuGetAdditionalFiles/RunCsc.cmd
+++ b/build/NuGetAdditionalFiles/RunCsc.cmd
@@ -1,4 +1,7 @@
-echo off
-if defined DOTNET_HOST_PATH set HOST_PATH=%DOTNET_HOST_PATH%\
-if not defined HOST_PATH set HOST_PATH=
+@echo off
+if defined DOTNET_HOST_PATH (
+    set HOST_PATH=%DOTNET_HOST_PATH%\
+) else (
+    set HOST_PATH=
+)
 %HOST_PATH%dotnet %~dp0\csc.dll %*

--- a/build/NuGetAdditionalFiles/RunCsc.cmd
+++ b/build/NuGetAdditionalFiles/RunCsc.cmd
@@ -1,2 +1,4 @@
 echo off
-dotnet %~dp0\csc.dll %*
+if defined DOTNET_HOST_PATH set HOST_PATH=%DOTNET_HOST_PATH%\
+if not defined HOST_PATH set HOST_PATH=
+%HOST_PATH%dotnet %~dp0\csc.dll %*

--- a/build/NuGetAdditionalFiles/RunVbc
+++ b/build/NuGetAdditionalFiles/RunVbc
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+set -e
+set -u
+
 THISDIR=$(dirname $0)
 
-dotnet $THISDIR/vbc.dll "$@"
+# The expression ${VAR:+TEXT} expands to:
+#  If VAR is null or empty => empty string
+#  If VAR is non-empty => TEXT
+# Do this expression to make sure HOST_PATH ends with a slash,
+#  but if it's unset, have it be completely empty (look up dotnet in PATH)
+HOST_PATH=${DOTNET_HOST_PATH:+${DOTNET_HOST_PATH-}/}
+
+exec ${HOST_PATH}dotnet $THISDIR/vbc.dll "$@"

--- a/build/NuGetAdditionalFiles/RunVbc.cmd
+++ b/build/NuGetAdditionalFiles/RunVbc.cmd
@@ -1,2 +1,4 @@
 echo off
-dotnet %~dp0\vbc.dll %*
+if defined DOTNET_HOST_PATH set HOST_PATH=%DOTNET_HOST_PATH%\
+if not defined HOST_PATH set HOST_PATH=
+%HOST_PATH%dotnet %~dp0\vbc.dll %*

--- a/build/NuGetAdditionalFiles/RunVbc.cmd
+++ b/build/NuGetAdditionalFiles/RunVbc.cmd
@@ -1,4 +1,7 @@
-echo off
-if defined DOTNET_HOST_PATH set HOST_PATH=%DOTNET_HOST_PATH%\
-if not defined HOST_PATH set HOST_PATH=
+@echo off
+if defined DOTNET_HOST_PATH (
+    set HOST_PATH=%DOTNET_HOST_PATH%\
+) else (
+    set HOST_PATH=
+)
 %HOST_PATH%dotnet %~dp0\vbc.dll %*


### PR DESCRIPTION
This is related to https://github.com/dotnet/cli/pull/7311

Logic: If `DOTNET_HOST_PATH` is set, use that as the path to `dotnet`. Otherwise, search in `PATH`.