### PR TITLE
Introduces a peverify-compat feature flag

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -137,6 +137,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return _module.Compilation.Options.DebugPlusMode;
         }
 
+        private bool IsPEVerifyCompatible()
+        {
+            //return true; 
+            return _module.Compilation.FeaturePEVerifyCompatEnabled;
+        }
+
         private LocalDefinition LazyReturnTemp
         {
             get

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -139,7 +139,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private bool IsPEVerifyCompatible()
         {
-            //return true; 
             return _module.Compilation.FeaturePEVerifyCompatEnabled;
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return _module.Compilation.Options.DebugPlusMode;
         }
 
-        private bool IsPEVerifyCompatible()
+        private bool EnablePEVerifyCompat()
         {
             return _module.Compilation.FeaturePEVerifyCompatEnabled;
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return false;
             }
 
-            if (!needWriteable)
+            if (!needWriteable && !IsPEVerifyCompatible())
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return false;
             }
 
-            if (!needWriteable && !IsPEVerifyCompatible())
+            if (!needWriteable && !EnablePEVerifyCompat())
             {
                 return true;
             }
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // it would be advantageous to make a temp for the field, not for the the outer struct, since the field is smaller and we can get to is by feching references.
                 // NOTE: this would not be profitable if we have to satisfy verifier, since for verifiability 
                 //       we would not be able to dig for the inner field using references and the outer struct will have to be copied to a temp anyways.
-                if (!IsPEVerifyCompatible())
+                if (!EnablePEVerifyCompat())
                 {
                     Debug.Assert(needWriteable == true);
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // this does not need to be writeable
                     // we may call "HasValue" on this, but it is not mutating 
                     // (however verification does not know that and considers all calls mutating)
-                    var addressKind = IsPEVerifyCompatible()? 
+                    var addressKind = EnablePEVerifyCompat()? 
                                             AddressKind.Writeable: 
                                             AddressKind.ReadOnly;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -424,9 +424,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
                 else
                 {
-                    //PROTOTYPE(verifier): this does not need to be writeable
-                    //                         we may call "HasValue" on this, but it is not mutating
-                    receiverTemp = EmitReceiverRef(receiver, AddressKind.Writeable);
+                    // this does not need to be writeable
+                    // we may call "HasValue" on this, but it is not mutating 
+                    // (however verification does not know that and considers all calls mutating)
+                    var addressKind = IsPEVerifyCompatible()? 
+                                            AddressKind.Writeable: 
+                                            AddressKind.ReadOnly;
+
+                    receiverTemp = EmitReceiverRef(receiver, addressKind);
                     _builder.EmitOpCode(ILOpCode.Dup);
                     // here we have loaded two copies of a reference   { O, O }  or  {&nub, &nub}
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -163,6 +163,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool FeatureStrictEnabled => Feature("strict") != null;
 
+        internal bool FeaturePEVerifyCompatEnabled => Feature("peverify-compat") != null;
+
         /// <summary>
         /// The language version that was used to parse the syntax trees of this compilation.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -163,6 +163,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool FeatureStrictEnabled => Feature("strict") != null;
 
+        /// <summary>
+        /// True when "peverify-compat" is set
+        /// With this flag we will avoid certain patterns known not be compatible with PEVerify.
+        /// The code may be less efficient and may deviate from spec in corner cases.
+        /// The flag is only to be used if PEVerify pass is extremely important.
+        /// </summary>
         internal bool FeaturePEVerifyCompatEnabled => Feature("peverify-compat") != null;
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -173,6 +173,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InParamPassRoField()
         {
             var text = @"
@@ -1099,6 +1100,7 @@ public struct S1
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void ReadonlyParamAsyncSpillReadOnlyStructThis()
         {
             var text = @"
@@ -1200,6 +1202,7 @@ public readonly struct S1
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void ReadonlyParamAsyncSpillReadOnlyStructThis_NoValCapture()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class CodeGenReadOnlyStructTests : CompilingTestBase
     {
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InvokeOnReadOnlyStaticField()
         {
             var text = @"
@@ -81,6 +82,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InvokeOnReadOnlyStaticFieldMetadata()
         {
             var text1 = @"
@@ -151,6 +153,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InvokeOnReadOnlyInstanceField()
         {
             var text = @"
@@ -220,6 +223,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InvokeOnReadOnlyInstanceFieldGeneric()
         {
             var text = @"
@@ -294,6 +298,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void InvokeOnReadOnlyInstanceFieldGenericMetadata()
         {
             var text1 = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -57,6 +57,27 @@ class Program
   IL_001f:  call       ""void System.Console.Write(string)""
   IL_0024:  ret
 }");
+
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       43 (0x2b)
+  .maxstack  1
+  .locals init (Program.S1 V_0)
+  IL_0000:  ldsfld     ""Program.S1 Program.sf""
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       ""string Program.S1.M1()""
+  IL_000d:  call       ""void System.Console.Write(string)""
+  IL_0012:  ldsfld     ""Program.S1 Program.sf""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  constrained. ""Program.S1""
+  IL_0020:  callvirt   ""string object.ToString()""
+  IL_0025:  call       ""void System.Console.Write(string)""
+  IL_002a:  ret
+}");
         }
 
         [Fact]
@@ -106,6 +127,27 @@ class Program
   IL_001f:  call       ""void System.Console.Write(string)""
   IL_0024:  ret
 }");
+
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       43 (0x2b)
+  .maxstack  1
+  .locals init (S1 V_0)
+  IL_0000:  ldsfld     ""S1 Program.sf""
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       ""string S1.M1()""
+  IL_000d:  call       ""void System.Console.Write(string)""
+  IL_0012:  ldsfld     ""S1 Program.sf""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  constrained. ""S1""
+  IL_0020:  callvirt   ""string object.ToString()""
+  IL_0025:  call       ""void System.Console.Write(string)""
+  IL_002a:  ret
+}");
         }
 
         [Fact]
@@ -151,6 +193,29 @@ class Program
   IL_0020:  callvirt   ""string object.ToString()""
   IL_0025:  call       ""void System.Console.Write(string)""
   IL_002a:  ret
+}");
+
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       49 (0x31)
+  .maxstack  2
+  .locals init (Program.S1 V_0)
+  IL_0000:  newobj     ""Program..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldfld      ""Program.S1 Program.f""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  call       ""string Program.S1.M1()""
+  IL_0013:  call       ""void System.Console.Write(string)""
+  IL_0018:  ldfld      ""Program.S1 Program.f""
+  IL_001d:  stloc.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  constrained. ""Program.S1""
+  IL_0026:  callvirt   ""string object.ToString()""
+  IL_002b:  call       ""void System.Console.Write(string)""
+  IL_0030:  ret
 }");
         }
 
@@ -201,6 +266,30 @@ class Program
   IL_0025:  callvirt   ""string object.ToString()""
   IL_002a:  call       ""void System.Console.Write(string)""
   IL_002f:  ret
+}");
+
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"hello2");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (Program.S1<string> V_0)
+  IL_0000:  newobj     ""Program..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldfld      ""Program.S1<string> Program.f""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldstr      ""hello""
+  IL_0013:  call       ""string Program.S1<string>.M1(string)""
+  IL_0018:  call       ""void System.Console.Write(string)""
+  IL_001d:  ldfld      ""Program.S1<string> Program.f""
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  constrained. ""Program.S1<string>""
+  IL_002b:  callvirt   ""string object.ToString()""
+  IL_0030:  call       ""void System.Console.Write(string)""
+  IL_0035:  ret
 }");
         }
 
