### PR TITLE
allowNewCompilerDiagnostics description clarified

### DIFF
--- a/src/Setup/Templates/CSharp/Diagnostic/Test/CodeFixVerifier.cs
+++ b/src/Setup/Templates/CSharp/Diagnostic/Test/CodeFixVerifier.cs
@@ -40,7 +40,7 @@ namespace TestHelper
         /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
         /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will ignore any new warnings intoduced by CodeFix application; 'true' means ignore any new warning during assertion; 'false' means the test will fail if new compiler warnings are introduced</param>
         protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
         {
             VerifyFix(LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
@@ -52,7 +52,7 @@ namespace TestHelper
         /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
         /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will ignore any new warnings intoduced by CodeFix application; 'true' means ignore any new warning during assertion; 'false' means the test will fail if new compiler warnings are introduced</param>
         protected void VerifyBasicFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false)
         {
             VerifyFix(LanguageNames.VisualBasic, GetBasicDiagnosticAnalyzer(), GetBasicCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics);
@@ -70,7 +70,7 @@ namespace TestHelper
         /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
         /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
-        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will ignore any new warnings intoduced by CodeFix application; 'true' means ignore any new warning during assertion; 'false' means the test will fail if new compiler warnings are introduced</param>
         private void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language);


### PR DESCRIPTION
bool allowNewCompilerDiagnostics param has an ambiguous name and description:
/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param> 
In this case 'allow' should be interpreted as 'the assertion will allow (ignore) new warnings', but may also be interpreted as 'the verifier will allow them to be added to diagnostics list'. This inverts the meaning of boolean parameter. 
New description makes it clear, what the parameter means:  
/// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will ignore any new warnings intoduced by CodeFix application; 'true' means ignore any new warning during assertion; 'false' means the test will fail if new compiler warnings are introduced</param>

**Customer scenario**

When using the template, it is not clear, which value of the parameter means 
'ignore any new compiler warnings'

**Risk**

None - only description changes

**Performance impact**

None

**Is this a regression from a previous update?**

None

**Root cause analysis:**

The author probably knew exactly what was happening, so there was no ambiguity in description for him, an outside look was needed to spot it. 

**How was the bug found?**

During development of an analyzer. 
