### PR TITLE
moved to List from ImmutableArray on json return type.

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {
@@ -240,6 +242,19 @@ namespace Roslyn.Utilities
             }
 
             return source.Where((Func<T, bool>)s_notNullTest);
+        }
+
+        public static ImmutableArray<TResult> SelectAsArray<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
+        {
+            if (source == null)
+            {
+                return ImmutableArray<TResult>.Empty;
+            }
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            builder.AddRange(source.Select(selector));
+
+            return builder.ToImmutableAndFree();
         }
 
         public static bool All(this IEnumerable<bool> source)

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -257,7 +257,7 @@ class C
             installerServiceMock.Verify();
         }
 
-        private Task<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(
+        private Task<IReadOnlyList<PackageWithTypeResult>> CreateSearchResult(
             string packageName, string typeName, ImmutableArray<string> containingNamespaceNames)
         {
             return CreateSearchResult(new PackageWithTypeResult(
@@ -265,8 +265,8 @@ class C
                 rank: 0, containingNamespaceNames: containingNamespaceNames));
         }
 
-        private Task<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
-            => Task.FromResult(ImmutableArray.Create(results));
+        private Task<IReadOnlyList<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
+            => Task.FromResult<IReadOnlyList<PackageWithTypeResult>>(ImmutableArray.Create(results));
 
         private ImmutableArray<string> CreateNameParts(params string[] parts) => parts.ToImmutableArray();
     }

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -257,7 +257,7 @@ class C
             installerServiceMock.Verify();
         }
 
-        private Task<IReadOnlyList<PackageWithTypeResult>> CreateSearchResult(
+        private Task<IList<PackageWithTypeResult>> CreateSearchResult(
             string packageName, string typeName, ImmutableArray<string> containingNamespaceNames)
         {
             return CreateSearchResult(new PackageWithTypeResult(
@@ -265,8 +265,8 @@ class C
                 rank: 0, containingNamespaceNames: containingNamespaceNames));
         }
 
-        private Task<IReadOnlyList<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
-            => Task.FromResult<IReadOnlyList<PackageWithTypeResult>>(ImmutableArray.Create(results));
+        private Task<IList<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
+            => Task.FromResult<IList<PackageWithTypeResult>>(ImmutableArray.Create(results));
 
         private ImmutableArray<string> CreateNameParts(params string[] parts) => parts.ToImmutableArray();
     }

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -87,19 +87,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             }
         }
 
-        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        private async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
             var service = document.GetLanguageService<ITodoCommentService>();
             if (service == null)
             {
                 // no inproc support
-                return SpecializedCollections.EmptyReadOnlyList<TodoComment>();
+                return SpecializedCollections.EmptyList<TodoComment>();
             }
 
             return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<ImmutableArray<TodoItem>> CreateItemsAsync(Document document, IReadOnlyList<TodoComment> comments, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<TodoItem>> CreateItemsAsync(Document document, IList<TodoComment> comments, CancellationToken cancellationToken)
         {
             var items = ImmutableArray.CreateBuilder<TodoItem>();
             if (comments != null)

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -87,19 +87,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             }
         }
 
-        private async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
             var service = document.GetLanguageService<ITodoCommentService>();
             if (service == null)
             {
                 // no inproc support
-                return SpecializedCollections.EmptyList<TodoComment>();
+                return SpecializedCollections.EmptyReadOnlyList<TodoComment>();
             }
 
             return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<ImmutableArray<TodoItem>> CreateItemsAsync(Document document, IList<TodoComment> comments, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<TodoItem>> CreateItemsAsync(Document document, IReadOnlyList<TodoComment> comments, CancellationToken cancellationToken)
         {
             var items = ImmutableArray.CreateBuilder<TodoItem>();
             if (comments != null)

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
@@ -61,31 +63,31 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
-                var results = await _session.TryInvokeAsync<ImmutableArray<PackageWithTypeResult>>(
+                var results = await _session.TryInvokeAsync<IList<PackageWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithTypeAsync),
                     new object[] { source, name, arity }, cancellationToken).ConfigureAwait(false);
 
-                return results.NullToEmpty();
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName, CancellationToken cancellationToken)
             {
-                var results = await _session.TryInvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
+                var results = await _session.TryInvokeAsync<IList<PackageWithAssemblyResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithAssemblyAsync),
                     new object[] { source, assemblyName }, cancellationToken).ConfigureAwait(false);
 
-                return results.NullToEmpty();
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
-                var results = await _session.TryInvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
+                var results = await _session.TryInvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindReferenceAssembliesWithTypeAsync),
                     new object[] { name, arity }, cancellationToken).ConfigureAwait(false);
 
