### PR TITLE
Do not insert Microsoft.DiaSymReader.Native

### DIFF
--- a/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
+++ b/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
@@ -25,9 +25,6 @@
     <PackageReference Include="Microsoft.DiaSymReader">
       <Version>$(MicrosoftDiaSymReaderVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.DiaSymReader.Native">
-      <Version>$(MicrosoftDiaSymReaderNativeVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie">
       <Version>$(MicrosoftCodeAnalysisElfieVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
Microsoft.DiaSymReader.Native is inserted by VCTools redist package. We should stop inserting it into ExternalAPIs.

I'll follow up with deleting the entry from corext config file in vsuml branch, once we insert with this change.