### PR TITLE
Include System.Runtime.Serialization.Primitives and System.Security.Cryptography.Csp in PortableFacades CoreXT package.

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -194,6 +194,7 @@
     <SystemRuntimeSerializationPrimitivesVersion>4.3.0</SystemRuntimeSerializationPrimitivesVersion>
     <SystemSecurityAccessControlVersion>4.3.0</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyAlgorithmsVersion>4.3.0</SystemSecurityCryptographyAlgorithmsVersion>
+    <SystemSecurityCryptographyCspVersion>4.3.0</SystemSecurityCryptographyCspVersion>
     <SystemSecurityCryptographyEncodingVersion>4.3.0</SystemSecurityCryptographyEncodingVersion>
     <SystemSecurityCryptographyPrimitivesVersion>4.3.0</SystemSecurityCryptographyPrimitivesVersion>
     <SystemSecurityCryptographyX509CertificatesVersion>4.3.0</SystemSecurityCryptographyX509CertificatesVersion>

--- a/src/Setup/DevDivPackages/Debugger/DevDivPackagesDebugger.csproj
+++ b/src/Setup/DevDivPackages/Debugger/DevDivPackagesDebugger.csproj
@@ -46,6 +46,9 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
       <Version>$(SystemRuntimeInteropServicesRuntimeInformationVersion)</Version>
     </PackageReference>
+    <PackageReference Include="System.Runtime.Serialization.Primitives">
+      <Version>$(SystemRuntimeSerializationPrimitivesVersion)</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Cryptography.X509Certificates">
       <Version>$(SystemSecurityCryptographyX509CertificatesVersion)</Version>
     </PackageReference>

--- a/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
+++ b/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
@@ -85,6 +85,9 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms">
       <Version>$(SystemSecurityCryptographyAlgorithmsVersion)</Version>
     </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Csp">
+      <Version>$(SystemSecurityCryptographyCspVersion)</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Encoding">
       <Version>$(SystemSecurityCryptographyEncodingVersion)</Version>
     </PackageReference>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=PortableFacades
-        version=1.4.0.0
+        version=1.5.0.0
 
 folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.AppContext\4.3.0\lib\net46\System.AppContext.dll" vs.file.ngen=yes
@@ -16,9 +16,11 @@ folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.Net.Security\4.3.0\runtimes\win\lib\net46\System.Net.Security.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Net.Sockets\4.3.0\lib\net46\System.Net.Sockets.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Reflection.TypeExtensions\4.3.0\lib\net46\System.Reflection.TypeExtensions.dll" vs.file.ngen=yes
+    file source="$(NuGetPackageRoot)\System.Runtime.Serialization.Primitives\4.3.0\lib\net46\System.Runtime.Serialization.Primitives.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.AccessControl\4.3.0\runtimes\win\lib\net46\System.Security.AccessControl.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Claims\4.3.0\lib\net46\System.Security.Claims.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Algorithms\4.3.0\runtimes\win\lib\net46\System.Security.Cryptography.Algorithms.dll" vs.file.ngen=yes
+    file source="$(NuGetPackageRoot)\System.Security.Cryptography.Csp\4.3.0\runtimes\win\lib\net46\System.Security.Cryptography.Csp.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Encoding\4.3.0\runtimes\win\lib\net46\System.Security.Cryptography.Encoding.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Primitives\4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.X509Certificates\4.3.0\runtimes\win\lib\net46\System.Security.Cryptography.X509Certificates.dll" vs.file.ngen=yes


### PR DESCRIPTION
Need to update [vsuml](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/80304) config files first before merging.