### PR TITLE
Correct the order of parameters to Version

### DIFF
--- a/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
+++ b/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
@@ -74,9 +74,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return false;
         }
 
-        private static bool TryRedirect(AssemblyName name, byte[] token, int major, int minor, int revision, int build)
+        private static bool TryRedirect(AssemblyName name, byte[] token, int major, int minor, int build, int revision)
         {
-            var version = new Version(major, minor, revision, build);
+            var version = new Version(major, minor, build, revision);
             if (KeysEqual(name.GetPublicKeyToken(), token) && name.Version < version)
             {
                 name.Version = version;


### PR DESCRIPTION
Fixes #21136

No behavior changes, as the order of parameters in the signature was incorrect as well. Manually verified all use sites do not use named arguments (all use sites are within the same file, in the same method).

Also quickly glanced over all calls to the Version ctor in Compilers.sln in non-test projects, and all of them are already correct.

@dotnet/roslyn-compiler this is *incredibly* easy to review :)