### PR TITLE
made NFW to use normal watson if given exception is non recoverable exception in OOP

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
@@ -40,6 +40,13 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
         /// <param name="exception">Exception that triggered this non-fatal error</param>
         public static void Report(string description, Exception exception)
         {
+            // if given exception is non recoverable exception,
+            // crash instead of NFW
+            if (IsNonRecoverableException(exception))
+            {
+                CodeAnalysis.FailFast.OnFatalException(exception);
+            }
+
             SessionOpt?.PostFault(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
@@ -52,6 +59,11 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
                     // we always send watson since dump itself can have valuable data
                     return 0;
                 });
+        }
+
+        private static bool IsNonRecoverableException(Exception exception)
+        {
+            return exception is OutOfMemoryException;
         }
     }
 }


### PR DESCRIPTION
this change is inspired by @tmeschter 's PR (https://github.com/dotnet/roslyn/pull/21264)

this make OOP to crash when OOM happens in OOP, but it will not crash VS, instead it will show the existing infobar asking users to save its data and rerun VS.