### PR TITLE
Use langver=latest for scripting

### DIFF
--- a/src/Scripting/CSharp/CSharpScriptCompiler.cs
+++ b/src/Scripting/CSharp/CSharpScriptCompiler.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Text;
 
@@ -13,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting
     {
         public static readonly ScriptCompiler Instance = new CSharpScriptCompiler();
 
-        private static readonly CSharpParseOptions s_defaultOptions = new CSharpParseOptions(kind: SourceCodeKind.Script);
+        private static readonly CSharpParseOptions s_defaultOptions = new CSharpParseOptions(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.Latest);
 
         private CSharpScriptCompiler()
         {

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -947,5 +947,48 @@ Bang!
 Bang!",
                 runner.Console.Error.ToString());
         }
+
+        [Fact]
+        [WorkItem(21327, "https://github.com/dotnet/roslyn/issues/21327")]
+        public void DefaultLiteral()
+        {
+            var runner = CreateRunner(input:
+@"int i = default;
+Print(i);
+");
+            runner.RunInteractive();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+$@"Microsoft (R) Visual C# Interactive Compiler version {s_compilerVersion}
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Type ""#help"" for more information.
+> int i = default;
+> Print(i);
+0
+> ", runner.Console.Out.ToString());
+        }
+
+        [Fact]
+        [WorkItem(21327, "https://github.com/dotnet/roslyn/issues/21327")]
+        public void InferredTupleNames()
+        {
+            var runner = CreateRunner(input:
+@"var a = 1;
+var t = (a, 2);
+Print(t.a);
+");
+            runner.RunInteractive();
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+$@"Microsoft (R) Visual C# Interactive Compiler version {s_compilerVersion}
+Copyright (C) Microsoft Corporation. All rights reserved.
+Type ""#help"" for more information.
+> var a = 1;
+> var t = (a, 2);
+> Print(t.a);
+1
+> ", runner.Console.Out.ToString());
+        }
     }
 }

--- a/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/Scripting/VisualBasic/VisualBasicScriptCompiler.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
 
         Public Shared ReadOnly Instance As ScriptCompiler = New VisualBasicScriptCompiler()
 
-        Private Shared ReadOnly s_defaultOptions As VisualBasicParseOptions = New VisualBasicParseOptions(kind:=SourceCodeKind.Script)
+        Private Shared ReadOnly s_defaultOptions As VisualBasicParseOptions = New VisualBasicParseOptions(kind:=SourceCodeKind.Script, languageVersion:=LanguageVersion.Latest)
         Private Shared ReadOnly s_vbRuntimeReference As MetadataReference = MetadataReference.CreateFromAssemblyInternal(GetType(CompilerServices.NewLateBinding).GetTypeInfo().Assembly)
 
         Private Sub New()

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -186,6 +186,33 @@ Type ""#help"" for more information.
 >", runner.Console.Out.ToString())
         End Sub
 
+        <Fact, WorkItem(21327, "https://github.com/dotnet/roslyn/issues/21327")>
+        Public Sub TestLatestLanguageVersion()
+            Dim runner = CreateRunner(args:={}, input:="
+Dim a = 1
+Dim t = (a, 2)
+System.Console.Write(t.a)
+")
+
+            runner.RunInteractive()
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+"Microsoft (R) Visual Basic Interactive Compiler version " + s_compilerVersion + "
+Copyright (C) Microsoft Corporation. All rights reserved.
+Type ""#help"" for more information.
+>
+> Dim a = 1
+> Dim t = (a, 2)
+> System.Console.Write(t.a)
+«Red»
+Public member 'a' on type 'ValueTuple(Of Object,Integer)' not found.
+  + Microsoft.VisualBasic.CompilerServices.Symbols.Container.GetMembers(ByRef String, Boolean)
+  + Submission#3.VB$StateMachine_1_<Initialize>.MoveNext()
+  + Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.<RunSubmissionsAsync>d__9(Of TResult).MoveNext()
+«Gray»
+>", runner.Console.Out.ToString())
+        End Sub
+
         <Fact>
         Public Sub Version()
             Dim runner = CreateRunner({"/version"})

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -186,33 +186,6 @@ Type ""#help"" for more information.
 >", runner.Console.Out.ToString())
         End Sub
 
-        <Fact, WorkItem(21327, "https://github.com/dotnet/roslyn/issues/21327")>
-        Public Sub TestLatestLanguageVersion()
-            Dim runner = CreateRunner(args:={}, input:="
-Dim a = 1
-Dim t = (a, 2)
-System.Console.Write(t.a)
-")
-
-            runner.RunInteractive()
-
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-"Microsoft (R) Visual Basic Interactive Compiler version " + s_compilerVersion + "
-Copyright (C) Microsoft Corporation. All rights reserved.
-Type ""#help"" for more information.
->
-> Dim a = 1
-> Dim t = (a, 2)
-> System.Console.Write(t.a)
-«Red»
-Public member 'a' on type 'ValueTuple(Of Object,Integer)' not found.
-  + Microsoft.VisualBasic.CompilerServices.Symbols.Container.GetMembers(ByRef String, Boolean)
-  + Submission#3.VB$StateMachine_1_<Initialize>.MoveNext()
-  + Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.<RunSubmissionsAsync>d__9(Of TResult).MoveNext()
-«Gray»
->", runner.Console.Out.ToString())
-        End Sub
-
         <Fact>
         Public Sub Version()
             Dim runner = CreateRunner({"/version"})


### PR DESCRIPTION
The Interactive Window was using langver=default. This PR makes it use langver=latest.

Fixes https://github.com/dotnet/roslyn/issues/21327
