### PR TITLE
Silently treat IncludePrivateMembers as true when emitting regular assemblies

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1576,6 +1576,36 @@ public class PublicClass
                     "System.Diagnostics.DebuggableAttribute" },
                 compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
 
+            // Verify metadata (types, members, attributes) of the regular assembly with IncludePrivateMembers accidentally set to false.
+            // Note this can happen because of binary clients compiled against old EmitOptions ctor which had IncludePrivateMembers=false by default.
+            // In this case, IncludePrivateMembers is silently set to true when emitting
+            // See https://github.com/dotnet/roslyn/issues/20873
+            var emitRegularWithoutPrivateMembers = EmitOptions.Default.WithIncludePrivateMembers(false);
+            CompileAndVerify(comp, emitOptions: emitRegularWithoutPrivateMembers, verify: true);
+
+            var realImage2 = comp.EmitToImageReference(emitRegularWithoutPrivateMembers);
+            var compWithReal2 = CreateCompilation("", references: new[] { MscorlibRef, realImage2 },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            AssertEx.Equal(
+                new[] { "<Module>", "<>f__AnonymousType0<<anonymous>j__TPar>", "PublicClass" },
+                compWithReal2.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
+
+            AssertEx.Equal(
+                new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
+                    "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
+                    "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
+                    "void PublicClass.InternalEvent.add", "void PublicClass.InternalEvent.remove",
+                    "PublicClass..ctor()",
+                    "event System.Action PublicClass.PublicEvent", "event System.Action PublicClass.InternalEvent" },
+                compWithReal2.GetMember<NamedTypeSymbol>("PublicClass").GetMembers()
+                    .Select(m => m.ToTestDisplayString()));
+
+            AssertEx.Equal(
+                new[] { "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
+                    "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+                    "System.Diagnostics.DebuggableAttribute" },
+                compWithReal2.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
+
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
             CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
@@ -1732,15 +1762,16 @@ struct S
         }
 
         [Fact]
-        public void MustIncludePrivateMembersUnlessRefAssembly()
+        [WorkItem(20873, "https://github.com/dotnet/roslyn/issues/20873")]
+        public void IncludePrivateMembersSilentlyAssumedTrueWhenEmittingRegular()
         {
             CSharpCompilation comp = CreateCompilation("", references: new[] { MscorlibRef },
                 options: TestOptions.DebugDll.WithDeterministic(true));
 
             using (var output = new MemoryStream())
             {
-                Assert.Throws<ArgumentException>(() => comp.Emit(output,
-                    options: EmitOptions.Default.WithIncludePrivateMembers(false)));
+                // no exception
+                _ = comp.Emit(output, options: EmitOptions.Default.WithIncludePrivateMembers(false));
             }
         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2086,9 +2086,10 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.IncludingPrivateMembersUnexpectedWhenEmittingToMetadataPeStream, nameof(metadataPEStream));
             }
 
-            if (metadataPEStream == null && options?.EmitMetadataOnly == false && options?.IncludePrivateMembers == false)
+            if (metadataPEStream == null && options?.EmitMetadataOnly == false)
             {
-                throw new ArgumentException(CodeAnalysisResources.MustIncludePrivateMembersUnlessRefAssembly, nameof(options.IncludePrivateMembers));
+                // EmitOptions used to default to IncludePrivateMembers=false, so to preserve binary compatibility we silently correct that unless emitting regular assemblies
+                options = options.WithIncludePrivateMembers(true);
             }
 
             if (options?.DebugInformationFormat == DebugInformationFormat.Embedded &&


### PR DESCRIPTION
This is proposed as a 15.3 servicing fix. We will likely publish a compiler package ahead of the actual 15.3.1 release, to minimize the number of ASP.NET Core users hitting this.

**Customer scenario**

In an ASP.NET Core application where ASP.NET Core was built against Roslyn 2.0 (or older), update the compiler package to Roslyn 2.3/dev15.3 (so that you can use C# 7.1 features or get bug fixes).
When Razor views are rendered, the compiler Emit API will be invoked and it will throw an exception.

This is because the Roslyn 2.0/dev15.0 EmitOptions constructor used a default value `false` for its `includePrivateMembers` parameter. 

In 2.0, `EmitOptions.ctor(…, bool includePrivateMembers = false, …) // this parameter was ignored`.
In 2.3, `EmitOptions.ctor(..., bool includePrivateMembers = true, ...) // this parameter now drives logic to strip members from emitted binaries, so it could not be left false by default`.

Such default values get inlined in the client's binary (in this case [ASP.NET Core](https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Razor/Internal/DefaultRoslynCompilationService.cs#L127)). Although this default value is wrong (very few customers don't want to include private members), it didn't matter because this parameter was not hooked up to any logic.
In Roslyn 2.3, the implementation of reference assemblies made this parameter meaningful. But it also changed the default value to `true`. 
Leaving the default value to `false` would have caused a breaking change for anyone relying on this default value.
So I avoided one compat break, but did not realize I introduced a binary compat break. Our process for maintaining shipped public APIs also failed to catch this (further investigation tracked by https://github.com/dotnet/roslyn/issues/21353).

The change of default value also affects other emit scenarios (metadata-only assembly for IDE, /refonly, /refout). But from those, only the first one even existed before Roslyn 2.3, and it is only used by the IDE as far as we know.

**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/20873

**Workarounds, if any**
Re-compile the client. 
In this case, use a newer version of ASP.NET Core which was compiled against Roslyn 2.3 API and thus uses the new default value (`includePrivateMembers` = `true`).

**Risk**
**Performance impact**
Low. Instead of producing an error when trying to exclude private members when emitting a regular assembly, we silently assume that you mean to include private members (even if `includePrivateMembers` was `false` due to default).

**Is this a regression from a previous update?**
Yes.

**Root cause analysis:**
See details above. We have a follow-up investigation to understand why the API was tracked as "unshipped" when the breaking change was made, when it fact it should have been tracked as "shipped.

**How was the bug found?**
Reported by customers
- ASP.NET Core: https://github.com/dotnet/roslyn/issues/20873 
- Orleans: https://github.com/dotnet/orleans/issues/3233 (they could work around by passing the parameter explicitly rather than using the default value)

@dotnet/roslyn-compiler @tmat for review. Thanks

Tracked in VSO 475761

More details on the various scenarios and settings:

Scenarios | metadataPEstream is null | metadataOnly | includePrivateMembers
-- | -- | -- | --
Regular | true | false | used to require true, but no longer matters (this is the only scenario that is modified by this PR)
IDE skeleton assembly | true | true | true
/Refonly | true | true | false
/Refout | false | false | false

