### PR TITLE
Fix error handling in unit tests

### DIFF
--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -16,7 +16,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         public void HandleError(object sender, Exception exception)
         {
-            _exceptions.Add(exception);
+            if (exception == null)
+            {
+                // Log an exception saying we didn't get an exception. I'd consider throwing here, but double-faults are just caught and consumed by
+                // the editor so that won't give a good debugging experience either.
+                _exceptions.Add(new Exception($"{nameof(TestExtensionErrorHandler)}.{nameof(HandleError)} called with null exception"));
+            }
+            else
+            {
+                _exceptions.Add(exception);
+            }
         }
 
         public ICollection<Exception> GetExceptions()

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -16,13 +16,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         public void HandleError(object sender, Exception exception)
         {
-            if (exception is ArgumentOutOfRangeException && ((ArgumentOutOfRangeException)exception).ParamName == "span")
-            {
-                // TODO: this is known bug 655591, fixed by Jack in changeset 931906
-                // Remove this workaround once the fix reaches the DP branch and we all move over.
-                return;
-            }
-
             _exceptions.Add(exception);
         }
 


### PR DESCRIPTION
I saw this on a unit test run:

```
System.ArgumentException : An element of innerExceptions was null.
   at System.AggregateException..ctor(String message, IList`1 innerExceptions)
   at System.AggregateException..ctor(String message, IEnumerable`1 innerExceptions)
   at System.AggregateException..ctor(IEnumerable`1 innerExceptions)
   at Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces.TestWorkspace.Flatten(ICollection`1 exceptions)
   at Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces.TestWorkspace.Dispose(Boolean finalize)
   at Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit.CommitTestData.Dispose() in E:\A\_work\7\s\src\EditorFeatures\VisualBasicTest\LineCommit\CommitTestData.vb:line 81
   at Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit.CommitWithViewTests.TestCommitIfThenOnlyAfterStartingNewBlock() in E:\A\_work\7\s\src\EditorFeatures\VisualBasicTest\LineCommit\CommitWithViewTests.vb:line 362
```