-                return results.NullToEmpty();
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task UpdateContinuouslyAsync(

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -239,7 +239,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
             installerServiceMock.Verify()
         End Function
 
-        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of ImmutableArray(Of PackageWithTypeResult))
+        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of IReadOnlyList(Of PackageWithTypeResult))
             Return CreateSearchResult(New PackageWithTypeResult(
                 packageName:=packageName,
                 typeName:=typeName,
@@ -248,8 +248,8 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 containingNamespaceNames:=nameParts))
         End Function
 
-        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of ImmutableArray(Of PackageWithTypeResult))
-            Return Task.FromResult(ImmutableArray.Create(results))
+        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of IReadOnlyList(Of PackageWithTypeResult))
+            Return Task.FromResult(Of IReadOnlyList(Of PackageWithTypeResult))(ImmutableArray.Create(results))
         End Function
 
         Private Function CreateNameParts(ParamArray parts As String()) As ImmutableArray(Of String)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -239,7 +239,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
             installerServiceMock.Verify()
         End Function
 
-        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of IReadOnlyList(Of PackageWithTypeResult))
+        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of IList(Of PackageWithTypeResult))
             Return CreateSearchResult(New PackageWithTypeResult(
                 packageName:=packageName,
                 typeName:=typeName,
@@ -248,8 +248,8 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 containingNamespaceNames:=nameParts))
         End Function
 
-        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of IReadOnlyList(Of PackageWithTypeResult))
-            Return Task.FromResult(Of IReadOnlyList(Of PackageWithTypeResult))(ImmutableArray.Create(results))
+        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of IList(Of PackageWithTypeResult))
+            Return Task.FromResult(Of IList(Of PackageWithTypeResult))(ImmutableArray.Create(results))
         End Function
 
         Private Function CreateNameParts(ParamArray parts As String()) As ImmutableArray(Of String)

--- a/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
+++ b/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TodoComments
         {
         }
 
-        protected override void AppendTodoComments(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
+        protected override void AppendTodoComments(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
         {
             if (PreprocessorHasComment(trivia))
             {

--- a/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
+++ b/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TodoComments
         {
         }
 
-        protected override void AppendTodoComments(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
+        protected override void AppendTodoComments(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
         {
             if (PreprocessorHasComment(trivia))
             {

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             if (RemoteSupportedLanguages.IsSupported(document.Project.Language))
             {
                 var callbackTarget = new RemoteSymbolSearchService(symbolSearchService, cancellationToken);
-                var result = await document.Project.Solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<AddImportFixData>>(
+                var result = await document.Project.Solution.TryRunCodeAnalysisRemoteAsync<IList<AddImportFixData>>(
                     RemoteFeatureOptions.AddImportEnabled,
                     callbackTarget,
                     nameof(IRemoteAddImportFeatureService.GetFixesAsync),
@@ -78,9 +78,9 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
-                if (!result.IsDefault)
+                if (result != null)
                 {
-                    return result;
+                    return result.ToImmutableArray();
                 }
             }
 

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,21 +40,21 @@ namespace Microsoft.CodeAnalysis.AddImport
                 throw new NotImplementedException();
             }
 
-            public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithTypeAsync(
                     source, name, arity, cancellationToken);
             }
 
-            public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string name, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithAssemblyAsync(
                     source, name, cancellationToken);
             }
 
-            public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindReferenceAssembliesWithTypeAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -40,21 +40,21 @@ namespace Microsoft.CodeAnalysis.AddImport
                 throw new NotImplementedException();
             }
 
-            public Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithTypeAsync(
                     source, name, arity, cancellationToken);
             }
 
-            public Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string name, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithAssemblyAsync(
                     source, name, cancellationToken);
             }
 
-            public Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindReferenceAssembliesWithTypeAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal interface IRemoteAddImportFeatureService
     {
-        Task<IReadOnlyList<AddImportFixData>> GetFixesAsync(
+        Task<IList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, IReadOnlyList<PackageSource> packageSources, CancellationToken cancellationToken);
+            bool searchReferenceAssemblies, IList<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,8 +11,8 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal interface IRemoteAddImportFeatureService
     {
-        Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
+        Task<IReadOnlyList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+            bool searchReferenceAssemblies, IReadOnlyList<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.SymbolSearch;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 var desiredName = GetDesiredName(isAttributeSearch, result.TypeName);
                 allReferences.Add(new AssemblyReference(
-                    _owner, new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames, weight), result));
+                    _owner, new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight), result));
             }
 
             private void HandleNugetReference(
@@ -177,7 +178,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 var desiredName = GetDesiredName(isAttributeSearch, result.TypeName);
                 allReferences.Add(new PackageReference(_owner,
-                    new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames, weight),
+                    new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight),
                     source, result.PackageName, result.Version));
             }
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 cancellationToken.ThrowIfCancellationRequested();
                 var results = await _symbolSearchService.FindReferenceAssembliesWithTypeAsync(
                     name, arity, cancellationToken).ConfigureAwait(false);
