### PR TITLE
Remove InvocationReasons enum boxing

### DIFF
--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons.cs
@@ -45,14 +45,19 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public IEnumerator<string> GetEnumerator()
+        public ImmutableHashSet<string>.Enumerator GetEnumerator()
+        {
+            return _reasons.GetEnumerator();
+        }
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
         {
             return _reasons.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return _reasons.GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/21177

> Over ~60MiB~ 100MiB is allocated in LogWorkItemEnqueue to box the enumerator returned for reasons. InvocationReasons should be updated to expose a struct enumerator to avoid this allocation.