### PR TITLE
Enable skipped tests and fix them

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2900,7 +2900,7 @@ public class C
             );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         [WorkItem(16947, "https://github.com/dotnet/roslyn/issues/16947")]
         public void Dynamic003()
         {
@@ -2930,13 +2930,12 @@ public class C
 ";
 
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
-                // (14,28): error CS8156: An expression cannot be used in this context because it may not be returned by reference
+                // (14,26): error CS8156: An expression cannot be used in this context because it may not be returned by reference
                 //         return ref G(ref d.Length);
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "d.Length").WithLocation(14, 28),
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "d.Length").WithLocation(14, 26),
                 // (14,20): error CS8164: Cannot return by reference a result of 'C.G(ref dynamic)' because the argument passed to parameter 'd' cannot be returned by reference
                 //         return ref G(ref d.Length);
                 Diagnostic(ErrorCode.ERR_RefReturnCall, "G(ref d.Length)").WithArguments("C.G(ref dynamic)", "d").WithLocation(14, 20)
-
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenThrowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenThrowTests.cs
@@ -81,7 +81,7 @@ class C
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void TestRethrowImplicit()
         {
             var source = @"
@@ -91,6 +91,7 @@ class C
     {
         try
         {
+            System.Console.WriteLine();
         }
         catch
         {
@@ -101,28 +102,24 @@ class C
             var compilation = CompileAndVerify(source);
 
             compilation.VerifyIL("C.Main", @"{
-  // Code size        11 (0xb)
+  // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  nop
   .try
   {
-    IL_0001:  nop
-    IL_0002:  nop
-    IL_0003:  leave.s    IL_0009
-  }  // end .try
-  catch [mscorlib]System.Object 
+    IL_0000:  call       ""void System.Console.WriteLine()""
+    IL_0005:  leave.s    IL_000a
+  }
+  catch object
   {
-    IL_0005:  pop
-    IL_0006:  nop
-    IL_0007:  rethrow
-  }  // end handler
-  IL_0009:  nop
-  IL_000a:  ret 
+    IL_0007:  pop
+    IL_0008:  rethrow
+  }
+  IL_000a:  ret
 }
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void TestRethrowTyped()
         {
             var source = @"
@@ -142,28 +139,52 @@ class C
             var compilation = CompileAndVerify(source);
 
             compilation.VerifyIL("C.Main", @"{
-  // Code size        11 (0xb)
-  .maxstack  1
-  IL_0000:  nop
-  .try
-  {
-    IL_0001:  nop
-    IL_0002:  nop
-    IL_0003:  leave.s    IL_0009
-  }  // end .try
-  catch [mscorlib]System.Exception 
-  {
-    IL_0005:  pop
-    IL_0006:  nop
-    IL_0007:  rethrow
-  }  // end handler
-  IL_0009:  nop
-  IL_000a:  ret 
+ // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
 }
 ");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
+        public void TestRethrowTyped2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        try
+        {
+            System.Console.WriteLine();
+        }
+        catch (System.Exception)
+        {
+            throw;
+        }
+    }
+}";
+            var compilation = CompileAndVerify(source);
+
+            compilation.VerifyIL("C.Main", @"{
+  // Code size       11 (0xb)
+  .maxstack  1
+  .try
+  {
+    IL_0000:  call       ""void System.Console.WriteLine()""
+    IL_0005:  leave.s    IL_000a
+  }
+  catch System.Exception
+  {
+    IL_0007:  pop
+    IL_0008:  rethrow
+  }
+  IL_000a:  ret
+}
+");
+        }
+
+        [Fact]
         public void TestRethrowNamed()
         {
             var source = @"
@@ -183,23 +204,47 @@ class C
             var compilation = CompileAndVerify(source);
 
             compilation.VerifyIL("C.Main", @"{
-  // Code size        11 (0xb)
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRethrowNamed2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        try
+        {
+            System.Console.WriteLine();
+        }
+        catch (System.Exception e)
+        {
+            throw;
+        }
+    }
+}";
+            var compilation = CompileAndVerify(source);
+
+            compilation.VerifyIL("C.Main", @"{
+  // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  nop
   .try
   {
-    IL_0001:  nop
-    IL_0002:  nop
-    IL_0003:  leave.s    IL_0009
-  }  // end .try
-  catch [mscorlib]System.Exception 
+    IL_0000:  call       ""void System.Console.WriteLine()""
+    IL_0005:  leave.s    IL_000a
+  }
+  catch System.Exception
   {
-    IL_0005:  stloc.0
-    IL_0006:  nop
-    IL_0007:  rethrow
-  }  // end handler
-  IL_0009:  nop
-  IL_000a:  ret 
+    IL_0007:  pop
+    IL_0008:  rethrow
+  }
+  IL_000a:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -6795,32 +6795,32 @@ class C
 
         #region Patterns
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void SyntaxOffset_Pattern()
         {
             var source = @"class C { bool F(object o) => o is int i && o is 3 && o is bool; }";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.F", @"<symbols>
-	  <methods>
-	    <method containingType=""C"" name=""F"" parameterNames=""o"">
-	      <customDebugInfo>
-	        <using>
-	          <namespace usingCount=""0"" />
-	        </using>
-	        <encLocalSlotMap>
-	          <slot kind=""0"" offset=""12"" />
-	          <slot kind=""temp"" />
-	        </encLocalSlotMap>
-	      </customDebugInfo>
-	      <sequencePoints>
-	        <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" />
-	      </sequencePoints>
-	      <scope startOffset=""0x0"" endOffset=""0x38"">
-	        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x38"" attributes=""0"" />
-	      </scope>
-	    </method>
-	  </methods>
-	</symbols>");
+  <methods>
+    <method containingType=""C"" name=""F"" parameterNames=""o"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""0"" offset=""12"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x35"">
+        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
+      </scope>
+    </method>
+  </methods>
+</symbols>");
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -136,7 +136,7 @@ IInvocationExpression (static void P.M2(System.Int32 x, [System.Double y = 0])) 
             VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void NamedArgumentInParameterOrderWithDefaultValue()
         {
             string source = @"
@@ -157,7 +157,7 @@ IInvocationExpression (static void P.M2([System.Int32 x = 1], [System.Int32 y = 
     IArgument (ArgumentKind.Explicit, Matching Parameter: z) (OperationKind.Argument) (Syntax: '2')
       ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
     IArgument (ArgumentKind.DefaultValue, Matching Parameter: x) (OperationKind.Argument) (Syntax: 'M2(y: 0, z: 2)')
-      ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: 'M2(y: 0, z: 2)')
+      ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: 'M2(y: 0, z: 2)')
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -1852,7 +1852,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Null(qs.Body.Continuation);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void TestFromGroupBy()
         {
             var text = "from a in A group b by c";
@@ -1864,10 +1864,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
 
             var qs = (QueryExpressionSyntax)expr;
-            Assert.Equal(1, qs.Body.Clauses.Count);
-            Assert.Equal(SyntaxKind.FromClause, qs.Body.Clauses[0].Kind());
+            Assert.Equal(0, qs.Body.Clauses.Count);
 
-            var fs = (FromClauseSyntax)qs.Body.Clauses[0];
+            var fs = qs.FromClause;
             Assert.NotNull(fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
@@ -1892,7 +1891,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Null(qs.Body.Continuation);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/21079")]
+        [Fact]
         public void TestFromGroupByIntoSelect()
         {
             var text = "from a in A group b by c into d select e";
@@ -1904,10 +1903,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
 
             var qs = (QueryExpressionSyntax)expr;
-            Assert.Equal(1, qs.Body.Clauses.Count);
-            Assert.Equal(SyntaxKind.FromClause, qs.Body.Clauses[0].Kind());
+            Assert.Equal(0, qs.Body.Clauses.Count);
 
-            var fs = (FromClauseSyntax)qs.Body.Clauses[0];
+            var fs = qs.FromClause;
             Assert.NotNull(fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);


### PR DESCRIPTION
Some tests were missing a `[Fact]`, but when the attribute was added, the tests failed and thus were skipped.
This PR enables those tests and fixes them.

Fixes https://github.com/dotnet/roslyn/issues/21079