-                if (results.IsDefault)
+                if (results == null)
                 {
                     return;
                 }
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 cancellationToken.ThrowIfCancellationRequested();
                 var results = await _symbolSearchService.FindPackagesWithTypeAsync(
                     source.Name, name, arity, cancellationToken).ConfigureAwait(false);
-                if (results.IsDefault)
+                if (results == null)
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
 {
     internal interface IRemoteDesignerAttributeService
     {
-        Task<IReadOnlyList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
+        Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
 {
     internal interface IRemoteDesignerAttributeService
     {
-        Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
+        Task<IReadOnlyList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
 {
     internal interface IRemoteDesignerAttributeService
     {
-        Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
+        Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
         private async Task<(bool succeeded, ImmutableArray<DocumentHighlights> highlights)> GetDocumentHighlightsInRemoteProcessAsync(
             Document document, int position, IImmutableSet<Document> documentsToSearch, CancellationToken cancellationToken)
         {
-            var result = await document.Project.Solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableDocumentHighlights>>(
+            var result = await document.Project.Solution.TryRunCodeAnalysisRemoteAsync<IList<SerializableDocumentHighlights>>(
                 RemoteFeatureOptions.DocumentHighlightingEnabled,
                 nameof(IRemoteDocumentHighlights.GetDocumentHighlightsAsync),
                 new object[]
@@ -50,12 +50,12 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                 },
                 cancellationToken).ConfigureAwait(false);
 
-            if (result.IsDefault)
+            if (result == null)
             {
                 return (succeeded: false, ImmutableArray<DocumentHighlights>.Empty);
             }
 
-            return (true, result.SelectAsArray(h => h.Rehydrate(document.Project.Solution)));
+            return (true, result.Select(h => h.Rehydrate(document.Project.Solution)).ToImmutableArray());
         }
 
         private async Task<ImmutableArray<DocumentHighlights>> GetDocumentHighlightsInCurrentProcessAsync(

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                 return (succeeded: false, ImmutableArray<DocumentHighlights>.Empty);
             }
 
-            return (true, result.Select(h => h.Rehydrate(document.Project.Solution)).ToImmutableArray());
+            return (true, result.SelectAsArray(h => h.Rehydrate(document.Project.Solution)));
         }
 
         private async Task<ImmutableArray<DocumentHighlights>> GetDocumentHighlightsInCurrentProcessAsync(

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -9,17 +10,17 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
 {
     internal interface IRemoteDocumentHighlights
     {
-        Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        Task<IReadOnlyList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken);
     }
 
     internal struct SerializableDocumentHighlights
     {
         public DocumentId DocumentId;
-        public ImmutableArray<HighlightSpan> HighlightSpans;
+        public IReadOnlyList<HighlightSpan> HighlightSpans;
 
         public DocumentHighlights Rehydrate(Solution solution)
-            => new DocumentHighlights(solution.GetDocument(DocumentId), HighlightSpans);
+            => new DocumentHighlights(solution.GetDocument(DocumentId), HighlightSpans.ToImmutableArray());
 
         public static SerializableDocumentHighlights Dehydrate(DocumentHighlights highlights)
             => new SerializableDocumentHighlights

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
@@ -10,14 +10,14 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
 {
     internal interface IRemoteDocumentHighlights
     {
-        Task<IReadOnlyList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        Task<IList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken);
     }
 
     internal struct SerializableDocumentHighlights
     {
         public DocumentId DocumentId;
-        public IReadOnlyList<HighlightSpan> HighlightSpans;
+        public IList<HighlightSpan> HighlightSpans;
 
         public DocumentHighlights Rehydrate(Solution solution)
             => new DocumentHighlights(solution.GetDocument(DocumentId), HighlightSpans.ToImmutableArray());

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
@@ -17,11 +19,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         {
             var solution = document.Project.Solution;
 
-            var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableNavigateToSearchResult>>(
+            var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchDocumentAsync),
                 new object[] { document.Id, searchPattern }, cancellationToken).ConfigureAwait(false);
 
-            return serializableResults.NullToEmpty().SelectAsArray(r => r.Rehydrate(solution));
+            return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }
 
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
@@ -29,11 +31,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         {
             var solution = project.Solution;
 
-            var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableNavigateToSearchResult>>(
+            var serializableResults = await client.TryRunCodeAnalysisRemoteAsync<IList<SerializableNavigateToSearchResult>>(
                 solution, nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
                 new object[] { project.Id, searchPattern }, cancellationToken).ConfigureAwait(false);
 
-            return serializableResults.NullToEmpty().SelectAsArray(r => r.Rehydrate(solution));
+            return serializableResults.SelectAsArray(r => r.Rehydrate(solution));
         }
 
         private static async Task<RemoteHostClient> TryGetRemoteHostClientAsync(Project project, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface IRemoteNavigateToSearchService
     {
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, CancellationToken cancellationToken);
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, CancellationToken cancellationToken);
+        Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, CancellationToken cancellationToken);
+        Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface IRemoteNavigateToSearchService
     {
-        Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, CancellationToken cancellationToken);
-        Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, CancellationToken cancellationToken);
+        Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, CancellationToken cancellationToken);
+        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -36,9 +36,9 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
         protected abstract string GetNormalizedText(string message);
         protected abstract int GetCommentStartingIndex(string message);
-        protected abstract void AppendTodoComments(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
+        protected abstract void AppendTodoComments(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
 
-        public async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             // make sure given input is right one
             Contract.ThrowIfFalse(_workspace == document.Project.Solution.Workspace);
@@ -58,17 +58,17 @@ namespace Microsoft.CodeAnalysis.TodoComments
             return await GetTodoCommentsInCurrentProcessAsync(document, commentDescriptors, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsInRemoteHostAsync(
-            RemoteHostClient client, Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        private async Task<IList<TodoComment>> GetTodoCommentsInRemoteHostAsync(
+            RemoteHostClient client, Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             var keepAliveSession = await TryGetKeepAliveSessionAsync(client, cancellationToken).ConfigureAwait(false);
 
-            var result = await keepAliveSession.TryInvokeAsync<IReadOnlyList<TodoComment>>(
+            var result = await keepAliveSession.TryInvokeAsync<IList<TodoComment>>(
                 nameof(IRemoteTodoCommentService.GetTodoCommentsAsync),
                 document.Project.Solution,
                 new object[] { document.Id, commentDescriptors }, cancellationToken).ConfigureAwait(false);
 
-            return result ?? SpecializedCollections.EmptyReadOnlyList<TodoComment>();
+            return result ?? SpecializedCollections.EmptyList<TodoComment>();
         }
 
         private async Task<KeepAliveSession> TryGetKeepAliveSessionAsync(RemoteHostClient client, CancellationToken cancellationToken)
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.TodoComments
             }
         }
 
-        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsInCurrentProcessAsync(
-            Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        private async Task<IList<TodoComment>> GetTodoCommentsInCurrentProcessAsync(
+            Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             return PreprocessorHasComment(trivia) || IsSingleLineComment(trivia) || IsMultilineComment(trivia);
         }
 
-        protected void AppendTodoCommentInfoFromSingleLine(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
+        protected void AppendTodoCommentInfoFromSingleLine(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
         {
             var index = GetCommentStartingIndex(message);
             if (index >= message.Length)
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             }
         }
 
-        protected void ProcessMultilineComment(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
+        protected void ProcessMultilineComment(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
         {
             // this is okay since we know it is already alive
             var text = document.Text;

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -36,9 +36,9 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
         protected abstract string GetNormalizedText(string message);
         protected abstract int GetCommentStartingIndex(string message);
-        protected abstract void AppendTodoComments(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
+        protected abstract void AppendTodoComments(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
 
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             // make sure given input is right one
             Contract.ThrowIfFalse(_workspace == document.Project.Solution.Workspace);
@@ -58,17 +58,17 @@ namespace Microsoft.CodeAnalysis.TodoComments
             return await GetTodoCommentsInCurrentProcessAsync(document, commentDescriptors, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<IList<TodoComment>> GetTodoCommentsInRemoteHostAsync(
-            RemoteHostClient client, Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsInRemoteHostAsync(
+            RemoteHostClient client, Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             var keepAliveSession = await TryGetKeepAliveSessionAsync(client, cancellationToken).ConfigureAwait(false);
 
-            var result = await keepAliveSession.TryInvokeAsync<IList<TodoComment>>(
+            var result = await keepAliveSession.TryInvokeAsync<IReadOnlyList<TodoComment>>(
                 nameof(IRemoteTodoCommentService.GetTodoCommentsAsync),
                 document.Project.Solution,
                 new object[] { document.Id, commentDescriptors }, cancellationToken).ConfigureAwait(false);
 
-            return result ?? SpecializedCollections.EmptyList<TodoComment>();
+            return result ?? SpecializedCollections.EmptyReadOnlyList<TodoComment>();
         }
 
         private async Task<KeepAliveSession> TryGetKeepAliveSessionAsync(RemoteHostClient client, CancellationToken cancellationToken)
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.TodoComments
             }
         }
 
-        private async Task<IList<TodoComment>> GetTodoCommentsInCurrentProcessAsync(
-            Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        private async Task<IReadOnlyList<TodoComment>> GetTodoCommentsInCurrentProcessAsync(
+            Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             return PreprocessorHasComment(trivia) || IsSingleLineComment(trivia) || IsMultilineComment(trivia);
         }
 
-        protected void AppendTodoCommentInfoFromSingleLine(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
+        protected void AppendTodoCommentInfoFromSingleLine(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
         {
             var index = GetCommentStartingIndex(message);
             if (index >= message.Length)
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             }
         }
 
-        protected void ProcessMultilineComment(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
+        protected void ProcessMultilineComment(IReadOnlyList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
         {
             // this is okay since we know it is already alive
             var text = document.Text;

--- a/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
     /// </summary>
     internal interface IRemoteTodoCommentService
     {
-        Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
+        Task<IList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
     /// </summary>
     internal interface IRemoteTodoCommentService
     {
-        Task<IList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
+        Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
@@ -42,6 +42,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
     internal interface ITodoCommentService : ILanguageService
     {
-        Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
+        Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
@@ -42,6 +42,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
     internal interface ITodoCommentService : ILanguageService
     {
-        Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
+        Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(Document document, IReadOnlyList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
+++ b/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.TodoComments
             MyBase.New(workspace)
         End Sub
 
-        Protected Overrides Sub AppendTodoComments(commentDescriptors As IReadOnlyList(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
+        Protected Overrides Sub AppendTodoComments(commentDescriptors As IList(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
             If PreprocessorHasComment(trivia) Then
                 Dim commentTrivia = trivia.GetStructure().DescendantTrivia().First(Function(t) t.RawKind = SyntaxKind.CommentTrivia)
 

--- a/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
+++ b/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.TodoComments
             MyBase.New(workspace)
         End Sub
 
-        Protected Overrides Sub AppendTodoComments(commentDescriptors As ImmutableArray(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
+        Protected Overrides Sub AppendTodoComments(commentDescriptors As IReadOnlyList(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
             If PreprocessorHasComment(trivia) Then
                 Dim commentTrivia = trivia.GetStructure().DescendantTrivia().First(Function(t) t.RawKind = SyntaxKind.CommentTrivia)
 

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                     return null;
                 }
 
-                var serializedResults = await session.InvokeAsync<IReadOnlyList<DesignerAttributeDocumentData>>(
+                var serializedResults = await session.InvokeAsync<IList<DesignerAttributeDocumentData>>(
                     nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), new object[] { project.Id }, cancellationToken).ConfigureAwait(false);
 
                 var data = serializedResults.ToImmutableDictionary(kvp => kvp.FilePath);

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                     return null;
                 }
 
-                var serializedResults = await session.InvokeAsync<ImmutableArray<DesignerAttributeDocumentData>>(
+                var serializedResults = await session.InvokeAsync<IList<DesignerAttributeDocumentData>>(
                     nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), new object[] { project.Id }, cancellationToken).ConfigureAwait(false);
 
                 var data = serializedResults.ToImmutableDictionary(kvp => kvp.FilePath);

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                     return null;
                 }
 
-                var serializedResults = await session.InvokeAsync<IList<DesignerAttributeDocumentData>>(
+                var serializedResults = await session.InvokeAsync<IReadOnlyList<DesignerAttributeDocumentData>>(
                     nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), new object[] { project.Id }, cancellationToken).ConfigureAwait(false);
 
                 var data = serializedResults.ToImmutableDictionary(kvp => kvp.FilePath);

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             await engine.UpdateContinuouslyAsync(sourceName, _localSettingsDirectory).ConfigureAwait(false);
         }
 
-        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return FilterAndOrderPackages(allPackagesWithType);
         }
 
-        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return result.ToImmutableAndFree();
         }
 
-        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             await engine.UpdateContinuouslyAsync(sourceName, _localSettingsDirectory).ConfigureAwait(false);
         }
 
-        public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return FilterAndOrderPackages(allPackagesWithType);
         }
 
-        public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return result.ToImmutableAndFree();
         }
 
-        public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -99,12 +100,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
 
-            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<IList<SerializableSymbolAndProjectId>>(
                 RemoteFeatureOptions.SymbolFinderEnabled,
                 nameof(IRemoteSymbolFinder.FindAllDeclarationsWithNormalQueryAsync),
                 new object[] { project.Id, query.Name, query.Kind, criteria }, cancellationToken).ConfigureAwait(false);
 
-            if (result.IsDefault)
+            if (result == null)
             {
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
@@ -116,9 +117,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static async Task<ImmutableArray<SymbolAndProjectId>> RehydrateAsync(
-            Solution solution, ImmutableArray<SerializableSymbolAndProjectId> array, CancellationToken cancellationToken)
+            Solution solution, IList<SerializableSymbolAndProjectId> array, CancellationToken cancellationToken)
         {
-            var result = ArrayBuilder<SymbolAndProjectId>.GetInstance(array.Length);
+            var result = ArrayBuilder<SymbolAndProjectId>.GetInstance(array.Count);
 
             foreach (var dehydrated in array)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -115,12 +116,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static async Task<(bool, ImmutableArray<SymbolAndProjectId>)> TryFindSourceDeclarationsWithNormalQueryInRemoteProcessAsync(
             Solution solution, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            var result = await solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+            var result = await solution.TryRunCodeAnalysisRemoteAsync<IList<SerializableSymbolAndProjectId>>(
                 RemoteFeatureOptions.SymbolFinderEnabled,
                 nameof(IRemoteSymbolFinder.FindSolutionSourceDeclarationsWithNormalQueryAsync),
                 new object[] { name, ignoreCase, criteria }, cancellationToken).ConfigureAwait(false);
 
-            if (result.IsDefault)
+            if (result == null)
             {
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
@@ -139,12 +140,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
 
-            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<IList<SerializableSymbolAndProjectId>>(
                 RemoteFeatureOptions.SymbolFinderEnabled,
                 nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithNormalQueryAsync),
                 new object[] { project.Id, name, ignoreCase, criteria }, cancellationToken).ConfigureAwait(false);
 
-            if (result.IsDefault)
+            if (result == null)
             {
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
@@ -163,12 +164,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }
 
-            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+            var result = await project.Solution.TryRunCodeAnalysisRemoteAsync<IList<SerializableSymbolAndProjectId>>(
                 RemoteFeatureOptions.SymbolFinderEnabled,
                 nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithPatternAsync),
                 new object[] { project.Id, pattern, criteria }, cancellationToken).ConfigureAwait(false);
 
-            if (result.IsDefault)
+            if (result == null)
             {
                 return (false, ImmutableArray<SymbolAndProjectId>.Empty);
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
@@ -14,16 +14,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken);
         Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken);
 
-        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,16 +14,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken);
         Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     {
         Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory);
 
-        Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
-        Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-        Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
+        Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
+        Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
+        Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,8 +11,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     {
         Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory);
 
-        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
-        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
-        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
+        Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
+        Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
+        Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken);
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken);
     }
 
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class PackageWithTypeResult : PackageResult
     {
-        public readonly ImmutableArray<string> ContainingNamespaceNames;
+        public readonly IReadOnlyList<string> ContainingNamespaceNames;
         public readonly string TypeName;
         public readonly string Version;
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             string typeName,
             string version,
             int rank,
-            ImmutableArray<string> containingNamespaceNames)
+            IReadOnlyList<string> containingNamespaceNames)
             : base(packageName, rank)
         {
             TypeName = typeName;
@@ -118,14 +118,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class ReferenceAssemblyWithTypeResult
     {
-        public readonly ImmutableArray<string> ContainingNamespaceNames;
+        public readonly IReadOnlyList<string> ContainingNamespaceNames;
         public readonly string AssemblyName;
         public readonly string TypeName;
 
         public ReferenceAssemblyWithTypeResult(
             string assemblyName,
             string typeName,
-            ImmutableArray<string> containingNamespaceNames)
+            IReadOnlyList<string> containingNamespaceNames)
         {
             AssemblyName = assemblyName;
             TypeName = typeName;
@@ -136,22 +136,22 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     [ExportWorkspaceService(typeof(ISymbolSearchService)), Shared]
     internal class DefaultSymbolSearchService : ISymbolSearchService
     {
-        public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<PackageWithTypeResult>();
+            return SpecializedTasks.EmptyReadOnlyList<PackageWithTypeResult>();
         }
 
-        public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<PackageWithAssemblyResult>();
+            return SpecializedTasks.EmptyReadOnlyList<PackageWithAssemblyResult>();
         }
 
-        public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<ReferenceAssemblyWithTypeResult>();
+            return SpecializedTasks.EmptyReadOnlyList<ReferenceAssemblyWithTypeResult>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken);
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken);
     }
 
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class PackageWithTypeResult : PackageResult
     {
-        public readonly IReadOnlyList<string> ContainingNamespaceNames;
+        public readonly IList<string> ContainingNamespaceNames;
         public readonly string TypeName;
         public readonly string Version;
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             string typeName,
             string version,
             int rank,
-            IReadOnlyList<string> containingNamespaceNames)
+            IList<string> containingNamespaceNames)
             : base(packageName, rank)
         {
             TypeName = typeName;
@@ -118,14 +118,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class ReferenceAssemblyWithTypeResult
     {
-        public readonly IReadOnlyList<string> ContainingNamespaceNames;
+        public readonly IList<string> ContainingNamespaceNames;
         public readonly string AssemblyName;
         public readonly string TypeName;
 
         public ReferenceAssemblyWithTypeResult(
             string assemblyName,
             string typeName,
-            IReadOnlyList<string> containingNamespaceNames)
+            IList<string> containingNamespaceNames)
         {
             AssemblyName = assemblyName;
             TypeName = typeName;
@@ -136,22 +136,22 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     [ExportWorkspaceService(typeof(ISymbolSearchService)), Shared]
     internal class DefaultSymbolSearchService : ISymbolSearchService
     {
-        public Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyReadOnlyList<PackageWithTypeResult>();
+            return SpecializedTasks.EmptyList<PackageWithTypeResult>();
         }
 
-        public Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyReadOnlyList<PackageWithAssemblyResult>();
+            return SpecializedTasks.EmptyList<PackageWithAssemblyResult>();
         }
 
-        public Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyReadOnlyList<ReferenceAssemblyWithTypeResult>();
+            return SpecializedTasks.EmptyList<ReferenceAssemblyWithTypeResult>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/IReadOnlyListExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IReadOnlyListExtensions.cs
@@ -1,12 +1,38 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
     internal static class IReadOnlyListExtensions
     {
+        public static IReadOnlyList<T> ToReadOnlyList<T>(this IList<T> list)
+        {
+            if (list is IReadOnlyList<T> readOnlyList)
+            {
+                return readOnlyList;
+            }
+
+            return new ReadOnlyList<T>(list);
+        }
+
         public static T Last<T>(this IReadOnlyList<T> list)
         {
             return list[list.Count - 1];
+        }
+
+        private class ReadOnlyList<T> : IReadOnlyList<T>
+        {
+            private readonly IList<T> _list;
+
+            public ReadOnlyList(IList<T> list)
+            {
+                _list = list;
+            }
+
+            public T this[int index] => _list[index];
+            public int Count => _list.Count;
+            public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
@@ -28,6 +28,16 @@ namespace Roslyn.Utilities
             return Task.FromResult(value);
         }
 
+        public static Task<IReadOnlyList<T>> EmptyReadOnlyList<T>()
+        {
+            return Empty<T>.EmptyReadOnlyList;
+        }
+
+        public static Task<IList<T>> EmptyList<T>()
+        {
+            return Empty<T>.EmptyList;
+        }
+
         public static Task<ImmutableArray<T>> EmptyImmutableArray<T>()
         {
             return Empty<T>.EmptyImmutableArray;
@@ -48,6 +58,8 @@ namespace Roslyn.Utilities
             public static readonly Task<T> Default = Task.FromResult<T>(default);
             public static readonly Task<IEnumerable<T>> EmptyEnumerable = Task.FromResult<IEnumerable<T>>(SpecializedCollections.EmptyEnumerable<T>());
             public static readonly Task<ImmutableArray<T>> EmptyImmutableArray = Task.FromResult(ImmutableArray<T>.Empty);
+            public static readonly Task<IList<T>> EmptyList = Task.FromResult(SpecializedCollections.EmptyList<T>());
+            public static readonly Task<IReadOnlyList<T>> EmptyReadOnlyList = Task.FromResult(SpecializedCollections.EmptyReadOnlyList<T>());
         }
 
         private static class FromResultCache<T> where T : class

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteAddImportFeatureService
     {
-        public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
+        public async Task<IReadOnlyList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
+            bool searchReferenceAssemblies, IReadOnlyList<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var result = await service.GetFixesAsync(
                     document, span, diagnosticId, placeSystemNamespaceFirst,
                     symbolSearchService, searchReferenceAssemblies,
-                    packageSources, cancellationToken).ConfigureAwait(false);
+                    packageSources.ToImmutableArray(), cancellationToken).ConfigureAwait(false);
 
                 return result;
             }
@@ -54,28 +55,28 @@ namespace Microsoft.CodeAnalysis.Remote
                 this.codeAnalysisService = codeAnalysisService;
             }
 
-            public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<PackageWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<PackageWithTypeResult>>(
                     nameof(FindPackagesWithTypeAsync), source, name, arity).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<PackageWithAssemblyResult>>(
                     nameof(FindPackagesWithAssemblyAsync), source, assemblyName).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<ReferenceAssemblyWithTypeResult>>(
                     nameof(FindReferenceAssembliesWithTypeAsync), name, arity).ConfigureAwait(false);
 
                 return result;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteAddImportFeatureService
     {
-        public async Task<IReadOnlyList<AddImportFixData>> GetFixesAsync(
+        public async Task<IList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, IReadOnlyList<PackageSource> packageSources, CancellationToken cancellationToken)
+            bool searchReferenceAssemblies, IList<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
@@ -55,28 +55,28 @@ namespace Microsoft.CodeAnalysis.Remote
                 this.codeAnalysisService = codeAnalysisService;
             }
 
-            public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<PackageWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithTypeResult>>(
                     nameof(FindPackagesWithTypeAsync), source, name, arity).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<PackageWithAssemblyResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithAssemblyResult>>(
                     nameof(FindPackagesWithAssemblyAsync), source, assemblyName).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<IReadOnlyList<ReferenceAssemblyWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
                     nameof(FindReferenceAssembliesWithTypeAsync), name, arity).ConfigureAwait(false);
 
                 return result;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, cancellationToken))
             {
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 if (data.Count == 0)
                 {
-                    return SpecializedCollections.EmptyList<DesignerAttributeDocumentData>();
+                    return SpecializedCollections.EmptyReadOnlyList<DesignerAttributeDocumentData>();
                 }
 
                 return data.Values.ToList();

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IReadOnlyList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
+        public async Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, cancellationToken))
             {
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 if (data.Count == 0)
                 {
-                    return SpecializedCollections.EmptyReadOnlyList<DesignerAttributeDocumentData>();
+                    return SpecializedCollections.EmptyList<DesignerAttributeDocumentData>();
                 }
 
                 return data.Values.ToList();

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DesignerAttributes;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Roslyn.Utilities;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -17,16 +19,22 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
+        public async Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, cancellationToken))
             {
                 var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
+
                 var data = await AbstractDesignerAttributeService.TryAnalyzeProjectInCurrentProcessAsync(
                     project, cancellationToken).ConfigureAwait(false);
 
-                return data.Values.ToImmutableArray();
+                if (data.Count == 0)
+                {
+                    return SpecializedCollections.EmptyList<DesignerAttributeDocumentData>();
+                }
+
+                return data.Values.ToList();
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : IRemoteDocumentHighlights
     {
-        public async Task<IReadOnlyList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        public async Task<IList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken)
         {
             // NOTE: In projection scenarios, we might get a set of documents to search

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : IRemoteDocumentHighlights
     {
-        public async Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        public async Task<IReadOnlyList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken)
         {
             // NOTE: In projection scenarios, we might get a set of documents to search

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteNavigateToSearchService
     {
-        public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(
+        public async Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchDocumentAsync(
             DocumentId documentId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(
+        public async Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchProjectAsync(
             ProjectId projectId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteNavigateToSearchService
     {
-        public async Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchDocumentAsync(
+        public async Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(
             DocumentId documentId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<IReadOnlyList<SerializableNavigateToSearchResult>> SearchProjectAsync(
+        public async Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(
             ProjectId projectId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -59,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        public async Task<IReadOnlyList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, ImmutableArray<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IReadOnlyList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, cancellationToken))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
                 }
 
-                return SpecializedCollections.EmptyList<TodoComment>();
+                return SpecializedCollections.EmptyReadOnlyList<TodoComment>();
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IReadOnlyList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IReadOnlyList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, cancellationToken))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
                 }
 
-                return SpecializedCollections.EmptyReadOnlyList<TodoComment>();
+                return SpecializedCollections.EmptyList<TodoComment>();
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
         }
 
-        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithTypeAsync(
                 source, name, arity, cancellationToken).ConfigureAwait(false);
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithAssemblyAsync(
                 source, assemblyName, cancellationToken).ConfigureAwait(false);
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindReferenceAssembliesWithTypeAsync(
                 name, arity, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
         }
 
-        public async Task<IReadOnlyList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
+        public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithTypeAsync(
                 source, name, arity, cancellationToken).ConfigureAwait(false);
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<IReadOnlyList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
+        public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithAssemblyAsync(
                 source, assemblyName, cancellationToken).ConfigureAwait(false);
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<IReadOnlyList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
+        public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindReferenceAssembliesWithTypeAsync(
                 name, arity, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
ImmutableArray is causing isssue on Json lib. use regular List since we don't actually need immutable array here.

fixing this 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/473979

no heap, but callstack shows that immutable array is default, but we are getting it from json.net lib. we could check isDefault, but I dont want to get into hassle until I know newston.json supports immutable array reliably. moving back to non immutable collection when crossing json.