@@ -256,6 +345,30 @@ class Program
   IL_0025:  callvirt   ""string object.ToString()""
   IL_002a:  call       ""void System.Console.Write(string)""
   IL_002f:  ret
+}");
+
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"hello2");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (S1<string> V_0)
+  IL_0000:  newobj     ""Program..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldfld      ""S1<string> Program.f""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldstr      ""hello""
+  IL_0013:  call       ""string S1<string>.M1(string)""
+  IL_0018:  call       ""void System.Console.Write(string)""
+  IL_001d:  ldfld      ""S1<string> Program.f""
+  IL_0022:  stloc.0
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  constrained. ""S1<string>""
+  IL_002b:  callvirt   ""string object.ToString()""
+  IL_0030:  call       ""void System.Console.Write(string)""
+  IL_0035:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -408,6 +408,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void ReadonlyFieldCanReturnByRefReadonly()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -486,6 +486,48 @@ class Program
   IL_0033:  ldflda     ""int System.ValueTuple<int, int>.Item1""
   IL_0038:  ret
 }");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: false);
+
+            comp.VerifyIL("Program.Test", @"
+{
+  // Code size       70 (0x46)
+  .maxstack  1
+  .locals init (bool V_0, //b
+                int V_1,
+                System.ValueTuple<int, int> V_2,
+                int V_3,
+                System.ValueTuple<int, int> V_4)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brfalse.s  IL_0020
+  IL_0005:  ldloc.0
+  IL_0006:  brfalse.s  IL_0012
+  IL_0008:  ldarg.0
+  IL_0009:  ldfld      ""int Program.F""
+  IL_000e:  stloc.1
+  IL_000f:  ldloca.s   V_1
+  IL_0011:  ret
+  IL_0012:  ldsfld     ""(int Alice, int Bob) Program.F1""
+  IL_0017:  stloc.2
+  IL_0018:  ldloca.s   V_2
+  IL_001a:  ldflda     ""int System.ValueTuple<int, int>.Item1""
+  IL_001f:  ret
+  IL_0020:  ldloc.0
+  IL_0021:  brfalse.s  IL_0032
+  IL_0023:  ldarg.0
+  IL_0024:  ldfld      ""Program.S Program.S1""
+  IL_0029:  ldfld      ""int Program.S.F""
+  IL_002e:  stloc.3
+  IL_002f:  ldloca.s   V_3
+  IL_0031:  ret
+  IL_0032:  ldsfld     ""Program.S Program.S2""
+  IL_0037:  ldfld      ""(int Alice, int Bob) Program.S.F1""
+  IL_003c:  stloc.s    V_4
+  IL_003e:  ldloca.s   V_4
+  IL_0040:  ldflda     ""int System.ValueTuple<int, int>.Item1""
+  IL_0045:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7221,6 +7221,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void ConditionalAccessOffReadOnlyNullable1()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7236,33 +7236,58 @@ class Program
     }
 }
 ";
