### PR TITLE
Add null checks for TaskExtensions before deferred execution

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
@@ -90,6 +90,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions continuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationAction, nameof(continuationAction));
+
             Func<Task, bool> continuationFunction = antecedent =>
             {
                 continuationAction(antecedent);
@@ -116,6 +118,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions continuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWith<TResult>(
                 (Task antecedent) => continuationFunction((Task<TInput>)antecedent), cancellationToken, continuationOptions, scheduler);
         }
@@ -127,6 +131,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions continuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationAction, nameof(continuationAction));
+
             return task.SafeContinueWith(
                 (Task antecedent) => continuationAction((Task<TInput>)antecedent), cancellationToken, continuationOptions, scheduler);
         }
@@ -155,6 +161,8 @@ namespace Roslyn.Utilities
             //
             // We do not want this, so we pass the LazyCancellation flag to the TPL which implements
             // the behavior we want.
+
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
 
             Func<Task, TResult> outerFunction = t =>
             {
@@ -223,6 +231,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions taskContinuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWith(t =>
                 Task.Delay(millisecondsDelay, cancellationToken).SafeContinueWith(
                     _ => continuationFunction(t), cancellationToken, TaskContinuationOptions.None, scheduler),
@@ -237,6 +247,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions taskContinuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWith(t =>
                 Task.Delay(millisecondsDelay, cancellationToken).SafeContinueWith(
                     _ => continuationFunction(t), cancellationToken, TaskContinuationOptions.None, scheduler),
@@ -251,6 +263,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions taskContinuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationAction, nameof(continuationAction));
+
             return task.SafeContinueWith(t =>
                 Task.Delay(millisecondsDelay, cancellationToken).SafeContinueWith(
                     _ => continuationAction(), cancellationToken, TaskContinuationOptions.None, scheduler),
@@ -264,6 +278,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions continuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWithFromAsync<TResult>(
                 (Task antecedent) => continuationFunction((Task<TInput>)antecedent), cancellationToken, continuationOptions, scheduler);
         }
@@ -350,6 +366,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions taskContinuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWith(t =>
                 Task.Delay(millisecondsDelay, cancellationToken).SafeContinueWithFromAsync(
                     _ => continuationFunction(t), cancellationToken, TaskContinuationOptions.None, scheduler),
@@ -364,6 +382,8 @@ namespace Roslyn.Utilities
             TaskContinuationOptions taskContinuationOptions,
             TaskScheduler scheduler)
         {
+            Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
+
             return task.SafeContinueWith(t =>
                 Task.Delay(millisecondsDelay, cancellationToken).SafeContinueWithFromAsync(
                     _ => continuationFunction(t), cancellationToken, TaskContinuationOptions.None, scheduler),


### PR DESCRIPTION
A null value for certain arguments in `TaskExtensions` results in an exception. We want this exception to reveal the caller who passed a null value. This commit updates methods which defer the evaluation of the argument to explicitly check for null early so the caller is revealed in the stack trace.

This is intended to aid in the resolution of [DevDiv Bug 459038](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20IDE/_queries?id=459038)¹.

¹ This bug is a crash report for a specific delegate which I'll identify with a comment.

## Ask Mode

**Customer scenario**

Visual Studio crashes in asynchronous code, and the culprit does not appear in the crash reports.

**Bugs this fixes:**

None, though it aims to provide us with information necessary to fix Bug 459038 and Bug 459039.

**Workarounds, if any**

None.

**Risk**

Low. This will cause an exception to be thrown earlier in cases where it was already inevitable.

**Performance impact**

Negligible.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This change will provide early notification and clear identification of the culprit when this issue occurs in the future.

**How was the bug found?**

Automatic crash reporting.
