### PR TITLE
Address non-trailing named argument test plan for C#

### DIFF
--- a/docs/Language Feature Status.md
+++ b/docs/Language Feature Status.md
@@ -24,7 +24,7 @@ efforts behind them.
 | [blittable](https://github.com/dotnet/csharplang/pull/206) | None | Proposal | None | | [jaredpar](https://github.com/jaredpar) |
 | strongname | [strongname](https://github.com/dotnet/roslyn/tree/features/strongname) | In Progress | [Ty Overby](https://github.com/tyoverby) | | [jaredpar](https://github.com/jaredpar) |
 | [interior pointer](https://github.com/dotnet/csharplang/pull/264) | None | Proposal | [vsadov](https://github.com/vsadov) | [jaredpar](https://github.com/jaredpar) | [jaredpar](https://github.com/jaredpar) |
-| [non-trailing named arguments](https://github.com/dotnet/csharplang/blob/master/proposals/non-trailing-named-arguments.md) | [non-trailing](https://github.com/dotnet/roslyn/tree/features/non-trailing) | Prototype | [jcouv](https://github.com/jcouv) | TBD | [jcouv](https://github.com/jcouv) |
+| [non-trailing named arguments](https://github.com/dotnet/csharplang/blob/master/proposals/non-trailing-named-arguments.md) | master | Merged | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) | [jcouv](https://github.com/jcouv) |
 
 # C# 8.0
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             IdentifierNameSyntax syntax = Names[i];
             return syntax == null ? null : syntax.Identifier.ValueText;
         }
-        
+
         public ImmutableArray<string> GetNames()
         {
             int count = this.Names.Count;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -62,11 +62,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(arguments != null);
 
             ImmutableArray<ParameterSymbol> parameters = symbol.GetParameters();
+            bool isVararg = symbol.GetIsVararg();
 
             // The easy out is that we have no named arguments and are in normal form.
             if (!expanded && arguments.Names.Count == 0)
             {
-                return AnalyzeArgumentsForNormalFormNoNamedArguments(parameters, arguments, isMethodGroupConversion, symbol.GetIsVararg());
+                return AnalyzeArgumentsForNormalFormNoNamedArguments(parameters, arguments, isMethodGroupConversion, isVararg);
             }
 
             // We simulate an additional non-optional parameter for a vararg method.
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We use -1 as a sentinel to mean that no parameter was found that corresponded to this argument.
                 bool isNamedArgument;
                 int parameterPosition = CorrespondsToAnyParameter(parameters, expanded, arguments, argumentPosition,
-                    isValidParams, out isNamedArgument, ref seenNamedParams, ref seenOutOfPositionNamedArgument) ?? -1;
+                    isValidParams, isVararg, out isNamedArgument, ref seenNamedParams, ref seenOutOfPositionNamedArgument) ?? -1;
 
                 if (parameterPosition == -1 && unmatchedArgumentIndex == null)
                 {
@@ -167,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // __arglist cannot be used with named arguments (as it doesn't have a name)
-            if (arguments.Names.Count != 0 && symbol.GetIsVararg())
+            if (arguments.Names.Any() && arguments.Names.Last() != null && symbol.GetIsVararg())
             {
                 return ArgumentAnalysisResult.RequiredParameterMissing(parameters.Length);
             }
@@ -223,6 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AnalyzedArguments arguments,
             int argumentPosition,
             bool isValidParams,
+            bool isVararg,
             out bool isNamedArgument,
             ref bool seenNamedParams,
             ref bool seenOutOfPositionNamedArgument)
@@ -273,9 +275,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
                 }
 
-                if (argumentPosition >= memberParameters.Length)
+                int parameterCount = memberParameters.Length + (isVararg ? 1 : 0);
+                if (argumentPosition >= parameterCount)
                 {
-                    return expanded ? memberParameters.Length - 1 : (int?)null;
+                    return expanded ? parameterCount - 1 : (int?)null;
                 }
 
                 return argumentPosition;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // __arglist cannot be used with named arguments (as it doesn't have a name)
-            if (arguments.Names.Any() && arguments.Names.Last() != null && symbol.GetIsVararg())
+            if (arguments.Names.Any() && arguments.Names.Last() != null && isVararg)
             {
                 return ArgumentAnalysisResult.RequiredParameterMissing(parameters.Length);
             }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6470,6 +6470,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation..
+        /// </summary>
+        internal static string ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation {
+            get {
+                return ResourceManager.GetString("ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Named argument &apos;{0}&apos; specifies a parameter for which a positional argument has already been given.
         /// </summary>
         internal static string ERR_NamedArgumentUsedInPositional {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3782,6 +3782,9 @@ You should consider suppressing the warning only if you're sure that you don't w
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
     <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.</value>
+  </data>
   <data name="ERR_BadNamedArgument" xml:space="preserve">
     <value>The best overload for '{0}' does not have a parameter named '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1498,6 +1498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnreferencedLocalFunction = 8321,
         ERR_DynamicLocalFunctionTypeParameter = 8322,
         ERR_BadNonTrailingNamedArgument = 8323,
+        ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation = 8324,
         #endregion diagnostics introduced for C# 7.2
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (feature)
             {
                 // C# 7.2 features.
-                case MessageID.IDS_FeatureNonTrailingNamedArguments:
+                case MessageID.IDS_FeatureNonTrailingNamedArguments: // semantic check
                     return LanguageVersion.CSharp7_2;
 
                 // C# 7.1 features.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -43,10 +43,24 @@ class C
             Assert.Equal("void C.M(System.Int32 a, System.Int32 b)",
                 model.GetSymbolInfo(firstInvocation).Symbol.ToTestDisplayString());
 
+            var firstNamedArgA = nodes.OfType<NameColonSyntax>().ElementAt(0);
+            Assert.Equal("a: 1", firstNamedArgA.Parent.ToString());
+            var firstASymbol = model.GetSymbolInfo(firstNamedArgA.Name);
+            Assert.Equal(SymbolKind.Parameter, firstASymbol.Symbol.Kind);
+            Assert.Equal("a", firstASymbol.Symbol.Name);
+            Assert.Equal("void C.M(System.Int32 a, System.Int32 b)", firstASymbol.Symbol.ContainingSymbol.ToTestDisplayString());
+
             var secondInvocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(3);
             Assert.Equal("M(3, a: 4)", secondInvocation.ToString());
             Assert.Equal("void C.M(System.Int64 b, System.Int64 a)",
                 model.GetSymbolInfo(secondInvocation).Symbol.ToTestDisplayString());
+
+            var secondNamedArgA = nodes.OfType<NameColonSyntax>().ElementAt(1);
+            Assert.Equal("a: 4", secondNamedArgA.Parent.ToString());
+            var secondASymbol = model.GetSymbolInfo(secondNamedArgA.Name);
+            Assert.Equal(SymbolKind.Parameter, secondASymbol.Symbol.Kind);
+            Assert.Equal("a", secondASymbol.Symbol.Name);
+            Assert.Equal("void C.M(System.Int64 b, System.Int64 a)", secondASymbol.Symbol.ContainingSymbol.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -66,10 +66,17 @@ class C
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
+
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (10,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         new C(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(10, 21)
+                );
         }
 
         [Fact]
-        public void TestSimpleConstructorWithOldLangVersion()
+        public void TestSimpleThis()
         {
             var source = @"
 class C
@@ -78,17 +85,39 @@ class C
     {
         System.Console.Write($""{a} {b}."");
     }
+    C() : this(a: 1, 2) { }
+
     static void Main()
     {
-        new C(a: 1, 2);
+        new C();
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
-            comp.VerifyDiagnostics(
-                // (10,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
-                //         new C(a: 1, 2);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(10, 21)
-                );
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleBase()
+        {
+            var source = @"
+public class C
+{
+    public C(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+}
+class Derived : C
+{
+    Derived() : base(a: 1, 2) { }
+
+    static void Main()
+    {
+        new Derived();
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -112,27 +141,7 @@ public class C
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, additionalRefs: new[] { SystemCoreRef });
             verifier.VerifyDiagnostics();
-        }
 
-        [Fact]
-        public void TestSimpleExtensionWithOldLangVersion()
-        {
-            var source = @"
-public static class Extension
-{
-    public static void M(this C c, int a, int b)
-    {
-        System.Console.Write($""{a} {b}."");
-    }
-}
-public class C
-{
-    static void Main()
-    {
-        var c = new C();
-        c.M(a: 1, 2);
-    }
-}";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, references: new[] { SystemCoreRef });
             comp.VerifyDiagnostics(
                 // (14,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
@@ -164,29 +173,7 @@ class C
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
-        }
 
-        [Fact]
-        public void TestSimpleDelegateWithOldLangVersion()
-        {
-            var source = @"
-class C
-{
-    delegate void MyDelegate(int a, int b);
-    event MyDelegate e;
-
-    static void M(int a, int b)
-    {
-        System.Console.Write($""{a} {b}."");
-    }
-
-    static void Main()
-    {
-        var c = new C();
-        c.e += M;
-        c.e.Invoke(a: 1, 2);
-    }
-}";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
                 // (16,26): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
@@ -214,27 +201,13 @@ class C
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
-        }
 
-        [Fact]
-        public void TestSimpleLocalFunctionWithOldLangVersion()
-        {
-            var source = @"
-class C
-{
-    static void Main()
-    {
-        var c = new C();
-        local(a: 1, 2);
-
-        void local(int a, int b)
-        {
-            System.Console.Write($""{a} {b}."");
-        }
-    }
-}";
-            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
-            verifier.VerifyDiagnostics();
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (7,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         local(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(7, 21)
+                );
         }
 
         [Fact]
@@ -259,28 +232,7 @@ class C
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
-        }
 
-        [Fact]
-        public void TestSimpleIndexerWithOldLangVersion()
-        {
-            var source = @"
-class C
-{
-    int this[int a, int b]
-    {
-        get
-        {
-            System.Console.Write($""{a} {b}."");
-            return 0;
-        }
-    }
-    static void Main()
-    {
-        var c = new C();
-        _ = c[a: 1, 2];
-    }
-}";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
                 // (15,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
@@ -440,8 +392,10 @@ class C
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
             var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
             Assert.Equal("M(c: 1, 2)", invocation.ToString());
+            SymbolInfo symbol = model.GetSymbolInfo(invocation);
             AssertEx.Equal(new[] { "void C.M(System.Int32 a, System.Int32 b, [System.Int32 c = 1])" },
-                model.GetSymbolInfo(invocation).CandidateSymbols.Select(c => c.ToTestDisplayString()));
+                symbol.CandidateSymbols.Select(c => c.ToTestDisplayString()));
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, symbol.CandidateReason);
         }
 
         [Fact]
@@ -832,6 +786,13 @@ class C
                 //         d.M(a: 1, 2);
                 Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation, "2").WithLocation(7, 19)
                 );
+
+            var comp2 = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp2.VerifyDiagnostics(
+                // (7,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         d.M(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(7, 19)
+                );
         }
 
         [Fact]
@@ -855,26 +816,6 @@ class C
                 // (7,21): error CS8323: Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.
                 //         local(x: 1, d); 
                 Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation, "d").WithLocation(7, 21)
-                );
-        }
-
-        [Fact]
-        public void TestDynamicInvocationWithOldLangVersion()
-        {
-            var source = @"
-class C
-{
-    void M()
-    {
-        dynamic d = new object();
-        d.M(a: 1, 2);
-    }
-}";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
-            comp.VerifyDiagnostics(
-                // (7,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
-                //         d.M(a: 1, 2);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(7, 19)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -826,6 +826,30 @@ class C
         }
 
         [Fact]
+        public void TestInvocationWithDynamicInLocalFunctionParams()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        dynamic d = new object[] { 0 };
+        local(x: 1, d); 
+        void local(int x, params object[] y) { }
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (7,9): error CS8108: Cannot pass argument with dynamic type to params parameter 'y' of local function 'local'.
+                //         local(x: 1, d); 
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionParamsParameter, "local(x: 1, d)").WithArguments("y", "local").WithLocation(7, 9),
+                // (7,21): error CS8323: Named argument specifications must appear after all fixed arguments have been specified in a dynamic invocation.
+                //         local(x: 1, d); 
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgumentInDynamicInvocation, "d").WithLocation(7, 21)
+                );
+        }
+
+        [Fact]
         public void TestDynamicInvocationWithOldLangVersion()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -50,6 +50,305 @@ class C
         }
 
         [Fact]
+        public void TestSimpleConstructor()
+        {
+            var source = @"
+class C
+{
+    C(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+    static void Main()
+    {
+        new C(a: 1, 2);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleConstructorWithOldLangVersion()
+        {
+            var source = @"
+class C
+{
+    C(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+    static void Main()
+    {
+        new C(a: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (10,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         new C(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(10, 21)
+                );
+        }
+
+        [Fact]
+        public void TestSimpleExtension()
+        {
+            var source = @"
+public static class Extension
+{
+    public static void M(this C c, int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+}
+public class C
+{
+    static void Main()
+    {
+        var c = new C();
+        c.M(a: 1, 2);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, additionalRefs: new[] { SystemCoreRef });
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleExtensionWithOldLangVersion()
+        {
+            var source = @"
+public static class Extension
+{
+    public static void M(this C c, int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+}
+public class C
+{
+    static void Main()
+    {
+        var c = new C();
+        c.M(a: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, references: new[] { SystemCoreRef });
+            comp.VerifyDiagnostics(
+                // (14,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         c.M(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(14, 19)
+                );
+        }
+
+        [Fact]
+        public void TestSimpleDelegate()
+        {
+            var source = @"
+class C
+{
+    delegate void MyDelegate(int a, int b);
+    event MyDelegate e;
+
+    static void M(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+
+    static void Main()
+    {
+        var c = new C();
+        c.e += M;
+        c.e.Invoke(a: 1, 2);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleDelegateWithOldLangVersion()
+        {
+            var source = @"
+class C
+{
+    delegate void MyDelegate(int a, int b);
+    event MyDelegate e;
+
+    static void M(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+
+    static void Main()
+    {
+        var c = new C();
+        c.e += M;
+        c.e.Invoke(a: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (16,26): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         c.e.Invoke(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(16, 26)
+                );
+        }
+
+        [Fact]
+        public void TestSimpleLocalFunction()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        local(a: 1, 2);
+
+        void local(int a, int b)
+        {
+            System.Console.Write($""{a} {b}."");
+        }
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleLocalFunctionWithOldLangVersion()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        local(a: 1, 2);
+
+        void local(int a, int b)
+        {
+            System.Console.Write($""{a} {b}."");
+        }
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleIndexer()
+        {
+            var source = @"
+class C
+{
+    int this[int a, int b]
+    {
+        get
+        {
+            System.Console.Write($""{a} {b}."");
+            return 0;
+        }
+    }
+    static void Main()
+    {
+        var c = new C();
+        _ = c[a: 1, 2];
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestSimpleIndexerWithOldLangVersion()
+        {
+            var source = @"
+class C
+{
+    int this[int a, int b]
+    {
+        get
+        {
+            System.Console.Write($""{a} {b}."");
+            return 0;
+        }
+    }
+    static void Main()
+    {
+        var c = new C();
+        _ = c[a: 1, 2];
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (15,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         _ = c[a: 1, 2];
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(15, 21)
+                );
+        }
+
+        [Fact]
+        public void TestSimpleError()
+        {
+            var source = @"
+class C
+{
+    int this[int a, int b]
+    {
+        get
+        {
+            throw null;
+        }
+    }
+
+    C(int a, int b) { }
+
+    static void Main()
+    {
+        var c = new C(b: 1, 2);
+        _ = c[b: 1, 2];
+        local(b: 1, 2);
+
+        void local(int a, int b) { }
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                );
+        }
+
+        [Fact]
+        public void TestMetadataAndPESymbols()
+        {
+            var lib_cs = @"
+public class C
+{
+    public static void M(int a, int b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+}";
+
+            var source = @"
+class D
+{
+    static void Main()
+    {
+        C.M(a: 1, 2);
+    }
+}";
+            var lib = CreateStandardCompilation(lib_cs, parseOptions: TestOptions.Regular7);
+
+            var verifier1 = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, additionalRefs: new[] { lib.ToMetadataReference() });
+            verifier1.VerifyDiagnostics();
+
+            var verifier2 = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2, additionalRefs: new[] { lib.EmitToImageReference() });
+            verifier2.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void TestPositionalUnaffected()
         {
             var source = @"
@@ -77,6 +376,32 @@ class C
             var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
             Assert.Equal("M(1, first: 2)", invocation.ToString());
             Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        }
+
+        [Fact]
+        public void TestGenericInference()
+        {
+            var source = @"
+class C
+{
+    static void M<T1, T2>(T1 a, T2 b)
+    {
+        System.Console.Write($""{a} {b}."");
+    }
+    static void Main()
+    {
+        C.M(a: 1, ""hi"");
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 hi.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+
+            var tree = verifier.Compilation.SyntaxTrees.First();
+            var model = verifier.Compilation.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal(@"C.M(a: 1, ""hi"")", invocation.ToString());
+            Assert.Equal("void C.M<System.Int32, System.String>(System.Int32 a, System.String b)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
         }
 
         [Fact]
@@ -166,6 +491,27 @@ class C
             var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
             Assert.Equal("M(1, x: 2)", invocation.ToString());
             Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        }
+
+        [Fact]
+        public void TestNamedParamsVariousForms()
+        {
+            var source = @"
+class C
+{
+    static void M(int x, params string[] y)
+    {
+        System.Console.Write($""{x} {string.Join("","", y)}. "");
+    }
+    static void Main()
+    {
+        M(x: 1, y: ""2"");
+        M(x: 2, ""3"");
+        M(x: 3, new[] { ""4"", ""5"" });
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "1 2. 2 3. 3 4,5.", parseOptions: TestOptions.RegularLatest);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -441,6 +787,45 @@ class C
         }
 
         [Fact]
+        public void TestOptionalValues()
+        {
+            var source = @"
+class C
+{
+    static void M(int a, int b, int c = 42)
+    {
+        System.Console.Write(c);
+    }
+    static void Main()
+    {
+        M(a: 1, 2);
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "42", parseOptions: TestOptions.RegularLatest);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestDynamicInvocation()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        dynamic d = new object();
+        d.M(a: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics(
+                // (7,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         d.M(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(7, 19)
+                );
+        }
+
+        [Fact]
         public void TestParams()
         {
             var source = @"
@@ -517,6 +902,42 @@ public class C
             Assert.Equal("MyAttribute(condition: true, 42)", invocation.ToString());
             Assert.Equal("MyAttribute..ctor(System.Boolean condition, System.Int32 other)",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestInAttributeWithOldLangVersion()
+        {
+            var source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+public class MyAttribute : Attribute
+{
+    public int P { get; set; }
+	public MyAttribute(bool condition, int other) { }
+}
+
+[MyAttribute(condition: true, 42)]
+[MyAttribute(condition: true, P = 1, 42)]
+[MyAttribute(42, condition: true)]
+public class C
+{
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (11,31): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                // [MyAttribute(condition: true, 42)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "42").WithArguments("7.2").WithLocation(11, 31),
+                // (12,38): error CS1016: Named attribute argument expected
+                // [MyAttribute(condition: true, P = 1, 42)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "42").WithLocation(12, 38),
+                // (12,38): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                // [MyAttribute(condition: true, P = 1, 42)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "42").WithArguments("7.2").WithLocation(12, 38),
+                // (13,18): error CS1744: Named argument 'condition' specifies a parameter for which a positional argument has already been given
+                // [MyAttribute(42, condition: true)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "condition").WithArguments("condition").WithLocation(13, 18)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -161,7 +161,7 @@ class C
 
     static void M(int a, int b)
     {
-        System.Console.Write($""{a} {b}."");
+        System.Console.Write($""{a} {b}. "");
     }
 
     static void Main()
@@ -169,16 +169,20 @@ class C
         var c = new C();
         c.e += M;
         c.e.Invoke(a: 1, 2);
+        c.e(a: 1, 2);
     }
 }";
-            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2. 1 2.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
                 // (16,26): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         c.e.Invoke(a: 1, 2);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(16, 26)
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(16, 26),
+                // (17,19): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         c.e(a: 1, 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(17, 19)
                 );
         }
 
@@ -220,24 +224,32 @@ class C
     {
         get
         {
-            System.Console.Write($""{a} {b}."");
+            System.Console.Write($""Get {a} {b}. "");
             return 0;
+        }
+        set
+        {
+            System.Console.Write($""Set {a} {b} {value}."");
         }
     }
     static void Main()
     {
         var c = new C();
         _ = c[a: 1, 2];
+        c[a: 3, 4] = 5;
     }
 }";
-            var verifier = CompileAndVerify(source, expectedOutput: "1 2.", parseOptions: TestOptions.Regular7_2);
+            var verifier = CompileAndVerify(source, expectedOutput: "Get 1 2. Set 3 4 5.", parseOptions: TestOptions.Regular7_2);
             verifier.VerifyDiagnostics();
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
-                // (15,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                // (19,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         _ = c[a: 1, 2];
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(15, 21)
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(19, 21),
+                // (20,17): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         c[a: 3, 4] = 5;
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "4").WithArguments("7.2").WithLocation(20, 17)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -316,6 +316,15 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
             comp.VerifyDiagnostics(
+                // (16,23): error CS8322: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+                //         var c = new C(b: 1, 2);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "b").WithArguments("b").WithLocation(16, 23),
+                // (17,15): error CS8322: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+                //         _ = c[b: 1, 2];
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "b").WithArguments("b").WithLocation(17, 15),
+                // (18,15): error CS8322: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+                //         local(b: 1, 2);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "b").WithArguments("b").WithLocation(18, 15)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -790,6 +790,7 @@ class C
     {
         dynamic d = new object();
         d.M(a: 1, 2);
+        d.M(1, 2);
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
@@ -239,8 +239,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If argumentNames(i) IsNot Nothing Then
                     seenName = True
                 ElseIf seenName Then
-                    Dim diagInfo = ErrorFactory.ErrorInfo(ERRID.ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation)
-                    ReportDiagnostic(diagnostics, arguments(i).Syntax, diagInfo)
+                    ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation)
                     Return
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
@@ -225,7 +225,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             arguments As ImmutableArray(Of BoundExpression),
                                                             diagnostics As DiagnosticBag)
 
-            If argumentNames.Count = 0 Then
+            Debug.Assert(Not arguments.IsDefault)
+
+            If argumentNames.IsDefault OrElse argumentNames.Count = 0 Then
                 Return
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1737,6 +1737,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_BadNonTrailingNamedArgument = 37302
         ERR_ExpectedNamedArgumentInAttributeList = 37303
+        ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation = 37304
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -7648,6 +7648,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation..
+        '''</summary>
+        Friend ReadOnly Property ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation() As String
+            Get
+                Return ResourceManager.GetString("ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Parameter &apos;{0}&apos; already has a matching argument..
         '''</summary>
         Friend ReadOnly Property ERR_NamedArgUsedTwice1() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -717,6 +717,9 @@
   <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
     <value>Named argument expected.</value>
   </data>
+  <data name="ERR_NamedArgumentSpecificationBeforeFixedArgumentInLateboundInvocation" xml:space="preserve">
+    <value>Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.</value>
+  </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
     <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -65,10 +65,24 @@ End Class
             Assert.Equal("Sub C.M(a As System.Int32, b As System.Int32)",
                 model.GetSymbolInfo(firstInvocation).Symbol.ToTestDisplayString())
 
+            Dim firstNamedArgA = nodes.OfType(Of NameColonEqualsSyntax)().ElementAt(0)
+            Assert.Equal("a:=1", firstNamedArgA.Parent.ToString())
+            Dim firstASymbol = model.GetSymbolInfo(firstNamedArgA.Name)
+            Assert.Equal(SymbolKind.Parameter, firstASymbol.Symbol.Kind)
+            Assert.Equal("a", firstASymbol.Symbol.Name)
+            Assert.Equal("Sub C.M(a As System.Int32, b As System.Int32)", firstASymbol.Symbol.ContainingSymbol.ToTestDisplayString())
+
             Dim secondInvocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(3)
             Assert.Equal("M(3, a:=4)", secondInvocation.ToString())
             Assert.Equal("Sub C.M(b As System.Int64, a As System.Int64)",
                 model.GetSymbolInfo(secondInvocation).Symbol.ToTestDisplayString())
+
+            Dim secondNamedArgA = nodes.OfType(Of NameColonEqualsSyntax)().ElementAt(1)
+            Assert.Equal("a:=4", secondNamedArgA.Parent.ToString())
+            Dim secondASymbol = model.GetSymbolInfo(secondNamedArgA.Name)
+            Assert.Equal(SymbolKind.Parameter, secondASymbol.Symbol.Kind)
+            Assert.Equal("a", secondASymbol.Symbol.Name)
+            Assert.Equal("Sub C.M(b As System.Int64, a As System.Int64)", secondASymbol.Symbol.ContainingSymbol.ToTestDisplayString())
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -72,6 +72,260 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub TestSimpleConstructor()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Sub New(a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+    Shared Sub Main()
+        Dim c = New C(a:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        Dim c = New C(a:=1, 2)
+                            ~
+                                            </errors>)
+
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleThis()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Sub New(a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+    Sub New()
+        Me.New(a:=1, 2)
+    End Sub
+    Shared Sub Main()
+        Dim c = New C()
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        Me.New(a:=1, 2)
+                     ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleBase()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Sub New(a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+End Class
+Class Derived
+    Inherits C
+
+    Sub New()
+        MyBase.New(a:=1, 2)
+    End Sub
+    Shared Sub Main()
+        Dim derived = New Derived()
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleExtension()
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Module Extensions
+    <System.Runtime.CompilerServices.Extension>
+    Sub M(ByVal c As C, a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+End Module
+Class C
+    Shared Sub Main()
+        Dim c = New C()
+        c.M(a:=1, 2)
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        c.M(a:=1, 2)
+                  ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleDelegate()
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Class C
+    Delegate Sub MyDelegate(a As Integer, b As Integer)
+
+    Shared Sub M(a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+
+    Shared Sub Main()
+        Dim f As MyDelegate = AddressOf M
+        f(a:=1, 2)
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        f(a:=1, 2)
+                ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleIndexer()
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Class C
+    Default ReadOnly Property Item(a As Integer, b As Integer) As Integer
+        Get
+            System.Console.Write($"First {a} {b}. ")
+            Return 0
+        End Get
+    End Property
+
+    Shared Sub Main()
+        Dim c = New C()
+        Dim x = c(a:=1, 2)
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2.",
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier.VerifyDiagnostics()
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        Dim x = c(a:=1, 2)
+                        ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestSimpleError()
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Class C
+    Sub New(a As Integer, b As Integer)
+    End Sub
+
+    Default ReadOnly Property Item(a As Integer, b As Integer) As Integer
+        Get
+            Return 0
+        End Get
+    End Property
+
+    Shared Sub Main()
+        Dim c = New C(b:=1, 2)
+        Dim x = c(b:=1, 2)
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source,
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            comp.AssertTheseDiagnostics(<errors>
+BC37302: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+        Dim c = New C(b:=1, 2)
+                      ~
+BC37302: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+        Dim x = c(b:=1, 2)
+                  ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestMetadataAndPESymbols()
+            Dim lib_vb =
+<compilation>
+    <file name="Lib.vb"><![CDATA[
+Public Class C
+    Public Shared Sub M(a As Integer, b As Integer)
+        System.Console.Write($"{a} {b}. ")
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Class D
+    Shared Sub Main()
+        C.M(a:=1, 2)
+    End Sub
+End Class
+    ]]></file>
+</compilation>
+
+            Dim libComp = CreateCompilationWithMscorlibAndVBRuntime(lib_vb, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15))
+
+            Dim verifier1 = CompileAndVerify(source, expectedOutput:="1 2.", additionalRefs:={libComp.ToMetadataReference()},
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier1.VerifyDiagnostics()
+
+            Dim verifier2 = CompileAndVerify(source, expectedOutput:="1 2.", additionalRefs:={libComp.EmitToImageReference()},
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
+            verifier2.VerifyDiagnostics()
+        End Sub
+
+        <Fact>
         Public Sub TestPositionalUnaffected()
             Dim source =
 <compilation>
@@ -538,6 +792,35 @@ End Class
             Assert.Equal("M(c:=valueC, valueB)", invocation.ToString())
             Assert.Equal("Sub C.M([c As System.Int32 = 1], [b As System.Int32 = 2])",
                 model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub TestDynamicInvocation()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Option Strict Off
+Class C
+    Shared Sub Main()
+        Dim d = New Object()
+        d.M(a:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC37304: Named argument specifications must appear after all fixed arguments have been specified in a late bound invocation.
+        d.M(a:=1, 2)
+                  ~
+                                        </errors>)
+
+            Dim comp2 = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15))
+            comp2.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
+        d.M(a:=1, 2)
+                  ~
+                                         </errors>)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -804,6 +804,7 @@ Class C
     Shared Sub Main()
         Dim d = New Object()
         d.M(a:=1, 2)
+        d.M(1, 2)
     End Sub
 End Class
     </file>


### PR DESCRIPTION
Adding tests for non-trailing named arguments in C#.
Fixing issue with dynamic invocation (should give an error with non-trailing names) and arglist.

Test plan https://github.com/dotnet/roslyn/issues/21236
@gafter @dotnet/roslyn-compiler for review.