### PR TITLE
Don't pick a project arbitrarily when navigating to symbols

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractNavigationBarItemService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Extensibility.NavigationBar
             if (symbol != null &&
                 !(symbol is ITypeSymbol) &&
                 !symbol.IsConstructor() &&
-                symbolNavigationService.TrySymbolNavigationNotify(symbol, document.Project.Solution, cancellationToken))
+                symbolNavigationService.TrySymbolNavigationNotify(symbol, document.Project, cancellationToken))
             {
                 return;
             }

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                     if (!_definitionToItem.TryGetValue(definition.Symbol, out var definitionItem))
                     {
                         definitionItem = await definition.Symbol.ToClassifiedDefinitionItemAsync(
-                            _solution, includeHiddenLocations: false, cancellationToken: _context.CancellationToken).ConfigureAwait(false);
+                            _solution.GetProject(definition.ProjectId), includeHiddenLocations: false, cancellationToken: _context.CancellationToken).ConfigureAwait(false);
 
                         _definitionToItem[definition.Symbol] = definitionItem;
                     }

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             foreach (var implementation in tuple.Value.implementations)
             {
                 var definitionItem = await implementation.ToClassifiedDefinitionItemAsync(
-                    project.Solution, includeHiddenLocations: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    project, includeHiddenLocations: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                 await context.OnDefinitionFoundAsync(definitionItem).ConfigureAwait(false);
             }
         }

