### PR TITLE
CSharpLanguageInstructionDecoder implementation of IDkmLanguageInstructionDecoder is slow (Merge to 15.4)

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
@@ -108,5 +108,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             appDomain.RemoveMetadataContext<CSharpMetadataContext>();
         }
+
+        internal override ImmutableArray<MetadataBlock> GetMetadataBlocks(DkmClrAppDomain appDomain, DkmClrRuntimeInstance runtimeInstance)
+        {
+            var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
+            return runtimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var appDomain = moduleInstance.AppDomain;
             var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
-            var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain);
+            var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
 
             CSharpCompilation compilation;
             if (previous.Matches(metadataBlocks))

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -42,11 +42,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 });
         }
 
-        internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
+        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(
+            this DkmClrRuntimeInstance runtime, 
+            DkmClrAppDomain appDomain, 
+            ImmutableArray<MetadataBlock> previousMetadataBlocks)
         {
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;
             uint size;
+            int index = 0;
             foreach (DkmClrModuleInstance module in runtime.GetModulesInAppDomain(appDomain))
             {
                 MetadataBlock block;
@@ -54,7 +58,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     ptr = module.GetMetaDataBytesPtr(out size);
                     Debug.Assert(size > 0);
-                    block = GetMetadataBlock(ptr, size);
+                    block = GetMetadataBlock(previousMetadataBlocks, index, ptr, size);
                 }
                 catch (NotImplementedException e) when (module is DkmClrNcModuleInstance)
                 {
@@ -67,10 +71,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
                 Debug.Assert(block.ModuleVersionId == module.Mvid);
                 builder.Add(block);
+                index++;
             }
             // Include "intrinsic method" assembly.
             ptr = runtime.GetIntrinsicAssemblyMetaDataBytesPtr(out size);
-            builder.Add(GetMetadataBlock(ptr, size));
+            builder.Add(GetMetadataBlock(previousMetadataBlocks, index, ptr, size));
             return builder.ToImmutableAndFree();
         }
 
@@ -139,6 +144,20 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var moduleVersionId = reader.GetGuid(moduleDef.Mvid);
             var generationId = reader.GetGuid(moduleDef.GenerationId);
             return new MetadataBlock(moduleVersionId, generationId, ptr, (int)size);
+        }
+
+        private static MetadataBlock GetMetadataBlock(ImmutableArray<MetadataBlock> previousMetadataBlocks, int index, IntPtr ptr, uint size)
+        {
+            if (!previousMetadataBlocks.IsDefault && index < previousMetadataBlocks.Length)
+            {
+                var previousBlock = previousMetadataBlocks[index];
+                if (previousBlock.Pointer == ptr && previousBlock.Size == size)
+                {
+                    return previousBlock;
+                }
+            }
+
+            return GetMetadataBlock(ptr, size);
         }
 
         internal static object GetSymReader(this DkmClrModuleInstance clrModule)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
@@ -109,6 +109,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             appDomain.RemoveMetadataContext(Of VisualBasicMetadataContext)()
         End Sub
 
+        Friend Overrides Function GetMetadataBlocks(appDomain As DkmClrAppDomain, runtimeInstance As DkmClrRuntimeInstance) As ImmutableArray(Of MetadataBlock)
+            Dim previous = appDomain.GetMetadataContext(Of VisualBasicMetadataContext)()
+            Return runtimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
+        End Function
+
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function GetCompilation(moduleInstance As DkmClrModuleInstance) As VisualBasicCompilation
             Dim appDomain = moduleInstance.AppDomain
             Dim previous = appDomain.GetMetadataContext(Of VisualBasicMetadataContext)()
-            Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain)
+            Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
 
             Dim compilation As VisualBasicCompilation
             If previous.Matches(metadataBlocks) Then


### PR DESCRIPTION
**Customer scenario**
	1. User debugs a C# project and a VB project.
	2. The call stack of the current frame is deep enough.
	3. The Call Stack window is open.
	4. It takes an essential time to fulfill the Call Stack window.
	5. When moving to another frame in code, it takes again an essential time to update the Call Stack window.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=189593&_a=edit
Fixes #20017

**Workarounds, if any**
No

**Risk**
Low. We avoid loading metadata blocks and allocating memory for them. Instead of this we compare pointers and sizes of the blocks.

**Performance impact**
It is expected to be a good improvement.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
We found that we load all metadata blocks for each frame in the call stack. This involves an essential memory allocation. After loading, we compare the block loaded with existing one. If they match, we throw away the block just loaded. 

Now we avoid loading blocks. Instead of this we compare pointers and block sizes. It should save on unnecessary memory allocation.

Metadata blocks can change e.g. on EnC but this happens essentially rarely than metadata loading. 

**How was the bug found?**
Watson 


This has already been reviewed/merged for 15.5 https://github.com/dotnet/roslyn/pull/20834 
This is to port the change over to dev15.4.x. 