-            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"");
+            var comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", verify: false);
 
-            verifier.VerifyIL("Program.Main", @"
-	{
-	  // Code size       47 (0x2f)
-	  .maxstack  2
-	  .locals init (System.Guid? V_0,
-	                System.Guid V_1)
-	  IL_0000:  nop
-	  IL_0001:  ldsfld     ""System.Guid? Program.g""
-	  IL_0006:  stloc.0
-	  IL_0007:  ldloca.s   V_0
-	  IL_0009:  dup
-	  IL_000a:  call       ""bool System.Guid?.HasValue.get""
-	  IL_000f:  brtrue.s   IL_0015
-	  IL_0011:  pop
-	  IL_0012:  ldnull
-	  IL_0013:  br.s       IL_0028
-	  IL_0015:  call       ""System.Guid System.Guid?.GetValueOrDefault()""
-	  IL_001a:  stloc.1
-	  IL_001b:  ldloca.s   V_1
-	  IL_001d:  constrained. ""System.Guid""
-	  IL_0023:  callvirt   ""string object.ToString()""
-	  IL_0028:  call       ""void System.Console.WriteLine(string)""
-	  IL_002d:  nop
-	  IL_002e:  ret
-	}");
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       44 (0x2c)
+  .maxstack  2
+  .locals init (System.Guid V_0)
+  IL_0000:  nop
+  IL_0001:  ldsflda    ""System.Guid? Program.g""
+  IL_0006:  dup
+  IL_0007:  call       ""bool System.Guid?.HasValue.get""
+  IL_000c:  brtrue.s   IL_0012
+  IL_000e:  pop
+  IL_000f:  ldnull
+  IL_0010:  br.s       IL_0025
+  IL_0012:  call       ""System.Guid System.Guid?.GetValueOrDefault()""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  constrained. ""System.Guid""
+  IL_0020:  callvirt   ""string object.ToString()""
+  IL_0025:  call       ""void System.Console.WriteLine(string)""
+  IL_002a:  nop
+  IL_002b:  ret
+}");
+
+            comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true);
+
+            comp.VerifyIL("Program.Main", @"
+{
+	// Code size       47 (0x2f)
+	.maxstack  2
+	.locals init (System.Guid? V_0,
+	            System.Guid V_1)
+	IL_0000:  nop
+	IL_0001:  ldsfld     ""System.Guid? Program.g""
+	IL_0006:  stloc.0
+	IL_0007:  ldloca.s   V_0
+	IL_0009:  dup
+	IL_000a:  call       ""bool System.Guid?.HasValue.get""
+	IL_000f:  brtrue.s   IL_0015
+	IL_0011:  pop
+	IL_0012:  ldnull
+	IL_0013:  br.s       IL_0028
+	IL_0015:  call       ""System.Guid System.Guid?.GetValueOrDefault()""
+	IL_001a:  stloc.1
+	IL_001b:  ldloca.s   V_1
+	IL_001d:  constrained. ""System.Guid""
+	IL_0023:  callvirt   ""string object.ToString()""
+	IL_0028:  call       ""void System.Console.WriteLine(string)""
+	IL_002d:  nop
+	IL_002e:  ret
+}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -12056,6 +12056,39 @@ struct MyManagedStruct
   IL_004b:  ret
 }
 ");
