### PR TITLE
Add tests for ExtractMethod on deconstruction. Test utility to output full actual result.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -1922,5 +1922,63 @@ class Program
     }
 }", TestOptions.Regular7_1);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task TestDeconstruction4()
+        {
+            await TestAsync(@"
+class Program
+{
+    void M()
+    {
+        [|var (x, y) = (1, 2);|]
+        System.Console.Write(x + y);
+    }
+}",
+@"
+class Program
+{
+    void M()
+    {
+        int x, y;
+        {|Rename:NewMethod|}(out x, out y);
+        System.Console.Write(x + y);
+    }
+
+    private static void NewMethod(out int x, out int y)
+    {
+        var (x, y) = (1, 2);
+    }
+}", TestOptions.Regular7_1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task TestDeconstruction5()
+        {
+            await TestAsync(@"
+class Program
+{
+    void M()
+    {
+        [|(var x, var y) = (1, 2);|]
+        System.Console.Write(x + y);
+    }
+}",
+@"
+class Program
+{
+    void M()
+    {
+        int x, y;
+        {|Rename:NewMethod|}(out x, out y);
+        System.Console.Write(x + y);
+    }
+
+    private static void NewMethod(out int x, out int y)
+    {
+        (x, y) = (1, 2);
+    }
+}", TestOptions.Regular7_1);
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -331,12 +331,12 @@ namespace Roslyn.Test.Utilities
 
         public static void Fail(string message)
         {
-            Assert.False(true, message);
+            throw new Xunit.Sdk.XunitException(message);
         }
 
         public static void Fail(string format, params object[] args)
         {
-            Assert.False(true, string.Format(format, args));
+            throw new Xunit.Sdk.XunitException(string.Format(format, args));
         }
 
         public static void NotNull<T>(T @object, string message = null)

--- a/src/Test/Utilities/Portable/Syntax/TokenUtilities.cs
+++ b/src/Test/Utilities/Portable/Syntax/TokenUtilities.cs
@@ -42,7 +42,7 @@ namespace Roslyn.Test.Utilities
                         }
                     }
 
-                    AssertEx.Fail($"Unexpected token.  Actual '{actualAll}' Expected '{expectedAll}'");
+                    AssertEx.Fail($"Unexpected token.  Actual '{actualAll}' Expected '{expectedAll}'\r\nActual:\r\n{actual}");
                 }
             }
 


### PR DESCRIPTION
It looks like refactoring issues with declaration expressions have been fixed already (likely by PR https://github.com/dotnet/roslyn/pull/15646). So I just added some tests.

Closes https://github.com/dotnet/roslyn/issues/14108