### PR TITLE
Recommend 'case' keyword after a pattern-case-clause.

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/CaseKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/CaseKeywordRecommenderTests.cs
@@ -95,6 +95,15 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterPatternCase()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"switch (expr) {
+    case String s:
+    $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterOneStatement()
         {
             await VerifyKeywordAsync(AddInsideMethod(
@@ -103,6 +112,17 @@ $$");
       Console.WriteLine();
     $$"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterOneStatementPatternCase()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"switch (expr) {
+    case String s:
+      Console.WriteLine();
+    $$"));
+        }
+
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterTwoStatements()
@@ -121,6 +141,16 @@ $$");
             await VerifyKeywordAsync(AddInsideMethod(
 @"switch (expr) {
     default: {
+    }
+    $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterBlockPatternCase()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"switch (expr) {
+    case String s: {
     }
     $$"));
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -387,7 +387,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             if (targetToken.Kind() == SyntaxKind.ColonToken)
             {
-                if (targetToken.Parent.IsKind(SyntaxKind.CaseSwitchLabel, SyntaxKind.DefaultSwitchLabel))
+                if (targetToken.Parent.IsKind(
+                        SyntaxKind.CaseSwitchLabel, SyntaxKind.DefaultSwitchLabel, SyntaxKind.CasePatternSwitchLabel))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21411