+
+            compilation = CompileAndVerify(source, expectedOutput: @"42", verify: true, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
+
+            // Dev10
+            compilation.VerifyIL("Program.Main",
+@"
+{
+  // Code size       76 (0x4c)
+  .maxstack  3
+  .locals init (MyManagedStruct V_0)
+  IL_0000:  newobj     ""cls1..ctor()""
+  IL_0005:  dup
+  IL_0006:  ldfld      ""MyManagedStruct cls1.y""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldc.i4.s   123
+  IL_0010:  call       ""void MyManagedStruct.mutate(int)""
+  IL_0015:  dup
+  IL_0016:  ldfld      ""MyManagedStruct cls1.y""
+  IL_001b:  stloc.0
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldflda     ""MyManagedStruct.Nested MyManagedStruct.n""
+  IL_0023:  ldflda     ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
+  IL_0028:  ldc.i4     0x1c8
+  IL_002d:  call       ""void MyManagedStruct.Nested.Nested1.mutate(int)""
+  IL_0032:  ldfld      ""MyManagedStruct cls1.y""
+  IL_0037:  ldfld      ""MyManagedStruct.Nested MyManagedStruct.n""
+  IL_003c:  ldfld      ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
+  IL_0041:  ldfld      ""int MyManagedStruct.Nested.Nested1.num""
+  IL_0046:  call       ""void System.Console.WriteLine(int)""
+  IL_004b:  ret
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -11973,6 +11973,7 @@ class B<T> : A<T>
         #endregion
 
         [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void MutateReadonlyNested()
         {
             string source = @"
@@ -12090,6 +12091,8 @@ struct MyManagedStruct
 ");
         }
 
+        [Fact]
+        [CompilerTrait(CompilerFeature.PEVerifyCompat)]
         public void MutateReadonlyNested1()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -12024,15 +12024,15 @@ struct MyManagedStruct
         n.n.num = x;
     }
 }";
-            var compilation = CompileAndVerify(source, expectedOutput: @"42", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: @"42", verify: false);
 
-            // Dev10
-            compilation.VerifyIL("Program.Main",
+            comp.VerifyIL("Program.Main",
 @"
 {
   // Code size       76 (0x4c)
   .maxstack  3
-  .locals init (MyManagedStruct V_0)
+  .locals init (MyManagedStruct V_0,
+                MyManagedStruct.Nested.Nested1 V_1)
   IL_0000:  newobj     ""cls1..ctor()""
   IL_0005:  dup
   IL_0006:  ldfld      ""MyManagedStruct cls1.y""
@@ -12041,11 +12041,11 @@ struct MyManagedStruct
   IL_000e:  ldc.i4.s   123
   IL_0010:  call       ""void MyManagedStruct.mutate(int)""
   IL_0015:  dup
-  IL_0016:  ldfld      ""MyManagedStruct cls1.y""
-  IL_001b:  stloc.0
-  IL_001c:  ldloca.s   V_0
-  IL_001e:  ldflda     ""MyManagedStruct.Nested MyManagedStruct.n""
-  IL_0023:  ldflda     ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
+  IL_0016:  ldflda     ""MyManagedStruct cls1.y""
+  IL_001b:  ldflda     ""MyManagedStruct.Nested MyManagedStruct.n""
+  IL_0020:  ldfld      ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
+  IL_0025:  stloc.1
+  IL_0026:  ldloca.s   V_1
   IL_0028:  ldc.i4     0x1c8
   IL_002d:  call       ""void MyManagedStruct.Nested.Nested1.mutate(int)""
   IL_0032:  ldflda     ""MyManagedStruct cls1.y""
@@ -12057,10 +12057,9 @@ struct MyManagedStruct
 }
 ");
 
-            compilation = CompileAndVerify(source, expectedOutput: @"42", verify: true, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(source, expectedOutput: @"42", verify: true, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
 
-            // Dev10
-            compilation.VerifyIL("Program.Main",
+            comp.VerifyIL("Program.Main",
 @"
 {
   // Code size       76 (0x4c)
@@ -12088,6 +12087,118 @@ struct MyManagedStruct
   IL_0046:  call       ""void System.Console.WriteLine(int)""
   IL_004b:  ret
 }
+");
+        }
+
+        public void MutateReadonlyNested1()
+        {
+            string source = @"
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            GetRoRef().ro.ro.ro.ro.ToString();
+            System.Console.Write(GetRoRef().ro.ro.ro.ro.x);
+        }
+
+        private static ref readonly Largest GetRoRef()
+        {
+            return ref (new Largest[1])[0];
+        }
+    }
+
+    struct Largest
+    {
+        public int x;
+        public readonly Large ro;
+    }
+
+    struct Large
+    {
+        public int x;
+        public Medium ro;
+    }
+
+    struct Medium
+    {
+        public int x;
+        public Small ro;
+    }
+
+    struct Small
+    {
+        public int x;
+        public Smallest ro;
+    }
+
+    struct Smallest
+    {
+        public int x;
+
+        public override string ToString()
+        {
+            x = -1;
+            System.Console.Write(x);
+            return null;
+        }
+    }";
+            var comp = CompileAndVerify(source, expectedOutput: @"-10", verify: false);
+
+            comp.VerifyIL("Program.Main",
+@"
+{
+  // Code size       76 (0x4c)
+  .maxstack  1
+  .locals init (Smallest V_0)
+  IL_0000:  call       ""ref readonly Largest Program.GetRoRef()""
+  IL_0005:  ldflda     ""Large Largest.ro""
+  IL_000a:  ldflda     ""Medium Large.ro""
+  IL_000f:  ldflda     ""Small Medium.ro""
+  IL_0014:  ldfld      ""Smallest Small.ro""
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  constrained. ""Smallest""
+  IL_0022:  callvirt   ""string object.ToString()""
+  IL_0027:  pop
+  IL_0028:  call       ""ref readonly Largest Program.GetRoRef()""
+  IL_002d:  ldflda     ""Large Largest.ro""
+  IL_0032:  ldflda     ""Medium Large.ro""
+  IL_0037:  ldflda     ""Small Medium.ro""
+  IL_003c:  ldflda     ""Smallest Small.ro""
+  IL_0041:  ldfld      ""int Smallest.x""
+  IL_0046:  call       ""void System.Console.Write(int)""
+  IL_004b:  ret
+}
+");
+
+            comp = CompileAndVerify(source, expectedOutput: @"-10", verify: true, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+
+            comp.VerifyIL("Program.Main",
+@"
+	{
+	  // Code size       76 (0x4c)
+	  .maxstack  1
+	  .locals init (Large V_0)
+	  IL_0000:  call       ""ref readonly Largest Program.GetRoRef()""
+	  IL_0005:  ldfld      ""Large Largest.ro""
+	  IL_000a:  stloc.0
+	  IL_000b:  ldloca.s   V_0
+	  IL_000d:  ldflda     ""Medium Large.ro""
+	  IL_0012:  ldflda     ""Small Medium.ro""
+	  IL_0017:  ldflda     ""Smallest Small.ro""
+	  IL_001c:  constrained. ""Smallest""
+	  IL_0022:  callvirt   ""string object.ToString()""
+	  IL_0027:  pop
+	  IL_0028:  call       ""ref readonly Largest Program.GetRoRef()""
+	  IL_002d:  ldfld      ""Large Largest.ro""
+	  IL_0032:  ldfld      ""Medium Large.ro""
+	  IL_0037:  ldfld      ""Small Medium.ro""
+	  IL_003c:  ldfld      ""Smallest Small.ro""
+	  IL_0041:  ldfld      ""int Smallest.x""
+	  IL_0046:  call       ""void System.Console.Write(int)""
+	  IL_004b:  ret
+	}
 ");
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return options.WithFeatures(options.Features.Concat(new[] { new KeyValuePair<string, string>("strict", "true") }));
         }
 
+        public static CSharpParseOptions WithPEVerifyCompatFeature(this CSharpParseOptions options)
+        {
+            return options.WithFeatures(options.Features.Concat(new[] { new KeyValuePair<string, string>("peverify-compat", "true") }));
+        }
+
         public static CSharpParseOptions WithLocalFunctionsFeature(this CSharpParseOptions options)
         {
             return options;

--- a/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
@@ -23,5 +23,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         Patterns,
         DefaultLiteral,
         AsyncMain,
+        PEVerifyCompat,
     }
 }


### PR DESCRIPTION
In some scenarios we have a choice of emitting faster code that is typesafe, but not formally verifiable vs. less efficient but verifiable code.

The most common occurrence is around accessing readonly fields of structs. If the intent is only to read, then we could just get a field reference and read to it. 
However verification rules do not make distinction when reference is used only to read and require that intermediate copy of the field value be made.

The flag allows suppressing peverify violations, where possible, typically at the cost of introducing intermediate copying.
