### PR TITLE
Fix crash when encountering a parenthesized expression when converting an 'if' to a 'switch'

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -875,5 +875,453 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     }
 }", ignoreTrivia: false);
         }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd1()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && i == 2)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd2()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && i == 2 && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd3()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && i == 2 && (i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd4()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && (i == 2) && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd5()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && (i == 2) && (i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd6()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && i == 2 && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd7()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && i == 2 && (i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd8()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && (i == 2) && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && (i == 2) && (i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd10()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (i == 1 && (i == 2 && i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd11()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1 && i == 2) && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd12()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if (((i == 1) && i == 2) && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd13()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1 && (i == 2)) && i == 3)
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd14()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1 && (i == 2)) && (i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd15()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && ((i == 2) && i == 3))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when (i == 2) && i == 3: return;
+            case 10: return;
+        }
+    }
+}");
+        }
+
+        [WorkItem(21360, "https://github.com/dotnet/roslyn/issues/21360")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)]
+        public async Task TestCompoundLogicalAnd16()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(int i)
+    {
+        [||]if ((i == 1) && (i == 2 && (i == 3)))
+            return;
+        else if (i == 10)
+            return;
+    }
+}",
+@"class C
+{
+    void M(int i)
+    {
+        switch (i)
+        {
+            case 1 when i == 2 && (i == 3): return;
+            case 10: return;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
@@ -120,8 +120,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
                             // separate out the leftmost expression and reconstruct the rest of conditions into a new
                             // expression, so that they would be evaluated entirely after "expr" e.g. "expr && (cond1 && cond2)".
                             // Afterwards, we can directly use it in a case guard e.g. "case pat when cond1 && cond2:".
-                            var condition = (leftmost.Parent.Parent as BinaryExpressionSyntax)
-                                ?.WithLeft(((BinaryExpressionSyntax)leftmost.Parent).Right);
+                            var parentBinary = (BinaryExpressionSyntax)leftmost.WalkUpParentheses().Parent;
+                            var grandparentBinary = parentBinary.WalkUpParentheses().Parent as BinaryExpressionSyntax;
+
+                            var condition = grandparentBinary?.WithLeft(parentBinary.Right);
 
                             return new Pattern.Guarded(pattern, (condition ?? node.Right).WalkDownParentheses());
                         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21360