--- a/src/EditorFeatures/Core/FindUsages/IDefinitionsAndReferencesFactory.cs
+++ b/src/EditorFeatures/Core/FindUsages/IDefinitionsAndReferencesFactory.cs
@@ -41,31 +41,31 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
     {
         public static DefinitionItem ToNonClassifiedDefinitionItem(
             this ISymbol definition,
-            Solution solution,
+            Project project,
             bool includeHiddenLocations)
         {
             // Because we're passing in 'false' for 'includeClassifiedSpans', this won't ever have
             // to actually do async work.  This is because the only asynchrony is when we are trying
             // to compute the classified spans for the locations of the definition.  So it's totally 
             // fine to pass in CancellationToken.None and block on the result.
-            return ToDefinitionItemAsync(definition, solution, includeHiddenLocations,
+            return ToDefinitionItemAsync(definition, project, includeHiddenLocations,
                 includeClassifiedSpans: false, cancellationToken: CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
         }
 
         public static Task<DefinitionItem> ToClassifiedDefinitionItemAsync(
             this ISymbol definition,
-            Solution solution,
+            Project project,
             bool includeHiddenLocations,
             CancellationToken cancellationToken)
         {
-            return ToDefinitionItemAsync(definition, solution,
+            return ToDefinitionItemAsync(definition, project,
                 includeHiddenLocations, includeClassifiedSpans: true, cancellationToken: cancellationToken);
         }
 
 
         private static async Task<DefinitionItem> ToDefinitionItemAsync(
             this ISymbol definition,
-            Solution solution,
+            Project project,
             bool includeHiddenLocations,
             bool includeClassifiedSpans,
             CancellationToken cancellationToken)
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                     if (location.IsInMetadata)
                     {
                         return DefinitionItem.CreateMetadataDefinition(
-                            tags, displayParts, nameDisplayParts, solution, 
+                            tags, displayParts, nameDisplayParts, project, 
                             definition, properties, displayIfNoReferences);
                     }
                     else if (location.IsInSource)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                             continue;
                         }
 
-                        var document = solution.GetDocument(location.SourceTree);
+                        var document = project.Solution.GetDocument(location.SourceTree);
                         if (document != null)
                         {
                             var documentLocation = !includeClassifiedSpans

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             // So, if we only have a single location to go to, this does no unnecessary work.  And,
             // if we do have multiple locations to show, it will just be done in the BG, unblocking
             // this command thread so it can return the user faster.
-            var definitionItem = symbol.ToNonClassifiedDefinitionItem(solution, includeHiddenLocations: true);
+            var definitionItem = symbol.ToNonClassifiedDefinitionItem(project, includeHiddenLocations: true);
 
             if (thirdPartyNavigationAllowed)
             {

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
             }
 
             var symbolNavigationService = solution.Workspace.Services.GetService<ISymbolNavigationService>();
-            var definitionItem = symbol.ToNonClassifiedDefinitionItem(solution, includeHiddenLocations: true);
+            var definitionItem = symbol.ToNonClassifiedDefinitionItem(project, includeHiddenLocations: true);
 
             if (symbolNavigationService.WouldNavigateToSymbol(
                     definitionItem, solution, cancellationToken,

--- a/src/EditorFeatures/TestUtilities2/Utilities/MockSymbolNavigationServiceProvider.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/MockSymbolNavigationServiceProvider.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public TryNavigateToSymbolProvidedOptions As OptionSet
 
             Public TrySymbolNavigationNotifyProvidedSymbol As ISymbol
-            Public TrySymbolNavigationNotifyProvidedSolution As Solution
+            Public TrySymbolNavigationNotifyProvidedProject As Project
             Public TrySymbolNavigationNotifyReturnValue As Boolean = False
 
             Public WouldNavigateToSymbolProvidedDefinitionItem As DefinitionItem
@@ -47,10 +47,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             End Function
 
             Public Function TrySymbolNavigationNotify(symbol As ISymbol,
-                                                      solution As Solution,
+                                                      project As Project,
                                                       cancellationToken As CancellationToken) As Boolean Implements ISymbolNavigationService.TrySymbolNavigationNotify
                 Me.TrySymbolNavigationNotifyProvidedSymbol = symbol
-                Me.TrySymbolNavigationNotifyProvidedSolution = solution
+                Me.TrySymbolNavigationNotifyProvidedProject = project
 
                 Return TrySymbolNavigationNotifyReturnValue
             End Function

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
@@ -101,15 +101,13 @@ namespace Microsoft.CodeAnalysis.FindUsages
             private (Project project, ISymbol symbol) TryResolveSymbolInCurrentSolution(
                 Workspace workspace, string symbolKey)
             {
-                if (!this.Properties.TryGetValue(MetadataAssemblyIdentityDisplayName, out var identityDisplayName) ||
-                    !AssemblyIdentity.TryParseDisplayName(identityDisplayName, out var identity))
+                if (!this.Properties.TryGetValue(MetadataSymbolOriginatingProjectIdGuid, out var projectIdGuid) ||
+                    !this.Properties.TryGetValue(MetadataSymbolOriginatingProjectIdDebugName, out var projectDebugName))
                 {
                     return (null, null);
                 }
 
-                var project = workspace.CurrentSolution
-                    .ProjectsWithReferenceToAssembly(identity)
-                    .FirstOrDefault();
+                var project = workspace.CurrentSolution.GetProject(ProjectId.CreateFromSerialized(Guid.Parse(projectIdGuid), projectDebugName));
 
                 if (project == null)
                 {

--- a/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         public bool TryNavigateToSymbol(ISymbol symbol, Project project, OptionSet options = null, CancellationToken cancellationToken = default)
             => false;
 
-        public bool TrySymbolNavigationNotify(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
+        public bool TrySymbolNavigationNotify(ISymbol symbol, Project project, CancellationToken cancellationToken)
             => false;
 
         public bool WouldNavigateToSymbol(

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Navigation
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>
-        bool TrySymbolNavigationNotify(ISymbol symbol, Solution solution, CancellationToken cancellationToken);
+        bool TrySymbolNavigationNotify(ISymbol symbol, Project project, CancellationToken cancellationToken);
 
         /// <returns>True if the navigation would be handled.</returns>
         bool WouldNavigateToSymbol(

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 if (symbol != null &&
                     !(symbol is ITypeSymbol) &&
                     !symbol.IsConstructor() &&
-                    symbolNavigationService.TrySymbolNavigationNotify(symbol, project.Solution, CancellationToken.None))
+                    symbolNavigationService.TrySymbolNavigationNotify(symbol, project, CancellationToken.None))
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -149,21 +149,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return true;
         }
 
-        public bool TrySymbolNavigationNotify(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
+        public bool TrySymbolNavigationNotify(ISymbol symbol, Project project, CancellationToken cancellationToken)
         {
-            return TryNotifyForSpecificSymbol(symbol, solution, cancellationToken);
+            return TryNotifyForSpecificSymbol(symbol, project, cancellationToken);
         }
 
         private bool TryNotifyForSpecificSymbol(
-            ISymbol symbol, Solution solution, CancellationToken cancellationToken)
+            ISymbol symbol, Project project, CancellationToken cancellationToken)
         {
             AssertIsForeground();
 
-            var definitionItem = symbol.ToNonClassifiedDefinitionItem(solution, includeHiddenLocations: true);
+            var definitionItem = symbol.ToNonClassifiedDefinitionItem(project, includeHiddenLocations: true);
             definitionItem.Properties.TryGetValue(DefinitionItem.RQNameKey1, out var rqName);
 
             if (!TryGetNavigationAPIRequiredArguments(
-                    definitionItem, rqName, solution, cancellationToken,
+                    definitionItem, rqName, cancellationToken,
                     out var hierarchy, out var itemID, out var navigationNotify))
             {
                 return false;
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             if (!TryGetNavigationAPIRequiredArguments(
-                    definitionItem, rqName, solution, cancellationToken,
+                    definitionItem, rqName, cancellationToken,
                     out var hierarchy, out var itemID, out var navigationNotify))
             {
                 return false;
@@ -244,7 +244,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private bool TryGetNavigationAPIRequiredArguments(
             DefinitionItem definitionItem,
             string rqName,
-            Solution solution,
             CancellationToken cancellationToken,
             out IVsHierarchy hierarchy,
             out uint itemID,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -453,54 +453,5 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             return null;
         }
-
-        /// <summary>
-        /// Finds projects in this solution that have a reference to an assembly with the 
-        /// identity provided.  Projects will be ordered such that those that have a 
-        /// reference that is <see cref="AssemblyIdentityComparer.ComparisonResult.Equivalent"/>
-        /// will be returned before those that are 
-        /// <see cref="AssemblyIdentityComparer.ComparisonResult.EquivalentIgnoringVersion"/>.
-        /// </summary>
-        public static IEnumerable<Project> ProjectsWithReferenceToAssembly(
-            this Solution solution, AssemblyIdentity identity)
-        {
-            var projectMatchesIgnoringVersion = new List<Project>();
-            foreach (var project in solution.Projects)
-            {
-                var referenceType = project.GetAssemblyReferenceType(a =>
-                    {
-                        var result = AssemblyIdentityComparer.Default.Compare(a.Identity, identity);
-
-                        // If the assembly and the identity are NotEquivalent, return null to indicate
-                        // that we need to keep checking the rest of the assemblies.  Otherwise,
-                        // return the result we got which will bubble out into 'referenceType'.
-                        return result == AssemblyIdentityComparer.ComparisonResult.NotEquivalent
-                            ? (AssemblyIdentityComparer.ComparisonResult?)null
-                            : result;
-                    });
-
-                if (referenceType.HasValue)
-                {
-                    if (referenceType.Value == AssemblyIdentityComparer.ComparisonResult.Equivalent)
-                    {
-                        // We found an assembly reference exactly matching the assembly identity.
-                        // Return it immediately.
-                        yield return project;
-                    }
-                    else if (referenceType.Value == AssemblyIdentityComparer.ComparisonResult.EquivalentIgnoringVersion)
-                    {
-                        // We found an assembly reference matching the assembly identity if
-                        // versions were ignored.  Return it after all the exact matches are
-                        // returned.
-                        projectMatchesIgnoringVersion.Add(project);
-                    }
-                }
-            }
-
-            foreach (var project in projectMatchesIgnoringVersion)
-            {
-                yield return project;
-            }
-        }
     }
 }


### PR DESCRIPTION
When we were navigating to a symbol with Go to Definition, we were roundtripping the symbol to a symbol key, and then trying to reconstitute the symbol by finding a project that had the reference and then grabbing that symbol. There are two problems with this approach:

1. We might get the symbol for the wrong language, which impacts the language we use to generate metadata as source. This fixes dotnet/roslyn#16818.

2. We might not even get the right symbol. Assembly identity in this case was using display name, which could be the wrong portable surface area or wrong version.

The fix is to instead carry along the project ID of the originating symbol, and resolve against that.