### PR TITLE
Turn on ref assemblies in all projects

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -22,6 +22,7 @@
     <RoslynPortableTargetFrameworks>net46;netcoreapp2.0</RoslynPortableTargetFrameworks>
  
     <Features>strict,IOperation</Features>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>
     <!-- The new SDK introduced a GenerateAssemblyInfo target, which is disabled by GenerateAssemblyInfo=false.

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -348,7 +348,7 @@ function Test-XUnit() {
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*netcoreapp.*") }
 
     # Exclude out the ref assemblies
-    $dlls = $dlls | ?{ -not ($_.FullName -match ".*\ref\.*") }
+    $dlls = $dlls | ?{ -not ($_.FullName -match ".*\\ref\\.*") }
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*/ref/.*") }
 
     if ($cibuild) {

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -347,6 +347,10 @@ function Test-XUnit() {
     # Exclude out the multi-targetted netcore app projects
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*netcoreapp.*") }
 
+    # Exclude out the ref assemblies
+    $dlls = $dlls | ?{ -not ($_.FullName -match ".*\ref\.*") }
+    $dlls = $dlls | ?{ -not ($_.FullName -match ".*/ref/.*") }
+
     if ($cibuild) {
         # Use a 50 minute timeout on CI
         $args += " -xml -timeout:50"


### PR DESCRIPTION
This dogfoods the end-to-end ref assembly feature in the Roslyn repo.
Some scenarios may be broken (likely LUT and LSL), but the main scenarios have been verified already (for instance, P2P references have been patched, TDD still works).

Relates to https://github.com/dotnet/roslyn/issues/20418

@dotnet/roslyn-infrastructure @jaredpar for review.
FYI @rainersigwald @panopticoncentral @sharwell @Pilchie @ManishJayaswal 