### PR TITLE
Consider trivia when testing code fixes and refactorings

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.cs
@@ -100,6 +100,7 @@ namespace Outer
             event Action I.e6 { add { } remote { } }
 
             static C() { }
+
             private C() { }
             public C(int i) { }
 

--- a/src/EditorFeatures/CSharpTest/AddBraces/AddBracesFixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddBraces/AddBracesFixAllTests.cs
@@ -26,7 +26,13 @@ class Program1
 {
     static void Main()
     {
-        if (true) { if (true) { return; } }
+        if (true)
+        {
+            if (true)
+            {
+                return;
+            }
+        }
     }
 }
 ";
@@ -53,7 +59,13 @@ class Program1
 {
     static void Main()
     {
-        if (true) { if (true) { return; } }
+        if (true)
+        {
+            if (true)
+            {
+                return;
+            }
+        }
     }
 }
 ";

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
             string initialMarkup,
             string expectedMarkup,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             CodeActionPriority? priority = null,
             IDictionary<OptionKey, object> options = null)
         {

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -1807,7 +1807,9 @@ ignoreTrivia: false);
         {
             await TestAsync(
 @"class Program { static void Main ( string [ ] args ) { [|Console|] . Out . NewLine = ""\r\n\r\n"" ; } } ",
-@"using System ; class Program { static void Main ( string [ ] args ) { Console . Out . NewLine = ""\r\n\r\n"" ; } } ");
+@"using System;
+
+class Program { static void Main ( string [ ] args ) { Console . Out . NewLine = ""\r\n\r\n"" ; } } ");
         }
 
         [WorkItem(539853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539853")]
@@ -1817,7 +1819,9 @@ ignoreTrivia: false);
             await TestAsync(
 @"using System.Console; WriteLine([|Expression|].Constant(123));",
 @"using System.Console;
-using System.Linq.Expressions; WriteLine(Expression.Constant(123));",
+using System.Linq.Expressions;
+
+WriteLine(Expression.Constant(123));",
 parseOptions: GetScriptOptions());
         }
 
@@ -2146,7 +2150,7 @@ ignoreTrivia: false);
 input,
 @"using System.Runtime.InteropServices;
 
-[assembly: Guid(""9ed54f84-a89d-4fcd-a854-44251e925f09"")]");
+[ assembly : Guid ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ");
         }
 
         [WorkItem(546833, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546833")]
@@ -2420,6 +2424,7 @@ namespace ExternAliases
             const string ExpectedDocumentText = @"extern alias P;
 
 using P::ProjectLib;
+
 namespace ExternAliases
 {
     class Program
@@ -2477,7 +2482,8 @@ namespace ExternAliases
     </Project>
 </Workspace>";
 
-            const string ExpectedDocumentText = @"extern alias P;
+            const string ExpectedDocumentText = @"
+extern alias P;
 
 using P::AnotherNS;
 using P::ProjectLib;
@@ -2531,6 +2537,7 @@ namespace ExternAliases
 </Workspace>";
 
             const string ExpectedDocumentText = @"extern alias P;
+
 using P::AnotherNS;
 namespace ExternAliases
 {
@@ -2646,7 +2653,7 @@ namespace N1
 
 public class MyClass
 {
-    public static explicit operator N1.D(MyClass f)
+    public static explicit operator N1.D (MyClass f)
     {
         return default(N1.D);
     }
@@ -3058,14 +3065,17 @@ namespace Extensions
 </Workspace> ";
 
             var expectedText =
-@"using Extensions;
+@"
+using Extensions;
+
 public class C
 {
     void Main(C a)
     {
         C x = a?.B();
     }
-}";
+}
+       ";
             await TestAsync(initialText, expectedText);
         }
 
@@ -3104,7 +3114,9 @@ namespace Extensions
 </Workspace> ";
 
             var expectedText =
-@"using Extensions;
+@"
+using Extensions;
+
 public class C
 {
     public E B { get; private set; }
@@ -3117,7 +3129,8 @@ public class C
     public class E
     {
     }
-}";
+}
+       ";
             await TestAsync(initialText, expectedText);
         }
 
@@ -3844,8 +3857,8 @@ namespace X
 }",
 @"namespace Microsoft.MyApp
 {
-#if true
     using Microsoft.Win32.SafeHandles;
+#if true
     using Win32;
 #else
     using System;
@@ -4102,7 +4115,7 @@ using System.Collections.Generic;
 
 static void Main(string[] args)
 {
-    Func<int> f = () => { List<int>.}
+    Func<int> f = () => { List<int>. }
 }";
             await TestAsync(initialText, expectedText);
         }
@@ -4125,7 +4138,7 @@ using System.Collections.Generic;
 
 static void Main(string[] args)
 {
-    Func<int> f = () => { List<int>}
+    Func<int> f = () => { List<int> }
 }";
             await TestAsync(initialText, expectedText);
         }
@@ -4645,6 +4658,7 @@ namespace Outer
     {
         void M()
         {
+            // Note: IVsStatusBar is cased incorrectly.
             IVsStatusbar b;
         }
     }

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -967,7 +967,9 @@ namespace Sample.Extensions
 </Workspace>";
 
             var expectedText =
-@"using Sample.Extensions;
+@"
+using Sample.Extensions;
+
 namespace Sample
 {
     class Program
@@ -978,7 +980,8 @@ namespace Sample
             var other = myString?.StringExtension().Substring(0);
         }
     }
-}";
+}
+       ";
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 
@@ -1014,14 +1017,17 @@ namespace Sample.Extensions
 </Workspace>";
 
             var expectedText =
-@"using Sample.Extensions;
+@"
+using Sample.Extensions;
+
 public class C
 {
     public T F<T>(T x)
     {
         return F(new C())?.F(new C())?.Extn();
     }
-}";
+}
+       ";
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 
@@ -1057,14 +1063,17 @@ namespace Sample.Extensions
 </Workspace>";
 
             var expectedText =
-@"using Sample.Extensions;
+@"
+using Sample.Extensions;
+
 public class C
 {
     public T F<T>(T x)
     {
         return F(new C())?.F(new C()).Extn()?.F(newC());
     }
-}";
+}
+       ";
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchTests.cs
@@ -897,8 +897,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2: return;
-            case 10: return;
+            case 1 when i == 2:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -925,8 +927,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && i == 3: return;
-            case 10: return;
+            case 1 when i == 2 && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -953,8 +957,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && (i == 3): return;
-            case 10: return;
+            case 1 when i == 2 && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -981,8 +987,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && i == 3: return;
-            case 10: return;
+            case 1 when (i == 2) && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1009,8 +1017,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && (i == 3): return;
-            case 10: return;
+            case 1 when (i == 2) && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1037,8 +1047,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && i == 3: return;
-            case 10: return;
+            case 1 when i == 2 && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1065,8 +1077,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && (i == 3): return;
-            case 10: return;
+            case 1 when i == 2 && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1093,8 +1107,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && i == 3: return;
-            case 10: return;
+            case 1 when (i == 2) && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1121,8 +1137,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && (i == 3): return;
-            case 10: return;
+            case 1 when (i == 2) && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1149,8 +1167,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && i == 3: return;
-            case 10: return;
+            case 1 when i == 2 && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1177,8 +1197,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && i == 3: return;
-            case 10: return;
+            case 1 when i == 2 && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1205,8 +1227,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && i == 3: return;
-            case 10: return;
+            case 1 when i == 2 && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1233,8 +1257,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && i == 3: return;
-            case 10: return;
+            case 1 when (i == 2) && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1261,8 +1287,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && (i == 3): return;
-            case 10: return;
+            case 1 when (i == 2) && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1289,8 +1317,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when (i == 2) && i == 3: return;
-            case 10: return;
+            case 1 when (i == 2) && i == 3:
+                return;
+            case 10:
+                return;
         }
     }
 }");
@@ -1317,8 +1347,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
     {
         switch (i)
         {
-            case 1 when i == 2 && (i == 3): return;
-            case 10: return;
+            case 1 when i == 2 && (i == 3):
+                return;
+            case 10:
+                return;
         }
     }
 }");

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -190,12 +190,7 @@ class goo
 {
     private int bar;
 
-    public int Bar
-    {
-        get => bar;
-
-        set => bar = value;
-    }
+    public int Bar { get => bar; set => bar = value; }
 
     void baz()
     {
@@ -999,7 +994,7 @@ partial class Program {
 partial class Program {}
 
 partial class Program {
-    private int x;
+   private int x;
 
     public int X
     {
@@ -1007,6 +1002,7 @@ partial class Program {
         {
             return x;
         }
+
         set
         {
             x = value;
@@ -1080,7 +1076,8 @@ namespace ConsoleApplication1
             }
         }
     }
-}";
+}
+";
 
             await TestAllOptionsOffAsync(text, expected);
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Encaps
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions = null,
             CompilationOptions compilationOptions = null,
-            int index = 0, bool ignoreTrivia = true,
+            int index = 0, bool ignoreTrivia = false,
             IDictionary<OptionKey, object> options = null)
         {
             options = options ?? new Dictionary<OptionKey, object>();

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -151,8 +151,8 @@ options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCode
 
     private static bool NewMethod(bool b)
     {
-        return b != 
-            true;
+        return b !=
+                    true;
     }
 }",
 options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.WhenOnSingleLineWithNoneEnforcement));
@@ -304,7 +304,8 @@ class C
 {
     static void Main(string[] args)
     {
-        del q = x => {
+        del q = x =>
+        {
             goto label2;
             return {|Rename:NewMethod|}(x);
         };
@@ -1291,6 +1292,7 @@ ignoreTrivia: false);
         int r;
         int y;
         {|Rename:NewMethod|}(out r, out y);
+
         System.Console.WriteLine(r + y);
     }
 
@@ -1331,6 +1333,7 @@ ignoreTrivia: false);
         int r;
         int y;
         {|Rename:NewMethod|}(out r, out y);
+
         System.Console.WriteLine(r + y);
     }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new InlineTemporaryCodeRefactoringProvider();
 
-        private async Task TestFixOneAsync(string initial, string expected, bool ignoreTrivia = true)
+        private async Task TestFixOneAsync(string initial, string expected, bool ignoreTrivia = false)
         {
             await TestInRegularAndScriptAsync(GetTreeText(initial), GetTreeText(expected));
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -117,7 +117,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
 @"{ int [||]x = 0;
 
 Console.WriteLine(x); }",
-                       @"{ Console.WriteLine(0); }");
+@"{
+        Console.WriteLine(0); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -127,7 +128,8 @@ Console.WriteLine(x); }",
 @"{ int [||]@x = 0;
 
 Console.WriteLine(x); }",
-                       @"{ Console.WriteLine(0); }");
+@"{
+        Console.WriteLine(0); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -137,7 +139,8 @@ Console.WriteLine(x); }",
 @"{ int [||]@x = 0;
 
 Console.WriteLine(@x); }",
-                       @"{ Console.WriteLine(0); }");
+@"{
+        Console.WriteLine(0); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -147,7 +150,8 @@ Console.WriteLine(@x); }",
 @"{ int [||]x = 0;
 
 Console.WriteLine(@x); }",
-                       @"{ Console.WriteLine(0); }");
+@"{
+        Console.WriteLine(0); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -361,7 +365,8 @@ class C
 @"{ var [||]x = 0;
 
 Console.WriteLine(x); }",
-                       @"{ Console.WriteLine(0); }");
+@"{
+        Console.WriteLine(0); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -646,7 +651,12 @@ class Program
     5
 };
 int a = Array.IndexOf(x, 3); }",
-                       @"{ int a = Array.IndexOf(new int[] { 3, 4, 5 }, 3);  }");
+@"{
+        int a = Array.IndexOf(new int[] {
+        3,
+        4,
+        5
+    }, 3); }");
         }
 
         [WorkItem(545657, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545657")]
@@ -1341,15 +1351,16 @@ class C
 
     int a = x;
 }",
-                       @"{
+@"
+{
         int
 #if true
-            y,
+        y,
 #endif
-            z;
+        z;
 
         int a = 1;
-    }",
+}",
 ignoreTrivia: false);
         }
 
@@ -1366,15 +1377,14 @@ ignoreTrivia: false);
 
     int a = x;
 }",
-                       @"{
+@"
+{
         int y,
-#if true
-
 #endif
-            z;
+        z;
 
         int a = 1;
-    }",
+}",
 ignoreTrivia: false);
         }
 
@@ -1391,15 +1401,14 @@ ignoreTrivia: false);
 
     int a = x;
 }",
-                       @"{
+@"
+{
         int y,
 #if true
-            z
-#endif
-            ;
+        z;
 
         int a = 1;
-    }",
+}",
 ignoreTrivia: false);
         }
 
@@ -4095,7 +4104,7 @@ class Program
 {
     static void Main()
     {
-        var(x1, x2) = KVP.Create(42, ""hello"");
+        var (x1, x2) = KVP.Create(42, ""hello"");
     }
 }
 public static class KVP

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2208,7 +2208,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, int> f = x => {
+        Func<int, int> f = x =>
+        {
             var {|Rename:v|} = x + 1;
             return v;
         };
@@ -2237,7 +2238,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, Func<int, int>> f = x => {
+        Func<int, Func<int, int>> f = x =>
+        {
             var {|Rename:v|} = x + 1;
             return y => v;
         };
@@ -2266,7 +2268,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, Func<int, int>> f = x => y => {
+        Func<int, Func<int, int>> f = x => y =>
+        {
             var {|Rename:v|} = y + 1;
             return v;
         };
@@ -2321,7 +2324,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int, Func<int, int>> f = x => {
+        Func<int, Func<int, int>> f = x =>
+        {
             Func<int, int> {|Rename:p|} = y => x + 1;
             return p;
         };
@@ -2349,7 +2353,8 @@ class Program
 {
     void M()
     {
-        Action<int> goo = x => {
+        Action<int> goo = x =>
+        {
             object {|Rename:goo1|} = x.Goo;
         };
     }
@@ -4034,8 +4039,7 @@ class C
         }
     }
 }",
-@"
-class Program
+@"class Program
 {
     class MySpan { public int Start { get; } public int End { get; } }
     void Method(MySpan span)

--- a/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InvertIf/InvertIfTests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
             return
 @"class A
 {
-  void Goo()
-  {
+    void Goo()
+    {
 " + initial + @"
-  }
+    }
 }";
         }
 
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) { a(); } else { b(); }",
-@"if (!a) { b(); } else { a(); }");
+@"        if (!a) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -45,7 +46,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (!a) { a(); } else { b(); }",
-@"if (a) { b(); } else { a(); }");
+@"        if (a) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -53,7 +55,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a == b) { a(); } else { b(); }",
-@"if (a != b) { b(); } else { a(); }");
+@"        if (a != b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -61,7 +64,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a != b) { a(); } else { b(); }",
-@"if (a == b) { b(); } else { a(); }");
+@"        if (a == b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -69,7 +73,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a > b) { a(); } else { b(); }",
-@"if (a <= b) { b(); } else { a(); }");
+@"        if (a <= b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -77,7 +82,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a >= b) { a(); } else { b(); }",
-@"if (a < b) { b(); } else { a(); }");
+@"        if (a < b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -85,7 +91,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a < b) { a(); } else { b(); }",
-@"if (a >= b) { b(); } else { a(); }");
+@"        if (a >= b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -93,7 +100,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a <= b) { a(); } else { b(); }",
-@"if (a > b) { b(); } else { a(); }");
+@"        if (a > b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -101,7 +109,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if ((a)) { a(); } else { b(); }",
-@"if (!a) { b(); } else { a(); }");
+@"        if (!a) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -109,7 +118,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a is Goo) { a(); } else { b(); }",
-@"if (!(a is Goo)) { b(); } else { a(); }");
+@"        if (!(a is Goo)) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -117,7 +127,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a.Goo()) { a(); } else { b(); }",
-@"if (!a.Goo()) { b(); } else { a(); }");
+@"        if (!a.Goo()) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -125,7 +136,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a || b) { a(); } else { b(); }",
-@"if (!a && !b) { b(); } else { a(); }");
+@"        if (!a && !b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -133,7 +145,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (!a || !b) { a(); } else { b(); }",
-@"if (a && b) { b(); } else { a(); }");
+@"        if (a && b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -141,7 +154,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a && b) { a(); } else { b(); }",
-@"if (!a || !b) { b(); } else { a(); }");
+@"        if (!a || !b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -149,7 +163,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (!a && !b) { a(); } else { b(); }",
-@"if (a || b) { b(); } else { a(); }");
+@"        if (a || b) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -157,7 +172,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a && b || c) { a(); } else { b(); }",
-@"if ((!a || !b) && !c) { b(); } else { a(); }");
+@"        if ((!a || !b) && !c) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -165,7 +181,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a + b) { a(); } else { b(); }",
-@"if (!(a + b)) { b(); } else { a(); }");
+@"        if (!(a + b)) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -173,7 +190,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (true) { a(); } else { b(); }",
-@"if (false) { b(); } else { a(); }");
+@"        if (false) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -181,7 +199,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (false) { a(); } else { b(); }",
-@"if (true) { b(); } else { a(); }");
+@"        if (true) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -189,7 +208,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (true && false) { a(); } else { b(); }",
-@"if (false || true) { b(); } else { a(); }");
+@"        if (false || true) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -197,7 +217,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) a(); else b();",
-@"if (!a) b(); else a();");
+@"        if (!a) b();
+        else a();");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -205,7 +226,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) { a(); } else b();",
-@"if (!a) b(); else { a(); }");
+@"        if (!a) b();
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -213,7 +235,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) a(); else { b(); }",
-@"if (!a) { b(); } else a();");
+@"        if (!a) { b(); }
+        else a();");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -221,7 +244,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) { a(); } else if (b) { b(); }",
-@"if (!a) { if (b) { b(); } } else { a(); }");
+@"        if (!a)
+        {
+            if (b) { b(); }
+        }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -229,7 +256,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (a) { a(); } else if (b) { b(); } else { c(); }",
-@"if (!a) { if (b) { b(); } else { c(); } } else { a(); }");
+@"        if (!a)
+        {
+            if (b) { b(); } else { c(); }
+        }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -237,7 +268,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Invert
         {
             await TestFixOneAsync(
 @"[||]if (((a == b) && (c != d)) || ((e < f) && (!g))) { a(); } else { b(); }",
-@"if ((a != b || c == d) && (e >= f || g)) { b(); } else { a(); }");
+@"        if ((a != b || c == d) && (e >= f || g)) { b(); }
+        else { a(); }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -255,17 +287,17 @@ else
 {
     b();
 }",
-@"if (!a &&
-    (!b ||
-    c >= // comment
-    d))
-{
-    b();
-}
-else
-{
-    a();
-}");
+@"        if (!a &&
+            (!b ||
+            c >= // comment
+            d))
+        {
+            b();
+        }
+        else
+        {
+            a();
+        }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -489,7 +521,8 @@ class C
         {
             await TestFixOneAsync(
 @"string x; [||]if (x.Length > 0) { GreaterThanZero(); } else { EqualsZero(); } } } ",
-@"string x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
+@"string x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); }
+    } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -497,7 +530,8 @@ class C
         {
             await TestFixOneAsync(
 @"string[] x; [||]if (x.Length > 0) { GreaterThanZero(); } else { EqualsZero(); } } } ",
-@"string[] x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
+@"string[] x; if (x.Length == 0) { EqualsZero(); } else { GreaterThanZero(); }
+    } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -505,7 +539,8 @@ class C
         {
             await TestFixOneAsync(
 @"string x; [||]if (x.Length > 0x0) { a(); } else { b(); } } } ",
-@"string x; if (x.Length == 0x0) { b(); } else { a(); } } } ");
+@"string x; if (x.Length == 0x0) { b(); } else { a(); }
+    } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -513,7 +548,8 @@ class C
         {
             await TestFixOneAsync(
 @"string x; [||]if (0 < x.Length) { a(); } else { b(); } } } ",
-@"string x; if (0 == x.Length) { b(); } else { a(); } } } ");
+@"string x; if (0 == x.Length) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -522,7 +558,8 @@ class C
         {
             await TestFixOneAsync(
 @"byte x = 1; [||]if (0 < x) { a(); } else { b(); } } } ",
-@"byte x = 1; if (0 == x) { b(); } else { a(); } } } ");
+@"byte x = 1; if (0 == x) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -531,7 +568,8 @@ class C
         {
             await TestFixOneAsync(
 @"ushort x = 1; [||]if (0 < x) { a(); } else { b(); } } } ",
-@"ushort x = 1; if (0 == x) { b(); } else { a(); } } } ");
+@"ushort x = 1; if (0 == x) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -540,7 +578,8 @@ class C
         {
             await TestFixOneAsync(
 @"uint x = 1; [||]if (0 < x) { a(); } else { b(); } } } ",
-@"uint x = 1; if (0 == x) { b(); } else { a(); } } } ");
+@"uint x = 1; if (0 == x) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -549,7 +588,8 @@ class C
         {
             await TestFixOneAsync(
 @"ulong x = 1; [||]if (0 < x) { a(); } else { b(); } } } ",
-@"ulong x = 1; if (0 == x) { b(); } else { a(); } } } ");
+@"ulong x = 1; if (0 == x) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -558,7 +598,8 @@ class C
         {
             await TestFixOneAsync(
 @"ulong x = 1; [||]if (0 == x) { a(); } else { b(); } } } ",
-@"ulong x = 1; if (0 < x) { b(); } else { a(); } } } ");
+@"ulong x = 1; if (0 < x) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(545986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545986")]
@@ -567,7 +608,8 @@ class C
         {
             await TestFixOneAsync(
 @"ulong x = 1; [||]if (x == 0) { a(); } else { b(); } } } ",
-@"ulong x = 1; if (x > 0) { b(); } else { a(); } } } ");
+@"ulong x = 1; if (x > 0) { b(); } else { a(); }
+    } } ");
         }
 
         [WorkItem(530505, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530505")]
@@ -576,7 +618,8 @@ class C
         {
             await TestFixOneAsync(
 @"string[] x; [||]if (x.LongLength > 0) { GreaterThanZero(); } else { EqualsZero(); } } } ",
-@"string[] x; if (x.LongLength == 0) { EqualsZero(); } else { GreaterThanZero(); } } } ");
+@"string[] x; if (x.LongLength == 0) { EqualsZero(); } else { GreaterThanZero(); }
+    } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -584,7 +627,8 @@ class C
         {
             await TestFixOneAsync(
 @"string x; [||]if (x.Length >= 0) { a(); } else { b(); } } } ",
-@"string x; if (x.Length < 0) { b(); } else { a(); } } } ");
+@"string x; if (x.Length < 0) { b(); } else { a(); }
+    } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)]
@@ -592,7 +636,8 @@ class C
         {
             await TestFixOneAsync(
 @"string x; [||]if (x.Length > 0.0f) { GreaterThanZero(); } else { EqualsZero(); } } } ",
-@"string x; if (x.Length <= 0.0f) { EqualsZero(); } else { GreaterThanZero(); } } } ");
+@"string x; if (x.Length <= 0.0f) { EqualsZero(); } else { GreaterThanZero(); }
+    } } ");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -59,7 +59,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
-            var destinationDocumentText = @"class Class1 { }";
+            var destinationDocumentText = @"class Class1 { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -78,10 +79,12 @@ class Class2 { }
         </Document>
     </Project>
 </Workspace>";
-            var codeAfterMove = @"class Class2 { }";
+            var codeAfterMove = @"class Class2 { }
+        ";
 
             var expectedDocumentName = "Class1.cs";
-            var destinationDocumentText = @"class Class1 { }";
+            var destinationDocumentText = @"class Class1 { }
+        ";
 
             await TestMoveTypeToNewFileAsync(
                 code, codeAfterMove, expectedDocumentName,
@@ -107,7 +110,8 @@ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
-            var destinationDocumentText = @"class Class1 { }";
+            var destinationDocumentText = @"class Class1 { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -121,7 +125,8 @@ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
-            var destinationDocumentText = @"class Class1 { }";
+            var destinationDocumentText = @"class Class1 { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -139,12 +144,13 @@ class Class2 { }";
             var codeAfterMove =
 @"// Banner Text
 using System;
-
 class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
             var destinationDocumentText =
-@"class Class1 { }";
+@"// Banner Text
+class Class1 { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -167,12 +173,11 @@ class Class2 { }";
 
             var codeAfterMove =
 @"// Banner Text
-
 class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
             var destinationDocumentText =
-@"
+@"// Banner Text
 using System;
 class Class1 
 { 
@@ -180,7 +185,8 @@ class Class1
     {
         Console.WriteLine(x);
     }
-}";
+}
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -222,7 +228,7 @@ class Class2
 
             var expectedDocumentName = "Class1.cs";
             var destinationDocumentText =
-@"
+@"// Banner Text
 using System;
 class Class1 
 { 
@@ -230,7 +236,8 @@ class Class1
     {
         Console.WriteLine(x);
     }
-}";
+}
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -244,7 +251,8 @@ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "IMoveType.cs";
-            var destinationDocumentText = @"interface IMoveType { }";
+            var destinationDocumentText = @"interface IMoveType { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -258,7 +266,8 @@ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "MyStruct.cs";
-            var destinationDocumentText = @"struct MyStruct { }";
+            var destinationDocumentText = @"struct MyStruct { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -272,7 +281,8 @@ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "MyEnum.cs";
-            var destinationDocumentText = @"enum MyEnum { }";
+            var destinationDocumentText = @"enum MyEnum { }
+";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -290,7 +300,7 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-        class Class2 { }
+    class Class2 { }
 }";
 
             var expectedDocumentName = "Class1.cs";
@@ -319,10 +329,10 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    partial class Class1
+    partial class Class1 
     {
-
     }
+    
 }";
 
             var expectedDocumentName = "Class2.cs";
@@ -332,10 +342,9 @@ class Class2 { }";
 {
     partial class Class1 
     {
-        class Class2
-        {
-        }
+        class Class2 { }
     }
+    
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -356,10 +365,10 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    abstract partial class Class1
+    abstract partial class Class1 
     {
-
     }
+    
 }";
 
             var expectedDocumentName = "Class2.cs";
@@ -369,10 +378,9 @@ class Class2 { }";
 {
     abstract partial class Class1 
     {
-        class Class2
-        {
-        }
+        class Class2 { }
     }
+    
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -397,10 +405,10 @@ class Class2 { }";
 @"namespace N1
 {
     [Outer]
-    partial class Class1
+    partial class Class1 
     {
-
     }
+    
 }";
 
             var expectedDocumentName = "Class2.cs";
@@ -411,10 +419,9 @@ class Class2 { }";
     partial class Class1 
     {
         [Inner]
-        class Class2
-        {
-        }
+        class Class2 { }
     }
+    
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -479,10 +486,10 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    partial class Class1
+    partial class Class1 
     {
-
     }
+    
 }";
 
             var expectedDocumentName = "Class1.Class2.cs";
@@ -492,10 +499,9 @@ class Class2 { }";
 {
     partial class Class1 
     {
-        class Class2
-        {
-        }
+        class Class2 { }
     }
+    
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText, index: 1);
         }
@@ -520,12 +526,13 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    partial class Class1
+    partial class Class1 
     {
         private int _field1;
 
         public void Method1() { }
     }
+    
 }";
 
             var expectedDocumentName = "Class2.cs";
@@ -535,10 +542,9 @@ class Class2 { }";
 {
     partial class Class1 
     {
-        class Class2
-        {
-        }
+        class Class2 { }
     }
+    
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
@@ -567,14 +573,14 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    partial class Class1
+    partial class Class1 
     {
         private int _field1;
 
         public void Method1() { }
     }
 
-    internal class Class3
+    internal class Class3 
     {
         private void Method1() { }
     }
@@ -587,9 +593,7 @@ class Class2 { }";
 {
     partial class Class1 
     {
-        class Class2
-        {
-        }
+        class Class2 { }
     }
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
@@ -618,7 +622,7 @@ class Class2 { }";
             var codeAfterMove =
 @"namespace N1
 {
-    partial class Class1
+    partial class Class1 
     {
         private int _field1;
 
@@ -633,7 +637,7 @@ class Class2 { }";
 {
     partial class Class1 
     {
-        class Class2
+        class Class2 
         {
             private string _field1;
             public void InnerMethod() { }
@@ -711,6 +715,7 @@ namespace OuterN2.N2
     {
         partial class OuterClass2
         {
+
             class InnerClass4
             {
             }
@@ -731,14 +736,15 @@ namespace OuterN2.N2
             }
         }
     }
-}";
+}
+";
 
             var expectedDocumentName = "InnerClass2.cs";
 
             var destinationDocumentText =
-@"
-namespace OuterN1.N1
+@"namespace OuterN1.N1
 {
+
     namespace InnerN3.N3
     {
         partial class OuterClass2
@@ -751,7 +757,8 @@ namespace OuterN1.N1
             }
         }
     }
-}";
+}
+";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
 
@@ -772,10 +779,12 @@ class Outer {
     }
 }";
             var codeAfterMove = @"
+// Only used by inner type.
+
 // Unused by both types.
 using System.Collections;
 
-partial class Outer {
+partial class Outer { 
 }";
 
             var expectedDocumentName = "Inner.cs";
@@ -784,8 +793,10 @@ partial class Outer {
 // Only used by inner type.
 using System;
 
+// Unused by both types.
+
 partial class Outer {
-    class Inner { 
+    class Inner {
         DateTime d;
     }
 }";
@@ -935,7 +946,8 @@ partial class Outer : IComparable {
             var expectedDocumentName = "Inner.cs";
             var destinationDocumentText =
 @"
-partial class Outer { 
+partial class Outer
+{
     class Inner : IWhatever {
         DateTime d;
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 }";
 
             var codeWithTypeRenamedToMatchFileName =
-@"class [|test1|] 
+@"class [|test1|]
 { 
     class Inner { }
 }";

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -70,7 +70,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ReplaceMeth
 }",
 @"class C
 {
-    int Goo { get { return 0; } }
+    int Goo
+    {
+        get
+        {
+            return 0;
+        }
+    }
 }");
         }
 
@@ -204,7 +210,6 @@ ignoreTrivia: false);
 }",
 @"class C
 {
-#if true
     int Goo
     {
         get
@@ -737,6 +742,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -776,6 +782,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -815,6 +822,7 @@ class C
 
 class C
 {
+
     public int Goo
     {
         get
@@ -885,6 +893,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -925,6 +934,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -961,6 +971,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -997,6 +1008,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -1181,6 +1193,7 @@ class C
 
 class C
 {
+
     int Goo
     {
         get
@@ -1236,6 +1249,7 @@ class C
 
 class C
 {
+
     (int, string) Goo
     {
         get
@@ -1270,6 +1284,7 @@ class C
 
 class C
 {
+
     (int a, string b) Goo
     {
         get
@@ -1488,10 +1503,7 @@ ignoreTrivia: false);
 }",
 @"class C
 {
-    int Goo
-    {
-        get => 1;
-    }
+    int Goo { get => 1; }
 }", options: PreferExpressionBodiedAccessors);
         }
 
@@ -1550,11 +1562,8 @@ ignoreTrivia: false);
 }",
 @"class C
 {
-    int Goo
-    {
-        get => 1;
-        set => _i = value;
-    }
+
+    int Goo { get => 1; set => _i = value; }
 }", 
 index: 1,
 options: PreferExpressionBodiedAccessors);
@@ -1579,10 +1588,18 @@ options: PreferExpressionBodiedAccessors);
 }",
 @"class C
 {
+
     int Goo
     {
-        get { return 1; }
-        set { _i = value; }
+        get
+        {
+            return 1;
+        }
+
+        set
+        {
+            _i = value;
+        }
     }
 }", 
 index: 1,
@@ -1608,11 +1625,8 @@ options: PreferExpressionBodiedProperties);
 }",
 @"class C
 {
-    int Goo
-    {
-        get => 1;
-        set => _i = value;
-    }
+
+    int Goo { get => 1; set => _i = value; }
 }",
 index: 1,
 options: PreferExpressionBodiedAccessorsAndProperties);
@@ -1707,8 +1721,8 @@ options: PreferExpressionBodiedAccessorsAndProperties);
     {
         get
         {
-            throw e + 
-                e;
+            throw e +
+   e;
         }
     }
 }", options: OptionsSet(

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -1787,7 +1787,7 @@ class C : IGoo
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup, 
             ParseOptions parseOptions = null, int index = 0, 
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             await TestAsync(
                 initialMarkup, expectedMarkup, parseOptions,

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -324,7 +324,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;
@@ -357,7 +356,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;
@@ -395,7 +393,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;
@@ -438,7 +435,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;
@@ -527,7 +523,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;
@@ -570,7 +565,6 @@ class D
     {
         return 0;
     }
-
     private void SetProp(int value)
     {
         var v = value;

--- a/src/EditorFeatures/CSharpTest/CodeActions/UseNamedArguments/UseNamedArgumentsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/UseNamedArguments/UseNamedArgumentsTests.cs
@@ -212,7 +212,7 @@ class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }"
 }",
 @"class C
 {
-    void M(int arg1, int arg2)
+    void M(int arg1, int arg2) 
         => M(arg1: 1 + 2, arg2: 2);
 }");
         }
@@ -229,7 +229,7 @@ class C : System.Attribute { public C(int arg1) {} public int P { get; set; } }"
 }",
 @"class C
 {
-    void M(int arg1, int arg2)
+    void M(int arg1, int arg2) 
         => M(arg1: 1 + 2, arg2: 2);
 }");
         }
@@ -293,7 +293,7 @@ using System;
 class C
 {
     void M(Action arg1, int arg2) 
-        => M(arg1: () => { }, arg2: 2);
+        => M(arg1: () => {  }, arg2: 2);
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/AddAwaitTests.cs
@@ -897,7 +897,7 @@ class Program
 {
     async Task<int> A()
     {
-        return await (null ?? Task.FromResult(1)) }
+        return await (null ?? Task.FromResult(1))}
 }");
         }
 
@@ -921,7 +921,7 @@ class Program
 {
     async Task<int> A()
     {
-        return await (null as Task<int>) }
+        return await (null as Task<int>)}
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Async/ChangeToAsyncTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Async/ChangeToAsyncTests.cs
@@ -39,7 +39,9 @@ class Program
         await gt();
     }
 
-    async Task gt()
+    async 
+    Task
+gt()
     {
     }
 }";

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -7364,7 +7364,8 @@ class C
         ref int i = ref [|Bar|]();
     }
 }",
-@"using System;
+@"
+using System;
 
 class C 
 {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -212,7 +212,9 @@ index: 2);
         {
             await TestAddDocumentInRegularAndScriptAsync(
 @"class Program { void Main ( ) { [|Goo|] f ; } } ",
-@"internal class Goo { } ",
+@"internal class Goo
+{
+}",
 expectedContainers: ImmutableArray<string>.Empty,
 expectedDocumentName: "Goo.cs");
         }
@@ -222,7 +224,12 @@ expectedDocumentName: "Goo.cs");
         {
             await TestAddDocumentInRegularAndScriptAsync(
 @"class Class { [|TestNamespace|].Goo f; }",
-@"namespace TestNamespace { internal class Goo { } }",
+@"namespace TestNamespace
+{
+    internal class Goo
+    {
+    }
+}",
 expectedContainers: ImmutableArray.Create("TestNamespace"),
 expectedDocumentName: "Goo.cs");
         }
@@ -916,7 +923,12 @@ index: 1);
         {
             await TestAddDocumentInRegularAndScriptAsync(
 @"class Class { static void Main(string[] args) { [|N|].C c; } }",
-@"namespace N { internal class C { } }",
+@"namespace N
+{
+    internal class C
+    {
+    }
+}",
 expectedContainers: ImmutableArray.Create("N"),
 expectedDocumentName: "C.cs");
         }
@@ -2904,7 +2916,15 @@ index: 1);
         {
             await TestAddDocumentInRegularAndScriptAsync(
 @"class Class { void F() { new [|Goo|].Bar(); } }",
-@"namespace Goo { internal class Bar { public Bar() { } } }",
+@"namespace Goo
+{
+    internal class Bar
+    {
+        public Bar()
+        {
+        }
+    }
+}",
 expectedContainers: ImmutableArray.Create("Goo"),
 expectedDocumentName: "Bar.cs");
         }
@@ -4178,7 +4198,9 @@ string.Format(FeaturesResources.Generate_0_1_in_new_file, "class", "Goo", Featur
         {
             await TestAddDocumentInRegularAndScriptAsync(
 @"class C : [|Goo|]",
-"internal class Goo { }",
+@"internal class Goo
+{
+}",
 ImmutableArray<string>.Empty,
 "Goo.cs");
         }
@@ -4230,7 +4252,8 @@ index: 1);
     x, x)private class x
     {
     }
-}",
+}
+",
 index: 2);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests.cs
@@ -334,6 +334,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     {
         var v = a;
         v?.Invoke();
+
         v = null;
     }
 }");
@@ -471,8 +472,7 @@ class C
         if (true != true)
         {
         }
-        else
-            this.E?.Invoke(this, EventArgs.Empty);
+        else this.E?.Invoke(this, EventArgs.Empty);
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessTests_FixAllTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");
@@ -78,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");
@@ -113,6 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");
@@ -148,6 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");
@@ -183,6 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");
@@ -218,6 +223,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.InvokeDeleg
     void Goo()
     {
         a?.Invoke();
+
         a?.Invoke();
     }
 }");

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -610,7 +610,8 @@ class C
     public void M1()
     {{
         // Leading trivia
-        /*1*/ {expectedReturn} /*2*/ M2/*3*/() /*4*/
+        /*1*/
+        {expectedReturn} /*2*/ M2/*3*/() /*4*/
         {{
             throw new NotImplementedException();
         }}
@@ -619,14 +620,14 @@ class C
         }
 
         [Theory]
-        [InlineData("", "Task<C>", "C")]
-        [InlineData("", "Task<int>", "int")]
-        [InlineData("", "Task", "void")]
-        [InlineData("", "void", "void")]
-        [InlineData("public", "Task<C>", "C")]
-        [InlineData("public", "Task<int>", "int")]
-        [InlineData("public", "Task", "void")]
-        [InlineData("public", "void", "void")]
+        [InlineData("", "Task<C>", "\r\n    C")]
+        [InlineData("", "Task<int>", "\r\n    int")]
+        [InlineData("", "Task", "\r\n    void")]
+        [InlineData("", "void", "\r\n    void")]
+        [InlineData("public", "Task<C>", " C")]
+        [InlineData("public", "Task<int>", " int")]
+        [InlineData("public", "Task", " void")]
+        [InlineData("public", "void", " void")]
         [Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         [WorkItem(18307, "https://github.com/dotnet/roslyn/issues/18307")]
         public async Task RemoveAsyncKeepsTrivia(string modifiers, string asyncReturn, string expectedReturn)
@@ -649,7 +650,7 @@ using System.Threading.Tasks;
 class C
 {{
     // Leading trivia
-    {modifiers}/*1*/ {expectedReturn} /*2*/ M2/*3*/() /*4*/
+    {modifiers}/*1*/{expectedReturn} /*2*/ M2/*3*/() /*4*/
     {{
         throw new NotImplementedException();
     }}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4050,7 +4050,7 @@ enum Sign
         void Goo()
         {
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( ~mySign );
+            Sign invertedSign = (Sign) ( ~mySign);
         }
     }");
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -513,7 +513,7 @@ namespace Root
             var content =
 @"class A
 {
-     [|[||]|] i;
+    [|[||]|] i;
 }
 ";
 
@@ -746,9 +746,7 @@ namespace Root
     {
         public class A2
         {
-            public class A1
-            {
-            }
+            public class A1 { }
 
             A1 a;
         }
@@ -2380,7 +2378,7 @@ class A
 @"using System;
 using System.Collections.Generic;
 /// <summary>
-/// <see cref=""A.M{T}(List{Nullable{T}}, T?})""/>
+/// <see cref=""A.M{T}(List{Nullable{T}}, T?)""/>
 /// </summary>
 class A
 {
@@ -2493,7 +2491,7 @@ class Program
 {
     static void Main()
     {
-        Program a = null;
+        Program a = null; 
     }
 }", parseOptions: null);
 
@@ -2548,7 +2546,7 @@ static class M
             await TestInRegularAndScriptAsync(source,
 @"class Preserve
 {
-    public static int Y;
+	public static int Y;
 }
 
 class Z<T> : Preserve
@@ -2557,10 +2555,10 @@ class Z<T> : Preserve
 
 static class M
 {
-    public static void Main()
-    {
-        int k = Preserve.Y;
-    }
+	public static void Main()
+	{
+		int k = Preserve.Y;
+	}
 }");
         }
 
@@ -2591,10 +2589,10 @@ class M
             await TestInRegularAndScriptAsync(source,
 @"class Preserve
 {
-    public class X
-    {
-        public static int Y;
-    }
+	public class X
+	{
+		public static int Y;
+	}
 }
 
 class Z<T> : Preserve
@@ -2603,10 +2601,10 @@ class Z<T> : Preserve
 
 class M
 {
-    public static void Main()
-    {
-        int k = Preserve.X.Y;
-    }
+	public static void Main()
+	{
+		int k = Preserve.X.Y;
+	}
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -378,13 +378,13 @@ class C2 { } /// <summary><see [|cref=""abc""|]/></summary>
 class C3 { } // comment
   // comment
 // comment",
-        @"class C1 { }
-class C2 { }
-#pragma warning disable CS1574
-/// <summary><see cref=""abc""/></summary>
-class C3 { } // comment
-#pragma warning enable CS1574
-// comment
+$@"class C1 {{ }}
+#pragma warning disable CS1574 // {CSharpResources.WRN_BadXMLRef_Title}
+class C2 {{ }} /// <summary><see cref=""abc""/></summary>
+class
+#pragma warning restore CS1574 // {CSharpResources.WRN_BadXMLRef_Title}
+C3 {{ }} // comment
+  // comment
 // comment", CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose));
                 }
             }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -34,7 +34,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 }");
         }
 
@@ -56,7 +59,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    public int P { get; private set; }
+
+    public int P
+    {
+        get; private set; }
 }",
             CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
         }
@@ -97,7 +103,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; } = 1;
+
+    int P
+    {
+        get; } = 1;
 }");
         }
 
@@ -137,7 +146,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 }");
         }
 
@@ -182,7 +194,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; set; }
+
+    int P
+    {
+        get; set; }
 }");
         }
 
@@ -204,7 +219,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 }");
         }
 
@@ -249,7 +267,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 }",
 @"class Class
 {
-    int P { get; set; }
+
+    int P
+    {
+        get; set; }
 }");
         }
 
@@ -482,7 +503,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int j, k;
 
-    int P { get; }
+    int P
+    {
+        get; }
 }");
         }
 
@@ -506,7 +529,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int i, k;
 
-    int P { get; }
+    int P
+    {
+        get; }
 }");
         }
 
@@ -530,7 +555,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int i, j;
 
-    int P { get; }
+    int P
+    {
+        get; }
 }");
         }
 
@@ -559,7 +586,9 @@ partial class Class
 
 partial class Class
 {
-    int P { get; }
+    int P
+    {
+        get; }
 }");
         }
 
@@ -605,7 +634,10 @@ partial class Class
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 
     public Class()
     {
@@ -637,7 +669,10 @@ partial class Class
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 
     public Class(int P)
     {
@@ -669,7 +704,10 @@ partial class Class
 }",
 @"class Class
 {
-    int P { get; }
+
+    int P
+    {
+        get; }
 
     public Class()
     {
@@ -701,7 +739,10 @@ partial class Class
 }",
 @"class Class
 {
-    int P { get; set; }
+
+    int P
+    {
+        get; set; }
 
     public Goo()
     {
@@ -733,7 +774,10 @@ partial class Class
 }",
 @"class Class
 {
-    public int P { get; private set; }
+
+    public int P
+    {
+        get; private set; }
 
     public Goo()
     {
@@ -832,7 +876,10 @@ partial class Class
 }",
 @"class Class
 {
-    (int, string) P { get; }
+
+    (int, string) P
+    {
+        get; }
 }");
         }
 
@@ -854,7 +901,10 @@ partial class Class
 }",
 @"class Class
 {
-    (int a, string b) P { get; }
+
+    (int a, string b) P
+    {
+        get; }
 }");
         }
 
@@ -894,7 +944,10 @@ partial class Class
 }",
 @"class Class
 {
-    (int a, string) P { get; }
+
+    (int a, string) P
+    {
+        get; }
 }");
         }
 
@@ -916,7 +969,10 @@ partial class Class
 }",
 @"class Class
 {
-    (int, string) P { get; } = (1, ""hello"");
+
+    (int, string) P
+    {
+        get; } = (1, ""hello"");
 }");
         }
 
@@ -943,7 +999,10 @@ partial class Class
 }",
 @"class Class
 {
-    (int, string) P { get; set; }
+
+    (int, string) P
+    {
+        get; set; }
 }");
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -741,8 +741,8 @@ class C
     {
         var customers = new List<Customer>();
         IEnumerable<Customer> expr = from c in customers
-                                     where c.City == ""London""
-                                     select c;
+                   where c.City == ""London""
+                   select c;
     }
 
     private class Customer

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -817,8 +817,8 @@ class C
     {
         var customers = new List<Customer>();
         var expr = from c in customers
-                   where c.City == ""London""
-                   select c;
+                                     where c.City == ""London""
+                                     select c;
     }
 
     private class Customer

--- a/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -1028,7 +1028,7 @@ class Program
 
             await TestInRegularAndScriptAsync(
 input,
-@"[assembly: System.Runtime.InteropServices.Guid(""9ed54f84-a89d-4fcd-a854-44251e925f09"")]");
+@"[ assembly : System.Runtime.InteropServices.Guid( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ");
         }
 
         [WorkItem(546027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546027")]

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -85,7 +85,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateConstructor
 {
     private int v;
 
-    public C(int v) => this.v = v; void M()
+    public C(int v) => this.v = v;
+
+    void M()
     {
         new C(1);
     }
@@ -3260,18 +3262,20 @@ class P {
     }
 } ",
 @"class C {
-    public C ( int prop ) {
-        Prop = prop ;
-    } 
+    public C(int prop)
+    {
+        Prop = prop;
+    }
+
     public int Prop { get ; }
 }
 
-class P {
-    static void M ( ) {
+class P { 
+    static void M ( ) { 
         var prop = 42 ;
         var c = new C ( prop ) ;
     }
-}");
+} ");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -56,7 +56,7 @@ class Z
 {
     int a;
 
-    public Z(int a{|Navigation:)|} => this . a = a ;
+    public Z(int a{|Navigation:)|} => this.a = a;
 }",
 options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CSharpCodeStyleOptions.WhenPossibleWithNoneEnforcement));
         }
@@ -77,7 +77,7 @@ class Z
 {
     int a;
 
-    public Z(int a{|Navigation:)|} => this . a = a ;
+    public Z(int a{|Navigation:)|} => this.a = a;
 }",
 options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CSharpCodeStyleOptions.WhenOnSingleLineWithNoneEnforcement));
         }
@@ -102,8 +102,8 @@ class Z
 
     public Z(int a, int b{|Navigation:)|}
     {
-        this . a = a ;
-        this . b = b ;
+        this.a = a;
+        this.b = b;
     }
 }",
 options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CSharpCodeStyleOptions.WhenOnSingleLineWithNoneEnforcement));
@@ -938,7 +938,7 @@ class Z
     protected C(int prop{|Navigation:)|}
     {
         Prop = prop;
-    } 
+    }
 
     public int Prop { get; set; }
 }",

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -40,7 +40,8 @@ class Program
     public override bool Equals(object obj)
     {
         var program = obj as Program;
-        return program != null && a == program.a;
+        return program != null &&
+               a == program.a;
     }
 }");
         }
@@ -72,7 +73,8 @@ class Program
     public override bool Equals(object obj)
     {
         var program = obj as Program;
-        return program != null && EqualityComparer<S>.Default.Equals(a, program.a);
+        return program != null &&
+               EqualityComparer<S>.Default.Equals(a, program.a);
     }
 }");
         }
@@ -104,7 +106,8 @@ class Program
     public override bool Equals(object obj)
     {
         var program = obj as Program;
-        return program != null && a.Equals(program.a);
+        return program != null &&
+               a.Equals(program.a);
     }
 }");
         }
@@ -128,7 +131,8 @@ class ReallyLongName
     public override bool Equals(object obj)
     {
         var name = obj as ReallyLongName;
-        return name != null && a == name.a;
+        return name != null &&
+               a == name.a;
     }
 }");
         }
@@ -152,7 +156,8 @@ class ReallyLongLong
     public override bool Equals(object obj)
     {
         var @long = obj as ReallyLongLong;
-        return @long != null && a == @long.a;
+        return @long != null &&
+               a == @long.a;
     }
 }");
         }
@@ -180,7 +185,9 @@ class ReallyLongName
     public override bool Equals(object obj)
     {
         var name = obj as ReallyLongName;
-        return name != null && a == name.a && B == name.B;
+        return name != null &&
+               a == name.a &&
+               B == name.B;
     }
 }");
         }
@@ -208,7 +215,8 @@ class Program : Base
     public override bool Equals(object obj)
     {
         var program = obj as Program;
-        return program != null && i == program.i;
+        return program != null &&
+               i == program.i;
     }
 }");
         }
@@ -304,8 +312,10 @@ class Program : Middle
     public override bool Equals(object obj)
     {
         var program = obj as Program;
-        return program != null && base.Equals(obj) &&
-               i == program.i && S == program.S;
+        return program != null &&
+               base.Equals(obj) &&
+               i == program.i &&
+               S == program.S;
     }
 }");
         }
@@ -338,7 +348,8 @@ struct ReallyLongName
         }
 
         var name = (ReallyLongName)obj;
-        return i == name.i && S == name.S;
+        return i == name.i &&
+               S == name.S;
     }
 }");
         }
@@ -1033,11 +1044,8 @@ class Program
                s == program.s;
     }
 
-    public static bool operator ==(Program program1, Program program2)
-        => EqualityComparer<Program>.Default.Equals(program1, program2);
-
-    public static bool operator !=(Program program1, Program program2)
-        => !(program1 == program2);
+    public static bool operator ==(Program program1, Program program2) => EqualityComparer<Program>.Default.Equals(program1, program2);
+    public static bool operator !=(Program program1, Program program2) => !(program1 == program2);
 }",
 chosenSymbols: null,
 optionsCallback: options => EnableOption(options, GenerateOperatorsId),
@@ -1266,7 +1274,8 @@ public class Class1
     {
         return 0;
     }
-}",
+}
+        ",
 chosenSymbols: new string[] { },
 index: 1);
         }

--- a/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
@@ -46,8 +46,7 @@ class C
     {
         return base.ToString();
     }
-}
-", new[] { "Equals", "GetHashCode", "ToString" });
+}", new[] { "Equals", "GetHashCode", "ToString" });
         }
 
         [WorkItem(17698, "https://github.com/dotnet/roslyn/issues/17698")]
@@ -93,8 +92,7 @@ class Derived : Base
     {
         return ref base.X();
     }
-}
-", new[] { "X", "Y", "this[]" });
+}", new[] { "X", "Y", "this[]" });
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -2508,14 +2508,12 @@ count: 1);
             await TestInRegularAndScriptAsync(
 Initial,
 @"class C
-{
-    const int y = 1;
+{   
+    const int y = 1 ;
     private const bool undeclared;
 
-    public void Goo(bool x = undeclared)
-    {
-    }
-}");
+    public void Goo ( bool x = undeclared ) { }
+} ");
         }
 
         [WorkItem(542900, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542900")]
@@ -3815,6 +3813,7 @@ index: 1);
 #if true
         // Banner Line 1
         // Banner Line 2
+
         int local;
         int.TryParse(""123"", out [|local|]);
 #endif
@@ -4346,7 +4345,8 @@ class C
             await TestExactActionSetOfferedAsync(code, new[] { string.Format(FeaturesResources.Generate_local_0, "Bar") });
 
             await TestInRegularAndScriptAsync(code,
-@"class C
+@"
+class C
 {
 #line 1 ""goo""
     void Goo()
@@ -4355,7 +4355,8 @@ class C
     }
 #line default
 #line hidden
-}", options: ImplicitTypingEverywhere());
+}
+", options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(546027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546027")]
@@ -6778,7 +6779,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        Func<int> goo = () => {
+        Func<int> goo = () =>
+        {
             return 0;
         };
     }
@@ -7140,7 +7142,8 @@ public class Goo
         [|String|] = goo;
     }
 }",
-@"using System;
+@"
+using System;
 
 public class Goo
 {
@@ -7168,7 +7171,8 @@ public class Goo
         [|String|] = goo;
     }
 }",
-@"using System;
+@"
+using System;
 
 public class Goo
 {
@@ -7436,7 +7440,6 @@ class C
 {
     public bool isDisposed;
     private int y;
-
     public readonly int x;
     public readonly int m;
 
@@ -7470,7 +7473,6 @@ class C
     public readonly int x;
     public readonly int m;
     private readonly int y;
-
     public bool isDisposed;
 
     public C()

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1386,11 +1386,8 @@ class [|T|] : A
 
 class T : A
 {
-    public override int M
-    {
-        get => throw new System.NotImplementedException();
-        }
-    }", options: OptionsSet(
+    public override int M { get => throw new System.NotImplementedException(); }
+}", options: OptionsSet(
     SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, ExpressionBodyPreference.Never, NotificationOption.None),
     SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, ExpressionBodyPreference.WhenPossible, NotificationOption.None)));
         }
@@ -1415,11 +1412,8 @@ class [|T|] : A
 
 class T : A
 {
-    public override int M
-    {
-        set => throw new System.NotImplementedException();
-        }
-    }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithNoneEnforcement));
+    public override int M { set => throw new System.NotImplementedException(); }
+}", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithNoneEnforcement));
         }
 
         [WorkItem(581500, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/581500")]
@@ -1442,12 +1436,8 @@ class [|T|] : A
 
 class T : A
 {
-    public override int M
-    {
-        get => throw new System.NotImplementedException();
-        set => throw new System.NotImplementedException();
-        }
-    }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithNoneEnforcement));
+    public override int M { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+}", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.WhenPossibleWithNoneEnforcement));
         }
 
         [WorkItem(15387, "https://github.com/dotnet/roslyn/issues/15387")]

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementAbstractClass
 
         internal Task TestAllOptionsOffAsync(
             string initialMarkup, string expectedMarkup,
-            int index = 0, bool ignoreTrivia = true,
+            int index = 0, bool ignoreTrivia = false,
             IDictionary<OptionKey, object> options = null)
         {
             options = options ?? new Dictionary<OptionKey, object>();

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
 
         internal async Task TestWithAllCodeStyleOptionsOffAsync(
             string initialMarkup, string expectedMarkup,
-            int index = 0, bool ignoreTrivia = true,
+            int index = 0, bool ignoreTrivia = false,
             ParseOptions parseOptions = null)
         {
             await TestAsync(initialMarkup, expectedMarkup, parseOptions, null,

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -213,7 +213,8 @@ class Class : IInterface
     {
         throw new System.NotImplementedException();
     }
-}" + s_tupleElementNamesAttribute);
+}
+" + s_tupleElementNamesAttribute);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -241,7 +242,8 @@ class Class : IInterface
     {
         throw new System.NotImplementedException();
     }
-}" + s_tupleElementNamesAttribute,
+}
+" + s_tupleElementNamesAttribute,
 index: 1);
         }
 
@@ -278,7 +280,8 @@ class Class : IInterface
             throw new System.NotImplementedException();
         }
     }
-}" + s_tupleElementNamesAttribute);
+}
+" + s_tupleElementNamesAttribute);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -303,7 +306,8 @@ class Class : [|IInterface|]
 class Class : IInterface
 {
     public event Func<(int a, int b)> Event1;
-}" + s_tupleElementNamesAttribute);
+}
+" + s_tupleElementNamesAttribute);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -355,7 +359,8 @@ class Class : IInterface
     {
         throw new System.NotImplementedException();
     }
-}");
+}
+");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -374,8 +379,7 @@ interface IInterface2 : IInterface1
 class Class : [|IInterface2|]
 {
 }",
-@"
-interface IInterface1
+@"interface IInterface1
 {
     void Method1();
 }
@@ -2484,26 +2488,28 @@ class HasCanGoo : [|IGoo|]
 using System;
 
 interface IGoo
-{ 
-    event System.EventHandler E; 
+{
+    event System.EventHandler E;
 }
 
 class CanGoo : IGoo
-{ 
+{
     public event EventHandler E;
 }
 
 class HasCanGoo : IGoo
-{ 
+{
     CanGoo canGoo;
+
     public event EventHandler E
     {
         add
         {
             ((IGoo)canGoo).E += value;
         }
+
         remove
-        { 
+        {
             ((IGoo)canGoo).E -= value;
         }
     }
@@ -2515,7 +2521,23 @@ class HasCanGoo : IGoo
         {
             await TestInRegularAndScriptAsync(
 @"interface IGoo { event System . EventHandler E ; } class CanGoo : IGoo { event IGoo.EventHandler E; } class HasCanGoo : [|IGoo|] { CanGoo canGoo; } ",
-@"using System ; interface IGoo { event System . EventHandler E ; } class CanGoo : IGoo { event IGoo.EventHandler E; } class HasCanGoo : IGoo { CanGoo canGoo; public event EventHandler E { add { ((IGoo)canGoo).E += value; } remove { ((IGoo)canGoo).E -= value; } } } ",
+@"using System;
+
+interface IGoo { event System . EventHandler E ; } class CanGoo : IGoo { event IGoo.EventHandler E; } class HasCanGoo : IGoo { CanGoo canGoo;
+
+    public event EventHandler E
+    {
+        add
+        {
+            ((IGoo)canGoo).E += value;
+        }
+
+        remove
+        {
+            ((IGoo)canGoo).E -= value;
+        }
+    }
+} ",
 index: 1);
         }
 
@@ -2532,6 +2554,7 @@ abstract class Goo : [|IGoo|]
 {
 }",
 @"using System;
+
 interface IGoo
 {
     event System.EventHandler E;
@@ -2817,6 +2840,7 @@ class A : [|I|]
 {
 }",
 @"using System;
+
 interface I
 {
     void Goo<T>() where T : System.Attribute;
@@ -3978,7 +4002,14 @@ public class Goo : IGoo
         {
             await TestWithAllCodeStyleOptionsOffAsync(
 @"interface IGoo { void Goo ( string s = ""\"""" ) ; } class B : [|IGoo|] { } ",
-@"interface IGoo { void Goo ( string s = ""\"""" ) ; } class B : IGoo { public void Goo ( string s = ""\"""" ) { throw new System.NotImplementedException ( ) ; } } ");
+@"interface IGoo { void Goo ( string s = ""\"""" ) ; }
+class B : IGoo
+{
+    public void Goo(string s = ""\"""")
+    {
+        throw new System.NotImplementedException();
+    }
+} ");
         }
 
         [WorkItem(916114, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916114")]
@@ -4914,7 +4945,8 @@ class C : I
     {
         throw new System.NotImplementedException();
     }
-}");
+}
+");
         }
 
         [WorkItem(545922, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545922")]
@@ -5409,12 +5441,13 @@ class D : I
 class C : [|IServiceProvider|] @""",
 @"using System;
 
-class C : IServiceProvider @"""" {
+class C : IServiceProvider @""""{
     public object GetService(Type serviceType)
     {
         throw new NotImplementedException();
     }
-}");
+}
+");
         }
 
         [WorkItem(545939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545939")]
@@ -5427,12 +5460,13 @@ class C : IServiceProvider @"""" {
 class C : [|IServiceProvider|] """,
 @"using System;
 
-class C : IServiceProvider """" {
+class C : IServiceProvider """"{
     public object GetService(Type serviceType)
     {
         throw new NotImplementedException();
     }
-}");
+}
+");
         }
 
         [WorkItem(545939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545939")]
@@ -5445,12 +5479,13 @@ class C : IServiceProvider """" {
 class C : [|IServiceProvider|] @""",
 @"using System;
 
-class C : IServiceProvider @"""" {
+class C : IServiceProvider @""""{
     public object GetService(Type serviceType)
     {
         throw new NotImplementedException();
     }
-}");
+}
+");
         }
 
         [WorkItem(545939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545939")]
@@ -5463,12 +5498,13 @@ class C : IServiceProvider @"""" {
 class C : [|IServiceProvider|] """,
 @"using System;
 
-class C : IServiceProvider """" {
+class C : IServiceProvider """"{
     public object GetService(Type serviceType)
     {
         throw new NotImplementedException();
     }
-}");
+}
+");
         }
 
         [WorkItem(545940, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545940")]
@@ -5943,7 +5979,7 @@ public class Test : IGoo
         throw new System.NotImplementedException();
     }
 }
-";
+        ";
 
             await TestWithAllCodeStyleOptionsOffAsync(initial, expected, index: 1);
         }
@@ -5982,13 +6018,13 @@ class C : I
     {
         throw new NotImplementedException();
     }
- 
+
     public void set_P(int x, object Value)
     {
         throw new NotImplementedException();
     }
 }
-";
+        ";
 
             await TestWithAllCodeStyleOptionsOffAsync(initial, expected, index: 0);
         }
@@ -6016,14 +6052,13 @@ class Goo : [|IComparable|]
 class Program : [|IDisposable|]
 {
 }",
-$@"
-using System;
+$@"using System;
 
 class Program : IDisposable
 {{
-{DisposePattern("protected virtual ", "C", "public void ")}
-}}
-", index: 1);
+
+{DisposePattern("protected virtual ", "Program", "public void ")}
+}}", index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -6036,15 +6071,14 @@ class Program : [|IDisposable|]
 {
     private bool DisposedValue;
 }",
-$@"
-using System;
+$@"using System;
 
 class Program : IDisposable
 {{
     private bool DisposedValue;
+
 {DisposePattern("protected virtual ", "Program", "void IDisposable.")}
-}}
-", index: 3);
+}}", index: 3);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -6106,14 +6140,13 @@ class Program : IDisposable
 sealed class Program : [|IDisposable|]
 {
 }",
-$@"
-using System;
+$@"using System;
 
 sealed class Program : IDisposable
 {{
+
 {DisposePattern("", "Program", "void IDisposable.")}
-}}
-", index: 3);
+}}", index: 3);
         }
 
         [WorkItem(939123, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/939123")]
@@ -6237,6 +6270,8 @@ class C : I
             throw new System.NotImplementedException();
         }
     }
+
+
     // Comment
 }");
         }
@@ -6675,7 +6710,6 @@ class Class : IInterface
     void M() { }
 
     public int Prop => throw new System.NotImplementedException();
-    
 }", options: Option(ImplementTypeOptions.InsertionBehavior, ImplementTypeInsertionBehavior.AtTheEnd));
         }
 
@@ -6699,7 +6733,8 @@ interface IComInterface
 class Class : [|IComInterface|]
 {
 }",
-@"using System.Runtime.InteropServices;
+@"
+using System.Runtime.InteropServices;
 
 [ComImport]
 interface IComInterface
@@ -6712,9 +6747,21 @@ interface IComInterface
 
 class Class : IComInterface
 {
-    public void MOverload() { throw new System.NotImplementedException(); }
-    public void X() { throw new System.NotImplementedException(); }
-    public void MOverload(int i) { throw new System.NotImplementedException(); }
+    public void MOverload()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void X()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public void MOverload(int i)
+    {
+        throw new System.NotImplementedException();
+    }
+
     public int Prop => throw new System.NotImplementedException();
 }");
         }
@@ -6783,9 +6830,7 @@ class Class : [|IInterface|]
 class Class : IInterface
 {
     public int ReadOnlyProp { get; }
-
     public int ReadWriteProp { get; set; }
-
     public int WriteOnlyProp { set => throw new System.NotImplementedException(); }
 }", parameters: new TestParameters(options: Option(
     ImplementTypeOptions.PropertyGenerationBehavior,

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -425,7 +425,7 @@ class C
         {
             throw new ArgumentNullException(nameof(s));
         }
-        
+
         Init();
     }
 }");
@@ -454,7 +454,7 @@ class C
         {
             throw new ArgumentNullException(nameof(s));
         }
-        
+
         Init();
     }
 }", parameters: new TestParameters(options:

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/InitializeMemberFromParameterTests.cs
@@ -183,6 +183,7 @@ class C
 class C
 {
     private string S => null;
+
     public string S1 { get; }
 
     public C(string s)
@@ -384,7 +385,7 @@ class C
     public C(string s, string t)
     {
         this.s = s;
-        this.t = t;
+        this.t = t;   
     }
 }");
         }
@@ -440,6 +441,7 @@ class C
     public C(string s)
     {
         if (true) { }
+
         this.s = s;
     }
 }");
@@ -562,7 +564,7 @@ class C
     public C(string s, string t)
     {
         S = s;
-        T = t;
+        T = t;   
     }
 
     public string S { get; }

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -1124,7 +1124,7 @@ class C
     {
         if (x != null && TryBaz(out object s))
         {
-            Console.WriteLine(s); 
+            Console.WriteLine(s);
         }
     }
 
@@ -1603,7 +1603,7 @@ class C
 {
     static void Main(string[] args)
     {
-        for ( ; TryExtractTokenFromEmail(out string token); )
+        for (; TryExtractTokenFromEmail(out string token);)
         {
         }
     }

--- a/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
             => new IntroduceVariableCodeRefactoringProvider();
 
-        protected Task TestAsync(string initial, string expected, int index = 0, bool ignoreTrivia = true)
+        protected Task TestAsync(string initial, string expected, int index = 0, bool ignoreTrivia = false)
         {
             return TestAsync(initial, expected, Options.Script, null, index, ignoreTrivia);
         }

--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -415,7 +415,8 @@ class Program
 {
     void Main()
     {
-        new[] { 1 }.AsParallel().ForAll((i) => {
+        new[] { 1 }.AsParallel().ForAll((i) =>
+        {
             {|Warning:var @lock = new object();|}
             lock (@lock)
             {

--- a/src/EditorFeatures/CSharpTest/OrderModifiers/OrderModifiersTests.cs
+++ b/src/EditorFeatures/CSharpTest/OrderModifiers/OrderModifiersTests.cs
@@ -23,8 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.OrderModifiers
 @"[|static|] internal class C
 {
 }",
-@"
-internal static class C
+@"internal static class C
 {
 }");
         }
@@ -36,8 +35,7 @@ internal static class C
 @"[|unsafe|] public struct C
 {
 }",
-@"
-public unsafe struct C
+@"public unsafe struct C
 {
 }");
         }
@@ -49,8 +47,7 @@ public unsafe struct C
 @"[|unsafe|] public interface C
 {
 }",
-@"
-public unsafe interface C
+@"public unsafe interface C
 {
 }");
         }
@@ -62,8 +59,7 @@ public unsafe interface C
 @"[|internal|] protected enum C
 {
 }",
-@"
-protected internal enum C
+@"protected internal enum C
 {
 }");
         }
@@ -84,8 +80,7 @@ protected internal enum C
 {
     [|unsafe|] public void M() { }
 }",
-@"
-class C
+@"class C
 {
     public unsafe void M() { }
 }");
@@ -99,8 +94,7 @@ class C
 {
     [|unsafe|] public int a;
 }",
-@"
-class C
+@"class C
 {
     public unsafe int a;
 }");
@@ -114,8 +108,7 @@ class C
 {
     [|unsafe|] public C() { }
 }",
-@"
-class C
+@"class C
 {
     public unsafe C() { }
 }");
@@ -129,8 +122,7 @@ class C
 {
     [|unsafe|] public int P { get; }
 }",
-@"
-class C
+@"class C
 {
     public unsafe int P { get; }
 }");
@@ -144,8 +136,7 @@ class C
 {
     int P { [|internal|] protected get; }
 }",
-@"
-class C
+@"class C
 {
     int P { protected internal get; }
 }");
@@ -159,8 +150,7 @@ class C
 {
     [|internal|] protected event Action P { add { } remove { } }
 }",
-@"
-class C
+@"class C
 {
     protected internal event Action P { add { } remove { } }
 }");
@@ -174,8 +164,7 @@ class C
 {
     [|internal|] protected event Action P;
 }",
-@"
-class C
+@"class C
 {
     protected internal event Action P;
 }");
@@ -189,8 +178,7 @@ class C
 {
     [|static|] public C operator +(C c1, C c2) { }
 }",
-@"
-class C
+@"class C
 {
     public static C operator +(C c1, C c2) { }
 }");
@@ -204,8 +192,7 @@ class C
 {
     [|static|] public implicit operator bool(C c1) { }
 }",
-@"
-class C
+@"class C
 {
     public static implicit operator bool(C c1) { }
 }");
@@ -219,8 +206,7 @@ class C
 {
     static internal class Nested { }
 }",
-@"
-internal static class C
+@"internal static class C
 {
     internal static class Nested { }
 }");
@@ -234,8 +220,7 @@ internal static class C
 {
     {|FixAllInDocument:static|} internal class Nested { }
 }",
-@"
-internal static class C
+@"internal static class C
 {
     internal static class Nested { }
 }");

--- a/src/EditorFeatures/CSharpTest/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnreachableCode/RemoveUnreachableCodeTests.cs
@@ -151,7 +151,7 @@ class C
     void M()
     {
         throw new System.Exception();
-    
+
         void Local() {}
     }
 }");
@@ -181,7 +181,7 @@ class C
     void M()
     {
         throw new System.Exception();
-    
+
         void Local() {}
         void Local2() {}
     }
@@ -215,8 +215,9 @@ class C
     void M()
     {
         throw new System.Exception();
-    
+
         void Local() {}
+
         void Local2() {}
     }
 }");
@@ -250,8 +251,9 @@ class C
     void M()
     {
         throw new System.Exception();
-    
+
         void Local() {}
+
         void Local2() {}
     }
 }");
@@ -281,7 +283,7 @@ class C
     void M()
     {
         throw new System.Exception();
-    
+
         label:
             Console.WriteLine();
 

--- a/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.cs
@@ -36,7 +36,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = x ?? y;
+        var z = x ?? y ;
     }
 }");
         }
@@ -84,7 +84,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        var z = (x + y) ?? y;
+        var z = (x + y) ?? y ;
     }
 }");
         }
@@ -134,7 +134,7 @@ class C
     void M(int? x, int? y)
     {
         var z1 = x ?? y;
-        var z2 = x ?? y;
+        var z2 = x ?? y ;
     }
 }");
         }
@@ -209,7 +209,7 @@ class C
 {
     void M(int? x, int? y)
     {
-        Expression<Func<int>> e = () => {|Warning:x ?? y|};
+        Expression<Func<int>> e = () => {|Warning:x ?? y|} ;
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -529,7 +529,8 @@ class C
 {
     void M()
     {
-        var list1 = new List<int>(() => {
+        var list1 = new List<int>(() =>
+        {
             var list2 = new List<int>
             {
                 2
@@ -567,7 +568,8 @@ class C
     {
         var list1 = new List<int>
         {
-            () => {
+            () =>
+            {
                 var list2 = new List<int>
                 {
                     2
@@ -632,14 +634,8 @@ class C
     {
         var c = new Dictionary<int, string>
         {
-            {
-                1,
-                ""x""
-            },
-            {
-                2,
-                ""y""
-            }
+            { 1, ""x"" },
+            { 2, ""y"" }
         };
     }
 }");

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
@@ -101,8 +101,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     int this[int i]
     {
         get => Bar();
-        }
-    }", options: UseExpressionBody);
+    }
+}", options: UseExpressionBody);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -144,8 +144,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     int Goo
     {
         set => [|Bar|]();
-        }
-    }", options: UseExpressionBody);
+    }
+}", options: UseExpressionBody);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -180,8 +180,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     int Goo
     {
         get => throw new NotImplementedException();
-        }
-    }", options: UseExpressionBody);
+    }
+}", options: UseExpressionBody);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
@@ -361,7 +361,7 @@ class C
 using System;
 class C
 {
-    int Goo 
+    int Goo
     {
         get
         {
@@ -387,15 +387,14 @@ class C
 using System;
 class C
 {
-    int Goo 
+    int Goo
     {
         get
         {
             throw new NotImplementedException();
         }
     }
-
-    int Bar 
+    int Bar
     {
         get
         {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForIndexersAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForIndexersAnalyzerTests.cs
@@ -163,7 +163,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int this[int i]
     {
-        get { return Bar(); }
+        get
+        {
+            return Bar();
+        }
     }
 }", options: UseBlockBodyExceptAccessor);
         }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForPropertiesAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForPropertiesAnalyzerTests.cs
@@ -180,7 +180,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int Goo
     {
-        get { return Bar(); }
+        get
+        {
+            return Bar();
+        }
     }
 }", options: UseBlockBodyExceptAccessor);
         }
@@ -381,7 +384,7 @@ class C
 using System;
 class C
 {
-    int Goo 
+    int Goo
     {
         get
         {
@@ -407,7 +410,7 @@ class C
 using System;
 class C
 {
-    int Goo 
+    int Goo
     {
         get
         {
@@ -415,7 +418,7 @@ class C
         }
     }
 
-    int Bar 
+    int Bar
     {
         get
         {

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -89,7 +89,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int Goo { get => Bar(); }
+    int Goo
+    {
+        get => Bar();
+    }
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
         }
 

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConstructorsRefactoringTests.cs
@@ -86,7 +86,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    public C() { Bar(); }
+    public C()
+    {
+        Bar();
+    }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForConversionOperatorsRefactoringTests.cs
@@ -86,7 +86,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    public static implicit operator bool(C c1) { return Bar(); }
+    public static implicit operator bool(C c1)
+    {
+        return Bar();
+    }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -96,7 +96,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int this[int i] { get { return Bar(); } }
+    int this[int i]
+    {
+        get
+        {
+            return Bar();
+        }
+    }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForMethodsRefactoringTests.cs
@@ -86,7 +86,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    void Goo() { Bar(); }
+    void Goo()
+    {
+        Bar();
+    }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForOperatorsRefactoringTests.cs
@@ -86,7 +86,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    public static bool operator +(C c1, C c2) { return Bar(); }
+    public static bool operator +(C c1, C c2)
+    {
+        return Bar();
+    }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
@@ -164,7 +164,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int Goo { get { return Bar(); } }
+    int Goo
+    {
+        get
+        {
+            return Bar();
+        }
+    }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
         }
 
@@ -178,7 +184,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int Goo { get { return Bar(); } }
+    int Goo
+    {
+        get
+        {
+            return Bar();
+        }
+    }
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_ExpressionBodyForProperties));
         }
 
@@ -193,7 +205,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int Goo { get { return Bar(); } }
+    int Goo
+    {
+        get
+        {
+            return Bar();
+        }
+    }
 }", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6),
     options: UseExpressionBodyForAccessors_ExpressionBodyForProperties);
         }

--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -39,7 +39,7 @@ class C
     void M()
     {
         int a = 1;
-        var t = (a, 2);
+        var t = ( a, 2);
     }
 }", parseOptions: s_parseOptions);
         }

--- a/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
@@ -1097,7 +1097,6 @@ class C
         int fibonacci(int v)
         {
             bool isTrue(bool b) => b;
-
             return fibonacci(v - 1, v - 2);
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -324,7 +324,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     void M()
     {
-        var v = new C(() => {
+        var v = new C(() =>
+        {
             var v2 = new C
             {
                 i = 1
@@ -364,7 +365,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
     {
         var v = new C
         {
-            j = () => {
+            j = () =>
+            {
                 var v2 = new C
                 {
                     i = 1

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
@@ -26,7 +26,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddNamespace()
             {
                 var input = "namespace [|N1|] { }";
-                var expected = "namespace N1 { namespace N2 { } }";
+                var expected = @"namespace N1 {
+    namespace N2
+    {
+    }
+}";
                 await TestAddNamespaceAsync(input, expected,
                     name: "N2");
             }
@@ -35,7 +39,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddField()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public int F; }";
+                var expected = @"class C
+{
+    public int F;
+}";
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(int)));
             }
@@ -44,7 +51,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddStaticField()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { private static string F; }";
+                var expected = @"class C
+{
+    private static string F;
+}";
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(string)),
                     accessibility: Accessibility.Private,
@@ -55,7 +65,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddArrayField()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public int[] F; }";
+                var expected = @"class C
+{
+    public int[] F;
+}";
                 await TestAddFieldAsync(input, expected,
                     type: CreateArrayType(typeof(int)));
             }
@@ -64,7 +77,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddUnsafeField()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public unsafe int F; }";
+                var expected = @"class C
+{
+    public unsafe int F;
+}";
                 await TestAddFieldAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     type: GetTypeSymbol(typeof(int)));
@@ -74,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddFieldToCompilationUnit()
             {
                 var input = "";
-                var expected = "public int F;";
+                var expected = "public int F;\n";
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(int)), addToCompilationUnit: true);
             }
@@ -83,7 +99,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddConstructor()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public C() { } }";
+                var expected = @"class C
+{
+    public C()
+    {
+    }
+}";
                 await TestAddConstructorAsync(input, expected);
             }
 
@@ -91,7 +112,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddConstructorWithoutBody()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public C(); }";
+                var expected = @"class C
+{
+    public C();
+}";
                 await TestAddConstructorAsync(input, expected,
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
             }
@@ -100,7 +124,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddConstructorResolveNamespaceImport()
             {
                 var input = "class [|C|] { }";
-                var expected = "using System; class C { public C(DateTime dt, int i) { } }";
+                var expected = @"using System;
+
+class C
+{
+    public C(DateTime dt, int i)
+    {
+    }
+}";
                 await TestAddConstructorAsync(input, expected,
                     parameters: Parameters(Parameter(typeof(DateTime), "dt"), Parameter(typeof(int), "i")));
             }
@@ -118,7 +149,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddStaticConstructor()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { static C() { } }";
+                var expected = @"class C
+{
+    static C()
+    {
+    }
+}";
                 await TestAddConstructorAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isStatic: true));
             }
@@ -141,7 +177,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddClassEscapeName()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public class @class { } }";
+                var expected = @"namespace N
+{
+    public class @class
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "class");
             }
@@ -150,16 +191,26 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddClassUnicodeName()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public class class\u00E6\u00F8\u00E5 { } }";
+                var expected = @"namespace N
+{
+    public class classæøå
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
-                    name: "cl\u0061ss\u00E6\u00F8\u00E5");
+                    name: "classæøå");
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration), WorkItem(544405, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544405")]
             public async Task AddStaticClass()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public static class C { } }";
+                var expected = @"namespace N
+{
+    public static class C
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isStatic: true));
             }
@@ -168,7 +219,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddSealedClass()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { private sealed class C { } }";
+                var expected = @"namespace N
+{
+    private sealed class C
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     accessibility: Accessibility.Private,
                     modifiers: new Editing.DeclarationModifiers(isSealed: true));
@@ -178,7 +234,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddAbstractClass()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { protected internal abstract class C { } }";
+                var expected = @"namespace N
+{
+    protected internal abstract class C
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     accessibility: Accessibility.ProtectedOrInternal,
                     modifiers: new Editing.DeclarationModifiers(isAbstract: true));
@@ -188,7 +249,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddStruct()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { internal struct S { } }";
+                var expected = @"namespace N
+{
+    internal struct S
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "S",
                     accessibility: Accessibility.Internal,
@@ -199,7 +265,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddSealedStruct()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public struct S { } }";
+                var expected = @"namespace N
+{
+    public struct S
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "S",
                     modifiers: new Editing.DeclarationModifiers(isSealed: true),
@@ -211,7 +282,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddInterface()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public interface I { } }";
+                var expected = @"namespace N
+{
+    public interface I
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "I",
                     typeKind: TypeKind.Interface);
@@ -221,7 +297,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddEnum()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public enum E { } }";
+                var expected = @"namespace N
+{
+    public enum E
+    {
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected, "E",
                     typeKind: TypeKind.Enum);
             }
@@ -230,7 +311,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddEnumWithValues()
             {
                 var input = "namespace [|N|] { }";
-                var expected = "namespace N { public enum E { F1 = 1, F2 = 2 } }";
+                var expected = @"namespace N
+{
+    public enum E
+    {
+        F1 = 1,
+        F2 = 2
+    }
+}";
                 await TestAddNamedTypeAsync(input, expected, "E",
                     typeKind: TypeKind.Enum,
                     members: Members(CreateEnumField("F1", 1), CreateEnumField("F2", 2)));
@@ -240,7 +328,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddDelegateType()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public delegate int D(string s); }";
+                var expected = @"class C
+{
+    public delegate int D(string s);
+}";
                 await TestAddDelegateTypeAsync(input, expected,
                     returnType: typeof(int),
                     parameters: Parameters(Parameter(typeof(string), "s")));
@@ -250,7 +341,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddSealedDelegateType()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public delegate int D(string s); }";
+                var expected = @"class C
+{
+    public delegate int D(string s);
+}";
                 await TestAddDelegateTypeAsync(input, expected,
                     returnType: typeof(int),
                     parameters: Parameters(Parameter(typeof(string), "s")),
@@ -261,7 +355,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddEvent()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public event System.Action E; }";
+                var expected = @"class C
+{
+    public event System.Action E;
+}";
                 await TestAddEventAsync(input, expected,
                     codeGenerationOptions: new CodeGenerationOptions(addImports: false));
             }
@@ -270,7 +367,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddUnsafeEvent()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public unsafe event System.Action E; }";
+                var expected = @"class C
+{
+    public unsafe event System.Action E;
+}";
                 await TestAddEventAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     codeGenerationOptions: new CodeGenerationOptions(addImports: false));
@@ -280,7 +380,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddEventWithAccessors()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public event System.Action E { add { } remove { } } }";
+                var expected = @"class C
+{
+    public event System.Action E
+    {
+        add
+        {
+        }
+
+        remove
+        {
+        }
+    }
+}";
                 await TestAddEventAsync(input, expected,
                     addMethod: CodeGenerationSymbolFactory.CreateAccessorSymbol(ImmutableArray<AttributeData>.Empty, Accessibility.NotApplicable, ImmutableArray<SyntaxNode>.Empty),
                     removeMethod: CodeGenerationSymbolFactory.CreateAccessorSymbol(ImmutableArray<AttributeData>.Empty, Accessibility.NotApplicable, ImmutableArray<SyntaxNode>.Empty),
@@ -291,7 +403,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddMethodToClass()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public void M() { } }";
+                var expected = @"class C
+{
+    public void M()
+    {
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(void));
             }
@@ -300,7 +417,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddMethodToClassEscapedName()
             {
                 var input = "class [|C|] { }";
-                var expected = "using System; class C { public DateTime @static() { } }";
+                var expected = @"using System;
+
+class C
+{
+    public DateTime @static()
+    {
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     name: "static",
                     returnType: typeof(DateTime));
@@ -310,7 +434,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddStaticMethodToStruct()
             {
                 var input = "struct [|S|] { }";
-                var expected = "struct S { public static int M() { $$ } }";
+                var expected = @"struct S
+{
+    public static int M()
+    {
+        $$
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isStatic: true),
                     returnType: typeof(int),
@@ -321,7 +451,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddSealedOverrideMethod()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public sealed override int GetHashCode() { $$ } }";
+                var expected = @"class C
+{
+    public sealed override int GetHashCode()
+    {
+        $$
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     name: "GetHashCode",
                     modifiers: new Editing.DeclarationModifiers(isOverride: true, isSealed: true),
@@ -333,7 +469,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddAbstractMethod()
             {
                 var input = "abstract class [|C|] { }";
-                var expected = "abstract class C { public abstract int M(); }";
+                var expected = @"abstract class C
+{
+    public abstract int M();
+}";
                 await TestAddMethodAsync(input, expected,
                     modifiers: new Editing.DeclarationModifiers(isAbstract: true),
                     returnType: typeof(int));
@@ -343,7 +482,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddMethodWithoutBody()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public int M(); }";
+                var expected = @"class C
+{
+    public int M();
+}";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(int),
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
@@ -353,7 +495,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddGenericMethod()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public int M<T>() { $$ } }";
+                var expected = @"class C
+{
+    public int M<T>()
+    {
+        $$
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(int),
                     typeParameters: ImmutableArray.Create(CodeGenerationSymbolFactory.CreateTypeParameterSymbol("T")),
@@ -364,7 +512,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddVirtualMethod()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { protected virtual int M() { $$ } }";
+                var expected = @"class C
+{
+    protected virtual int M()
+    {
+        $$
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     accessibility: Accessibility.Protected,
                     modifiers: new Editing.DeclarationModifiers(isVirtual: true),
@@ -376,7 +530,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddUnsafeNewMethod()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public unsafe new string ToString() { $$ } }";
+                var expected = @"class C
+{
+    public unsafe new string ToString()
+    {
+        $$
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     name: "ToString",
                     modifiers: new Editing.DeclarationModifiers(isNew: true, isUnsafe: true),
@@ -388,7 +548,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddExplicitImplementationOfUnsafeMethod()
             {
                 var input = "interface I { unsafe void M(int i); } class [|C|] : I { }";
-                var expected = "interface I { unsafe void M(int i); } class C : I { unsafe void I.M(int i) { } }";
+                var expected = @"interface I { unsafe void M(int i); }
+class C : I
+{
+    unsafe void I.M(int i)
+    {
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     name: "M",
                     returnType: typeof(void),
@@ -401,7 +567,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddExplicitImplementation()
             {
                 var input = "interface I { void M(int i); } class [|C|] : I { }";
-                var expected = "interface I { void M(int i); } class C : I { void I.M(int i) { } }";
+                var expected = @"interface I { void M(int i); }
+class C : I
+{
+    void I.M(int i)
+    {
+    }
+}";
                 await TestAddMethodAsync(input, expected,
                     name: "M",
                     returnType: typeof(void),
@@ -419,10 +591,16 @@ class [|C|]
                 var expected = @"
 class C
 {
-    public static bool operator true (C other) { $$ }
-    public static bool operator false (C other) { $$ }
-}
-";
+    public static bool operator true(C other)
+    {
+        $$
+    }
+
+    public static bool operator false(C other)
+    {
+        $$
+    }
+}";
                 await TestAddOperatorsAsync(input, expected,
                     new[] { CodeGenerationOperatorKind.True, CodeGenerationOperatorKind.False },
                     parameters: Parameters(Parameter("C", "other")),
@@ -440,12 +618,35 @@ class [|C|]
                 var expected = @"
 class C
 {
-    public static object operator + (C other) { $$ }
-    public static object operator - (C other) { $$ }
-    public static object operator ! (C other) { $$ }
-    public static object operator ~ (C other) { $$ }
-    public static object operator ++ (C other) { $$ }
-    public static object operator -- (C other) { $$ }
+    public static object operator +(C other)
+    {
+        $$
+    }
+
+    public static object operator -(C other)
+    {
+        $$
+    }
+
+    public static object operator !(C other)
+    {
+        $$
+    }
+
+    public static object operator ~(C other)
+    {
+        $$
+    }
+
+    public static object operator ++(C other)
+    {
+        $$
+    }
+
+    public static object operator --(C other)
+    {
+        $$
+    }
 }";
                 await TestAddOperatorsAsync(input, expected,
                     new[]
@@ -472,16 +673,55 @@ class [|C|]
                 var expected = @"
 class C
 {
-    public static object operator + (C a, C b) { $$ }
-    public static object operator - (C a, C b) { $$ }
-    public static object operator * (C a, C b) { $$ }
-    public static object operator / (C a, C b) { $$ }
-    public static object operator % (C a, C b) { $$ }
-    public static object operator & (C a, C b) { $$ }
-    public static object operator | (C a, C b) { $$ }
-    public static object operator ^ (C a, C b) { $$ }
-    public static object operator << (C a, C b) { $$ }
-    public static object operator >> (C a, C b) { $$ }
+    public static object operator +(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator -(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator *(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator /(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator %(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator &(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator |(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator ^(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator <<(C a, C b)
+    {
+        $$
+    }
+
+    public static object operator >>(C a, C b)
+    {
+        $$
+    }
 }";
                 await TestAddOperatorsAsync(input, expected,
                     new[]
@@ -512,12 +752,35 @@ class [|C|]
                 var expected = @"
 class C
 {
-    public static bool operator == (C a, C b) { $$ }
-    public static bool operator != (C a, C b) { $$ }
-    public static bool operator < (C a, C b) { $$ }
-    public static bool operator > (C a, C b) { $$ }
-    public static bool operator <= (C a, C b) { $$ }
-    public static bool operator >= (C a, C b) { $$ }
+    public static bool operator ==(C a, C b)
+    {
+        $$
+    }
+
+    public static bool operator !=(C a, C b)
+    {
+        $$
+    }
+
+    public static bool operator <(C a, C b)
+    {
+        $$
+    }
+
+    public static bool operator >(C a, C b)
+    {
+        $$
+    }
+
+    public static bool operator <=(C a, C b)
+    {
+        $$
+    }
+
+    public static bool operator >=(C a, C b)
+    {
+        $$
+    }
 }";
                 await TestAddOperatorsAsync(input, expected,
                     new[]
@@ -549,7 +812,13 @@ class C
             public async Task AddExplicitConversion()
             {
                 var input = @"class [|C|] { }";
-                var expected = @"class C { public static explicit operator int(C other) { $$ } }";
+                var expected = @"class C
+{
+    public static explicit operator int(C other)
+    {
+        $$
+    }
+}";
                 await TestAddConversionAsync(input, expected,
                     toType: typeof(int),
                     fromType: Parameter("C", "other"),
@@ -560,7 +829,13 @@ class C
             public async Task AddImplicitConversion()
             {
                 var input = @"class [|C|] { }";
-                var expected = @"class C { public static implicit operator int(C other) { $$ } }";
+                var expected = @"class C
+{
+    public static implicit operator int(C other)
+    {
+        $$
+    }
+}";
                 await TestAddConversionAsync(input, expected,
                     toType: typeof(int),
                     fromType: Parameter("C", "other"),
@@ -572,7 +847,7 @@ class C
             public async Task AddStatements()
             {
                 var input = "class C { public void [|M|]() { Console.WriteLine(1); } }";
-                var expected = "class C { public void M() { Console.WriteLine(1); $$ } }";
+                var expected = "class C { public void M() { Console.WriteLine(1); $$} }";
                 await TestAddStatementsAsync(input, expected, "Console.WriteLine(2);");
             }
 
@@ -581,7 +856,7 @@ class C
             public async Task AddDefaultParameterWithNonDefaultValueToMethod()
             {
                 var input = "class C { public void [|M|]() { } }";
-                var expected = "class C { public void M(string text = \"Hello\") { } }";
+                var expected = "class C { public void M(string text =\"Hello\") { } }";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(string), "text", true, "Hello")));
             }
@@ -590,7 +865,7 @@ class C
             public async Task AddDefaultParameterWithDefaultValueToMethod()
             {
                 var input = "class C { public void [|M|]() { } }";
-                var expected = "class C { public void M(double number = 0) { } }";
+                var expected = "class C { public void M(double number =0) { } }";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(double), "number", true)));
             }
@@ -599,7 +874,7 @@ class C
             public async Task AddParametersToMethod()
             {
                 var input = "class C { public void [|M|]() { } }";
-                var expected = "class C { public void M(int num, string text =\"Hello!\", float floating = 0.5F) { } }";
+                var expected = "class C { public void M(int num, string text =\"Hello!\", float floating =0.5F) { } }";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(int), "num"), Parameter(typeof(string), "text", true, "Hello!"), Parameter(typeof(float), "floating", true, .5f)));
             }
@@ -609,7 +884,7 @@ class C
             public async Task AddParamsParameterToMethod()
             {
                 var input = "class C { public void [|M|]() { } }";
-                var expected = "class C { public void M(params char[] characters) { } }";
+                var expected = "class C { public void M(params char[]characters) { } }";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(char[]), "characters", isParams: true)));
             }
@@ -618,7 +893,10 @@ class C
             public async Task AddAutoProperty()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public int P { get; internal set; } }";
+                var expected = @"class C
+{
+    public int P { get; internal set; }
+}";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(int),
                     setterAccessibility: Accessibility.Internal);
@@ -628,7 +906,10 @@ class C
             public async Task AddUnsafeAutoProperty()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public unsafe int P { get; internal set; } }";
+                var expected = @"class C
+{
+    public unsafe int P { get; internal set; }
+}";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(int),
                     modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
@@ -652,7 +933,16 @@ class C
             public async Task AddIndexer2()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public string this[int i] { get { $$ } } }";
+                var expected = @"class C
+{
+    public string this[int i]
+    {
+        get
+        {
+            $$
+        }
+    }
+}";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(string),
                     parameters: Parameters(Parameter(typeof(int), "i")),
@@ -668,7 +958,17 @@ class C
             public async Task AddParameterfulProperty()
             {
                 var input = "class [|C|] { }";
-                var expected = "class C { public string get_P(int i, int j) { $$ } public void set_P(int i, int j, string value) { } }";
+                var expected = @"class C
+{
+    public string get_P(int i, int j)
+    {
+        $$
+    }
+
+    public void set_P(int i, int j, string value)
+    {
+    }
+}";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(string),
                     getStatements: "return String.Empty;",
@@ -680,7 +980,8 @@ class C
             public async Task AddAttributeToTypes()
             {
                 var input = "class [|C|] { }";
-                var expected = "[System.Serializable] class C { }";
+                var expected = @"[System.Serializable]
+class C { }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -696,7 +997,7 @@ class C
             public async Task AddAttributeToMethods()
             {
                 var input = "class C { public void [|M()|] { } }";
-                var expected = "class C { [System.Serializable] public void M() { } }";
+                var expected = "class C {[System.Serializable] public void M() { } }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -712,7 +1013,7 @@ class C
             public async Task AddAttributeToFields()
             {
                 var input = "class C { [|public int F|]; }";
-                var expected = "class C { [System.Serializable] public int F; }";
+                var expected = "class C {[System.Serializable] public int F; }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -728,7 +1029,7 @@ class C
             public async Task AddAttributeToProperties()
             {
                 var input = "class C { public int [|P|] { get; set; }}";
-                var expected = "class C { [System.Serializable] public int P { get; set; } }";
+                var expected = "class C {[System.Serializable] public int P { get; set; } }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -744,7 +1045,7 @@ class C
             public async Task AddAttributeToPropertyAccessor()
             {
                 var input = "class C { public int P { [|get|]; set; }}";
-                var expected = "class C { public int P { [System.Serializable] get; set; } }";
+                var expected = "class C { public int P { [System.Serializable] get; set; }}";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -760,7 +1061,8 @@ class C
             public async Task AddAttributeToEnums()
             {
                 var input = "enum [|C|] { One, Two }";
-                var expected = "[System.Serializable] enum C { One, Two }";
+                var expected = @"[System.Serializable]
+enum C { One, Two }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -776,7 +1078,7 @@ class C
             public async Task AddAttributeToEnumMembers()
             {
                 var input = "enum C { [|One|], Two }";
-                var expected = "enum C { [System.Serializable] One, Two }";
+                var expected = "enum C {[System.Serializable] One, Two }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -792,7 +1094,7 @@ class C
             public async Task AddAttributeToIndexer()
             {
                 var input = "class C { public int [|this[int y]|] { get; set; }}";
-                var expected = "class C { [System.Serializable] public int this[int y] { get; set; } }";
+                var expected = "class C {[System.Serializable] public int this[int y] { get; set; } }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -808,7 +1110,7 @@ class C
             public async Task AddAttributeToOperator()
             {
                 var input = "class C { public static C operator [|+|] (C c1, C c2) { return new C(); }}";
-                var expected = "class C { [System.Serializable] public static C operator + (C c1, C c2) { return new C(); } }";
+                var expected = "class C {[System.Serializable] public static C operator +(C c1, C c2) { return new C(); } }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -824,7 +1126,8 @@ class C
             public async Task AddAttributeToDelegate()
             {
                 var input = "delegate int [|D()|];";
-                var expected = "[System.Serializable] delegate int D();";
+                var expected = @"[System.Serializable]
+delegate int D();";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -872,7 +1175,10 @@ class C
             public async Task AddAttributeToCompilationUnit()
             {
                 var input = "[|class C { } class D {} |]";
-                var expected = "[assembly: System.Serializable] class C{ } class D {}";
+                var expected = @"[assembly: System.Serializable]
+
+class C { }
+class D { }";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute), SyntaxFactory.Token(SyntaxKind.AssemblyKeyword));
             }
 
@@ -1048,12 +1354,23 @@ public static class C
             {
                 var generationSource = "public class [|C|] { public C(){} public int this[int index]{get{return 0;}set{value = 0;}} }";
                 var initial = "public class [|C|] { ~C(){} }";
-                var expected = @"
-public class C
-{
-    public C(){}
+                var expected = @"public class C {
+    public C()
+    {
+    }
+
     ~C(){}
-    public int this[int index] { get{} set{} }
+
+    public int this[int index]
+    {
+        get
+        {
+        }
+
+        set
+        {
+        }
+    }
 }";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
             }
@@ -1098,8 +1415,7 @@ namespace N
     }
 }";
                 var initial = "namespace [|N|] { }";
-                var expected = @"
-namespace N
+                var expected = @"namespace N
 {
     public class C
     {
@@ -1145,12 +1461,10 @@ public static class [|C|]
     public static void ExtMethod1(this string s, int y, string z) {}
 }";
             var initial = "public static class [|C|] {}";
-            var expected = @"
-public static class C
+            var expected = @"public static class C
 {
     public static void ExtMethod1(this string s, int y, string z);
-}
-";
+}";
             await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                 codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false),
                 onlyGenerateMembers: true);
@@ -1175,16 +1489,14 @@ End Namespace
 ";
 
             var initial = "namespace [|N|] {}";
-            var expected = @"
-namespace N 
-{ 
-    public class C 
-    { 
-        public virtual string get_IndexProp ( int p1 ) ; 
-        public virtual void set_IndexProp ( int p1 , string value ) ; 
-    } 
-} 
-";
+            var expected = @"namespace N
+{
+    public class C
+    {
+        public virtual string get_IndexProp(int p1);
+        public virtual void set_IndexProp(int p1, string value);
+    }
+}";
             await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                 codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
         }
@@ -1199,12 +1511,10 @@ Public Class [|C|]
     End Sub
 End Class";
             var initial = "public class [|C|] {}";
-            var expected = @"
-public class C
+            var expected = @"public class C
 {
     public void Goo(int x, ref int y, ref object z);
-}
-";
+}";
             await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                 codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false),
                 onlyGenerateMembers: true);
@@ -1225,16 +1535,21 @@ namespace N
 }
 ";
             var initial = "namespace [|N|] {}";
-            var expected = @"
-namespace N
+            var expected = @"namespace N
 {
-    public class C<T, U> where T : struct where U : class
+    public class C<T, U>
+        where T : struct
+        where U : class
     {
-        public void Goo<Q, R>() where Q : new() where R : IComparable;
-        public delegate void D<T, U>(T t, U u) where T : struct where U : class;
+        public void Goo<Q, R>()
+            where Q : new()
+            where R : IComparable;
+
+        public delegate void D<T, U>(T t, U u)
+            where T : struct
+            where U : class;
     }
-}
-";
+}";
             await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                 codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false),
                 onlyGenerateMembers: true);

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.Shared.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.Shared.cs
@@ -129,8 +129,7 @@ namespace N
         public string FAccessE;
     }
 }";
-                var expected = @"
-namespace N
+                var expected = @"namespace N
 {
     public class C
     {
@@ -343,8 +342,7 @@ namespace N
                     forceLanguage: LanguageNames.CSharp);
 
                 initial = "Namespace [|N|] \n End Namespace";
-                expected = @"
-Namespace N
+                expected = @"Namespace N
     Public Class C
         Public Const FConst As String
         Public Shared FStatic As String
@@ -516,9 +514,7 @@ End Namespace";
             {
                 var generationSource = "public class [|C|] { private string B; public string C; }";
                 var initial = "public class [|C|] { string A; }";
-                var expected = @"
-public class C
-{
+                var expected = @"public class C {
     public string C;
     string A;
     private string B;
@@ -526,9 +522,7 @@ public class C
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "public struct [|S|] { string A; }";
-                expected = @"
-public struct S
-{
+                expected = @"public struct S {
     public string C;
     string A;
     private string B;
@@ -536,8 +530,7 @@ public struct S
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Class [|C|] \n Dim A As String \n End Class";
-                expected = @"
-Public Class C
+                expected = @"Public Class C
     Public C As String
     Dim A As String
     Private B As String
@@ -545,8 +538,7 @@ End Class";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Module [|M|] \n Dim A As String \n End Module";
-                expected = @"
-Public Module M
+                expected = @"Public Module M
     Public C As String
     Dim A As String
     Private B As String
@@ -554,9 +546,8 @@ End Module";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Structure [|S|] \n Dim A As String \n End Structure";
-                expected = @"
-Public Structure S
-    Dim A As String
+                expected = @"Public Structure S 
+ Dim A As String
     Public C As String
     Private B As String
 End Structure";
@@ -568,43 +559,41 @@ End Structure";
             {
                 var generationSource = "public class [|C|] { private void B(){} public void C(){}  }";
                 var initial = "public interface [|I|] { void A(); }";
-                var expected = @"
-public interface I
-{
-    void A();
+                var expected = @"public interface I { void A();
     void B();
     void C();
 }";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Interface [|I|] \n Sub A() \n End Interface";
-                expected = @"
-Public Interface I
-    Sub A()
+                expected = @"Public Interface I 
+ Sub A()
     Sub B()
     Sub C()
 End Interface";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Class [|C|] \n Sub A() \n End Sub \n End Class";
-                expected = @"
-Public Class C
-    Sub A()
-    End Sub
+                expected = @"Public Class C 
+ Sub A() 
+ End Sub
+
     Public Sub C()
     End Sub
+
     Private Sub B()
     End Sub
 End Class";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected, onlyGenerateMembers: true);
 
                 initial = "Public Module [|M|] \n Sub A() \n End Sub \n End Module";
-                expected = @"
-Public Module M
-    Sub A()
-    End Sub
+                expected = @"Public Module M 
+ Sub A() 
+ End Sub
+
     Public Sub C()
     End Sub
+
     Private Sub B()
     End Sub
 End Module";
@@ -616,11 +605,22 @@ End Module";
             {
                 var generationSource = "internal class [|B|]{}";
                 var initial = "namespace [|N|] { class A{} }";
-                var expected = "namespace N { class A{} internal class B{} }";
+                var expected = @"namespace N { class A{}
+
+    internal class B
+    {
+    }
+}";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected);
 
                 initial = "Namespace [|N|] \n Class A \n End Class \n End Namespace";
-                expected = "Namespace N \n Class A \n End Class \n Friend Class B \n End Class \n End Namespace";
+                expected = @"Namespace N 
+ Class A 
+ End Class
+
+    Friend Class B
+    End Class
+End Namespace";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected);
             }
 
@@ -629,11 +629,17 @@ End Module";
             {
                 var generationSource = "public class [|C|]{}";
                 var initial = "namespace [|N|] { class A{} }";
-                var expected = "namespace N { public class C{} class A{} }";
+                var expected = "namespace N { public class C { } class A{} }";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected);
 
                 initial = "Namespace [|N|] \n Class A \n End Class \n End Namespace";
-                expected = "Namespace N \n Public Class C \n End Class \n Class A \n End Class \n End Namespace";
+                expected = @"Namespace N
+    Public Class C
+    End Class
+
+    Class A 
+ End Class 
+ End Namespace";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected);
             }
 
@@ -647,10 +653,13 @@ public class [|C|]
     public C() { }
 }";
                 var initial = "public class [|C|] { }";
-                var expected = @"
-public class C
+                var expected = @"public class C
 {
-    /// <summary>When in need, a documented method is a friend, indeed.</summary>
+    /// 
+    /// <member name=""M:C.#ctor"">
+    ///     <summary>When in need, a documented method is a friend, indeed.</summary>
+    /// </member>
+    /// 
     public C();
 }";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
@@ -681,48 +690,43 @@ namespace [|N|]
 }";
 
                 var initial = "namespace [|N|] { }";
-                var expected = @"
-namespace N
-{
-namespace N
-{
-    public class A 
+                var expected = @"namespace N {
+    namespace N
     {
-        public static abstract string Property1 { get; }
-        public virtual string Property { get; }
+        public class A
+        {
+            public static abstract string Property1 { get; }
+            public virtual string Property { get; }
 
-        public abstract static void Method2();
-        public virtual void Method1();
-    }
+            public abstract static void Method2();
+            public virtual void Method1();
+        }
 
-    public class C
-    {
-        public sealed override string Property { get; }
-        public sealed override void Method1();
+        public class C
+        {
+            public sealed override string Property { get; }
+
+            public sealed override void Method1();
+        }
     }
-}
-}
-";
+}";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
 
                 var initialVB = "Namespace [|N|] End Namespace";
-                var expectedVB = @"
-Namespace N 
-Namespace N
-    Public Class A
-        Public Shared MustOverride ReadOnly Property Property1 As String
-        Public Overridable ReadOnly Property [Property] As String
-        Public MustOverride Shared Sub Method2()
-        Public Overridable Sub Method1()
-    End Class
+                var expectedVB = @"Namespace N End NamespaceNamespace N
+        Public Class A
+            Public Shared MustOverride ReadOnly Property Property1 As String
+            Public Overridable ReadOnly Property [Property] As String
+            Public MustOverride Shared Sub Method2()
+            Public Overridable Sub Method1()
+        End Class
 
-    Public Class C
-        Public Overrides NotOverridable ReadOnly Property [Property] As String
-        Public NotOverridable Overrides Sub Method1()
-    End Class
-End Namespace
-";
+        Public Class C
+            Public Overrides NotOverridable ReadOnly Property [Property] As String
+            Public NotOverridable Overrides Sub Method1()
+        End Class
+    End Namespace";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initialVB, expectedVB,
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
             }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.VisualBasic.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.VisualBasic.cs
@@ -25,7 +25,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddNamespace()
             {
                 var input = "Namespace [|N1|]\n End Namespace";
-                var expected = "Namespace N1\n Namespace N2\n End Namespace\n End Namespace";
+                var expected = @"Namespace N1
+    Namespace N2
+    End Namespace
+End Namespace";
                 await TestAddNamespaceAsync(input, expected,
                     name: "N2");
             }
@@ -34,7 +37,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddField()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public F As Integer\n End Class";
+                var expected = @"Class C
+    Public F As Integer
+End Class";
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(int)));
             }
@@ -43,7 +48,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddSharedField()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Private Shared F As String\n End Class";
+                var expected = @"Class C
+    Private Shared F As String
+End Class";
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(string)),
                     accessibility: Accessibility.Private,
@@ -54,7 +61,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddArrayField()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public F As Integer()\n End Class";
+                var expected = @"Class C
+    Public F As Integer()
+End Class";
                 await TestAddFieldAsync(input, expected,
                     type: CreateArrayType(typeof(int)));
             }
@@ -63,7 +72,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             public async Task AddConstructor()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Sub New()\n End Sub\n End Class";
+                var expected = @"Class C
+    Public Sub New()
+    End Sub
+End Class";
                 await TestAddConstructorAsync(input, expected);
             }
 
@@ -96,7 +108,9 @@ End Class";
             public async Task AddConstructorWithoutBody()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Sub New()\n End Class";
+                var expected = @"Class C
+    Public Sub New()
+End Class";
                 await TestAddConstructorAsync(input, expected,
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
             }
@@ -105,7 +119,12 @@ End Class";
             public async Task AddConstructorResolveNamespaceImport()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Imports System.Text\n Class C\n Public Sub New(s As StringBuilder)\n End Sub\n End Class";
+                var expected = @"Imports System.Text
+
+Class C
+    Public Sub New(s As StringBuilder)
+    End Sub
+End Class";
                 await TestAddConstructorAsync(input, expected,
                     parameters: Parameters(Parameter(typeof(StringBuilder), "s")));
             }
@@ -114,7 +133,10 @@ End Class";
             public async Task AddSharedConstructor()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Shared Sub New()\n End Sub\n End Class";
+                var expected = @"Class C
+    Shared Sub New()
+    End Sub
+End Class";
                 await TestAddConstructorAsync(input, expected,
                     modifiers: new DeclarationModifiers(isStatic: true));
             }
@@ -123,7 +145,14 @@ End Class";
             public async Task AddChainedConstructor()
             {
                 var input = "Class [|C|]\n Public Sub New(i As Integer)\n End Sub\n End Class";
-                var expected = "Class C\n Public Sub New()\n Me.New(42)\n End Sub\n Public Sub New(i As Integer)\n End Sub\n End Class";
+                var expected = @"Class C
+    Public Sub New()
+        Me.New(42)
+    End Sub
+
+    Public Sub New(i As Integer)
+ End Sub
+ End Class";
                 await TestAddConstructorAsync(input, expected,
                     thisArguments: ImmutableArray.Create<SyntaxNode>(VB.SyntaxFactory.ParseExpression("42")));
             }
@@ -144,7 +173,10 @@ End Namespace";
             public async Task AddClassEscapeName()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Class [Class]\n End Class\n End Namespace";
+                var expected = @"Namespace N
+    Public Class [Class]
+    End Class
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "Class");
             }
@@ -153,16 +185,22 @@ End Namespace";
             public async Task AddClassUnicodeName()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Class [Class]\n End Class\n End Namespace";
+                var expected = @"Namespace N
+    Public Class [Class]
+    End Class
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
-                    name: "Cl\u0061ss");
+                    name: "Class");
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration), WorkItem(544477, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544477")]
             public async Task AddNotInheritableClass()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public NotInheritable Class C\n End Class\n End Namespace";
+                var expected = @"Namespace N
+    Public NotInheritable Class C
+    End Class
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     modifiers: new DeclarationModifiers(isSealed: true));
             }
@@ -171,7 +209,10 @@ End Namespace";
             public async Task AddMustInheritClass()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Friend MustInherit Class C\n End Class\n End Namespace";
+                var expected = @"Namespace N
+    Friend MustInherit Class C
+    End Class
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     accessibility: Accessibility.Internal,
                     modifiers: new DeclarationModifiers(isAbstract: true));
@@ -181,7 +222,10 @@ End Namespace";
             public async Task AddStructure()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Friend Structure S\n End Structure\n End Namespace";
+                var expected = @"Namespace N
+    Friend Structure S
+    End Structure
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "S",
                     accessibility: Accessibility.Internal,
@@ -192,7 +236,10 @@ End Namespace";
             public async Task AddSealedStructure()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Structure S\n End Structure\n End Namespace";
+                var expected = @"Namespace N
+    Public Structure S
+    End Structure
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "S",
                     accessibility: Accessibility.Public,
@@ -204,7 +251,10 @@ End Namespace";
             public async Task AddInterface()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Interface I\n End Interface\n End Namespace";
+                var expected = @"Namespace N
+    Public Interface I
+    End Interface
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "I",
                     typeKind: TypeKind.Interface);
@@ -214,7 +264,11 @@ End Namespace";
             public async Task AddEnum()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Enum E\n F1\n End Enum\n End Namespace";
+                var expected = @"Namespace N
+    Public Enum E
+        F1
+    End Enum
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected, "E",
                     typeKind: TypeKind.Enum,
                     members: Members(CreateEnumField("F1", null)));
@@ -224,7 +278,12 @@ End Namespace";
             public async Task AddEnumWithValues()
             {
                 var input = "Namespace [|N|]\n End Namespace";
-                var expected = "Namespace N\n Public Enum E\n F1 = 1\n F2 = 2\n End Enum\n End Namespace";
+                var expected = @"Namespace N
+    Public Enum E
+        F1 = 1
+        F2 = 2
+    End Enum
+End Namespace";
                 await TestAddNamedTypeAsync(input, expected, "E",
                     typeKind: TypeKind.Enum,
                     members: Members(CreateEnumField("F1", 1), CreateEnumField("F2", 2)));
@@ -234,7 +293,11 @@ End Namespace";
             public async Task AddEnumMember()
             {
                 var input = "Public Enum [|E|]\n F1 = 1\n F2 = 2\n End Enum";
-                var expected = "Public Enum E\n F1 = 1\n F2 = 2\n F3\n End Enum";
+                var expected = @"Public Enum E
+ F1 = 1
+ F2 = 2
+    F3
+End Enum";
                 await TestAddFieldAsync(input, expected,
                     name: "F3");
             }
@@ -243,7 +306,11 @@ End Namespace";
             public async Task AddEnumMemberWithValue()
             {
                 var input = "Public Enum [|E|]\n F1 = 1\n F2\n End Enum";
-                var expected = "Public Enum E\n F1 = 1\n F2\n F3 = 3\n End Enum";
+                var expected = @"Public Enum E
+ F1 = 1
+ F2
+    F3 = 3
+End Enum";
                 await TestAddFieldAsync(input, expected,
                     name: "F3", hasConstantValue: true, constantValue: 3);
             }
@@ -252,7 +319,9 @@ End Namespace";
             public async Task AddDelegateType()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Delegate Function D(s As String) As Integer\n End Class";
+                var expected = @"Class C
+    Public Delegate Function D(s As String) As Integer
+End Class";
                 await TestAddDelegateTypeAsync(input, expected,
                     returnType: typeof(int),
                     parameters: Parameters(Parameter(typeof(string), "s")));
@@ -262,7 +331,9 @@ End Namespace";
             public async Task AddSealedDelegateType()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Delegate Function D(s As String) As Integer\n End Class";
+                var expected = @"Class C
+    Public Delegate Function D(s As String) As Integer
+End Class";
                 await TestAddDelegateTypeAsync(input, expected,
                     returnType: typeof(int),
                     modifiers: new DeclarationModifiers(isSealed: true),
@@ -287,19 +358,15 @@ End Class";
             public async Task AddEventWithAccessorAndImplementsClause()
             {
                 var input = "Class [|C|] \n End Class";
-                var expected = @"
-Class C
-	Public Custom Event E As ComponentModel.PropertyChangedEventHandler Implements ComponentModel.INotifyPropertyChanged.PropertyChanged
-
-		AddHandler ( value As ComponentModel . PropertyChangedEventHandler )
-		End AddHandler
-
-		RemoveHandler ( value As ComponentModel . PropertyChangedEventHandler ) 
-		End RemoveHandler
-
-		RaiseEvent ( sender As Object , e As ComponentModel . PropertyChangedEventArgs ) 
-		End RaiseEvent
-	End Event
+                var expected = @"Class C
+    Public Custom Event E As ComponentModel.PropertyChangedEventHandler Implements ComponentModel.INotifyPropertyChanged.PropertyChanged
+        AddHandler(value As ComponentModel.PropertyChangedEventHandler)
+        End AddHandler
+        RemoveHandler(value As ComponentModel.PropertyChangedEventHandler)
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As ComponentModel.PropertyChangedEventArgs)
+        End RaiseEvent
+    End Event
 End Class";
                 ImmutableArray<IEventSymbol> GetExplicitInterfaceEvent(SemanticModel semanticModel)
                 {
@@ -332,16 +399,12 @@ End Class";
                 var expected = @"
 Class C
     Public Custom Event E As Action
-
         AddHandler(value As Action)
         End AddHandler
-
         RemoveHandler(value As Action)
         End RemoveHandler
-
         RaiseEvent()
         End RaiseEvent
-
     End Event
 End Class";
                 await TestAddEventAsync(input, expected,
@@ -358,15 +421,12 @@ End Class";
                 var expected = @"
 Class C
     Public Custom Event E As Action
-
         AddHandler(value As Action)
             Console.WriteLine(0)
         End AddHandler
-
         RemoveHandler(value As Action)
             Console.WriteLine(1)
         End RemoveHandler
-
         RaiseEvent()
             Console.WriteLine(2)
         End RaiseEvent
@@ -389,7 +449,10 @@ End Class";
             public async Task AddMethodToClass()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Sub M()\n End Sub\n End Class";
+                var expected = @"Class C
+    Public Sub M()
+    End Sub
+End Class";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(void));
             }
@@ -398,7 +461,10 @@ End Class";
             public async Task AddMethodToClassEscapedName()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Protected Friend Sub [Sub]()\n End Sub\n End Class";
+                var expected = @"Class C
+    Protected Friend Sub [Sub]()
+    End Sub
+End Class";
                 await TestAddMethodAsync(input, expected,
                     accessibility: Accessibility.ProtectedOrInternal,
                     name: "Sub",
@@ -409,7 +475,11 @@ End Class";
             public async Task AddSharedMethodToStructure()
             {
                 var input = "Structure [|S|]\n End Structure";
-                var expected = "Structure S\n Public Shared Function M() As Integer\n Return 0\n End Function\n End Structure";
+                var expected = @"Structure S
+    Public Shared Function M() As Integer
+        Return 0
+    End Function
+End Structure";
                 await TestAddMethodAsync(input, expected,
                     modifiers: new DeclarationModifiers(isStatic: true),
                     returnType: typeof(int),
@@ -420,7 +490,11 @@ End Class";
             public async Task AddNotOverridableOverridesMethod()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public NotOverridable Overrides Function GetHashCode() As Integer\n $$ \nEnd Function\n End Class";
+                var expected = @"Class C
+    Public NotOverridable Overrides Function GetHashCode() As Integer
+        $$
+    End Function
+End Class";
                 await TestAddMethodAsync(input, expected,
                     name: "GetHashCode",
                     modifiers: new DeclarationModifiers(isOverride: true, isSealed: true),
@@ -432,7 +506,7 @@ End Class";
             public async Task AddMustOverrideMethod()
             {
                 var input = "MustInherit Class [|C|]\n End Class";
-                var expected = "MustInherit Class C\n Public MustOverride Sub M()\n End Class";
+                var expected = "MustInherit Class C\n    Public MustOverride Sub M()\nEnd Class";
                 await TestAddMethodAsync(input, expected,
                     modifiers: new DeclarationModifiers(isAbstract: true),
                     returnType: typeof(void));
@@ -442,7 +516,9 @@ End Class";
             public async Task AddMethodWithoutBody()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Sub M()\n End Class";
+                var expected = @"Class C
+    Public Sub M()
+End Class";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(void),
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false));
@@ -452,7 +528,11 @@ End Class";
             public async Task AddGenericMethod()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Function M(Of T)() As Integer\n $$ \nEnd Function\n End Class";
+                var expected = @"Class C
+    Public Function M(Of T)() As Integer
+        $$
+    End Function
+End Class";
                 await TestAddMethodAsync(input, expected,
                     returnType: typeof(int),
                     typeParameters: ImmutableArray.Create(CodeGenerationSymbolFactory.CreateTypeParameterSymbol("T")),
@@ -463,32 +543,48 @@ End Class";
             public async Task AddVirtualMethod()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Protected Overridable Function M() As Integer\n $$ End Function\n End Class";
+                var expected = @"Class C
+    Protected Overridable Function M() As Integer
+        $$
+    End Function
+End Class";
                 await TestAddMethodAsync(input, expected,
                     accessibility: Accessibility.Protected,
                     modifiers: new DeclarationModifiers(isVirtual: true),
                     returnType: typeof(int),
-                    statements: "Return 0\n");
+                    statements: "Return 0");
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
             public async Task AddShadowsMethod()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Shadows Function ToString() As String\n $$ End Function\n End Class";
+                var expected = @"Class C
+    Public Shadows Function ToString() As String
+        $$
+    End Function
+End Class";
                 await TestAddMethodAsync(input, expected,
                     name: "ToString",
                     accessibility: Accessibility.Public,
                     modifiers: new DeclarationModifiers(isNew: true),
                     returnType: typeof(string),
-                    statements: "Return String.Empty\n");
+                    statements: "Return String.Empty");
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
             public async Task AddExplicitImplementation()
             {
                 var input = "Interface I\n Sub M(i As Integer)\n End Interface\n Class [|C|]\n Implements I\n End Class";
-                var expected = "Interface I\n Sub M(i As Integer)\n End Interface\n Class C\n Implements I\n Public Sub M(i As Integer) Implements I.M\n End Sub\n End Class";
+                var expected = @"Interface I
+ Sub M(i As Integer)
+ End Interface
+ Class C
+ Implements I
+
+    Public Sub M(i As Integer) Implements I.M
+    End Sub
+End Class";
                 await TestAddMethodAsync(input, expected,
                     name: "M",
                     returnType: typeof(void),
@@ -508,6 +604,7 @@ Class C
     Public Shared Operator IsTrue(other As C) As Boolean
         $$
     End Operator
+
     Public Shared Operator IsFalse(other As C) As Boolean
         $$
     End Operator
@@ -529,12 +626,14 @@ End Class
 ";
                 var expected = @"
 Class C
-    Public Shared Operator + (other As C) As Object
+    Public Shared Operator +(other As C) As Object
         $$
     End Operator
+
     Public Shared Operator -(other As C) As Object
         $$
     End Operator
+
     Public Shared Operator Not(other As C) As Object
         $$
     End Operator
@@ -562,44 +661,57 @@ End Class
                 var expected = @"
 Class C
     Public Shared Operator +(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator -(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator *(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator /(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator \(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator ^(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator &(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator Like(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator Mod(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator And(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator Or(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator Xor(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator <<(a As C, b As C) As Object
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator >>(a As C, b As C) As Object
         $$
     End Operator
@@ -638,23 +750,28 @@ End Class
                 var expected = @"
 Class C
     Public Shared Operator =(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator <>(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator >(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator <(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator >=(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
+
     Public Shared Operator <=(a As C, b As C) As Boolean
-		$$
-	End Operator
+        $$
+    End Operator
 End Class
 ";
                 await TestAddOperatorsAsync(input, expected,
@@ -687,7 +804,11 @@ End Class
             public async Task AddExplicitConversion()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Shared Narrowing Operator CType(other As C) As Integer\n $$\n End Operator\n End Class";
+                var expected = @"Class C
+    Public Shared Narrowing Operator CType(other As C) As Integer
+        $$
+    End Operator
+End Class";
                 await TestAddConversionAsync(input, expected,
                     toType: typeof(int),
                     fromType: Parameter("C", "other"),
@@ -698,7 +819,11 @@ End Class
             public async Task AddImplicitConversion()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Shared Widening Operator CType(other As C) As Integer\n $$\n End Operator\n End Class";
+                var expected = @"Class C
+    Public Shared Widening Operator CType(other As C) As Integer
+        $$
+    End Operator
+End Class";
                 await TestAddConversionAsync(input, expected,
                     toType: typeof(int),
                     fromType: Parameter("C", "other"),
@@ -710,7 +835,11 @@ End Class
             public async Task AddStatementsToSub()
             {
                 var input = "Class C\n [|Public Sub M\n Console.WriteLine(1)\n End Sub|]\n End Class";
-                var expected = "Class C\n Public Sub M\n Console.WriteLine(1)\n $$\n End Sub\n End Class";
+                var expected = @"Class C
+ Public Sub M
+ Console.WriteLine(1)
+$$ End Sub
+ End Class";
                 await TestAddStatementsAsync(input, expected, "Console.WriteLine(2)");
             }
 
@@ -718,7 +847,11 @@ End Class
             public async Task AddStatementsToOperator()
             {
                 var input = "Class C\n [|Shared Operator +(arg As C) As C\n Return arg\n End Operator|]\n End Class";
-                var expected = "Class C\n Shared Operator +(arg As C) As C\n Return arg\n $$\n End Operator\n End Class";
+                var expected = @"Class C
+ Shared Operator +(arg As C) As C
+ Return arg
+$$ End Operator
+ End Class";
                 await TestAddStatementsAsync(input, expected, "Return Nothing");
             }
 
@@ -726,7 +859,13 @@ End Class
             public async Task AddStatementsToPropertySetter()
             {
                 var input = "Imports System\n Class C\n WriteOnly Property P As String\n [|Set\n End Set|]\n End Property\n End Class";
-                var expected = "Imports System\n Class C\n WriteOnly Property P As String\n Set\n $$\n End Set\n End Property\n End Class";
+                var expected = @"Imports System
+ Class C
+ WriteOnly Property P As String
+ Set
+$$ End Set
+ End Property
+ End Class";
                 await TestAddStatementsAsync(input, expected, "Console.WriteLine(\"Setting the value\"");
             }
 
@@ -734,7 +873,10 @@ End Class
             public async Task AddParametersToMethod()
             {
                 var input = "Class C\n Public [|Sub M()\n End Sub|]\n End Class";
-                var expected = "Class C\n Public Sub M(num As Integer, Optional text As String = \"Hello!\", Optional floating As Single = 0.5)\n End Sub\n End Class";
+                var expected = @"Class C
+ Public Sub M(numAs Integer, OptionaltextAs String = ""Hello!"",OptionalfloatingAs Single = 0.5)
+ End Sub
+ End Class";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(int), "num"), Parameter(typeof(string), "text", true, "Hello!"), Parameter(typeof(float), "floating", true, .5F)));
             }
@@ -744,7 +886,15 @@ End Class
             public async Task AddParametersToPropertyBlock()
             {
                 var input = "Class C\n [|Public Property P As String\n Get\n Return String.Empty\n End Get\n Set(value As String)\n End Set\n End Property|]\n End Class";
-                var expected = "Class C\n Public Property P(num As Integer) As String\n Get\n Return String.Empty\n End Get\n Set(value As String)\n End Set\n End Property\n End Class";
+                var expected = @"Class C
+ Public Property P (numAs Integer) As String
+ Get
+ Return String.Empty
+ End Get
+ Set(value As String)
+ End Set
+ End Property
+ End Class";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(int), "num")));
             }
@@ -754,7 +904,15 @@ End Class
             public async Task AddParametersToPropertyStatement()
             {
                 var input = "Class C\n [|Public Property P As String|]\n Get\n Return String.Empty\n End Get\n Set(value As String)\n End Set\n End Property\n End Class";
-                var expected = "Class C\n Public Property P(num As Integer) As String\n Get\n Return String.Empty\n End Get\n Set(value As String)\n End Set\n End Property\n End Class";
+                var expected = @"Class C
+ Public Property P (numAs Integer) As String
+ Get
+ Return String.Empty
+ End Get
+ Set(value As String)
+ End Set
+ End Property
+ End Class";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter(typeof(int), "num")));
             }
@@ -783,7 +941,11 @@ End Class
             public async Task AddParametersToOperator()
             {
                 var input = "Class C\n [|Shared Operator +(a As C) As C\n Return a\n End Operator|]\n End Class";
-                var expected = "Class C\n Shared Operator +(a As C, b As C) As C\n Return a\n End Operator\n End Class";
+                var expected = @"Class C
+ Shared Operator +(a As C,bAs C) As C
+ Return a
+ End Operator
+ End Class";
                 await TestAddParametersAsync(input, expected,
                     Parameters(Parameter("C", "b")));
             }
@@ -792,7 +954,9 @@ End Class
             public async Task AddAutoProperty()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Property P As Integer\n End Class";
+                var expected = @"Class C
+    Public Property P As Integer
+End Class";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(int));
             }
@@ -801,7 +965,9 @@ End Class
             public async Task AddPropertyWithoutAccessorBodies()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Public Property P As Integer\n End Class";
+                var expected = @"Class C
+    Public Property P As Integer
+End Class";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(int),
                     getStatements: "Return 0",
@@ -813,7 +979,13 @@ End Class
             public async Task AddIndexer()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "Class C\n Default Public ReadOnly Property Item(i As Integer) As String\n Get\n $$ \nEnd Get\n End Property\n End Class";
+                var expected = @"Class C
+    Default Public ReadOnly Property Item(i As Integer) As String
+        Get
+            $$
+        End Get
+    End Property
+End Class";
                 await TestAddPropertyAsync(input, expected,
                     name: "Item",
                     type: typeof(string),
@@ -826,7 +998,9 @@ End Class
             public async Task AddAttributeToTypes()
             {
                 var input = "Class [|C|]\n End Class";
-                var expected = "<Serializable> Class C\n End Class";
+                var expected = @"<Serializable>
+Class C
+End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -847,7 +1021,11 @@ End Class";
             public async Task AddAttributeToMethods()
             {
                 var input = "Class C\n Public Sub [|M()|] \n End Sub \n End Class";
-                var expected = "Class C\n <Serializable> Public Sub M() \n End Sub \n End Class";
+                var expected = @"Class C
+    <Serializable>
+    Public Sub M()
+    End Sub 
+ End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -872,7 +1050,10 @@ End Class";
             public async Task AddAttributeToFields()
             {
                 var input = "Class C\n [|Public F As Integer|]\n End Class";
-                var expected = "Class C\n <Serializable> Public F As Integer\n End Class";
+                var expected = @"Class C
+    <Serializable>
+    Public F As Integer
+End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -895,7 +1076,10 @@ End Class";
             public async Task AddAttributeToProperties()
             {
                 var input = "Class C \n Public Property [|P|] As Integer \n End Class";
-                var expected = "Class C \n <Serializable> Public Property P As Integer \n End Class";
+                var expected = @"Class C
+    <Serializable>
+    Public Property P As Integer
+End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -918,7 +1102,14 @@ End Class";
             public async Task AddAttributeToPropertyAccessor()
             {
                 var input = "Class C \n Public ReadOnly Property P As Integer \n [|Get|] \n Return 10 \n End Get \n End Property \n  End Class";
-                var expected = "Class C \n Public ReadOnly Property P As Integer \n <Serializable> Get \n Return 10 \n End Get \n End Property \n  End Class";
+                var expected = @"Class C 
+ Public ReadOnly Property P As Integer
+        <Serializable>
+        Get
+            Return 10 
+ End Get 
+ End Property 
+  End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -947,7 +1138,13 @@ End Class";
             public async Task AddAttributeToEnums()
             {
                 var input = "Module M \n [|Enum C|] \n One \n Two \n End Enum\n End Module";
-                var expected = "Module M \n <Serializable> Enum C \n One \n Two \n End Enum\n End Module";
+                var expected = @"Module M
+    <Serializable>
+    Enum C
+        One 
+ Two 
+ End Enum
+ End Module";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -976,7 +1173,13 @@ End Module";
             public async Task AddAttributeToEnumMembers()
             {
                 var input = "Module M \n Enum C \n [|One|] \n Two \n End Enum\n End Module";
-                var expected = "Module M \n Enum C \n <Serializable> One \n Two \n End Enum\n End Module";
+                var expected = @"Module M 
+ Enum C
+        <Serializable>
+        One
+        Two 
+ End Enum
+ End Module";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -1005,7 +1208,9 @@ End Module";
             public async Task AddAttributeToModule()
             {
                 var input = "Module [|M|] \n End Module";
-                var expected = "<Serializable> Module M \n End Module";
+                var expected = @"<Serializable>
+Module M
+End Module";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -1026,7 +1231,12 @@ End Module";
             public async Task AddAttributeToOperator()
             {
                 var input = "Class C \n Public Shared Operator [|+|] (x As C, y As C) As C \n Return New C() \n End Operator \n End Class";
-                var expected = "Class C \n <Serializable> Public Shared Operator +(x As C, y As C) As C \n Return New C() \n End Operator \n End Class";
+                var expected = @"Class C
+    <Serializable>
+    Public Shared Operator +(x As C, y As C) As C
+        Return New C() 
+ End Operator 
+ End Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -1057,7 +1267,7 @@ End Module";
             public async Task AddAttributeToDelegate()
             {
                 var input = "Module M \n Delegate Sub [|D()|]\n End Module";
-                var expected = "Module M \n <Serializable> Delegate Sub D()\n End Module";
+                var expected = "Module M\n    <Serializable>\n    Delegate Sub D()\nEnd Module";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute));
             }
 
@@ -1104,7 +1314,7 @@ End Class";
             public async Task AddAttributeToCompilationUnit()
             {
                 var input = "[|Class C \n End Class \n Class D \n End Class|]";
-                var expected = "<Assembly: Serializable> Class C \n End Class \n Class D \n End Class";
+                var expected = "<Assembly: Serializable>\nClass C\nEnd Class\nClass D\nEnd Class";
                 await TestAddAttributeAsync(input, expected, typeof(SerializableAttribute), VB.SyntaxFactory.Token(VB.SyntaxKind.AssemblyKeyword));
             }
 
@@ -1257,7 +1467,13 @@ End Class";
             {
                 var generationSource = "Public Class [|C|] \n End Class";
                 var initial = "Namespace [|N|] \n Module M \n End Module \n End Namespace";
-                var expected = "Namespace N \n Public Class C \n End Class \n Module M \n End Module \n End Namespace";
+                var expected = @"Namespace N
+    Public Class C
+    End Class
+
+    Module M 
+ End Module 
+ End Namespace";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected);
             }
 
@@ -1351,8 +1567,7 @@ Namespace N
     End Class
 End Namespace";
                 var initial = "Namespace [|N|] \n End Namespace";
-                var expected = @"
-Namespace N
+                var expected = @"Namespace N
     Public Class C
         Public Shared Operator +(other As C) As C
         Public Shared Operator +(a As C, b As C) As C
@@ -1401,14 +1616,12 @@ Namespace N
 End Namespace
 ";
                 var initial = "Namespace [|N|] \n End Namespace";
-                var expected = @"
-Namespace N
+                var expected = @"Namespace N
     Public Class C(Of T As Structure, U As Class)
         Public Sub Goo(Of Q As New, R As IComparable)()
         Public Delegate Sub D(Of T1 As Structure, T2 As Class)(t As T1, u As T2)
     End Class
-End Namespace
-";
+End Namespace";
                 await TestGenerateFromSourceSymbolAsync(generationSource, initial, expected,
                     codeGenerationOptions: new CodeGenerationOptions(generateMethodBodies: false),
                     onlyGenerateMembers: true);

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             IList<ISymbol> imports = null,
             IList<INamespaceOrTypeSymbol> members = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Accessibility accessibility = Accessibility.Public,
             Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             bool hasConstantValue = false,
             object constantValue = null,
             bool addToCompilationUnit = false)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             ImmutableArray<SyntaxNode> baseArguments = default(ImmutableArray<SyntaxNode>),
             ImmutableArray<SyntaxNode> thisArguments = default(ImmutableArray<SyntaxNode>),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string statements = null,
             ImmutableArray<SyntaxNode> handlesExpressions = default(ImmutableArray<SyntaxNode>),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             if (statements != null)
             {
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             string statements = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             if (statements != null)
             {
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             string statements = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, initial, ignoreResult: true))
             {
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             string statements = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             if (statements != null)
             {
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             string statements,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             if (statements != null)
             {
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             ImmutableArray<ITypeParameterSymbol> typeParameters = default(ImmutableArray<ITypeParameterSymbol>),
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             IMethodSymbol removeMethod = null,
             IMethodSymbol raiseMethod = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             bool isIndexer = false,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             IDictionary<OptionKey, object> options = null)
         {
             // This assumes that tests will not use place holders for get/set statements at the same time
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             SpecialType specialType = SpecialType.None,
             ImmutableArray<Func<SemanticModel, ISymbol>> members = default(ImmutableArray<Func<SemanticModel, ISymbol>>),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             Type attributeClass,
             SyntaxToken? target = null,
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia))
             {
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             bool onlyGenerateMembers = false,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             string forceLanguage = null)
         {
             using (var context = await TestContext.CreateAsync(initial, expected, ignoreTrivia, forceLanguage))
@@ -837,7 +837,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 this.Service = Document.Project.LanguageServices.GetService<ICodeGenerationService>();
             }
 
-            public static async Task<TestContext> CreateAsync(string initial, string expected, bool ignoreTrivia = true, string forceLanguage = null, bool ignoreResult = false)
+            public static async Task<TestContext> CreateAsync(string initial, string expected, bool ignoreTrivia = false, string forceLanguage = null, bool ignoreResult = false)
             {
                 var language = forceLanguage != null ? forceLanguage : GetLanguage(initial);
                 var isVisualBasic = language == LanguageNames.VisualBasic;

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -104,17 +104,17 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                     // Compare tokens and verify location relative to the generated tokens
                     expected = GetSpaceSeparatedTokens(expected);
                     actual = GetSpaceSeparatedTokens(actual.Insert(actualSpan.Start, "[|").Insert(actualSpan.End + 2, "|]"));
+                    Assert.Equal(expected, actual);
                 }
                 else
                 {
                     // Compare exact texts and verify that the location returned is exactly that
                     // indicated by expected
-                    MarkupTestFile.GetSpan(expected.TrimStart().TrimEnd(), out expected, out var expectedSpan);
+                    MarkupTestFile.GetSpan(expected, out expected, out var expectedSpan);
+                    Assert.Equal(expected, actual);
                     Assert.Equal(expectedSpan.Start, actualSpan.Start);
                     Assert.Equal(expectedSpan.End, actualSpan.End);
                 }
-
-                Assert.Equal(expected, actual);
             }
 
             public async Task GenerateAndVerifySourceAsync(string symbolMetadataName, string expected, bool ignoreTrivia = false, Project project = null)

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 return string.Join(" ", tokens);
             }
 
-            public void VerifyResult(MetadataAsSourceFile file, string expected, bool ignoreTrivia = true)
+            public void VerifyResult(MetadataAsSourceFile file, string expected, bool ignoreTrivia = false)
             {
                 var actual = File.ReadAllText(file.FilePath).Trim();
                 var actualSpan = file.IdentifierLocation.SourceSpan;
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 Assert.Equal(expected, actual);
             }
 
-            public async Task GenerateAndVerifySourceAsync(string symbolMetadataName, string expected, bool ignoreTrivia = true, Project project = null)
+            public async Task GenerateAndVerifySourceAsync(string symbolMetadataName, string expected, bool ignoreTrivia = false, Project project = null)
             {
                 var result = await GenerateSourceAsync(symbolMetadataName, project);
                 VerifyResult(result, expected, ignoreTrivia);

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
     {
         internal static async Task GenerateAndVerifySourceAsync(
             string metadataSource, string symbolName, string projectLanguage, string expected,
-            bool ignoreTrivia = true, bool includeXmlDocComments = false, string languageVersion = null)
+            bool ignoreTrivia = false, bool includeXmlDocComments = false, string languageVersion = null)
         {
             using (var context = TestContext.Create(projectLanguage, SpecializedCollections.SingletonEnumerable(metadataSource), includeXmlDocComments, languageVersion: languageVersion))
             {

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.VisualBasic.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.VisualBasic.cs
@@ -20,8 +20,7 @@ Module M
     Public Class D
     End Class
 End Module";
-                await GenerateAndVerifySourceAsync(metadataSource, "M+D", LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+                await GenerateAndVerifySourceAsync(metadataSource, "M+D", LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
             var metadataSource = "public class C {}";
             var symbolName = "C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -28,8 +27,7 @@ public class [|C|]
 {{
     public C();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -45,16 +43,14 @@ End Class");
             var metadataSource = "public interface I {}";
             var symbolName = "I";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
 public interface [|I|]
 {{
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -68,8 +64,7 @@ End Interface");
             var metadataSource = "public class C {}";
             var symbolName = "C..ctor";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -77,8 +72,7 @@ public class C
 {{
     public [|C|]();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -93,8 +87,7 @@ End Class");
             var metadataSource = "public class C { public void Goo() {} }";
             var symbolName = "C.Goo";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -104,8 +97,7 @@ public class C
 
     public void [|Goo|]();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -122,8 +114,7 @@ End Class");
             var metadataSource = "public class C { public string S; }";
             var symbolName = "C.S";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -133,8 +124,7 @@ public class C
 
     public C();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -152,8 +142,7 @@ End Class");
             var metadataSource = "public class C { public string S { get; protected set; } }";
             var symbolName = "C.S";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -163,8 +152,7 @@ public class C
 
     public string [|S|] {{ get; protected set; }}
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -183,8 +171,7 @@ End Class");
             var metadataSource = "using System; public class C { public event Action E; }";
             var symbolName = "C.E";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -196,8 +183,7 @@ public class C
 
     public event Action [|E|];
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -216,8 +202,7 @@ End Class");
             var metadataSource = "public class C { protected class D { } }";
             var symbolName = "C+D";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -230,8 +215,7 @@ public class C
         public D();
     }}
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -251,8 +235,7 @@ End Class");
             var metadataSource = "public enum E { A, B, C }";
             var symbolName = "E";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -262,8 +245,7 @@ public enum [|E|]
     B = 1,
     C = 2
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -281,8 +263,7 @@ End Enum");
             var metadataSource = "public enum E { A, B, C }";
             var symbolName = "E.C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -292,8 +273,7 @@ public enum E
     B = 1,
     [|C|] = 2
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -311,8 +291,7 @@ End Enum");
             var metadataSource = "public enum E : short { A = 0, B = 1, C = 2 }";
             var symbolName = "E.C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -322,15 +301,14 @@ public enum E : short
     B = 1,
     [|C|] = 2
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
 Public Enum E As Short
     A = 0
     B = 1
-    [|C|] = 2 
+    [|C|] = 2
 End Enum");
         }
 
@@ -341,8 +319,7 @@ End Enum");
             var metadataSource = "public enum E : ulong { A = 9223372036854775808 }";
             var symbolName = "E.A";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -350,8 +327,7 @@ public enum E : ulong
 {{
     [|A|] = 9223372036854775808
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -366,8 +342,7 @@ End Enum");
             var metadataSource = "public enum E : short { A = 1, B = 2, C = 3 }";
             var symbolName = "E.C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -377,8 +352,7 @@ public enum E : short
     B = 2,
     [|C|] = 3
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -396,8 +370,7 @@ End Enum");
             var metadataSource = "namespace N { public class C {} }";
             var symbolName = "N.C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -408,8 +381,7 @@ namespace N
         public C();
     }}
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -427,8 +399,7 @@ End Namespace");
             var metadataSource = @"public class C { public const string S = ""Hello mas""; }";
             var symbolName = "C.S";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -438,8 +409,7 @@ public class C
 
     public C();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -467,8 +437,7 @@ public class C {}";
 
             var symbolName = "C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -477,8 +446,7 @@ public class [|C|]
 {{
     public C();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -495,16 +463,14 @@ End Class");
             var metadataSource = "public struct S {}";
             var symbolName = "S";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
 public struct [|S|]
 {{
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -518,8 +484,7 @@ End Structure");
             var metadataSource = "public class C { public static C Create() { return new C(); } }";
             var symbolName = "C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -529,8 +494,7 @@ public class [|C|]
 
     public static C Create();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -548,8 +512,7 @@ End Class");
             var metadataSource = "public class G<SomeType> { public SomeType S; }";
             var symbolName = "G`1";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -559,8 +522,7 @@ public class [|G|]<SomeType>
 
     public G();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -578,8 +540,7 @@ End Class");
             var metadataSource = "public class C { public delegate void D<SomeType>(SomeType s); }";
             var symbolName = "C+D`1";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -589,14 +550,12 @@ public class C
 
     public delegate void [|D|]<SomeType>(SomeType s);
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
 Public Class C
     Public Sub New()
-
     Public Delegate Sub [|D|](Of SomeType)(s As SomeType)
 End Class");
         }
@@ -621,8 +580,7 @@ public class C {}";
 
             var symbolName = "C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -633,8 +591,7 @@ public class [|C|]
 {{
     public C();
 }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -771,8 +728,7 @@ Public Class C
         End Set
     End Property
 End Class";
-            var expected = $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            var expected = $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -805,10 +761,10 @@ public class MyAttribute : Attribute
     public MyAttribute(Type t) { }
 }";
 
-            var expected = $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            var expected = $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
+
 [My(typeof(D))]
 public class [|C|]
 {{
@@ -861,8 +817,7 @@ public class C
     public static C operator + (C c1, C c2) { return new C(); }
 }
 ";
-            var expectedCS = $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            var expectedCS = $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -903,13 +858,11 @@ public class [|C|]
 
     [Obsolete]
     public static C operator +(C c1, C c2);
-}}
-";
+}}";
             var symbolName = "C";
             await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, expectedCS);
 
-            var expectedVB = $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+            var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -1003,8 +956,7 @@ public class [|C|]
 
     public static C operator +(C c1, C c2);
     public static C operator -(C c1, C c2);
-}}
-";
+}}";
             var symbolName = "C";
             await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, expectedCS, ignoreTrivia: false);
 
@@ -1077,8 +1029,7 @@ public interface [|IGoo|]
     // {FeaturesResources.Summary_colon}
     //     M:IGoo.Method1
     Uri Method1();
-}}
-";
+}}";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS, ignoreTrivia: false, includeXmlDocComments: true);
 
             var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
@@ -1100,8 +1051,7 @@ Public Interface [|IGoo|]
     ' {FeaturesResources.Summary_colon}
     '     M:IGoo.Method1
     Function Method1() As Uri
-End Interface
-";
+End Interface";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.VisualBasic, expectedVB, ignoreTrivia: false, includeXmlDocComments: true);
         }
 
@@ -1124,22 +1074,24 @@ public class Test
 
 using System.IO;
 
-public class [|Test|] 
+public class [|Test|]
 {{
-    public Test(); 
+    public Test();
+
     public void goo(FileOptions options = FileOptions.None);
-}}
-";
+}}";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS);
 
-            var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" 
+            var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
-Imports System.IO 
 
-Public Class [|Test|] 
-    Public Sub New() 
-    Public Sub goo(Optional options As FileOptions = FileOptions.None) 
+Imports System.IO
+
+Public Class [|Test|]
+    Public Sub New()
+
+    Public Sub goo(Optional options As FileOptions = FileOptions.None)
 End Class";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.VisualBasic, expectedVB);
         }
@@ -1164,25 +1116,25 @@ public class TestAttribute : Attribute
 #endregion
 
 using System;
- 
+
 [Test(null)]
 public class [|TestAttribute|] : Attribute
 {{
     public TestAttribute(int[] i);
-}}
-";
+}}";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS);
 
-            var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" 
+            var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
-Imports System 
+
+Imports System
 
 <Test(Nothing)>
 Public Class [|TestAttribute|]
-    Inherits Attribute 
-    
-    Public Sub New(i() As Integer) 
+    Inherits Attribute
+
+    Public Sub New(i() As Integer)
 End Class";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.VisualBasic, expectedVB);
         }
@@ -1207,12 +1159,11 @@ class C
             var expected = $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
- 
+
 public static class ObjectExtensions
 {{
     public static void [|M|](this object o, int x);
-}}
-";
+}}";
 
             using (var context = TestContext.Create(
                 LanguageNames.CSharp,
@@ -1249,12 +1200,13 @@ End Module";
             var expected = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
+
 Imports System.Runtime.CompilerServices
 
 Namespace NS
-    <Extension> 
-    Public Module StringExtensions
-        <Extension> Public Sub [|M|](o As String, x As Integer)
+    <Extension>
+    Public Module StringExtensions <Extension>
+        Public Sub [|M|](o As String, x As Integer)
     End Module
 End Namespace";
 
@@ -1294,8 +1246,7 @@ End Namespace";
 }";
             var symbolName = "Program";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -1303,15 +1254,14 @@ using System.Reflection;
 
 [DefaultMember(""Item"")]
 public class [|Program|]
-        {{
-            public Program();
+{{
+    public Program();
 
-            public int this[int x] {{ get; set; }}
+    public int this[int x] {{ get; set; }}
 
-            public static Program operator +(Program p1, Program p2);
-        }}");
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"
-#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+    public static Program operator +(Program p1, Program p2);
+}}");
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
@@ -1345,10 +1295,10 @@ public interface IComImport
 }";
             var symbolName = "IComImport";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
+
 using System.Runtime.InteropServices;
 
 [Guid(""666A175D-2448-447A-B786-CCC82CBEF156"")]
@@ -1357,6 +1307,7 @@ public interface [|IComImport|]
     void MOverload();
     void X();
     void MOverload(int i);
+
     int Prop {{ get; }}
 }}");
         }
@@ -1372,8 +1323,7 @@ public class C {
 }";
             var symbolName = "C";
 
-            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"
-#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
@@ -1382,6 +1332,7 @@ using System.Threading;
 public class [|C|]
 {{
     public C();
+
     public void M(CancellationToken cancellationToken = default);
 }}", languageVersion: "CSharp7_1");
         }
@@ -1423,8 +1374,7 @@ public interface [|IGoo|]
     // {FeaturesResources.Summary_colon}
     //     M:IGoo.Method1 ABCDE FGHIJK
     Uri Method1();
-}}
-";
+}}";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.CSharp, expectedCS, ignoreTrivia: false, includeXmlDocComments: true);
 
             var expectedVB = $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
@@ -1446,8 +1396,7 @@ Public Interface [|IGoo|]
     ' {FeaturesResources.Summary_colon}
     '     M:IGoo.Method1 ABCDE FGHIJK
     Function Method1() As Uri
-End Interface
-";
+End Interface";
             await GenerateAndVerifySourceAsync(source, symbolName, LanguageNames.VisualBasic, expectedVB, ignoreTrivia: false, includeXmlDocComments: true);
         }
     }

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             ImmutableArray<string> expectedContainers,
             string expectedDocumentName,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             TestParameters parameters = default(TestParameters))
         {
             await TestAddDocument(
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             int index,
             string expectedDocumentName,
             ImmutableArray<string> expectedContainers,
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             var codeActions = await GetCodeActionsAsync(workspace, parameters);
             return await TestAddDocument(
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             ImmutableArray<string> expectedContainers,
             string expectedDocumentName,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             TestParameters parameters = default(TestParameters))
         {
             using (var workspace = CreateWorkspaceFromOptions(initialMarkup, parameters))
@@ -313,7 +313,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             string initialMarkup,
             string expectedMarkup,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             CodeActionPriority? priority = null,
             CompilationOptions compilationOptions = null,
             IDictionary<OptionKey, object> options = null,
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             string initialMarkup,
             string expectedMarkup,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             CodeActionPriority? priority = null,
             TestParameters parameters = default(TestParameters))
         {
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions,
             CompilationOptions compilationOptions = null,
-            int index = 0, bool ignoreTrivia = true,
+            int index = 0, bool ignoreTrivia = false,
             IDictionary<OptionKey, object> options = null,
             string fixAllActionEquivalenceKey = null,
             object fixProviderData = null,

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             int index,
             ImmutableArray<CodeAction> actions,
             string expectedPreviewContents = null,
-            bool ignoreTrivia = true)
+            bool ignoreTrivia = false)
         {
             var operations = await VerifyInputsAndGetOperationsAsync(index, actions);
 
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             string[] chosenSymbols,
             Action<ImmutableArray<PickMembersOption>> optionsCallback = null,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             CodeActionPriority? priority = null,
             TestParameters parameters = default(TestParameters))
         {

--- a/src/EditorFeatures/TestUtilities/MoveType/AbstractMoveTypeTest.cs
+++ b/src/EditorFeatures/TestUtilities/MoveType/AbstractMoveTypeTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
             string originalCode,
             string expectedCode = null,
             bool expectedCodeAction = true,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             string fixAllActionEquivalenceKey = null,
             object fixProviderData = null)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
             string originalCode,
             string expectedDocumentName = null,
             bool expectedCodeAction = true,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             IList<string> destinationDocumentContainers = null,
             string fixAllActionEquivalenceKey = null,
             object fixProviderData = null)
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
             ImmutableArray<string> destinationDocumentContainers = default(ImmutableArray<string>),
             bool expectedCodeAction = true,
             int index = 0,
-            bool ignoreTrivia = true,
+            bool ignoreTrivia = false,
             Action<Workspace> onAfterWorkspaceCreated = null)
         {
             var testOptions = new TestParameters();

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Text;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
     [Export(typeof(IExtensionErrorHandler))]
     internal class TestExtensionErrorHandler : IExtensionErrorHandler
     {
-        private List<Exception> _exceptions = new List<Exception>();
+        private ImmutableList<Exception> _exceptions = ImmutableList<Exception>.Empty;
 
         public void HandleError(object sender, Exception exception)
         {
@@ -20,20 +21,32 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             {
                 // Log an exception saying we didn't get an exception. I'd consider throwing here, but double-faults are just caught and consumed by
                 // the editor so that won't give a good debugging experience either.
-                _exceptions.Add(new Exception($"{nameof(TestExtensionErrorHandler)}.{nameof(HandleError)} called with null exception"));
+                try
+                {
+                    ThrowExceptionToGetStackTrace();
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                }
             }
-            else
-            {
-                _exceptions.Add(exception);
-            }
+
+            ImmutableInterlocked.Update(
+                ref _exceptions,
+                (list, item) => list.Add(item),
+                exception);
         }
 
-        public ICollection<Exception> GetExceptions()
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowExceptionToGetStackTrace()
+        {
+            throw new Exception($"{nameof(TestExtensionErrorHandler)}.{nameof(HandleError)} called with null exception");
+        }
+
+        public ImmutableList<Exception> GetExceptions()
         {
             // We'll clear off our list, so that way we don't report this for other tests
-            var newExceptions = _exceptions;
-            _exceptions = new List<Exception>();
-            return newExceptions;
+            return Interlocked.Exchange(ref _exceptions, ImmutableList<Exception>.Empty);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddAccessibilityModifiers/AddAccessibilityModifiersTests.vb
@@ -157,7 +157,7 @@ namespace N
             end sub
 
             Public property P1 as integer
-            
+
             Public property P2 as integer
                 get
                 end get

--- a/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
@@ -179,7 +179,8 @@ class D
     sub M()
         dim a = new C(1, true)
     end sub
-end class")
+end class
+")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
@@ -209,7 +210,8 @@ class D
     sub M()
         dim a = new C(true, 1)
     end sub
-end class")
+end class
+")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AbstractVisualBasicCodeActionTest.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AbstractVisualBasicCodeActionTest.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
             Return input.Replace("\n", vbCrLf)
         End Function
 
-        Protected Overloads Async Function TestAsync(initialMarkup As XElement, expected As XElement, Optional index As Integer = 0, Optional ignoreTrivia As Boolean = True) As Threading.Tasks.Task
+        Protected Overloads Async Function TestAsync(initialMarkup As XElement, expected As XElement, Optional index As Integer = 0, Optional ignoreTrivia As Boolean = False) As Threading.Tasks.Task
             Dim initialMarkupStr = initialMarkup.ConvertTestSourceTag()
             Dim expectedStr = expected.ConvertTestSourceTag()
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/EncapsulateField/EncapsulateFieldTests.vb
@@ -525,7 +525,8 @@ Public Class Class1
     Sub goo()
         Name = ""
     End Sub
-End Class</File>.ConvertTestSourceTag()
+End Class
+</File>.ConvertTestSourceTag()
 
             Await TestInRegularAndScriptAsync(text, expected, ignoreTrivia:=False)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -34,6 +34,7 @@ End Class",
                               Return {|Rename:GetArg|}(arg)
                           End Function
     End Sub
+
     Private Shared Function GetArg(arg As Integer) As Integer
         Return arg
     End Function
@@ -60,6 +61,7 @@ Module Program
     Sub Main(args As String())
         If True Then Dim q As Action = {|Rename:GetQ|}()
     End Sub
+
     Private Function GetQ() As Action
         Return Sub()
                End Sub
@@ -81,9 +83,11 @@ End Class",
     Sub Main()
         {|Rename:NewMethod|}()
     End Sub
+
     Private Shared Sub NewMethod()
         Dim x As New List(Of Program) From {New Program}
     End Sub
+
     Public Property Name As String
 End Class")
         End Function
@@ -111,6 +115,7 @@ Module Program
         Dim q As Object
         If True Then q = {|Rename:NewMethod|}()
     End Sub
+
     Private Function NewMethod() As Object
         Return Sub()
                End Sub
@@ -164,6 +169,7 @@ End Module",
         Dim p As Object = Nothing
         Dim Obj1 = If(New With {.a = True}.a, p, {|Rename:NewMethod|}())
     End Sub
+
     Private Function NewMethod() As Object
         Return Nothing
     End Function
@@ -183,6 +189,7 @@ End Module",
     Sub Main()
         Dim x(0 To {|Rename:NewMethod|}()) ' Extract method 
     End Sub
+
     Private Function NewMethod() As Integer
         Return 1 + 2
     End Function
@@ -208,6 +215,7 @@ End Module",
             x += 1
         Loop
     End Sub
+
     Private Function NewMethod(x As Integer) As Boolean
         Return x * x < 100
     End Function
@@ -277,6 +285,7 @@ End Module",
     Sub Main()
         {|Rename:NewMethod|}()
     End Sub
+
     Private Sub NewMethod()
         With """"""""
             Dim x = .GetHashCode Xor &H7F3E ' Introduce Local 
@@ -455,9 +464,11 @@ End Namespace",
         Dim x As (Integer, Integer) = {|Rename:NewMethod|}()
         M(x)
     End Sub
+
     Private Shared Function NewMethod() As (Integer, Integer)
         Return (1, 2)
     End Function
+
     Private Sub M(x As (Integer, Integer))
     End Sub
 End Class
@@ -488,6 +499,7 @@ End Namespace",
         Dim x As (a As Integer, b As Integer) = {|Rename:NewMethod|}()
         System.Console.WriteLine(x.a)
     End Sub
+
     Private Shared Function NewMethod() As (a As Integer, b As Integer)
         Return (1, 2)
     End Function
@@ -519,6 +531,7 @@ End Namespace",
         Dim x As (a As Integer, Integer) = {|Rename:NewMethod|}()
         System.Console.WriteLine(x.a)
     End Sub
+
     Private Shared Function NewMethod() As (a As Integer, Integer)
         Return (1, 2)
     End Function

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -3152,6 +3152,7 @@ Module M
         Dim z = 1
     End Sub
 End Module
+
 </File>
             Await TestAsync(code, expected, ignoreTrivia:=False)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -341,8 +341,8 @@ End Module"
         Dim GooMember1 As String
     End Structure
     Sub Main(x As Integer)
-        Const {|Rename:V|} As String = ""t"" + ""test"" 
- Dim f1 = New GooStruct With {.GooMember1 = V}
+        Const {|Rename:V|} As String = ""t"" + ""test""
+        Dim f1 = New GooStruct With {.GooMember1 = V}
     End Sub
 End Module"
             Await TestInRegularAndScriptAsync(source, expected, index:=2)
@@ -393,8 +393,8 @@ End Module
  End Sub
 End Class"
             Dim expected = "Class Program
-    Private Const {|Rename:V|} As String = ""t"" + ""test"" 
- Dim q = New With {.str = V}
+    Private Const {|Rename:V|} As String = ""t"" + ""test""
+    Dim q = New With {.str = V}
     Dim r = New With {.str = V}
     Sub Goo()
         Dim x = V
@@ -466,6 +466,7 @@ End Class"
 End Module"
             Dim expected = "Module Module1
     Private Const {|Rename:V|} As Integer = 42
+
     Sub Goo(Optional x As Integer = V)
     End Sub
 End Module"
@@ -483,6 +484,7 @@ End Module"
 End Module"
             Dim expected = "Module Module1
     Private Const {|Rename:V|} As Integer = 42
+
     Sub Bar(Optional x As Integer = V)
     End Sub
     Sub Goo(Optional x As Integer = V)
@@ -692,6 +694,7 @@ count:=2)
 End Class",
 "Class Goo
     Private Const {|Rename:V|} As Integer = 2 + 2
+
     Sub New()
         Me.New(V)
     End Sub
@@ -827,6 +830,7 @@ End Class")
 End Class",
 "Class Goo
     Private Const {|Rename:X|} As Integer = 42
+
     Sub New()
         MyClass.New(X)
     End Sub
@@ -1014,6 +1018,7 @@ Imports System.Linq
 Module Program
     Sub Main(args As String())
         Dim q As Object
+
         If True Then
             Dim {|Rename:p|} As Object = Sub()
                               End Sub
@@ -1111,10 +1116,11 @@ count:=2)
 NewLines(input),
 "Module Program
     Private Const {|Rename:V|} As String = """"
-    <Obsolete(V)>
-    Sub Main(args As String())
-    End Sub
-End Module")
+
+    <Obsolete(V)> 
+ Sub Main(args As String()) 
+ End Sub 
+ End Module")
         End Function
 
         <WorkItem(542947, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542947")>
@@ -1257,10 +1263,9 @@ End Module",
 "Imports System
 Module Program
     Sub Main
-        Dim a = Sub(x As Integer)
-                    Dim {|Rename:value|} As Integer = x + 1
-                    Console.WriteLine(value) ' Introduce local 
-                End Sub
+        Dim a = Sub(x As Integer) Dim {|Rename:value|} As Integer = x + 1
+                    Console.WriteLine(value)
+                End Sub ' Introduce local 
     End Sub
 End Module")
         End Function
@@ -1279,6 +1284,7 @@ End Module",
 Module Program
     Sub Main
         Dim a = Sub(x As Integer)
+
                     If True Then
                         Dim {|Rename:value|} As Integer = x + 1
                         Console.WriteLine(value)
@@ -1304,6 +1310,7 @@ End Module",
 Module Program
     Sub Main
         Dim a = Sub(x As Integer)
+
                     If True Then
                         Console.WriteLine()
                     Else
@@ -1350,8 +1357,7 @@ index:=1)
 End Module",
 "Module Program
     Sub Main(args As String())
-        Dim query = Sub(a)
-                        Dim {|Rename:arg1|} As Object = a Or a
+        Dim query = Sub(a) Dim {|Rename:arg1|} As Object = a Or a
                         a = New With {Key .Key = Function(ByVal arg As Integer) As Integer
                                                      Return arg
                                                  End Function}.Key.Invoke(arg1)
@@ -1442,7 +1448,8 @@ End Class",
 "Imports System.Linq
 Public Class Base
     Public Function Sample(ByVal arg As Integer) As Integer
-        Dim results = From s In New Integer() {1} Let {|Rename:v|} = Sample(s)
+        Dim results = From s In New Integer() {1}
+                      Let {|Rename:v|} = Sample(s)
                       Select v
         Return 0
     End Function
@@ -1480,8 +1487,8 @@ End Class",
 "Imports System.Linq
 Public Class Base
     Public Function Sample(ByVal arg As Integer) As Integer
-        Dim results = From s In New Integer() {1} Let {|Rename:v|} = Sample(s)
-                      Where v > 21
+        Dim results = From s In New Integer() {1}
+                      Let {|Rename:v|} = Sample(s) Where v > 21
                       Select Sample(s)
         Return 0
     End Function
@@ -1504,8 +1511,8 @@ End Class",
 "Imports System.Linq
 Public Class Base
     Public Function Sample(ByVal arg As Integer) As Integer
-        Dim results = From s In New Integer() {1} Let {|Rename:v|} = Sample(s)
-                      Where v > 21
+        Dim results = From s In New Integer() {1}
+                      Let {|Rename:v|} = Sample(s) Where v > 21
                       Select v
         Return 0
     End Function
@@ -1530,7 +1537,8 @@ End Class",
 Public Class Base
     Public Function Sample(ByVal arg As Integer) As Integer
         Dim results = From s In New Integer() {1}
-                      Where Sample(s) > 21 Let {|Rename:v|} = Sample(s)
+                      Where Sample(s) > 21
+                      Let {|Rename:v|} = Sample(s)
                       Select v
         Return 0
     End Function
@@ -1552,7 +1560,8 @@ End Class",
 "Imports System.Linq
 Public Class Base
     Public Function Sample(ByVal arg As Integer) As Integer
-        Dim results = From s In New Integer() {1} Let {|Rename:v|} = Sample(s)
+        Dim results = From s In New Integer() {1}
+                      Let {|Rename:v|} = Sample(s)
                       Where v > 21
                       Select v
         Return 0
@@ -1776,8 +1785,8 @@ End Module")
     Property Prop As New List(Of String) From {[|""One""|], ""two""}
 End Module",
 "Module Module1
-    Private Const {|Rename:V|} As String = ""One"" 
- Property Prop As New List(Of String) From {V, ""two""}
+    Private Const {|Rename:V|} As String = ""One""
+    Property Prop As New List(Of String) From {V, ""two""}
 End Module")
         End Function
 
@@ -1993,8 +2002,9 @@ Partial Class C
     End Sub
 End Class",
 "Partial Class C
-    Private Const {|Rename:V|} As String = ""HELLO"" 
- Sub goo1(Optional x As String = V)
+    Private Const {|Rename:V|} As String = ""HELLO""
+
+    Sub goo1(Optional x As String = V)
     End Sub
 End Class
 Partial Class C
@@ -2071,6 +2081,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Private Const {|Rename:V|} As Boolean = True
+
     Sub Main(args As String())
         If V Then
         End If

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InvertIf/InvertIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InvertIf/InvertIfTests.vb
@@ -880,7 +880,7 @@ End Module",
     Sub Main(args As String())
         Dim x() As String
         If x.Length = 0x0 Then 
- EqualsZero()
+            EqualsZero()
         Else
             GreaterThanZero()
         End If
@@ -1360,6 +1360,7 @@ Module Program
         End Select
     End Sub
 End Module
+
 </File>
 
             Await TestAsync(markup, expected, ignoreTrivia:=False)

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/BasicMoveTypeTestsBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/BasicMoveTypeTestsBase.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
             originalCode As XElement,
             Optional expectedCode As XElement = Nothing,
             Optional expectedCodeAction As Boolean = True,
-            Optional ignoreTrivia As Boolean = True
+            Optional ignoreTrivia As Boolean = False
         ) As Task
 
             Dim expectedText As String = Nothing
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
             originalCode As XElement,
             Optional expectedDocumentName As String = Nothing,
             Optional expectedCodeAction As Boolean = True,
-            Optional ignoreTrivia As Boolean = True
+            Optional ignoreTrivia As Boolean = False
         ) As Task
 
             Return MyBase.TestRenameFileToMatchTypeAsync(
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
             Optional destinationDocumentContainers As ImmutableArray(Of String) = Nothing,
             Optional expectedCodeAction As Boolean = True,
             Optional index As Integer = 0,
-            Optional ignoreTrivia As Boolean = True
+            Optional ignoreTrivia As Boolean = False
         ) As Task
 
             Dim originalCodeText = originalCode.ConvertTestSourceTag()

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
@@ -46,8 +46,7 @@ End Class
             Dim expectedDocumentName = "Class1.vb"
 
             Dim destinationDocumentText =
-"
-Class Class1
+"Class Class1
 End Class
 "
             Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText)
@@ -99,7 +98,6 @@ End Class
 "
 Public Partial Class Class1
     Class Class2
-
     End Class
 End Class
 "
@@ -158,6 +156,8 @@ End Class
 "
             Dim codeAfterMove =
 "
+' Used only by inner
+
 ' Not used
 Imports System.Collections
 
@@ -170,6 +170,8 @@ End Class
 "
 ' Used only by inner
 Imports System
+
+' Not used
 
 Partial Class Outer
     Class Inner
@@ -204,7 +206,8 @@ End Class
 Partial Class Outer
     Inherits Something
     Implements ISomething
-End Class"
+End Class
+"
             Dim expectedDocumentName = "Inner.vb"
 
             Dim destinationDocumentText =
@@ -217,7 +220,8 @@ Partial Class Outer
         Sub M(d as DateTime)
         End Sub
     End Class
-End Class"
+End Class
+"
             Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText)
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
@@ -92,7 +92,8 @@ End class")
     End function
 End class",
 "class C
-    <A> ReadOnly Property Goo as integer
+    <A>
+    ReadOnly Property Goo as integer
         Get
         End Get
     End Property
@@ -286,6 +287,7 @@ End class",
         Get
         End Get
     End Property
+
     sub Bar()
         dim x = Goo
     End sub
@@ -307,6 +309,7 @@ End class",
         Get
         End Get
     End Property
+
     sub Bar()
         dim x = me.Goo
     End sub
@@ -329,6 +332,7 @@ End class",
         Get
         End Get
     End Property
+
     sub Bar()
         dim x as C
         dim v = x?.Goo
@@ -395,6 +399,7 @@ End class",
         Get
         End Get
     End Property
+
     sub Bar()
         dim i = Goo
     End sub
@@ -442,6 +447,7 @@ class C
         Set(i as integer)
         End Set
     End Property
+
     sub Bar()
         dim i as Action(of integer) = addressof {|Conflict:Goo|}
     End sub
@@ -460,10 +466,11 @@ index:=1)
 End class",
 "class C
     public Property Goo as integer
-        Get End Get 
- Private Set(i as integer) 
- End Set
- End Property
+        Get
+        End Get
+        Private Set(i as integer)
+        End Set
+    End Property
 End class",
 index:=1)
         End Function
@@ -487,9 +494,9 @@ End class",
         Set(i as integer)
         End Set
     End Property
+
     sub Bar()
-        Goo = Goo + 1
-    End sub
+        Goo = Goo + 1    End sub
 End class",
 index:=1)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
@@ -86,8 +86,9 @@ end class",
     Public Function GetProp() As Integer
         return 0
     End Function
+
     public sub M()
-        dim v = new with { .P = me.GetProp() }
+        dim v = new with { .P = me.GetProp()}
     end sub
 end class")
         End Function
@@ -109,8 +110,10 @@ end class",
     Public Function GetProp() As Integer
         return 0
     End Function
+
     public sub M()
-        dim v = new with { .Prop = me.GetProp() }
+        dim v = new with {
+        .Prop = me.GetProp()}
     end sub
 end class")
         End Function
@@ -134,6 +137,7 @@ end class",
     Public Function GetProp() As Integer
         return 0
     End Function
+
     public sub RefM(byref i as integer)
     end sub
     public sub M()
@@ -175,7 +179,8 @@ end class
 
 <C({|Conflict:Prop|}:=1)>
 class D
-end class")
+end class
+")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)>
@@ -229,9 +234,10 @@ end class",
     Public Sub SetProp(val As Integer)
         dim v = val
     End Sub
-    sub M() 
-        me.SetProp(1)
-    end sub
+
+    sub M()
+        me.SetProp(1
+) end sub
 end class")
         End Function
 
@@ -252,6 +258,7 @@ end class",
     Public Function GetProp() As Integer
         return 0
     End Function
+
     Public Sub SetProp(Value As Integer)
         dim v = value
     End Sub
@@ -287,7 +294,8 @@ end class")
 end class",
 "class C
     Public Sub SetProp(Value As Integer)
-        me.SetProp(value + 1)
+        me.SetProp(value + 1
+)
     End Sub
 end class")
         End Function
@@ -303,6 +311,7 @@ end class")
 end class",
 "class C
     Public MustOverride Function GetProp() As Integer
+
     public sub M()
         dim v = me.GetProp()
     end sub
@@ -327,6 +336,7 @@ end class",
     Public Overridable Function GetProp() As Integer
         return 0
     End Function
+
     public sub M()
         dim v = me.GetProp()
     end sub
@@ -375,6 +385,7 @@ end interface")
 end class",
 "class C
     Private _Prop As Integer
+
     Public Function GetProp() As Integer
         Return _Prop
     End Function
@@ -392,9 +403,11 @@ end class")
 end class",
 "class C
     Private _Prop As Integer
+
     Public Function GetProp() As Integer
         Return _Prop
     End Function
+
     public sub new()
         me._Prop = 1
     end sub

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/UseNamedArguments/UseNamedArgumentsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/UseNamedArguments/UseNamedArgumentsTests.vb
@@ -225,7 +225,7 @@ End Class")
 End Class",
 "Class C
     Sub M(arg1 As Integer, optional arg2 As Integer=1, optional arg3 as Integer=1)
-        M(1,,arg3:=3)
+        M(1,, arg3:=3)
     End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.vb
@@ -28,7 +28,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{1}"
+        Dim a = $"{1 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -49,7 +49,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{1}{2}{3}"
+        Dim a = $"{1 }{2 }{3 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -70,7 +70,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{1}{3}{2}"
+        Dim a = $"{1 }{3 }{2 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -91,7 +91,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{1}{1}{1}"
+        Dim a = $"{1 }{1 }{1 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -133,7 +133,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{0.5}{"Hello"}{3}"
+        Dim a = $"{0.5 }{"Hello" }{3 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -154,7 +154,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{0.5}{"Hello"}{3}"
+        Dim a = $"{0.5 }{"Hello" }{3 }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -175,7 +175,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{(New Object)}"
+        Dim a = $"{(New Object) }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -198,9 +198,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{If(True,
-                              "Yes",
-                              TryCast(False, Object))}"
+        Dim a = $"{If(True, "Yes", TryCast(False, Object)) }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -276,7 +274,7 @@ Module T
         Dim population As Integer() = {1025632, 1105967, 1148203}
         Dim s = String.Format("{0,6} {1,15}\n\n", "Year", "Population")
         For index = 0 To years.Length - 1
-            s += $"{years(index),6} {population(index),15: N0}\n"
+            s += $"{years(index), 6} {population(index), 15: N0}\n"
         Next
     End Sub
 End Module</File>.ConvertTestSourceTag()
@@ -450,7 +448,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"This {"test"} {"also"} works"
+        Dim a = $"This {"test" } {"also" } works"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -472,7 +470,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"This {"test"} {"also"} works"
+        Dim a = $"This {"test" } {"also" } works"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -494,7 +492,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{"10"} {"11"} {"12"}"
+        Dim a = $"{"10" } {"11" } {"12" }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -516,7 +514,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{"10"} {"11"} {"12"}"
+        Dim a = $"{"10" } {"11" } {"12" }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -538,7 +536,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{"10"} {"11"} {"12"} {3}"
+        Dim a = $"{"10" } {"11" } {"12" } {3}"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 
@@ -560,7 +558,7 @@ End Module</File>.ConvertTestSourceTag()
 Imports System
 Module T
     Sub M()
-        Dim a = $"{"10"} {"11"} {"12"}"
+        Dim a = $"{"10" } {"11" } {"12" }"
     End Sub
 End Module</File>.ConvertTestSourceTag()
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
 
         Friend Overloads Async Function TestAsync(
                 initialMarkup As XElement, expected As XElement, Optional index As Integer = 0,
-                Optional ignoreTrivia As Boolean = True, Optional priority As CodeActionPriority? = Nothing) As Threading.Tasks.Task
+                Optional ignoreTrivia As Boolean = False, Optional priority As CodeActionPriority? = Nothing) As Threading.Tasks.Task
             Dim initialMarkupStr = initialMarkup.ConvertTestSourceTag()
             Dim expectedStr = expected.ConvertTestSourceTag()
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -66,6 +66,7 @@ Namespace SomeNamespace
     End Class
 End Namespace",
 "Imports SomeNamespace
+
 Class Class1
     Dim v As SomeClass1
 End Class
@@ -88,8 +89,7 @@ Class Class1
     Inherits [|Textbox|]
 
 End Class",
-"
-Imports N1
+"Imports N1
 
 Namespace N1
     Public Class TextBox
@@ -109,6 +109,7 @@ End Class", priority:=CodeActionPriority.Medium)
     Dim v As [|Thread|]
 End Class",
 "Imports System.Threading
+
 Class Class1
     Dim v As Thread
 End Class")
@@ -133,6 +134,7 @@ End Namespace
 Class SomeClass(Of x As [|Base|])
 End Class",
 "Imports SomeNamespace
+
 Namespace SomeNamespace
     Class Base
     End Class
@@ -156,6 +158,7 @@ Class Goo
     End Sub
 End Class",
 "Imports SomeNamespace
+
 Namespace SomeNamespace
     Class SomeClass
     End Class
@@ -181,6 +184,7 @@ Class Goo
     End Sub
 End Class",
 "Imports SomeNamespace
+
 Namespace SomeNamespace
     Class SomeClass
     End Class
@@ -206,6 +210,7 @@ Class Goo
     End Sub
 End Class",
 "Imports SomeNamespace
+
 Namespace SomeNamespace
     Class SomeClass
     End Class
@@ -231,6 +236,7 @@ Namespace SomeNamespace
     End Class
 End Namespace",
 "Imports SomeNamespace
+
 <Something()>
 Class Goo
 End Class
@@ -257,6 +263,7 @@ Namespace SomeNamespace
     End Class
 End Namespace",
 "Imports SomeNamespace
+
 <Existing()>
 <Something()>
 Class Goo
@@ -287,6 +294,7 @@ Namespace SomeNamespace
     End Class
 End Namespace",
 "Imports SomeNamespace
+
 <Something()>
 <Existing()>
 Class Goo
@@ -312,6 +320,7 @@ Namespace [Namespace]
     End Class
 End Namespace",
 "Imports [Namespace]
+
 Class SomeClass
     Dim x As Something
 End Class
@@ -334,6 +343,7 @@ Namespace Outer
     End Namespace
 End Namespace",
 "Imports Outer.Namespace
+
 Class SomeClass
     Dim x As Something
 End Class
@@ -395,6 +405,7 @@ Namespace SomeNamespace
     End Class
 End Namespace",
 "Imports SomeNamespace
+
 Class Goo
     Dim x As SomeClass
 End Class
@@ -412,6 +423,7 @@ End Namespace")
     End Function
 End Class",
 "Imports System.Collections
+
 Class Goo
     Function F() As IDictionary
     End Function
@@ -426,6 +438,7 @@ End Class")
     End Function
 End Class",
 "Imports System.Collections.Generic
+
 Class Goo
     Function F() As IDictionary
     End Function
@@ -441,6 +454,7 @@ index:=1)
     End Function
 End Class",
 "Imports System.Collections.Generic
+
 Class Goo
     Function F() As List
     End Function
@@ -455,6 +469,7 @@ End Class")
     End Function
 End Class",
 "Imports System.Collections.Generic
+
 Class Goo
     Function F() As List(Of Integer)
     End Function
@@ -488,6 +503,7 @@ End Class")
     End Sub
 End Class",
 "Imports System.Collections.Generic
+
 Class Goo
     Sub Test()
         Dim x As New List(Of Integer)
@@ -504,6 +520,7 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class Goo
     Sub Test()
         Dim x As New List(Of Int32)
@@ -522,6 +539,7 @@ Class Goo
 End Class",
 "Imports System
 Imports System.Collections.Generic
+
 Class Goo
     Sub Test()
         Dim x As New List(Of Integer)
@@ -542,6 +560,7 @@ Namespace NS
 End Namespace",
 "Imports System
 Imports System.Collections.Generic
+
 Namespace NS
     Class Goo
         Sub Test()
@@ -598,6 +617,7 @@ Class Test
 End Class",
 "Imports System.Collections.Generic
 Imports System.Linq
+
 Class Test
     Private Sub Method(args As IList(Of Integer))
         args.Where()
@@ -662,6 +682,7 @@ Namespace SomeNamespace
     End Namespace
 End Namespace",
 "Imports SomeNamespace
+
 Class GOo
     Sub bar()
         Dim q As InnerNamespace.SomeClass
@@ -690,6 +711,7 @@ Namespace SomeNamespace
     End Namespace
 End Namespace",
 "Imports SomeNamespace
+
 Class GOo
     Sub bar()
         Dim q As InnerNamespace.SomeClass
@@ -719,6 +741,7 @@ Namespace OUTER
     End Namespace
 End Namespace",
 "Imports OUTER.INNER
+
 Module Program
     Sub Main(args As String())
         Dim x As GOO
@@ -786,6 +809,7 @@ ignoreTrivia:=False)
     End Sub
 End Class",
 "Imports System.Linq
+
 Class Program
     Public Sub Linq1()
         Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
@@ -809,6 +833,7 @@ Class Program
 End Class",
 "Imports System.Collections.Generic
 Imports System.Linq
+
 Class Program
     Public Sub Linq1()
         Dim numbers() As Integer = New Integer(9) {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
@@ -840,6 +865,7 @@ End Class")
     End Sub
 End Module",
 "Imports System.IO
+
 Module Program
     Sub Main(args As String())
         File
@@ -860,11 +886,11 @@ Class C
 #End ExternalSource
     End Sub
 End Class",
-"#ExternalSource (""Default.aspx"", 1) 
+"#ExternalSource (""Default.aspx"", 1)
 Imports System
 Imports System.IO
 #End ExternalSource
-#ExternalSource (""Default.aspx"", 2) 
+#ExternalSource (""Default.aspx"", 2)
 Class C
     Sub Goo()
         Dim x As New [|StreamReader|]
@@ -945,6 +971,7 @@ ignoreTrivia:=False)
     End Sub
 End Module",
 "Imports System.IO
+
 Module Goo
     Sub Bar(args As String())
         Dim a = From f In args
@@ -964,6 +991,7 @@ End Module")
     End Sub
 End Module",
 "Imports System.IO
+
 Module Goo
     Sub Bar(args As String())
         Dim a = From f In args
@@ -988,6 +1016,7 @@ Class C
 End Class",
 "Imports System.Diagnostics
 Imports N
+
 Namespace N
     Public Class Log
     End Class
@@ -1006,6 +1035,7 @@ End Class", index:=1)
 "<[|Description|]> Public Class Description
 End Class",
 "Imports System.ComponentModel
+
 <[|Description|]> Public Class Description
 End Class")
         End Function
@@ -1038,6 +1068,7 @@ End Namespace",
 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
+
 Namespace NS1
     Class Program
         Sub main()
@@ -1088,6 +1119,7 @@ End Namespace",
 "Option Strict On
 Imports System.Runtime.CompilerServices
 Imports NS2
+
 Namespace NS1
     Class Program
         Sub main()
@@ -1148,6 +1180,7 @@ End Namespace",
 Imports System.Runtime.CompilerServices
 Imports NS2
 Imports NS3
+
 Namespace NS1
     Class Program
         Sub main()
@@ -1477,7 +1510,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
     End Class
 End Namespace",
 "Imports System
-Imports Microsoft.VisualStudio.Utilities 
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Utilities
     Public Class ContentTypeAttribute
@@ -1877,6 +1910,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1919,6 +1953,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -1961,6 +1996,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2003,6 +2039,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2045,6 +2082,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2094,6 +2132,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2150,6 +2189,7 @@ End Namespace",
 Imports System.Collections
 Imports System.Runtime.CompilerServices
 Imports Ext2
+
 Class X
     Implements IEnumerable
     Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
@@ -2197,6 +2237,7 @@ End Namespace",
 "Imports System.Linq
 Imports System.Runtime.CompilerServices
 Imports X
+
 Module Program
     Sub Main(args As String())
         Dim i = 0.All()
@@ -2235,6 +2276,7 @@ End Namespace",
 "Imports System.Linq
 Imports System.Runtime.CompilerServices
 Imports X
+
 Module Program
     Sub Main(args As String())
         Dim a = New Integer?
@@ -2282,6 +2324,7 @@ End Namespace",
 "Imports System.Runtime.CompilerServices
 Imports X
 Imports Y
+
 Module Program
     Sub Main(args As String())
         Dim a = 0
@@ -2337,6 +2380,7 @@ End Namespace",
 "Imports System.Runtime.CompilerServices
 Imports X
 Imports Y
+
 Module Program
     Sub Main(args As String())
         Dim a = New Integer?
@@ -2436,6 +2480,7 @@ End Namespace", placeSystemFirst:=True)
     <[|Extension|]>
 End Class",
 "Imports System.Runtime.CompilerServices
+
 Class Class1
     <Extension>
 End Class")
@@ -2452,6 +2497,7 @@ End Class")
     <C([|List(Of Integer)|])>
 End Class",
 "Imports System.Collections.Generic
+
 Class C
     Inherits Attribute
     Public Sub New(x As System.Type)
@@ -2468,6 +2514,7 @@ End Class")
     <[|Tasks.Task|]>
 End Class",
 "Imports System.Threading
+
 Class Class1
     <Tasks.Task>
 End Class")
@@ -2481,6 +2528,7 @@ End Class")
     <[|Extension|]>
 End Module",
 "Imports System.Runtime.CompilerServices
+
 Module Goo
     <Extension>
 End Module")
@@ -2490,6 +2538,7 @@ End Module")
     <[|Extension()|]>
 End Module",
 "Imports System.Runtime.CompilerServices
+
 Module Goo
     <Extension()>
 End Module")
@@ -2526,6 +2575,7 @@ Namespace T
     End Class
 End Namespace",
 "Imports T
+
 Class A
     Dim a As Action = Sub()
                           Try
@@ -2554,6 +2604,7 @@ Class C
                               Dim a = New [|Test|]()",
 "Imports System.Linq
 Imports X
+
 Namespace X
     Class Test
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
         Friend Overloads Async Function TestAsync(initialMarkup As String,
                                                   expectedMarkup As String,
                                                   Optional index As Integer = 0,
-                                                  Optional ignoreTrivia As Boolean = True,
+                                                  Optional ignoreTrivia As Boolean = False,
                                                   Optional priority As CodeActionPriority? = Nothing,
                                                   Optional placeSystemFirst As Boolean = True) As Task
             Await TestAsync(initialMarkup, expectedMarkup, index, ignoreTrivia, priority, placeSystemFirst, outOfProcess:=False)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/AddAwaitTests.vb
@@ -206,9 +206,9 @@ Imports System.Threading.Tasks
 
 Module Program
     Sub MySub()
-        Dim a = Async Sub() 
-                        Await Task.Delay(1)
-                      End Sub
+        Dim a = Async Sub()
+                    Await Task.Delay(1)
+                End Sub
     End Sub
 End Module
 </File>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/ChangeToAsyncTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Async/ChangeToAsyncTests.vb
@@ -24,9 +24,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Async
     Async Function rtrt() As Task
         Await gt()
     End Function
- 
-    Async Function gt() As Task
-    End Function
+
+Async Function gt() As Task
+End Function
 </ModuleDeclaration>
             Await TestAsync(initial, expected)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEndConstruct/GenerateEndConstructTests.vb
@@ -45,7 +45,7 @@ End Using</MethodBody>
             Dim text = <File>
 Structure Goo[||]</File>
 
-            Dim expected = StringFromLines("Structure Goo", "End Structure", "")
+            Dim expected = StringFromLines("", "Structure Goo", "End Structure", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function
@@ -56,7 +56,7 @@ Structure Goo[||]</File>
 Module Goo[||]
 </File>
 
-            Dim expected = StringFromLines("Module Goo", "End Module", "")
+            Dim expected = StringFromLines("", "Module Goo", "", "End Module", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function
@@ -67,7 +67,7 @@ Module Goo[||]
 Namespace Goo[||]
 </File>
 
-            Dim expected = StringFromLines("Namespace Goo", "End Namespace", "")
+            Dim expected = StringFromLines("", "Namespace Goo", "", "End Namespace", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function
@@ -78,7 +78,7 @@ Namespace Goo[||]
 Class Goo[||]
 </File>
 
-            Dim expected = StringFromLines("Class Goo", "End Class", "")
+            Dim expected = StringFromLines("", "Class Goo", "", "End Class", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function
@@ -89,7 +89,7 @@ Class Goo[||]
 Interface Goo[||]
 </File>
 
-            Dim expected = StringFromLines("Interface Goo", "End Interface", "")
+            Dim expected = StringFromLines("", "Interface Goo", "", "End Interface", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function
@@ -100,7 +100,7 @@ Interface Goo[||]
 Enum Goo[||]
 </File>
 
-            Dim expected = StringFromLines("Enum Goo", "End Enum", "")
+            Dim expected = StringFromLines("", "Enum Goo", "", "End Enum", "")
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected, ignoreTrivia:=False)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEnumMember/GenerateEnumMemberTests.vb
@@ -1163,6 +1163,7 @@ End Enum",
         Color.Blue
     End Sub
 End Class
+
 Enum Color As Long
     Red = &H8000000000000000
     Blue = &H8000000000000001

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEvent/GenerateEventTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateEvent/GenerateEventTests.vb
@@ -143,6 +143,7 @@ End Class")
 End Class",
 "Public Class C
     Public Event MyEvent(x As Integer)
+
     Sub EventHandler(ByVal x As Integer) Handles Me.MyEvent
         ' Place code to handle events from BaseClass here. 
     End Sub
@@ -160,6 +161,7 @@ End Class")
 End Class",
 "Public Class C
     Public Event MyEvent(x As Integer)
+
     Sub EventHandler(ByVal x As Integer) Handles MyClass.MyEvent
         ' Place code to handle events from BaseClass here. 
     End Sub
@@ -193,6 +195,7 @@ End Class",
 "Public Class B
     Dim WithEvents x As B
     Public Event E1(x As String)
+
     Private Sub Test(Optional x As String = Nothing) Handles x.E1 'mark 1 
     End Sub
     Private Sub Test2(ParamArray x As String()) Handles x.E2 'mark 2 
@@ -214,6 +217,7 @@ End Class",
 "Public Class B
     Dim WithEvents x As B
     Public Event E2(x() As String)
+
     Private Sub Test(Optional x As String = Nothing) Handles x.E1 'mark 1 
     End Sub
     Private Sub Test2(ParamArray x As String()) Handles x.E2 'mark 2 
@@ -354,7 +358,9 @@ End Class",
     Public Sub New()
         AddHandler XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")
@@ -377,7 +383,9 @@ End Class",
     Public Sub New()
         RemoveHandler XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")
@@ -400,7 +408,9 @@ End Class",
     Public Sub New()
         AddHandler Me.XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")
@@ -423,7 +433,9 @@ End Class",
     Public Sub New()
         RemoveHandler Me.XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")
@@ -446,7 +458,9 @@ End Class",
     Public Sub New()
         AddHandler MyClass.XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")
@@ -469,7 +483,9 @@ End Class",
     Public Sub New()
         RemoveHandler MyClass.XEvent, AddressOf EClass_EventHandler
     End Sub
+
     Public Event XEvent()
+
     Sub EClass_EventHandler()
     End Sub
 End Class")

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -21,10 +21,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo()
     End Sub
+
     Private Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -42,8 +44,7 @@ End Class")
         End Sub
     End Module
 End Namespace",
-"
-Imports System
+"Imports System
 
 Namespace N
     Module Module1
@@ -67,10 +68,12 @@ End Namespace")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Me.Goo()
     End Sub
+
     Private Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -86,10 +89,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         C.Goo()
     End Sub
+
     Private Shared Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -105,10 +110,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(0)
     End Sub
+
     Private Sub Goo(v As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -124,10 +131,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(0, 0)
     End Sub
+
     Private Sub Goo(v1 As Integer, v2 As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -143,10 +152,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(i)
     End Sub
+
     Private Sub Goo(i As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -162,10 +173,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(bar:=i)
     End Sub
+
     Private Sub Goo(bar As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -183,13 +196,16 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo()
     End Sub
+
     Private Sub Goo()
         Throw New NotImplementedException()
     End Sub
+
     Sub NextMethod()
     End Sub
 End Class")
@@ -206,13 +222,16 @@ End Class")
     End Function
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(NextMethod())
     End Sub
+
     Private Sub Goo(goo As IGoo)
         Throw New NotImplementedException()
     End Sub
+
     Function NextMethod() As IGoo
     End Function
 End Class")
@@ -229,13 +248,16 @@ End Class")
     End Function
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(NextMethod)
     End Sub
+
     Private Sub Goo(nextMethod As String)
         Throw New NotImplementedException()
     End Sub
+
     Function NextMethod() As String
     End Function
 End Class")
@@ -252,13 +274,16 @@ End Class")
     End Function
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(NextMethod)
     End Sub
+
     Private Sub Goo(nextMethod As Func(Of Integer, String))
         Throw New NotImplementedException()
     End Sub
+
     Function NextMethod(i As Integer) As String
     End Function
 End Class")
@@ -275,6 +300,7 @@ End Class")
     End Function
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(AddressOf NextMethod)
@@ -297,13 +323,14 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
-        Goo(NextMethod)
-    End Sub
-    Private Sub Goo(nextMethod As Object)
+        Goo(NextMethod) End Sub 
+Private Sub Goo(nextMethod As Object)
         Throw New NotImplementedException()
     End Sub
+
     Sub NextMethod()
     End Sub
 End Class")
@@ -320,13 +347,16 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(i As Integer)
         Goo(NextMethod)
     End Sub
+
     Private Sub Goo(nextMethod As Action(Of Integer))
         Throw New NotImplementedException()
     End Sub
+
     Sub NextMethod(i As Integer)
     End Sub
 End Class")
@@ -342,11 +372,13 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         If Goo()
         End If
     End Sub
+
     Private Function Goo() As Boolean
         Throw New NotImplementedException()
     End Function
@@ -363,13 +395,16 @@ End Class")
     Dim Bar As Integer
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(Me.Bar)
     End Sub
+
     Private Sub Goo(bar As Integer)
         Throw New NotImplementedException()
     End Sub
+
     Dim Bar As Integer
 End Class")
         End Function
@@ -384,13 +419,16 @@ End Class")
     Dim Bar As Integer
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo((Bar))
     End Sub
+
     Private Sub Goo(bar As Integer)
         Throw New NotImplementedException()
     End Sub
+
     Dim Bar As Integer
 End Class")
         End Function
@@ -406,10 +444,12 @@ End Class
 Class Bar
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(DirectCast(Me.Baz, Bar))
     End Sub
+
     Private Sub Goo(baz As Bar)
         Throw New NotImplementedException()
     End Sub
@@ -430,13 +470,16 @@ End Class
 Class Bar
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(DirectCast(Me.Baz, Bar), Me.Baz)
     End Sub
+
     Private Sub Goo(baz1 As Bar, baz2 As Integer)
         Throw New NotImplementedException()
     End Sub
+
     Dim Baz As Integer
 End Class
 Class Bar
@@ -452,10 +495,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(Of Integer)()
     End Sub
+
     Private Sub Goo(Of T)()
         Throw New NotImplementedException()
     End Sub
@@ -471,10 +516,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Goo(Of Integer, String)()
     End Sub
+
     Private Sub Goo(Of T1, T2)()
         Throw New NotImplementedException()
     End Sub
@@ -491,10 +538,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(Of X, Y)(x As X, y As Y)
         Goo(x)
     End Sub
+
     Private Sub Goo(Of X)(x1 As X)
         Throw New NotImplementedException()
     End Sub
@@ -510,10 +559,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(Of X)(y1 As X(), x1 As System.Func(Of X))
         Goo(Of X)(y1, x1)
     End Sub
+
     Private Sub Goo(Of X)(y1() As X, x1 As Func(Of X))
         Throw New NotImplementedException()
     End Sub
@@ -529,10 +580,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(Of X, Y)(y1 As Y(), x1 As System.Func(Of X))
         Goo(Of X, Y)(y1, x1)
     End Sub
+
     Private Sub Goo(Of X, Y)(y1() As Y, x1 As Func(Of X))
         Throw New NotImplementedException()
     End Sub
@@ -549,10 +602,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(Of X, Y)(x As X, y As Y)
         Goo(x, y)
     End Sub
+
     Private Sub Goo(Of X, Y)(x1 As X, y1 As Y)
         Throw New NotImplementedException()
     End Sub
@@ -569,10 +624,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M(Of X, Y)(y As Y(), x As System.Func(Of X))
         Goo(y, x)
     End Sub
+
     Private Sub Goo(Of Y, X)(y1() As Y, x1 As Func(Of X))
         Throw New NotImplementedException()
     End Sub
@@ -590,12 +647,14 @@ End Class")
     End Class
 End Class",
 "Imports System
+
 Class Outer
     Class C
         Sub M(o As Outer)
             o.Goo()
         End Sub
     End Class
+
     Private Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -613,13 +672,16 @@ End Class")
     End Class
 End Class",
 "Imports System
+
 Class Outer
     Class C
         Sub M(o As Outer)
             Outer.Goo()
         End Sub
-    End Class Private Shared Sub Goo() 
- Throw New NotImplementedException()
+    End Class
+
+    Private Shared Sub Goo()
+        Throw New NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -635,6 +697,7 @@ End Class
 Class Sibling
 End Class",
 "Imports System
+
 Class C
     Sub M(s As Sibling)
         s.Goo()
@@ -658,6 +721,7 @@ End Class
 Class Sibling
 End Class",
 "Imports System
+
 Class C
     Sub M(s As Sibling)
         Sibling.Goo()
@@ -702,6 +766,7 @@ End Class",
     Sub M()
         Goo()
     End Sub
+
     Friend MustOverride Sub Goo()
 End Class",
 index:=1)
@@ -717,13 +782,16 @@ index:=1)
     End Sub
 End Module",
 "Imports System
+
 Module Class C 
  Sub M()
         Goo()
     End Sub
+
     Private Sub Goo()
-        Throw New NotImplementedException() End Sub 
- End Module")
+        Throw New NotImplementedException()
+    End Sub
+End Module")
         End Function
 
         <WorkItem(539506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539506")>
@@ -737,11 +805,13 @@ Module Class C
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Do While Goo()
         Loop
     End Sub
+
     Private Function Goo() As Boolean
         Throw New NotImplementedException()
     End Function
@@ -758,10 +828,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         [Sub]()
     End Sub
+
     Private Sub [Sub]()
         Throw New NotImplementedException()
     End Sub
@@ -778,10 +850,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         Call S
     End Sub
+
     Private Sub S()
         Throw New NotImplementedException()
     End Sub
@@ -798,10 +872,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S
     End Sub
+
     Private Sub S()
         Throw New NotImplementedException()
     End Sub
@@ -828,10 +904,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S%()
     End Sub
+
     Private Function S() As Integer
         Throw New NotImplementedException()
     End Function
@@ -848,10 +926,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S&()
     End Sub
+
     Private Function S() As Long
         Throw New NotImplementedException()
     End Function
@@ -868,10 +948,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S@()
     End Sub
+
     Private Function S() As Decimal
         Throw New NotImplementedException()
     End Function
@@ -888,10 +970,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S!()
     End Sub
+
     Private Function S() As Single
         Throw New NotImplementedException()
     End Function
@@ -908,10 +992,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S#()
     End Sub
+
     Private Function S() As Double
         Throw New NotImplementedException()
     End Function
@@ -928,10 +1014,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class C
     Sub M()
         S$()
     End Sub
+
     Private Function S() As String
         Throw New NotImplementedException()
     End Function
@@ -1005,6 +1093,7 @@ Module Program
         Dim v As Void
         Goo(v)
     End Sub
+
     Private Sub Goo(v As Object)
         Throw New NotImplementedException()
     End Sub
@@ -1043,9 +1132,11 @@ End Sub",
 Shared Sub Main(args As String())
     Goo()
 End Sub
+
 Private Shared Sub Goo()
     Throw New NotImplementedException()
-End Sub",
+End Sub
+",
             parseOptions:=GetScriptOptions())
         End Function
 
@@ -1060,9 +1151,11 @@ End Sub",
 Shared Sub Main(args As String())
     Goo()
 End Sub
+
 Private Shared Sub Goo()
     Throw New NotImplementedException()
-End Sub")
+End Sub
+")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -1079,6 +1172,7 @@ Namespace N
     Shared Sub Main(args As String())
         Goo()
     End Sub
+
     Private Shared Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -1095,6 +1189,7 @@ End Namespace",
 "Imports System
 Namespace N
     Dim a As Integer = Goo()
+
     Private Function Goo() As Integer
         Throw New NotImplementedException()
     End Function
@@ -1239,11 +1334,13 @@ End Class")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         Dim [string] As String = ""hello"" 
  [Me]([string])
     End Sub
+
     Private Sub [Me]([string] As String)
         Throw New NotImplementedException()
     End Sub
@@ -1260,10 +1357,12 @@ End Module")
     End Sub
 End Class",
 "Imports System
+
 Class Test
     Sub M(Of T)(x As T)
         Goo(Of Integer)(x)
     End Sub
+
     Private Sub Goo(Of T)(x As T)
         Throw New NotImplementedException()
     End Sub
@@ -1280,10 +1379,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Class Test(Of T)
     Sub M()
         Method(Of T)()
     End Sub
+
     Private Sub Method(Of T1)()
         Throw New NotImplementedException()
     End Sub
@@ -1304,6 +1405,7 @@ Class C
     Sub M()
         Goo()
     End Sub
+
     Private Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -1354,11 +1456,13 @@ Class C
     End Sub
 End Class",
 "Imports System
+
 Delegate Sub D(x As Integer)
 Class C
     Public Sub Goo()
         Dim x As D = New D(AddressOf Method)
     End Sub
+
     Private Sub Method(x As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -1389,11 +1493,13 @@ Class C
     End Sub
 End Class",
 "Imports System
+
 Delegate Sub D(x As Integer)
 Class C
     Private Sub M()
         Dim d As New D(AddressOf Test)
     End Sub
+
     Private Sub Test(x As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -1436,10 +1542,12 @@ End Class")
 End Module",
 "Imports System
 Imports System.Collections.Generic
+
 Module Program
     Sub Main(args As String())
         For Each v As Integer In HERE() : Next
     End Sub
+
     Private Function HERE() As IEnumerable(Of Integer)
         Throw New NotImplementedException()
     End Function
@@ -1459,6 +1567,7 @@ End Module",
     Sub Main(args As String())
         For Each v As Integer In HERE() : Next
     End Sub
+
     Private Function HERE() As IEnumerable(Of Integer)
         Throw New NotImplementedException()
     End Function
@@ -1480,6 +1589,7 @@ End Module",
     Sub Main(args As String())
         For Each v In HERE : Next
     End Sub
+
     Private Function HERE() As IEnumerable(Of Object)
         Throw New NotImplementedException()
     End Function
@@ -1505,6 +1615,7 @@ End Module",
         ElseIf HERE Then
         End If
     End Sub
+
     Private Function HERE() As Boolean
         Throw New NotImplementedException()
     End Function
@@ -1526,6 +1637,7 @@ End Module",
     Sub Main(args As String())
         For x As Integer = 1 To HERE
  End Sub
+
     Private Function HERE() As Integer
         Throw New NotImplementedException()
     End Function
@@ -1559,9 +1671,11 @@ Module Program
         Dim products = ToList(product)
         HERE(products)
     End Sub
+
     Private Sub HERE(products As IEnumerable(Of Object))
         Throw New NotImplementedException()
     End Sub
+
     Function ToList(Of T)(a As T) As IEnumerable(Of T)
         Return Nothing
     End Function
@@ -1744,6 +1858,7 @@ Module Program
         Dim v As Func(Of String) = Nothing
         Dim a1 = If(False, v, AddressOf TestMethod)
     End Sub
+
     Private Function TestMethod() As String
         Throw New NotImplementedException()
     End Function
@@ -1761,6 +1876,7 @@ Class B
     End Sub
 End Class",
 "Imports System
+
 Class C
     Friend Shared Sub Bar()
         Throw New NotImplementedException()
@@ -1783,10 +1899,12 @@ End Class")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(,,)
     End Sub
+
     Private Sub goo(Optional p1 As Object = Nothing, Optional p2 As Object = Nothing, Optional p3 As Object = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1803,10 +1921,12 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(1,,)
     End Sub
+
     Private Sub goo(v As Integer, Optional p1 As Object = Nothing, Optional p2 As Object = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1823,10 +1943,12 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(, 1,)
     End Sub
+
     Private Sub goo(Optional p1 As Object = Nothing, Optional v As Integer = Nothing, Optional p2 As Object = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1843,10 +1965,12 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(,, 1)
     End Sub
+
     Private Sub goo(Optional p1 As Object = Nothing, Optional p2 As Object = Nothing, Optional v As Integer = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1863,10 +1987,12 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(1,, 1)
     End Sub
+
     Private Sub goo(v1 As Integer, Optional p As Object = Nothing, Optional v2 As Integer = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1883,10 +2009,12 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main(args As String())
         goo(1, 1, )
     End Sub
+
     Private Sub goo(v1 As Integer, v2 As Integer, Optional p As Object = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -1917,14 +2045,17 @@ End Class")
     End Class
 End Module",
 "Imports System
+
 Module Module1
     Sub Main()
         Dim c1 As New Class1
         AddHandler c1.AnEvent, AddressOf EventHandler1
     End Sub
+
     Private Sub EventHandler1()
         Throw New NotImplementedException()
     End Sub
+
     Public Class Class1
         Public Event AnEvent()
     End Class
@@ -1948,6 +2079,7 @@ Module M
     Sub Goo(Of T, S)(x As List(Of T), y As List(Of S))
         Bar(x, Function() y) ' Generate Bar 
     End Sub
+
     Private Sub Bar(Of T, S)(x As List(Of T), p As Func(Of List(Of S)))
         Throw New NotImplementedException()
     End Sub
@@ -2020,6 +2152,7 @@ Module Program
     Sub Main(args As String())
         Bar(1, {1})
     End Sub
+
     Private Sub Bar(v As Integer, p() As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -2041,6 +2174,7 @@ Module M
     Sub Main()
         Goo({{1}})
     End Sub
+
     Private Sub Goo(p(,) As Integer)
         Throw New NotImplementedException()
     End Sub
@@ -2062,6 +2196,7 @@ Module Program
     Sub Main()
         Prop(1) = 2
     End Sub
+
     Private Function Prop(v As Integer) As Integer
         Throw New NotImplementedException()
     End Function
@@ -2083,6 +2218,7 @@ Module Program
     Sub Main()
         Prop(1) = 2
     End Sub
+
     Private Property Prop(v As Integer) As Integer
         Get
             Throw New NotImplementedException()
@@ -3134,10 +3270,12 @@ End Class
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C = a?.B
     End Sub
+
     Private Function B() As C
         Throw New NotImplementedException()
     End Function
@@ -3154,10 +3292,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x = a?.B
     End Sub
+
     Private Function B() As Object
         Throw New NotImplementedException()
     End Function
@@ -3174,10 +3314,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As Integer? = a?.B
     End Sub
+
     Private Function B() As Integer
         Throw New NotImplementedException()
     End Function
@@ -3194,10 +3336,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C? = a?.B
     End Sub
+
     Private Function B() As C
         Throw New NotImplementedException()
     End Function
@@ -3433,10 +3577,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C = a?.B()
     End Sub
+
     Private Function B() As C
         Throw New NotImplementedException()
     End Function
@@ -3453,10 +3599,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x = a?.B()
     End Sub
+
     Private Function B() As Object
         Throw New NotImplementedException()
     End Function
@@ -3473,10 +3621,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As Integer? = a?.B()
     End Sub
+
     Private Function B() As Integer
         Throw New NotImplementedException()
     End Function
@@ -3493,10 +3643,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C? = a?.B()
     End Sub
+
     Private Function B() As C
         Throw New NotImplementedException()
     End Function
@@ -3513,10 +3665,12 @@ End Class")
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C = a?.B()
     End Sub
+
     Private ReadOnly Property B As C
         Get
             Throw New NotImplementedException()
@@ -3536,10 +3690,12 @@ index:=1)
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x = a?.B()
     End Sub
+
     Private ReadOnly Property B As Object
         Get
             Throw New NotImplementedException()
@@ -3559,10 +3715,12 @@ index:=1)
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As Integer? = a?.B()
     End Sub
+
     Private ReadOnly Property B As Integer
         Get
             Throw New NotImplementedException()
@@ -3582,10 +3740,12 @@ index:=1)
     End Sub
 End Class",
 "Imports System
+
 Public Class C
     Sub Main(a As C)
         Dim x As C? = a?.B()
     End Sub
+
     Private ReadOnly Property B As C
         Get
             Throw New NotImplementedException()
@@ -3639,11 +3799,13 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module C
     Sub Test()
         If TypeOf B Is String Then
         End If
     End Sub
+
     Private Function B() As String
         Throw New NotImplementedException()
     End Function
@@ -3660,11 +3822,13 @@ End Module")
     End Sub
 End Module",
 "Imports System
+
 Module C
     Sub Test()
         If TypeOf B() Is String Then
         End If
     End Sub
+
     Private Function B() As String
         Throw New NotImplementedException()
     End Function
@@ -3741,13 +3905,15 @@ Module M
         Dim x As Boolean = Await [|F|]().ConfigureAwait(False)
     End Sub 
 End Module",
-"Imports System 
-Imports System.Linq 
+"Imports System
+Imports System.Linq
 Imports System.Threading.Tasks
+
 Module M 
     Async Sub T() 
         Dim x As Boolean = Await F().ConfigureAwait(False)
-    End Sub 
+    End Sub
+
     Private Function F() As Task(Of Boolean)
         Throw New NotImplementedException()
     End Function
@@ -3775,6 +3941,7 @@ Module Program
         If TypeOf Prop IsNot TypeOfIsNotDerived Then
         End If
     End Sub
+
     Private Function Prop() As TypeOfIsNotDerived
         Throw New NotImplementedException()
     End Function
@@ -3798,6 +3965,7 @@ Module Program
     Sub M()
         Dim x = New List(Of Integer) From {T()}
     End Sub
+
     Private Function T() As Integer
         Throw New NotImplementedException()
     End Function
@@ -3821,6 +3989,7 @@ Module Program
     Sub M()
         Dim x = New Dictionary(Of Integer, Boolean) From {{1, T()}}
     End Sub
+
     Private Function T() As Boolean
         Throw New NotImplementedException()
     End Function
@@ -3902,7 +4071,8 @@ Class C
     Shared Sub TestError()
         Repository.AgreementType.NewFunction("", "")
     End Sub
-End Class</text>.Value.Replace(vbLf, vbCrLf))
+End Class
+</text>.Value.Replace(vbLf, vbCrLf))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateType/GenerateTypeTests.vb
@@ -35,8 +35,10 @@ End Module",
         Dim f As Goo(Of Integer)
     End Sub
 End Module
+
 Friend Class Goo(Of T)
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -48,6 +50,7 @@ index:=1)
 End Class",
 "Class C
     Dim emp As List(Of Employee)
+
     Private Class Employee
     End Class
 End Class",
@@ -62,6 +65,7 @@ index:=2)
 End Class",
 "Class C
     dim f as Goo
+
     Private Class Goo
     End Class
 End Class",
@@ -77,8 +81,10 @@ End Class",
 "Class C
     dim f as Goo
 End Class
+
 Friend Class Goo
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -103,6 +109,7 @@ End Namespace",
     Class Goo
         Private x As New NS.Bar
     End Class
+
     Friend Class Bar
     End Class
 End Namespace",
@@ -118,6 +125,7 @@ parseOptions:=Nothing) ' Namespaces not supported in script
 End Class",
 "Class C
     Dim f As Goo = New Goo()
+
     Private Class Goo
         Public Sub New()
         End Sub
@@ -181,25 +189,33 @@ End Module",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
+
 Module Program
     Sub Main(args As String())
         Throw New Goo()
     End Sub
 End Module
-<Serializable> Friend Class Goo
+
+<Serializable>
+Friend Class Goo
     Inherits Exception
+
     Public Sub New()
     End Sub
+
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
+
     Public Sub New(message As String, innerException As Exception)
         MyBase.New(message, innerException)
     End Sub
+
     Protected Sub New(info As SerializationInfo, context As StreamingContext)
         MyBase.New(info, context)
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -222,14 +238,17 @@ Module Program
         Call New Goo(1, ""blah"")
     End Sub
 End Module
+
 Friend Class Goo
     Private v1 As Integer
     Private v2 As String
+
     Public Sub New(v1 As Integer, v2 As String)
         Me.v1 = v1
         Me.v2 = v2
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -256,12 +275,15 @@ Module Program
         Dim d As B = New D(4)
     End Sub
 End Module
+
 Friend Class D
     Inherits B
+
     Public Sub New(value As Integer)
         MyBase.New(value)
     End Sub
 End Class
+
 Class B
     Protected Sub New(value As Integer)
     End Sub
@@ -291,6 +313,7 @@ Namespace Outer
             Call New Blah()
         End Sub
     End Module
+
     Friend Class Blah
         Public Sub New()
         End Sub
@@ -321,12 +344,15 @@ Module Program
         Dim d As B = New D(i)
     End Sub
 End Module
+
 Friend Class D
     Inherits B
+
     Public Sub New(i As Integer)
         Me.i = i
     End Sub
 End Class
+
 Class B
     Protected i As Integer
 End Class",
@@ -352,8 +378,10 @@ Class Outer(Of M)
         Call New Goo(Of M)
     End Sub
 End Class
+
 Friend Class Goo(Of M)
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -375,6 +403,7 @@ Class Outer(Of M)
     Sub Main(i As Integer)
         Call New Goo(Of M)
     End Sub
+
     Private Class Goo(Of M)
     End Class
 End Class",
@@ -393,6 +422,7 @@ End Class",
     Sub Test()
         Dim d = New Program.Goo()
     End Sub
+
     Private Class Goo
         Public Sub New()
         End Sub
@@ -417,6 +447,7 @@ End Namespace",
             Dim d = New Goo.Bar()
         End Sub
     End Class
+
     Friend Class Bar
         Public Sub New()
         End Sub
@@ -439,8 +470,10 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class Program(Of T As {Goo, IBar})
 End Class
+
 Friend Interface IBar
-End Interface",
+End Interface
+",
 index:=1)
         End Function
 
@@ -460,7 +493,8 @@ End Class",
         Public Sub New()
         End Sub
     End Class
-End Namespace",
+End Namespace
+",
 expectedContainers:=ImmutableArray.Create("Goo"),
 expectedDocumentName:="Bar.vb")
         End Function
@@ -546,7 +580,8 @@ Module Program
     End Sub
 End Module",
 "Friend Class Goo
-End Class",
+End Class
+",
 expectedContainers:=ImmutableArray(Of String).Empty,
 expectedDocumentName:="Goo.vb")
         End Function
@@ -570,8 +605,10 @@ Module Program
         Dim d As IGoo = New Goo()
     End Sub
 End Module
+
 Friend Interface IGoo
-End Interface",
+End Interface
+",
 index:=1)
         End Function
 
@@ -596,9 +633,11 @@ Module Program
         Dim d As IGoo = New Goo()
     End Sub
 End Module
+
 Friend Class Goo
     Implements IGoo
 End Class
+
 Friend Interface IGoo
 End Interface",
 index:=1)
@@ -617,12 +656,15 @@ End Class",
         Dim x = New Bar(value:=7)
     End Sub
 End Class
+
 Friend Class Bar
     Private value As Integer
+
     Public Sub New(value As Integer)
         Me.value = value
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -649,8 +691,10 @@ End Class",
     Function F() As Bar
     End Function
 End Class
+
 Public Class Bar
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -663,8 +707,10 @@ End Class",
 "Class Goo
     Dim x As New [Class]
 End Class
+
 Friend Class [Class]
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -677,8 +723,10 @@ End Class",
 "Class Goo
     Dim x as New [Bar]
 End Class
+
 Friend Class Bar
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -695,6 +743,7 @@ End Namespace",
     Class Goo
         Dim x As New NS.Bar
     End Class
+
     Friend Class Bar
     End Class
 End Namespace",
@@ -711,6 +760,7 @@ parseOptions:=Nothing) ' Namespaces not supported in script
 End Module",
 "Module M
     Dim x As C
+
     Private Class C
     End Class
 End Module",
@@ -727,8 +777,10 @@ End Class",
 "Class C
     Implements D
 End Class
+
 Friend Interface D
-End Interface",
+End Interface
+",
 index:=1)
         End Function
 
@@ -758,7 +810,8 @@ End Class",
 "Friend Class Derived
     Public Sub New()
     End Sub
-End Class",
+End Class
+",
 expectedContainers:=ImmutableArray(Of String).Empty,
 expectedDocumentName:="Derived.vb")
         End Function
@@ -821,9 +874,11 @@ End Class",
         Dim p() As Base = New Derived(10) {}
     End Sub
 End Class
+
 Friend Class Derived
     Inherits Base
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -841,9 +896,11 @@ End Class",
         Dim p As Base() = New Derived(10) {}
     End Sub
 End Class
+
 Friend Class Derived
     Inherits Base
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -861,8 +918,10 @@ End Class",
         Dim p As Base = New Derived(10) {}
     End Sub
 End Class
+
 Friend Class Derived
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -882,8 +941,10 @@ End Class",
         Dim f As Goo(Of Integer)
     End Sub
 End Class
+
 Friend Class Goo(Of T)
 End Class
+
 Class Goo
 End Class",
 index:=1)
@@ -903,14 +964,17 @@ End Class",
         Dim a As Test = New Test(x, y)
     End Sub
 End Class
+
 Friend Class Test
     Private x As Object
     Private y As Object
+
     Public Sub New(x As Object, y As Object)
         Me.x = x
         Me.y = y
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -928,14 +992,17 @@ End Class",
         Dim a As Test(Of T1, T2) = New Test(Of T1, T2)(x, y)
     End Sub
 End Class
+
 Friend Class Test(Of T1, T2)
     Private x As T1
     Private y As T2
+
     Public Sub New(x As T1, y As T2)
         Me.x = x
         Me.y = y
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -957,12 +1024,15 @@ End Module",
     Sub M()
     End Sub
 End Module
+
 Friend Class C
     Private v As Object
+
     Public Sub New(v As Object)
         Me.v = v
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -980,12 +1050,15 @@ End Class",
         Dim x As New C(4)
     End Sub
 End Class
+
 Friend Class C
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1008,12 +1081,15 @@ End Class")
 Class C
 End Class",
 "Imports System
+
 <AttClass()>
 Class C
 End Class
+
 Friend Class AttClassAttribute
     Inherits Attribute
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1029,9 +1105,11 @@ End Class",
 <AttClass()>
 Class C
 End Class
+
 Friend Class AttClassAttribute
     Inherits Attribute
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1069,6 +1147,7 @@ Module StringExtensions
     Public Sub Print(ByVal aString As String, x As C)
         Console.WriteLine(aString)
     End Sub
+
     Public Class C
     End Class
 End Module",
@@ -1218,17 +1297,21 @@ index:=1)
     End Sub
 End Module",
 "Imports System
+
 Module Program
     Sub Main()
         Dim c = New C(Function() x)
     End Sub
 End Module
+
 Friend Class C
     Private p As Func(Of Object)
+
     Public Sub New(p As Func(Of Object))
         Me.p = p
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1248,14 +1331,17 @@ Module Program
         Dim x = New C(,)
     End Sub
 End Module
+
 Friend Class C
     Private p1 As Object
     Private p2 As Object
+
     Public Sub New(p1 As Object, p2 As Object)
         Me.p1 = p1
         Me.p2 = p2
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1275,9 +1361,11 @@ Module Program
     Sub Main()
     End Sub
 End Module
+
 Friend Class SystemAttribute
     Inherits Attribute
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1426,16 +1514,20 @@ Module Program
         Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = ""John"", .Age = Date.Today}
     End Sub
 End Module
+
 Friend Class Customer
     Private x As Integer
     Private y As String
+
     Public Sub New(x As Integer, y As String)
         Me.x = x
         Me.y = y
     End Sub
+
     Public Property Name As String
     Public Property Age As Date
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1455,16 +1547,20 @@ Module Program
         Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = Nothing, .Age = Date.Today}
     End Sub
 End Module
+
 Friend Class Customer
     Private x As Integer
     Private y As String
+
     Public Sub New(x As Integer, y As String)
         Me.x = x
         Me.y = y
     End Sub
+
     Public Property Name As Object
     Public Property Age As Date
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1484,16 +1580,20 @@ Module Program
         Dim c As New [|Customer|](x:=1, y:=""Hello"") With {.Name = Goo, .Age = Date.Today}
     End Sub
 End Module
+
 Friend Class Customer
     Private x As Integer
     Private y As String
+
     Public Sub New(x As Integer, y As String)
         Me.x = x
         Me.y = y
     End Sub
+
     Public Property Name As Object
     Public Property Age As Date
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1513,10 +1613,12 @@ Module Program
         Dim c As New [|Customer|] With {.Name = ""John"", .Age = Date.Today}
     End Sub
 End Module
+
 Friend Class Customer
     Public Property Name As String
     Public Property Age As Date
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1536,8 +1638,10 @@ Module Program
         Dim x = nameof([|Z|])
     End Sub
 End Module
+
 Friend Class Z
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1556,6 +1660,7 @@ Class Program
     Sub Main()
         Dim x = nameof([|Z|])
     End Sub
+
     Private Class Z
     End Class
 End Class",
@@ -1577,6 +1682,7 @@ Class Program
     Sub Main()
         Dim x = nameof([|Program.Z|])
     End Sub
+
     Private Class Z
     End Class
 End Class")
@@ -1616,8 +1722,10 @@ End Class
             Await TestInRegularAndScriptAsync(
 "Imports [|Fizz|]",
 "Imports Fizz
+
 Friend Class Fizz
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1631,7 +1739,8 @@ End Class",
 "Public Class B
     Public Sub New()
     End Sub
-End Class")
+End Class
+")
         End Function
 
         <WorkItem(1107929, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1107929")>
@@ -1648,7 +1757,8 @@ End Class
 Public Class B
     Public Sub New()
     End Sub
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1661,6 +1771,7 @@ index:=1)
 End Class",
 "Public Class A
     Public B As New B()
+
     Public Class B
         Public Sub New()
         End Sub
@@ -1677,7 +1788,8 @@ index:=2)
     Public B As New [|B|]
 End Class",
 "Public Class B
-End Class")
+End Class
+")
         End Function
 
         <WorkItem(1107929, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1107929")>
@@ -1692,7 +1804,8 @@ End Class",
 End Class
 
 Public Class B
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1705,6 +1818,7 @@ index:=1)
 End Class",
 "Public Class A
     Public B As New B
+
     Public Class B
     End Class
 End Class",
@@ -1719,7 +1833,8 @@ index:=2)
     Public B As New [|B(Of Integer)|]
 End Class",
 "Public Class B(Of T)
-End Class")
+End Class
+")
         End Function
 
         <WorkItem(1107929, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1107929")>
@@ -1734,7 +1849,8 @@ End Class",
 End Class
 
 Public Class B(Of T)
-End Class",
+End Class
+",
 index:=1)
         End Function
 
@@ -1747,6 +1863,7 @@ index:=1)
 End Class",
 "Public Class A
     Public B As New B(Of Integer)
+
     Public Class B(Of T)
     End Class
 End Class",
@@ -1773,12 +1890,15 @@ index:=2)
     <[|Extension|]>
 End Module",
 "Imports System
+
 Module Program
     <Extension>
 End Module
+
 Friend Class ExtensionAttribute
     Inherits Attribute
-End Class",
+End Class
+",
 index:=1)
             End Function
         End Class

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -28,6 +28,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
 End Module",
 "Module Program
     Public Property Bar As Object
+
     Sub Main(args As String())
         Goo(Bar)
     End Sub
@@ -44,6 +45,7 @@ End Module")
 End Module",
 "Module Program
     Private Bar As Object
+
     Sub Main(args As String())
         Goo(Bar)
     End Sub
@@ -61,6 +63,7 @@ index:=1)
 End Module",
 "Module Program
     Private ReadOnly Bar As Object
+
     Sub Main(args As String())
         Goo(Bar)
     End Sub
@@ -79,6 +82,7 @@ index:=2)
 End Class",
 "Class C
     Private Shared Goo As Integer
+
     Shared Sub M
         Goo = 3
     End Sub
@@ -249,6 +253,7 @@ Class C
 End Class",
 "Module Program
     Public Property P As Integer
+
     Sub Main(args As String())
     End Sub
 End Module
@@ -274,6 +279,7 @@ Class C
 End Class",
 "Module Program
     Friend P As Integer
+
     Sub Main(args As String())
     End Sub
 End Module
@@ -296,6 +302,7 @@ index:=1)
 End Module",
 "Module Program
     Private HERE As Object
+
     Sub Main(args As String())
         HERE.ToString()
     End Sub
@@ -341,6 +348,7 @@ End Class")
 End Module",
 "Module Program
     Public Property P As Integer
+
     Function Fun() As Integer
         Return P
     End Function
@@ -359,6 +367,7 @@ End Module")
 End Module",
 "Module Program
     Public Property P As Integer
+
     Sub Main(args As String())
         Dim x As Integer
         x = P
@@ -376,6 +385,7 @@ End Module")
 End Class",
 "Class GenPropTest
     Private Shared genStaticUnqualified As String
+
     Public Shared Sub Main()
         genStaticUnqualified = """"
     End Sub
@@ -392,6 +402,7 @@ End Class")
 End Class",
 "Class GenPropTest
     Private Shared genStaticUnqualified As String
+
     Public Sub Main()
         GenPropTest.genStaticUnqualified = """"
     End Sub
@@ -408,6 +419,7 @@ End Class")
 End Class",
 "Class GenPropTest
     Private field As String
+
     Public Sub Main()
         Me.field = """"
     End Sub
@@ -424,6 +436,7 @@ End Class")
 End Class",
 "Class GenPropTest
     Private field As String
+
     Public Sub Main()
         field = """"
     End Sub
@@ -528,6 +541,7 @@ End Class", index:=1)
 End Module",
 "Module Program
     Private field As Integer
+
     Sub Main(args As String())
         field = 5
     End Sub
@@ -544,6 +558,7 @@ End Module")
 End Module",
 "Module Program
     Public Property Field As Integer
+
     Sub Main(args As String())
         Field = 5
     End Sub
@@ -590,6 +605,7 @@ Class C(Of T)
 End Class",
 "Class A
     Private field As C(Of B)
+
     Sub Main()
         field = New C(Of B)
     End Sub
@@ -641,6 +657,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class A
     Private z As Type
+
     Sub Goo(Of T)
         z = GetType(T)
     End Sub
@@ -685,6 +702,7 @@ End Interface")
 End Class",
 "Class [Class]
     Public Property [Enum] As Integer
+
     Private Sub Method(i As Integer)
         [Enum] = 5
     End Sub
@@ -701,6 +719,7 @@ End Class")
 End Class",
 "Class [Class]
     Private [Enum] As Integer
+
     Private Sub Method(i As Integer)
         [Enum] = 5
     End Sub
@@ -723,6 +742,7 @@ index:=1)
 End Class",
 "Class [Class]
     Private test As Object
+
     Private Sub Method()
         test = Function(ByRef x As Integer) InlineAssignHelper(x, 10)
     End Sub
@@ -954,6 +974,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Private a As Object
+
     Sub Main(args As String())
         a = New With {.a = ., .b = 1}
     End Sub
@@ -983,6 +1004,7 @@ Module StringExtensions
 End Module
 Module M
     Private s As String
+
     Sub Main()
         Print(s)
     End Sub
@@ -1015,6 +1037,7 @@ Module StringExtensions
 End Module
 Module M
     Private s As String
+
     Sub Main()
         Print(s)
     End Sub
@@ -1035,6 +1058,7 @@ parseOptions:=Nothing) ' TODO (tomat): Modules nested in Script class not suppor
 End Module",
 "Module P
     Public Property Goo As Integer
+
     Sub M()
         Dim t As System.Action = Sub()
                                      P.Goo = 5
@@ -1085,6 +1109,7 @@ End Module
 End Module",
 "Module Program
     Private a As Integer
+
     Sub Main(args As String())
         Main(a + b)
     End Sub
@@ -1101,6 +1126,7 @@ End Module")
 End Module",
 "Module Program
     Private b As Integer
+
     Sub Main(args As String())
         Main(a + b)
     End Sub
@@ -1117,6 +1143,7 @@ End Module")
 End Module",
 "Module Program
     Private bar As Object
+
     Sub Main(args As String())
         Goo(bar)
     End Sub
@@ -1171,6 +1198,7 @@ Module Program
 #If True
         ' Banner Line 1
         ' Banner Line 2
+
         Dim local As Integer = Nothing
         Integer.TryParse(""123"", local)
 #End If
@@ -1213,6 +1241,7 @@ End Module",
 "Imports System.Linq
 Module Program
     Private v As Object
+
     Sub Main(args As String())
         Dim q = From a In args
                 Select v
@@ -1233,6 +1262,7 @@ End Module",
 "Module Program
     Sub Main()
         Dim a As Object = Nothing
+
         If (a Mod b <> 0) Then
         End If
     End Sub
@@ -1265,8 +1295,10 @@ End Module")
  End Function
 End Module",
 "Imports System
+
 Module Program
     Private d As Func(Of String)
+
     Sub Main(args As String())
         d = AddressOf test
     End Sub
@@ -1375,6 +1407,7 @@ End Class",
 "Imports System
 Public Class A
     Private MyExp As Exception
+
     Public Sub B()
         Throw MyExp
     End Sub
@@ -1394,6 +1427,7 @@ End Class",
 "Imports System
 Class C
     Public Property Z As Object
+
     Sub M()
         Dim x = NameOf(Z)
     End Sub
@@ -1413,6 +1447,7 @@ End Class",
 "Imports System
 Class C
     Private Z As Object
+
     Sub M()
         Dim x = NameOf(Z)
     End Sub
@@ -1432,6 +1467,7 @@ End Class",
 "Imports System
 Class C
     Private ReadOnly Z As Object
+
     Sub M()
         Dim x = NameOf(Z)
     End Sub
@@ -1468,6 +1504,7 @@ End Class", index:=3)
 End Class",
 "Public Class C
     Public Property B As C
+
     Sub Main(a As C)
         Dim x As C = a?.B
     End Sub
@@ -1485,6 +1522,7 @@ End Class")
 End Class",
 "Public Class C
     Public Property B As Object
+
     Sub Main(a As C)
         Dim x = a?.B
     End Sub
@@ -1502,6 +1540,7 @@ End Class")
 End Class",
 "Public Class C
     Public Property B As Integer
+
     Sub Main(a As C)
         Dim x As Integer? = a?.B
     End Sub
@@ -1519,6 +1558,7 @@ End Class")
 End Class",
 "Public Class C
     Public Property B As C
+
     Sub Main(a As C)
         Dim x As C? = a?.B
     End Sub
@@ -1536,6 +1576,7 @@ End Class")
 End Class",
 "Public Class C
     Private B As C
+
     Sub Main(a As C)
         Dim x As C = a?.B
     End Sub
@@ -1554,6 +1595,7 @@ index:=1)
 End Class",
 "Public Class C
     Private B As Object
+
     Sub Main(a As C)
         Dim x = a?.B
     End Sub
@@ -1572,6 +1614,7 @@ index:=1)
 End Class",
 "Public Class C
     Private B As Integer
+
     Sub Main(a As C)
         Dim x As Integer? = a?.B
     End Sub
@@ -1590,6 +1633,7 @@ index:=1)
 End Class",
 "Public Class C
     Private B As C
+
     Sub Main(a As C)
         Dim x As C? = a?.B
     End Sub
@@ -1608,6 +1652,7 @@ index:=1)
 End Class",
 "Public Class C
     Private ReadOnly B As C
+
     Sub Main(a As C)
         Dim x As C = a?.B
     End Sub
@@ -1626,6 +1671,7 @@ index:=2)
 End Class",
 "Public Class C
     Private ReadOnly B As Object
+
     Sub Main(a As C)
         Dim x = a?.B
     End Sub
@@ -1644,6 +1690,7 @@ index:=2)
 End Class",
 "Public Class C
     Private ReadOnly B As Integer
+
     Sub Main(a As C)
         Dim x As Integer? = a?.B
     End Sub
@@ -1662,6 +1709,7 @@ index:=2)
 End Class",
 "Public Class C
     Private ReadOnly B As C
+
     Sub Main(a As C)
         Dim x As C? = a?.B
     End Sub
@@ -2135,6 +2183,7 @@ Friend Class Customer
 End Class",
 "Module Program
     Public Property name As Object
+
     Sub Main(args As String())
         Dim x As New Customer With {.Name = name}
     End Sub
@@ -2198,6 +2247,7 @@ Friend Class Customer
 End Class",
 "Module Program
     Private name As Object
+
     Sub Main(args As String())
         Dim x As New Customer With {.Name = name}
     End Sub
@@ -2263,6 +2313,7 @@ index:=3)
 End Module",
 "Module C
     Public Property B As String
+
     Sub Test()
         If TypeOf B Is String Then
         End If
@@ -2281,6 +2332,7 @@ End Module")
 End Module",
 "Module C
     Private B As String
+
     Sub Test()
         If TypeOf B Is String Then
         End If
@@ -2300,6 +2352,7 @@ index:=1)
 End Module",
 "Module C
     Private ReadOnly B As String
+
     Sub Test()
         If TypeOf B Is String Then
         End If
@@ -2320,6 +2373,7 @@ End Module",
 "Module C
     Sub Test()
         Dim B As String = Nothing
+
         If TypeOf B Is String Then
         End If
     End Sub
@@ -2345,6 +2399,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Public Property Prop As TypeOfIsNotDerived
+
     Sub M()
         If TypeOf Prop IsNot TypeOfIsNotDerived Then
         End If
@@ -2370,6 +2425,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Private Prop As TypeOfIsNotDerived
+
     Sub M()
         If TypeOf Prop IsNot TypeOfIsNotDerived Then
         End If
@@ -2396,6 +2452,7 @@ Imports System.Collections.Generic
 Imports System.Linq
 Module Program
     Private ReadOnly Prop As TypeOfIsNotDerived
+
     Sub M()
         If TypeOf Prop IsNot TypeOfIsNotDerived Then
         End If
@@ -2423,6 +2480,7 @@ Imports System.Linq
 Module Program
     Sub M()
         Dim Prop As TypeOfIsNotDerived = Nothing
+
         If TypeOf Prop IsNot TypeOfIsNotDerived Then
         End If
     End Sub
@@ -2508,6 +2566,7 @@ index:=2)
 End Class",
 "Class [Class]
     Private tuple As (Integer, String)
+
     Private Sub Method(i As (Integer, String))
         Method(tuple)
     End Sub
@@ -2523,8 +2582,9 @@ End Class")
     End Sub
 End Class",
 "Class [Class]
-    Private tuple As (a As Integer, String) 
-  Private Sub Method(i As (a As Integer, String))
+    Private tuple As (a As Integer, String)
+
+    Private Sub Method(i As (a As Integer, String)) 
  Method(tuple)
     End Sub
 End Class")
@@ -2540,6 +2600,7 @@ End Class")
 End Class",
 "Class [Class]
     Private tuple As (Integer, String)
+
     Private Sub Method()
         tuple = (1, ""hello"") 
  End Sub
@@ -2555,8 +2616,9 @@ End Class")
  End Sub
 End Class",
 "Class [Class]
-    Private tuple As (a As Integer, String) 
-  Private Sub Method()
+    Private tuple As (a As Integer, String)
+
+    Private Sub Method()
         tuple = (a:=1, ""hello"") 
  End Sub
 End Class")
@@ -2677,7 +2739,6 @@ end class",
 class C
     public isDisposed as boolean
     Private y As Integer
-
     public readonly x as integer
     public readonly m as integer
 
@@ -2706,7 +2767,6 @@ class C
     public readonly x as integer
     public readonly m as integer
     Private ReadOnly y As Integer
-
     public isDisposed as boolean
 
     public sub new()

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/InsertMissingCast/InsertMissingCastTests.vb
@@ -113,8 +113,8 @@ Module M1
     Sub goo(d As Integer)
     End Sub
     Sub Main()
-        goo(CInt(""10"")) 
- End Sub
+        goo(CInt(""10""))
+    End Sub
 End Module")
         End Function
 
@@ -149,8 +149,8 @@ End Module",
 "Option Strict On
 Module M1
     Function goo() As Integer
-        Return CInt(""10"") 
- End Function
+        Return CInt(""10"")
+    End Function
 End Module")
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Iterator/IteratorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Iterator/IteratorTests.vb
@@ -29,8 +29,8 @@ Imports System.Collections.Generic
 
 Module Module1
     Iterator Function M() As IEnumerable(Of Integer)
-        Yield 1
-    End Function
+        Yield 1 
+ End Function
 End Module")
         End Function
 
@@ -63,8 +63,8 @@ Imports System.Collections.Generic
 Module Module1
     Sub M()
         Dim a As Func(Of IEnumerable(Of Integer)) = Iterator Function()
-                                                        Yield 0
-                                                    End Function
+                                                        Yield 0 
+ End Function
     End Sub
 End Module")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.vb
@@ -26,8 +26,8 @@ End Module",
 Imports System.Threading.Tasks
 Module Program
     Async Sub TestAsync()
-        Await Task.Delay(1)
-    End Sub
+        Await Task.Delay(1) 
+ End Sub
 End Module",
                 index:=1)
         End Function
@@ -46,8 +46,8 @@ End Module",
 Imports System.Threading.Tasks
 Module Program
     Public Shared Async Sub TestAsync()
-        Await Task.Delay(1)
-    End Sub
+        Await Task.Delay(1) 
+ End Sub
 End Module",
                 index:=1)
         End Function
@@ -66,7 +66,7 @@ Module Program
 Imports System.Threading.Tasks
 Module Program
     Async Function TestAsync() As Task(Of Integer)
-        Await Task.Delay(1)
+        Await Task.Delay(1) 
  Function Sub
  End Module")
         End Function
@@ -85,7 +85,7 @@ Module Program
 Imports System.Threading.Tasks
 Module Program
     Public Shared Async Function TestAsync() As Task(Of Integer)
-        Await Task.Delay(1)
+        Await Task.Delay(1) 
  Function Sub
  End Module"
                 )
@@ -146,7 +146,7 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Function rtrtAsync() As Task
+Async Function rtrtAsync() As Task
         Await Nothing
     End Function
 </ModuleDeclaration>
@@ -163,7 +163,7 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Sub rtrtAsync()
+Async Sub rtrtAsync()
         Await Nothing
     End Sub
 </ModuleDeclaration>
@@ -180,8 +180,8 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Function rtrtAsync() As Threading.Tasks.Task
-        Await Nothing
+Async Function rtrtAsync() As Threading.Tasks.Task
+    Await Nothing
     End Function
 </ModuleDeclaration>
             Await TestAsync(initial, expected)
@@ -197,7 +197,7 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Function rtrtAsync() As Task
+Async Function rtrtAsync() As Task
         Await Nothing
     End Function
 </ModuleDeclaration>
@@ -214,7 +214,7 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Function rtrtAsync() As Task(Of Integer)
+Async Function rtrtAsync() As Task(Of Integer)
         Await Nothing
     End Function
 </ModuleDeclaration>
@@ -231,8 +231,8 @@ Module Program
 </ModuleDeclaration>
             Dim expected =
 <ModuleDeclaration>
-    Async Function rtrtAsync() As Threading.Tasks.Task(Of Integer)
-        Await Nothing
+Async Function rtrtAsync() As Threading.Tasks.Task(Of Integer)
+    Await Nothing
     End Function
 </ModuleDeclaration>
             Await TestAsync(initial, expected)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MoveToTopOfFile/MoveToTopOfFileTests.vb
@@ -51,10 +51,12 @@ End Module")
     End Sub
 End Module
 [|Imports System|]",
-"Imports System Module Program 
- Sub Main(args As String())
-End Sub
-End Module")
+"Imports System
+Module Program
+    Sub Main(args As String())
+    End Sub
+End Module
+")
         End Function
 
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
@@ -77,7 +79,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -102,7 +105,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -127,7 +131,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -152,7 +157,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -208,7 +214,8 @@ End Module
 Module Program
     Sub Main(args As String())
     End Sub
-End Module")
+End Module
+")
         End Function
 
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsMoveToTopOfFile)>
@@ -231,7 +238,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -256,7 +264,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -281,7 +290,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -307,7 +317,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -335,7 +346,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -363,7 +375,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -381,15 +394,16 @@ Module Program
 End Module
 [|Option Compare Binary|]</File>
 
-            Dim expected = <File>
-Option Compare Binary
+            Dim expected = <File>Option Compare Binary
+
 #Const A = 5
 
 Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -421,7 +435,8 @@ Module Program
     Sub Main(args As String())
 
     End Sub
-End Module</File>
+End Module
+</File>
 
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -469,8 +484,8 @@ End Module
 &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt;
 </File>
 
-            Dim expected = <File>
-&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;                               
+            Dim expected = <File>&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;
+
 Module Program
     Sub Main(args As String())
 
@@ -491,12 +506,13 @@ Module Program
 End Module 
 </File>
 
-            Dim expected = <File>
-&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;
+            Dim expected = <File>&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;
+
 Module Program
     Sub Main(args As String())
+
     End Sub
-End Module
+End Module 
 </File>
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -518,8 +534,9 @@ End Module
 &lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt; 'Another Comment
 Module Program
     Sub Main(args As String())
+
     End Sub
-End Module
+End Module 
 </File>
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
@@ -539,10 +556,10 @@ End Module
 &lt;[|Assembly:|] Reflection.AssemblyCultureAttribute("de")&gt;
 </File>
 
-            Dim expected = <File>
+            Dim expected = <File>&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;
+
 ' Copyright
 ' License information.
-&lt;Assembly: Reflection.AssemblyCultureAttribute("de")&gt;
 
 Module Program
     Sub Main(args As String())
@@ -576,9 +593,10 @@ End Class
 &lt;Assembly:CLSCompliant(True)&gt;
 [|Imports System|]</File>
 
-            Dim expected = <File>
-[|Imports System|]
-&lt;Assembly:CLSCompliant(True)&gt;</File>
+            Dim expected = <File>[|Imports System|]
+
+&lt;Assembly:CLSCompliant(True)&gt;
+</File>
             Await TestInRegularAndScriptAsync(text.ConvertTestSourceTag(), expected.ConvertTestSourceTag())
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/PreferFrameworkType/PreferFrameworkTypeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/PreferFrameworkType/PreferFrameworkTypeTests.vb
@@ -200,7 +200,8 @@ End Class
 "Imports System
 Class C
     Protected i As Int32
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -214,7 +215,8 @@ End Class
 "Imports System
 Class C
     Protected i As Int32 = 5
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -228,7 +230,8 @@ End Class
 "Imports System
 Class C
     Public Delegate Function PerformCalculation(x As Integer, y As Integer) As Int32
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -242,7 +245,8 @@ End Class
 "Imports System
 Class C
     Public Property X As Int64
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -258,7 +262,8 @@ End Class
 Imports System.Collections.Generic
 Class C
     Public Property X As List(Of Int64)
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -274,7 +279,8 @@ End Class
 Class C
     Public Function F() As Int32
     End Function
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -290,7 +296,8 @@ End Class
 Class C
     Public Sub F(x As Int32)
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -312,7 +319,8 @@ Class C
     Public Sub Test()
         Method(Of Int32)()
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -330,7 +338,8 @@ Class C
     Public Sub Test()
         Dim x As Int32 = 5
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -348,7 +357,8 @@ Class C
     Public Sub Test()
         Dim x = Int32.MaxValue
     End Sub
-End Class", options:=FrameworkTypeInMemberAccess)
+End Class
+", options:=FrameworkTypeInMemberAccess)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -366,7 +376,8 @@ Class C
     Public Sub Test()
         Dim x = Int32.Parse(""1"")
     End Sub
-End Class", options:=FrameworkTypeInMemberAccess)
+End Class
+", options:=FrameworkTypeInMemberAccess)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -381,10 +392,11 @@ End Class
 ",
 "Imports System
 Class C
-    ''' <see cref=""Int32.MaxValue""/>
+    ''' <see cref=""Integer.MaxValue""/>
     Public Sub Test()
     End Sub
-End Class", options:=FrameworkTypeInMemberAccess)
+End Class
+", options:=FrameworkTypeInMemberAccess)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -402,7 +414,8 @@ Class C
     Public Sub Test()
          Dim x = GetType(Int32)
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -420,7 +433,8 @@ Class C
     Public Sub Test()
         Dim func3 As Func(Of Integer, Integer) = Function(z As Int32) z + 1
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -438,7 +452,8 @@ Class C
     Public Sub Test()
         Dim z = New DateTime(2016, 8, 23)
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -456,7 +471,8 @@ Class C
     Public Sub Test()
         Dim k As Int32() = New Integer(3) {}
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -474,7 +490,8 @@ Class C
     Public Sub Test()
         Dim k As Integer() = New Int32(3) {0, 1, 2, 3}
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -494,7 +511,8 @@ Class C
     Public Sub Test()
         Dim a As List(Of Int32()(,)(,,,))
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -514,7 +532,8 @@ Class C
         For j As Int32 = 0 To 3
         Next
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>
@@ -534,7 +553,8 @@ Class C
         For Each item As Int32 In New Integer() {1, 2, 3}
         Next
     End Sub
-End Class", options:=FrameworkTypeInDeclaration)
+End Class
+", options:=FrameworkTypeInDeclaration)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseFrameworkType)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.vb
@@ -348,6 +348,7 @@ Module Module1
                                                           End Function
     End Sub
 End Module
+
 </File>
 
             Await TestAsync(markup, expected, ignoreTrivia:=False)
@@ -1510,6 +1511,7 @@ Module Program
         If True Then : Dim x As Action = (Sub() If True Then) : Else : Return : End If
     End Sub
 End Module
+
 </File>
 
             Await TestAsync(markup, expected, ignoreTrivia:=False)
@@ -1571,6 +1573,7 @@ Module Program
         x() : Console.WriteLine() 
     End Sub
 End Module
+
 </File>
 
             Await TestAsync(markup, expected, ignoreTrivia:=False)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -877,6 +877,7 @@ End Namespace",
 Namespace N1
     Class Test
         Private a As List(Of String()(,)(,,,))
+
     End Class
 End Namespace")
         End Function
@@ -1604,7 +1605,7 @@ End Namespace
 Namespace bar
     Module b
         Sub m()
-             goo.Main(Nothing)
+            goo.Main(Nothing)
         End Sub
     End Module
 End Namespace
@@ -1921,7 +1922,7 @@ Public Class Test_Dev11
     '''&lt;summary&gt;
     ''' &lt;see cref="Microsoft.VisualBasic.Left"/&gt;
     ''' &lt;/Code&gt;
-        Public Async Function Testtestscenarios() As Task
+    Public Async Function Testtestscenarios() As Task
         End Sub
     End Class
 </Code>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -478,37 +478,37 @@ Class C
 
     End Sub
 End Class]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 Class C
 
-#Disable Warning BC42309
-' Comment
-' Comment
-''' <summary><see cref="abc"/></summary>
+    ' Comment
+    ' Comment
+#Disable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
+    ''' <summary><see cref=""abc""/></summary>
     Sub M() ' Comment  
-#Enable Warning BC42309
+#Enable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
 
     End Sub
-End Class]]>
+End Class"
 
                     Dim enableDocCommentProcessing = VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose)
-                    Await TestAsync(source.Value, expected.Value, enableDocCommentProcessing)
+                    Await TestAsync(source.Value, expected, enableDocCommentProcessing)
 
                     ' Also verify that the added directive does indeed suppress the diagnostic.
-                    Dim fixedSource = <![CDATA[
+                    Dim fixedSource = $"
 Class C
 
-#Disable Warning BC42309
-' Comment
-' Comment
-''' <summary><see [|cref="abc"|]/></summary>
+    ' Comment
+    ' Comment
+#Disable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
+    ''' <summary><see [|cref=""abc""|]/></summary>
     Sub M() ' Comment  
-#Enable Warning BC42309
+#Enable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
 
     End Sub
-End Class]]>
+End Class"
 
-                    Await TestMissingAsync(fixedSource.Value,
+                    Await TestMissingAsync(fixedSource,
                                            New TestParameters(enableDocCommentProcessing))
                 End Function
 
@@ -516,22 +516,22 @@ End Class]]>
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Async Function TestPragmaWarningDirectiveAroundTrivia2() As Task
                     Dim source = <![CDATA['''[|<summary></summary>|]]]>
-                    Dim expected = <![CDATA[#Disable Warning BC42312
-  '''<summary></summary>
-#Enable Warning BC42312]]>
+                    Dim expected = $"#Disable Warning BC42312 ' {WRN_XMLDocWithoutLanguageElement_Title}
+'''<summary></summary>
+#Enable Warning BC42312 ' {WRN_XMLDocWithoutLanguageElement_Title}"
 
-                    Await TestAsync(source.Value, expected.Value, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <WorkItem(1066576, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)>
                 Public Async Function TestPragmaWarningDirectiveAroundTrivia3() As Task
                     Dim source = <![CDATA[   '''[|<summary></summary>|]   ]]>
-                    Dim expected = <![CDATA[#Disable Warning BC42312
-  '''<summary></summary>   
-#Enable Warning BC42312]]>
+                    Dim expected = $"#Disable Warning BC42312 ' {WRN_XMLDocWithoutLanguageElement_Title}
+'''<summary></summary>   
+#Enable Warning BC42312 ' {WRN_XMLDocWithoutLanguageElement_Title}"
 
-                    Await TestAsync(source.Value, expected.Value, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <WorkItem(1066576, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
@@ -543,16 +543,16 @@ End Class]]>
 Class C : End Class
 
 ]]>
-                    Dim expected = <![CDATA[
+                    Dim expected = $"
 
-#Disable Warning BC42309
-'''<summary><see cref="abc"/></summary>
+#Disable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
+'''<summary><see cref=""abc""/></summary>
 Class C : End Class
-#Enable Warning BC42309
+#Enable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
 
-]]>
+"
 
-                    Await TestAsync(source.Value, expected.Value, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <WorkItem(1066576, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
@@ -562,14 +562,14 @@ Class C : End Class
 '''<summary><see [|cref="abc"|]/></summary>
 Class C2 : End Class
 Class C3 : End Class]]>
-                    Dim expected = <![CDATA[class C1 : End Class
-#Disable Warning BC42309
-'''<summary><see cref="abc"/></summary>
+                    Dim expected = $"class C1 : End Class
+#Disable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
+'''<summary><see cref=""abc""/></summary>
 Class C2 : End Class
-#Enable Warning BC42309
-Class C3 : End Class]]>
+#Enable Warning BC42309 ' {WRN_XMLDocCrefAttributeNotFound1_Title}
+Class C3 : End Class"
 
-                    Await TestAsync(source.Value, expected.Value, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
 
                 <WorkItem(1066576, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1066576")>
@@ -578,14 +578,14 @@ Class C3 : End Class]]>
                     Dim source = <![CDATA[class C1 : End Class
 Class C2 : End Class [|'''|]
 Class C3 : End Class]]>
-                    Dim expected = <![CDATA[class C1 : End Class
-#Disable Warning BC42309
+                    Dim expected = $"class C1 : End Class
+#Disable Warning BC42302 ' {WRN_XMLDocNotFirstOnLine_Title}
 Class C2 : End Class '''
-#Enable Warning BC42309
+#Enable Warning BC42302 ' {WRN_XMLDocNotFirstOnLine_Title}
 
-Class C3 : End Class]]>
+Class C3 : End Class"
 
-                    Await TestAsync(source.Value, expected.Value, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
+                    Await TestAsync(source.Value, expected, VisualBasicParseOptions.Default.WithDocumentationMode(DocumentationMode.Diagnose))
                 End Function
             End Class
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -86,7 +86,8 @@ end class")
     end property|]
 end class",
 "class Class1
-    readonly property P as integer = 1
+    readonly property P as integer
+= 1
 end class")
         End Function
 
@@ -463,7 +464,7 @@ end class")
 end class",
 "class Class1
     ReadOnly property P as Integer
-    public sub new(dim P as integer)
+ public sub new(dim P as integer)
         Me.P = 1
     end sub
 end class")
@@ -540,8 +541,9 @@ end class")
 end class",
 "class Class1
     public property P as Integer
-    public sub Goo() P = 1 
- end sub
+    public sub Goo()
+        P = 1
+    end sub
 end class")
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
@@ -26,11 +26,13 @@ End Class",
     Private v1 As Integer
     Private v2 As Integer
     Private v3 As Integer
+
     Public Sub New(v1 As Integer, v2 As Integer, v3 As Integer)
         Me.v1 = v1
         Me.v2 = v2
         Me.v3 = v3
     End Sub
+
     Sub Main()
         Dim f = New C(4, 5, 6)
     End Sub
@@ -56,6 +58,7 @@ End Class",
 End Class
 Friend Class B
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -106,6 +109,7 @@ End Class
 Class A
     Public Sub New()
     End Sub
+
     Sub New(x As Integer)
     End Sub
 End Class")
@@ -128,6 +132,7 @@ End Class",
 End Class
 Class A
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -153,8 +158,10 @@ End Class",
 End Class
 Class A
     Private v As Integer
+
     Public Sub New()
     End Sub
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -181,8 +188,10 @@ End Class",
 End Class
 Class A
     Private v As Integer
+
     Public Sub New()
     End Sub
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -207,9 +216,11 @@ Public Class A
 End Class",
 "Public Partial Class Test
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
+
     Public Sub S1()
     End Sub
 End Class
@@ -242,9 +253,11 @@ Public Class A
 End Class",
 "Public Partial Class Test
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
+
     Public Sub S1()
     End Sub
 End Class
@@ -273,6 +286,7 @@ Public Class A
 End Class",
 "Public Partial Class Test2
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -316,6 +330,7 @@ End Class",
 "Class Goo
     Class Bar
         Private v As Integer
+
         Public Sub New(v As Integer)
             Me.v = v
         End Sub
@@ -351,9 +366,11 @@ End Class",
 "Public Partial Class Test
     Public Partial Class NestedTest
         Private v As Integer
+
         Public Sub New(v As Integer)
             Me.v = v
         End Sub
+
         Public Sub S1()
         End Sub
     End Class
@@ -382,6 +399,7 @@ End Class",
 "Class Outer(Of T)
     Public Class Inner
         Private v As Integer
+
         Public Sub New(v As Integer)
             Me.v = v
         End Sub
@@ -403,6 +421,7 @@ End Class",
 "Class Base(Of T, V)
     Private v1 As Integer
     Private v2 As Integer
+
     Public Sub New(v1 As Integer, v2 As Integer)
         Me.v1 = v1
         Me.v2 = v2
@@ -433,7 +452,9 @@ End Class",
 End Class
 Class Derived(Of V)
     Inherits Base(Of Integer, V)
+
     Private v1 As Integer
+
     Public Sub New(v1 As Integer)
         Me.v1 = v1
     End Sub
@@ -471,7 +492,9 @@ Class Derived(Of V)
 End Class
 Class MoreDerived
     Inherits Derived(Of Double)
+
     Private v As Double
+
     Public Sub New(v As Double)
         Me.v = v
     End Sub
@@ -498,6 +521,7 @@ Class A
 End Class",
 "Class Goo
     Private now As Date
+
     Public Sub New(now As Date)
         Me.now = now
     End Sub
@@ -524,6 +548,7 @@ Class Derived
 End Class",
 "Class Base
     Private x As Integer
+
     Public Sub New(x As Integer)
         Me.x = x
     End Sub
@@ -556,6 +581,7 @@ Class Derived
 End Class",
 "MustInherit Class Base
     Private x As Integer
+
     Protected Sub New(x As Integer)
         Me.x = x
     End Sub
@@ -619,7 +645,7 @@ Class C
     Public v1 As Integer
     Private i As Char
 
-    Public Sub New(v1 As Integer) 
+    Public Sub New(v1 As Integer)
         Me.v1 = v1
     End Sub
 
@@ -647,6 +673,7 @@ End Class",
 End Module
 Friend Class C
     Private c As C
+
     Public Sub New(c As C)
         Me.c = c
     End Sub
@@ -672,6 +699,7 @@ End Class
 Friend Class Test
     Private x As Object
     Private y As Object
+
     Public Sub New(x As Object, y As Object)
         Me.x = x
         Me.y = y
@@ -699,6 +727,7 @@ End Class",
 End Class
 Class A
     Private [class] As Integer
+
     Public Sub New([class] As Integer)
         Me.class = [class]
     End Sub
@@ -723,6 +752,7 @@ End Class",
 End Class
 Class A
     Private p As Object
+
     Public Sub New(p As Object)
         Me.p = p
     End Sub
@@ -747,6 +777,7 @@ End Class",
 End Class
 Class Bar(Of V)
     Private v1 As Integer
+
     Public Sub New(v1 As Integer)
         Me.v1 = v1
     End Sub
@@ -766,9 +797,11 @@ End Class")
 End Class",
 "Class C
     ReadOnly x As Integer
+
     Public Sub New(x As Integer)
         Me.x = x
     End Sub
+
     Sub Test()
         Dim x As Integer = 1
         Dim obj As New C(x)
@@ -796,6 +829,7 @@ Class A
     Public Sub New(P As Integer)
         Me.P = P
     End Sub
+
     Public Property P As Integer
 End Class")
         End Function
@@ -820,9 +854,11 @@ End Class",
 End Class
 Class C
     Private u1 As Integer
+
     Public Sub New(u As Integer)
         u1 = u
     End Sub
+
     Public Sub u()
     End Sub
 End Class")
@@ -847,9 +883,11 @@ End Class",
 End Class
 Class A
     Private P1 As Integer
+
     Public Sub New(P As Integer)
         P1 = P
     End Sub
+
     Shared Property P As Integer
 End Class")
         End Function
@@ -874,6 +912,7 @@ End Class
 Class B
     Private x As String
     Private x1 As Integer
+
     Public Sub New(x As Integer)
         x1 = x
     End Sub
@@ -903,6 +942,7 @@ End Class
 Class C
     Inherits B
     Private x As String
+
     Public Sub New(u As Integer)
         Me.u = u
     End Sub
@@ -923,9 +963,11 @@ End Class")
 End Class",
 "Class C
     Private v As Integer
+
     Sub New
         Me.New(1)
     End Sub
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -958,9 +1000,11 @@ End Class")
 End Class",
 "Class C
     Private v As Integer
+
     Sub New
         MyClass.New(1)
     End Sub
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -1002,6 +1046,7 @@ End Class",
 End Class
 Class B
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -1113,6 +1158,7 @@ Class C
 End Class
 Class D
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -1163,9 +1209,11 @@ End Module
 Class C
     Private prop As String
     Private v As Integer
+
     Public Sub New(prop As String)
         Me.prop = prop
     End Sub
+
     Public Sub New(v As Integer, prop As String)
         Me.v = v
         Me.prop = prop
@@ -1209,7 +1257,9 @@ End Class",
 "<AttributeUsage(AttributeTargets.Class)>
 Public Class MyAttribute
     Inherits System.Attribute
+
     Private v As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
@@ -1233,9 +1283,11 @@ End Class",
 "<AttributeUsage(AttributeTargets.Class)>
 Public Class MyAttribute
     Inherits System.Attribute
+
     Private v1 As Boolean
     Private v2 As Integer
     Private v3 As String
+
     Public Sub New(v1 As Boolean, v2 As Integer, v3 As String)
         Me.v1 = v1
         Me.v2 = v2
@@ -1297,9 +1349,11 @@ Public Class MyAttribute
     Inherits System.Attribute
     Private v As Integer
     Private v1 As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
+
     Public Sub New(v As Integer, v1 As Integer)
         Me.New(v)
         Me.v1 = v1
@@ -1329,6 +1383,7 @@ End Enum
 <AttributeUsage(AttributeTargets.Class)>
 Public Class MyAttribute
     Inherits System.Attribute
+
     Private v1 As Short()
     Private a1 As A
     Private v2 As Boolean
@@ -1340,6 +1395,7 @@ Public Class MyAttribute
     Private v8 As Double
     Private v9 As Single
     Private v10 As String
+
     Public Sub New(v1() As Short, a1 As A, v2 As Boolean, v3 As Integer, v4 As Char, v5 As Short, v6 As Integer, v7 As Long, v8 As Double, v9 As Single, v10 As String)
         Me.v1 = v1
         Me.a1 = a1
@@ -1355,8 +1411,7 @@ Public Class MyAttribute
     End Sub
 End Class
 <MyAttribute(New Short(1) {1, 2, 3}, A.A1, True, 1, ""Z""c, 5S, 1I, 5L, 6.0R, 2.1F, ""abc"")>
-Public Class D
-End Class")
+Public Class D End Class")
         End Function
 
         <WorkItem(530003, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530003")>
@@ -1432,9 +1487,11 @@ Module Module1
     Class Classic
         Private int As Integer
         Private obj As Object
+
         Public Sub New(int As Integer)
             Me.int = int
         End Sub
+
         Public Sub New(obj As Object)
             Me.obj = obj
         End Sub
@@ -1458,6 +1515,7 @@ End Class",
 "Class Goo
     Private Class Bar
         Private v As Integer
+
         Public Sub New(v As Integer)
             Me.v = v
         End Sub
@@ -1490,12 +1548,14 @@ Class C
 "Imports System.Linq
 Class C
     Private v As Integer
+
     Sub New()
         Dim s As Action = Sub()
-                              Dim a = New C(0)Public Sub New(v As Integer) 
- Me.v = v
-                          End Sub
- End Class")
+                              Dim a = New C(0)Public Sub New(v As Integer)
+        Me.v = v
+    End Sub
+End Class
+")
             End Function
 
             <WorkItem(5920, "https://github.com/dotnet/roslyn/issues/5920")>
@@ -1515,17 +1575,18 @@ Class C
 Class C
     Private v As Integer
     Private v1 As Integer
+
     Public Sub New(v As Integer)
         Me.v = v
     End Sub
     Sub New()
         Dim s As Action = Sub()
-                              Dim a = New C(0, 0) 
- Public Sub New(v As Integer, v1 As Integer)
+                              Dim a = New C(0, 0)Public Sub New(v As Integer, v1 As Integer)
         Me.New(v)
         Me.v1 = v1
     End Sub
-End Class")
+End Class
+")
             End Function
         End Class
 

--- a/src/EditorFeatures/VisualBasicTest/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
@@ -21,6 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.GenerateConstructo
 End Class",
 "Class Program
     Private i As Integer
+
     Public Sub New(i As Integer{|Navigation:)|}
         Me.i = i
     End Sub
@@ -37,6 +38,7 @@ End Class",
 "Class Program
     Private i As Integer
     Private b As String
+
     Public Sub New(i As Integer, b As String{|Navigation:)|}
         Me.i = i
         Me.b = b
@@ -60,6 +62,7 @@ End Class",
     Public Sub New(i As Integer)
         Me.i = i
     End Sub
+
     Public Sub New(b As String{|Navigation:)|}
         Me.b = b
     End Sub
@@ -82,6 +85,7 @@ End Class",
     Public Sub New(i As Integer)
         Me.i = i
     End Sub
+
     Public Sub New(i As Integer, b As String{|Navigation:)|}
         Me.i = i
         Me.b = b
@@ -113,6 +117,7 @@ End Class")
 End Structure",
 "Structure S
     Private i As Integer
+
     Public Sub New(i As Integer{|Navigation:)|}
         Me.i = i
     End Sub
@@ -127,6 +132,7 @@ End Structure")
 End Class",
 "Class Program(Of T)
     Private i As Integer
+
     Public Sub New(i As Integer{|Navigation:)|}
         Me.i = i
     End Sub
@@ -150,6 +156,7 @@ End Class",
     Public Sub New(i As Integer)
         Me.i = i
     End Sub
+
     Public Sub New(i As Integer, b As String{|Navigation:)|}
         Me.New(i)
         Me.b = b
@@ -171,6 +178,7 @@ End Class",
         Me.A = a
         Me.B = b
     End Sub
+
     Public Property A As Integer
     Public Property B As String
 End Class")
@@ -214,6 +222,7 @@ End Class")
 End Class",
 "Class Program
     Private i As Integer
+
     Public Sub New(i As Integer{|Navigation:)|}
         Me.i = i
     End Sub
@@ -229,6 +238,7 @@ End Class", chosenSymbols:={"i"})
 End Class",
 "Class Program
     Private i As Integer
+
     Public Sub New({|Navigation:)|}
     End Sub
 End Class", chosenSymbols:={})
@@ -245,6 +255,7 @@ End Class",
 "Class Program
     Private i As Integer
     Private j As String
+
     Public Sub New(j As String, i As Integer{|Navigation:)|}
         Me.j = j
         Me.i = i
@@ -260,6 +271,7 @@ End Class", chosenSymbols:={"j", "i"})
 End Class",
 "Class Program
     Private i As Integer
+
     Public Sub New(i As Integer{|Navigation:)|}
         Me.i = i
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -28,8 +28,10 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class Program
     Inherits Exception
+
     Public Sub New()
     End Sub
+
     Sub Main(args As String())
     End Sub
 End Class")
@@ -51,9 +53,11 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class Program
     Inherits Exception
+
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
+
     Sub Main(args As String())
     End Sub
 End Class",
@@ -74,7 +78,6 @@ End Class",
 "Imports System
 Imports System.Collections.Generic
 Imports System.Linq
-
 Class Program
     Inherits Exception
 
@@ -103,6 +106,7 @@ End Class",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
+
 Class Program
     Inherits Exception
 
@@ -214,19 +218,24 @@ End Class",
 Imports System.Collections.Generic
 Imports System.Linq
 Imports System.Runtime.Serialization
+
 Class Program
     Inherits Exception
     Public Sub New()
     End Sub
+
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
+
     Public Sub New(message As String, innerException As Exception)
         MyBase.New(message, innerException)
     End Sub
+
     Protected Sub New(info As SerializationInfo, context As StreamingContext)
         MyBase.New(info, context)
     End Sub
+
     Sub Main(args As String())
     End Sub
 End Class",
@@ -258,8 +267,10 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class Program
     Inherits Exception
+
     Public Sub New()
     End Sub
+
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
@@ -299,9 +310,11 @@ Class Program
 
     Public Sub New()
     End Sub
+
     Public Sub New(message As String)
         MyBase.New(message)
     End Sub
+
     Public Sub New(message As String, innerException As Exception)
         MyBase.New(message, innerException)
     End Sub
@@ -331,8 +344,10 @@ Imports System.Collections.Generic
 Imports System.Linq
 Class Program
     Inherits Exception
+
     Public Sub New()
     End Sub
+
     Sub Main(args As String())
     End Sub
 End Class")

--- a/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.vb
@@ -90,11 +90,14 @@ index:=1, ignoreTrivia:=False)
     [|Dim x As New V|]
 End Class",
 "Imports System.Collections.Generic
+
 Partial Class c1(Of V As {New}, U)
     Dim x As New V
+
     Public Overrides Function Equals(obj As Object) As Boolean
         Dim c = TryCast(obj, c1(Of V, U))
-        Return c IsNot Nothing AndAlso EqualityComparer(Of V).Default.Equals(x, c.x)
+        Return c IsNot Nothing AndAlso
+               EqualityComparer(Of V).Default.Equals(x, c.x)
     End Function
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassTests.vb
@@ -30,9 +30,11 @@ End Class",
 End Class
 Public Class Bar
     Inherits Goo
+
     Public Overrides Sub Goo(i As Integer)
         Throw New System.NotImplementedException()
     End Sub
+
     Protected Overrides Function Bar(s As String, ByRef d As Double) As Boolean
         Throw New System.NotImplementedException()
     End Function
@@ -53,6 +55,7 @@ End Class",
 End Class
 Public Class Derived
     Inherits Base
+
     Protected Overrides Function Bar(x As (a As Integer, Integer)) As (c As Integer, Integer)
         Throw New System.NotImplementedException()
     End Function
@@ -73,6 +76,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Integer = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -93,6 +97,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Boolean = True)
         Throw New System.NotImplementedException()
     End Sub
@@ -113,6 +118,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Boolean = False)
         Throw New System.NotImplementedException()
     End Sub
@@ -133,6 +139,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As String = ""a"")
         Throw New System.NotImplementedException()
     End Sub
@@ -153,6 +160,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Char = ""c""c)
         Throw New System.NotImplementedException()
     End Sub
@@ -173,6 +181,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Long = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -188,12 +197,12 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Short = 3)
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Short = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -209,12 +218,12 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As UShort = 3)
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As UShort = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -235,6 +244,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Integer = -3)
         Throw New System.NotImplementedException()
     End Sub
@@ -255,6 +265,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As UInteger = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -275,6 +286,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As ULong = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -295,6 +307,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Decimal = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -315,6 +328,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Double = 3)
         Throw New System.NotImplementedException()
     End Sub
@@ -339,6 +353,7 @@ MustInherit Class b
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As S = Nothing)
         Throw New System.NotImplementedException()
     End Sub
@@ -364,6 +379,7 @@ MustInherit Class b
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As S? = Nothing)
         Throw New System.NotImplementedException()
     End Sub
@@ -385,6 +401,7 @@ End Class",
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5)
         Throw New System.NotImplementedException()
     End Sub
@@ -409,6 +426,7 @@ MustInherit Class b
 End Class
 Class c
     Inherits b
+
     Public Overrides Sub g(Optional x As S = Nothing)
         Throw New System.NotImplementedException()
     End Sub
@@ -429,6 +447,7 @@ MustInherit Class D
     MustOverride Sub Goo()
 End Class
 Class C : Inherits D
+
     Public Overrides Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -449,6 +468,7 @@ MustInherit Class D
     MustOverride Sub Goo()
 End Class
 Class C : Inherits D : Implements IDisposable
+
     Public Overrides Sub Goo()
         Throw New NotImplementedException()
     End Sub
@@ -470,6 +490,7 @@ End Class",
 End Class
 Class C(Of S)
     Inherits A(Of S)
+
     Public Overrides Sub Goo(Of S1 As S)()
         Throw New System.NotImplementedException()
     End Sub

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
@@ -29,6 +29,7 @@ End Class",
 End Interface
 Class C
     Implements I
+
     Public Sub M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -48,6 +49,7 @@ End Interface",
 "Imports System
 Class Goo
     Implements IGoo
+
     Public Function Method(x As (Alice As Integer, Bob As Integer)) As (String, String) Implements IGoo.Method
         Throw New NotImplementedException()
     End Function
@@ -73,9 +75,11 @@ End Class",
 End Interface
 Class C
     Implements I
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
+
     Function M() As Integer
     End Function
 End Class")
@@ -99,6 +103,7 @@ Class C
     Implements IGoo
     Public Sub Bar()
     End Sub
+
     Private Sub IGoo_Bar() Implements IGoo.Bar
         Throw New System.NotImplementedException()
     End Sub
@@ -122,6 +127,7 @@ End Interface
 Class C
     Implements I
     Private m As Integer
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -145,6 +151,7 @@ End Interface
 Class C
     Implements I
     Public Property M As Integer
+
     Private Property I_M As Integer Implements I.M
         Get
             Throw New System.NotImplementedException()
@@ -178,7 +185,6 @@ End Class",
 End Interface
 Class C
     Implements I
-
     Private Property M As Integer
         Get
             Return 5
@@ -223,6 +229,7 @@ End Class
 Class C
     Inherits B
     Implements I
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -252,6 +259,7 @@ End Class
 Class C
     Inherits B
     Implements I
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -281,6 +289,7 @@ End Class
 Class C
     Inherits B
     Implements I
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -301,6 +310,7 @@ End Class",
 End Interface
 MustInherit Class C
     Implements I
+
     Public MustOverride Sub M() Implements I.M
 End Class",
 index:=1)
@@ -320,6 +330,7 @@ End Class",
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
+
     Public Sub Method1(t As Integer) Implements IInterface1(Of Integer).Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -340,6 +351,7 @@ End Class",
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
+
     Public Sub Method1(Of U)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -362,6 +374,7 @@ Interface IInterface1(Of T)
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
+
     Public Sub Method1(Of U As IList(Of Integer))(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -382,6 +395,7 @@ End Class",
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
+
     Public Sub Method1(Of U As Integer)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -404,6 +418,7 @@ End Interface
 Class C
     Implements I
     Private x As I
+
     Public Sub M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -426,6 +441,7 @@ End Interface
 Class C
     Implements I
     Private x As I
+
     Public Sub M() Implements I.M
         x.M()
     End Sub
@@ -549,10 +565,12 @@ Class M
 "Imports System
 Class M
     Implements IServiceProvider
+
     Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
         Throw New NotImplementedException()
     End Function
-End Class")
+End Class
+")
         End Function
 
         <WorkItem(540367, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540367")>
@@ -570,6 +588,7 @@ End Class",
 End Interface
 Class M
     Implements I1
+
     Public Property Goo As Integer Implements I1.Goo
         Get
             Throw New System.NotImplementedException()
@@ -595,6 +614,7 @@ End Class",
 End Interface
 Class C
     Implements I
+
     Public Function M() As String() Implements I.M
         Throw New System.NotImplementedException()
     End Function
@@ -615,9 +635,11 @@ End Interface",
 "Class C
     Implements I
     Private goo As I
+
     Public Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) Implements I.Method1
         Throw New System.NotImplementedException()
     End Sub
+
     Public Function Method2() As Integer Implements I.Method2
         Throw New System.NotImplementedException()
     End Function
@@ -642,6 +664,7 @@ End Class",
 End Interface
 Class C
     Implements I1
+
     Public Function Method1() As String Implements I1.Method1
         Throw New System.NotImplementedException()
     End Function
@@ -662,6 +685,7 @@ End Class",
 End Interface
 Class C
     Implements I1
+
     Public Sub Method1(ByRef arg As Double) Implements I1.Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -695,9 +719,11 @@ End Interface",
 "Class C
     Implements I
     Private goo As I
+
     Public Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) Implements I.Method1
         Throw New System.NotImplementedException()
     End Sub
+
     Public Function Method2() As Integer Implements I.Method2
         Throw New System.NotImplementedException()
     End Function
@@ -723,6 +749,7 @@ End Class",
 End Interface
 Class C
     Implements I1
+
     Default Public Property Goo(arg As Integer) As Object Implements I1.Goo
         Get
             Throw New System.NotImplementedException()
@@ -756,6 +783,7 @@ End Class",
 End Interface
 Class C
     Implements I1.I2
+
     Public Sub Goo(arg As I1.Del) Implements I1.I2.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -777,6 +805,7 @@ End Class",
 End Interface
 Class C
     Implements I1
+
     Public Sub Method1(arg() As Integer) Implements I1.Method1
         Throw New System.NotImplementedException()
     End Sub
@@ -801,6 +830,7 @@ End Namespace",
     End Interface
     Class C
         Implements I1
+
         Public Sub Method1() Implements I1.Method1
             Throw New System.NotImplementedException()
         End Sub
@@ -824,6 +854,7 @@ End Class",
 End Interface
 Class A
     Implements I2
+
     Public Function G(ParamArray args() As Double) As Integer Implements I2.G
         Throw New System.NotImplementedException()
     End Function
@@ -845,6 +876,7 @@ End Class",
 End Interface
 Class A
     Implements I1
+
     Public Sub Goo() Implements I1.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -893,6 +925,7 @@ End Interface
 Class C
     Implements I
     Public Property X As I
+
     Public Sub M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -912,6 +945,7 @@ End Interface
 Class C
     Implements I
     Public Property X As I
+
     Public Sub M() Implements I.M
         X.M()
     End Sub
@@ -1025,6 +1059,7 @@ End Class
 Class B
     Implements I
     Dim x As A
+
     Public Sub M() Implements I.M
         DirectCast(x, I).M()
     End Sub
@@ -1109,6 +1144,7 @@ Class B
     Implements I
     Implements I2
     Dim x As A
+
     Public Sub M() Implements I.M
         DirectCast(x, I).M()
     End Sub
@@ -1149,6 +1185,7 @@ Class B
     Implements I
     Implements I2
     Dim x As A
+
     Public Sub M2() Implements I2.M2
         DirectCast(x, I2).M2()
     End Sub
@@ -1205,6 +1242,7 @@ Class B
     Implements I
     Dim x As A
     Dim y As A
+
     Public Sub M() Implements I.M
         DirectCast(x, I).M()
     End Sub
@@ -1239,6 +1277,7 @@ Class B
     Implements I
     Dim x As A
     Dim y As A
+
     Public Sub M() Implements I.M
         DirectCast(y, I).M()
     End Sub
@@ -1351,6 +1390,7 @@ Class C
     Implements I2
     Dim x As A
     Dim y as B
+
     Public Sub M() Implements I.M
         DirectCast(x, I).M()
     End Sub
@@ -1405,6 +1445,7 @@ Class C
     Implements I2
     Dim x As A
     Dim y as B
+
     Public Sub M2() Implements I2.M2
         DirectCast(y, I2).M2()
     End Sub
@@ -1533,6 +1574,7 @@ End Class
 Class C
     Inherits B
     Implements I
+
     Private Sub I_M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -1554,6 +1596,7 @@ End Class",
 End Interface
 Class C
     Implements I ' Implement interface 
+
     Public Sub [Rem]() Implements I.[Rem]
         Throw New System.NotImplementedException()
     End Sub
@@ -1582,6 +1625,7 @@ End Class",
 "Imports System.ComponentModel
 Class C
     Implements INotifyPropertyChanged
+
     Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
 End Class")
         End Function
@@ -1615,19 +1659,16 @@ Class Boss
 
 	Private worker As Worker
 
-	Public Custom Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
-
-		AddHandler(value As PropertyChangedEventHandler)
-			AddHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
-		End AddHandler
-
-		RemoveHandler(value As PropertyChangedEventHandler)
-			RemoveHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
-		End RemoveHandler
-
-		RaiseEvent(sender As Object, e As PropertyChangedEventArgs)
-		End RaiseEvent
-	End Event
+    Public Custom Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+        AddHandler(value As PropertyChangedEventHandler)
+            AddHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
+        End AddHandler
+        RemoveHandler(value As PropertyChangedEventHandler)
+            RemoveHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As PropertyChangedEventArgs)
+        End RaiseEvent
+    End Event
 End Class", index:=1)
         End Function
 
@@ -1646,6 +1687,7 @@ End Class",
 End Interface
 Class C(Of T, R)
     Implements I(Of T, R)
+
     Public Sub Goo() Implements I(Of T, R).Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -1675,6 +1717,7 @@ Interface I2
 End Interface
 Class C
     Implements I2
+
     Public Property Bar As Integer Implements I2.Bar
         Get
             Throw New System.NotImplementedException()
@@ -1683,6 +1726,7 @@ Class C
             Throw New System.NotImplementedException()
         End Set
     End Property
+
     Private Property I1_Bar As Integer Implements I1.Bar
         Get
             Throw New System.NotImplementedException()
@@ -1731,6 +1775,7 @@ End Class
 Class C
     Inherits B
     Implements I1
+
     Private Property I1_Bar As Integer Implements I1.Bar
         Get
             Throw New System.NotImplementedException()
@@ -1739,6 +1784,7 @@ Class C
             Throw New System.NotImplementedException()
         End Set
     End Property
+
     Public Sub Goo() Implements I1.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -1760,6 +1806,7 @@ End Class",
 End Interface
 Class C
     Implements I1
+
     Public Event E(x As String) Implements I1.E
 End Class")
         End Function
@@ -1778,6 +1825,7 @@ End Class",
 End Interface
 Class Bar
     Implements IGoo
+
     Public Sub Goo(Optional s As String = """""""") Implements IGoo.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -1803,6 +1851,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub VBNullChar(Optional x As String = Constants.vbNullChar) Implements I.VBNullChar
         Throw New System.NotImplementedException()
     End Sub
@@ -1832,6 +1881,7 @@ End Interface
 Namespace N
     Class Microsoft
         Implements I
+
         Public Sub VBNullChar(Optional x As String = Constants.vbNullChar) Implements I.VBNullChar
             Throw New NotImplementedException()
         End Sub
@@ -1861,6 +1911,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub ChrW(Optional x As String = Strings.ChrW(1)) Implements I.ChrW
         Throw New NotImplementedException()
     End Sub
@@ -1882,6 +1933,7 @@ End Class",
 End Interface
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Date = #6/29/2012 12:00:00 AM#) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -1909,6 +1961,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As DayOfWeek = DayOfWeek.Friday) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -1932,6 +1985,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(x As Integer()()) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -1959,6 +2013,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As String = ChrW(8220)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -1982,6 +2037,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Long = Long.MinValue) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2303,6 +2359,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(x(,) As Integer) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2328,6 +2385,7 @@ Interface I
 End Interface
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Char = ChrW(8220)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2351,6 +2409,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = ""‟"") Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2378,6 +2437,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Decimal = Decimal.MaxValue) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2409,6 +2469,7 @@ Class C
     Implements I
 
     Property DayOfWeek As DayOfWeek
+
     Public Sub Goo(Optional x As DayOfWeek = DayOfWeek.Monday) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2436,6 +2497,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As DayOfWeek? = DayOfWeek.Friday) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2461,6 +2523,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Double = 2.8025969286496341E-45) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2488,6 +2551,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Char = ChrW(55401)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2517,6 +2581,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Char = ChrW(13)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2544,6 +2609,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As ConsoleColor = CType(-1, ConsoleColor)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2567,6 +2633,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(x As Integer?()) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2590,6 +2657,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x() As Integer = Nothing) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2625,6 +2693,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As E = E.[Rem]) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2648,6 +2717,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Byte = 1) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2671,6 +2741,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = 1L) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2702,6 +2773,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As E = 0) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2725,6 +2797,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = CByte(1)) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2751,6 +2824,7 @@ Class C
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
 <Text>Option Strict On
+
 Interface I
     Sub M1(Optional x As Decimal = 2D)
     Sub M2(Optional x As Decimal = 2.0D)
@@ -2804,12 +2878,14 @@ Class C
     Implements [|I|]
 End Class",
 "Option Strict On
+
 Interface I
     Sub Goo(Optional x As Decimal = Long.MinValue)
 End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Decimal = -9223372036854775808D) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2839,6 +2915,7 @@ Interface IB
 End Interface
 Class C
     Implements IB
+
     Public Event E As Action Implements IB.E
     Private Event IA_E As EventHandler Implements IA.E
 End Class")
@@ -2865,6 +2942,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = 1D) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2892,6 +2970,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = 1R) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2919,6 +2998,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Decimal = 10000000000000000000D) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2940,6 +3020,7 @@ End Class",
 End Interface
 Class C
     Implements I
+
     Public Sub Goo(Optional x As String = ""𪛖"") Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -2967,6 +3048,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As String = vbTab) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -2990,6 +3072,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Of [TO], TP, TQ)() Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -3017,6 +3100,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As ULong = 10000000000000000000UL) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -3181,6 +3265,7 @@ End Class
 Class C : Implements [|IServiceProvider|] : End Class",
 "Imports System
 Class C : Implements IServiceProvider
+
     Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
         Throw New NotImplementedException()
     End Function
@@ -3201,6 +3286,7 @@ MustInherit Class D
     MustOverride Sub Goo()
 End Class
 Class C : Inherits D : Implements IServiceProvider
+
     Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
         Throw New NotImplementedException()
     End Function
@@ -3228,6 +3314,7 @@ End Interface
 
 Class C
     Implements I ' Implement 
+
     Public Sub Goo(Optional x As Object = CStr(ChrW(1))) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -3255,6 +3342,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As String = ChrW(1)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -3286,6 +3374,7 @@ Class C
     Implements I
     Public Sub ChrW(x As Integer)
     End Sub
+
     Public Sub Goo(Optional x As String = Strings.ChrW(1)) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -3309,6 +3398,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub [ＲＥＭ]() Implements I.[ＲＥＭ]
         Throw New System.NotImplementedException()
     End Sub
@@ -3364,6 +3454,7 @@ Interface I
 End Interface
 Class C
     Implements I ' Implement 
+
     Public Sub Goo(Of M)(Optional x As C(Of M()).E = C(Of M()).E.X) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -3397,6 +3488,7 @@ Interface I
 End Interface
 Class C
     Implements I
+
     Public Sub Goo(Of T)(Optional x As C(Of T()).E = C(Of T()).E.X) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -3422,6 +3514,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Sub Goo(Optional x As Object = """"""""c) Implements I.Goo
         Throw New NotImplementedException()
     End Sub
@@ -3457,6 +3550,7 @@ End Class
 
 Partial Class C
     Implements I
+
     Public Sub M() Implements I.M
         Throw New System.NotImplementedException()
     End Sub
@@ -3484,9 +3578,8 @@ End Interface
 
 Class C
     Implements I
-    Public Function Goo(<MarshalAs(UnmanagedType.U1)>
-    x As Boolean) As <MarshalAs(UnmanagedType.U1)>
-    Boolean Implements I.Goo
+
+    Public Function Goo(<MarshalAs(UnmanagedType.U1)> x As Boolean) As <MarshalAs(UnmanagedType.U1)> Boolean Implements I.Goo
         Throw New System.NotImplementedException()
     End Function
 End Class")
@@ -3509,6 +3602,7 @@ Interface I
 End Interface
 Class C
     Implements I ' Implement 
+
     Public Sub Goo(Optional x As Decimal = 1000000000000000000) Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -3532,6 +3626,7 @@ End Interface
 
 MustInherit Class C
     Implements I ' Implement interface abstractly 
+
     Public Property Goo As Integer Implements I.Goo
         Get
             Throw New System.NotImplementedException()
@@ -3560,6 +3655,7 @@ End Structure",
 End Interface
 Class c
     Implements I
+
     Public ReadOnly Property g(Optional x As S? = Nothing) As Object Implements I.g
         Get
             Throw New System.NotImplementedException()
@@ -3585,6 +3681,7 @@ End Class",
 End Interface
 Class c
     Implements I
+
     Public ReadOnly Property g(Optional x As Long? = Nothing, Optional y As Long? = 5) As Object Implements I.g
         Get
             Throw New System.NotImplementedException()
@@ -3645,6 +3742,7 @@ End Interface
 
 Class C
     Implements I
+
     Public Property P(<MarshalAs(UnmanagedType.I4)> x As Integer) As <MarshalAs(UnmanagedType.I4)> Integer Implements I.P
         Get
             Throw New System.NotImplementedException()
@@ -3675,6 +3773,7 @@ Partial Class C
 End Class
 Partial Class C
     Implements I
+
     Public Sub Goo() Implements I.Goo
         Throw New System.NotImplementedException()
     End Sub
@@ -3885,15 +3984,12 @@ Class C
     Implements I
 
     Default Public Property Prop(p As Long) As Integer Implements I.Prop
-
         Get
             Throw New System.NotImplementedException()
         End Get
-
         Set(value As Integer)
             Throw New System.NotImplementedException()
         End Set
-
     End Property
 End Class")
         End Function
@@ -4507,10 +4603,10 @@ Imports System
 interface I
     Function F() As ValueTuple(Of Object)
 end interface
-class C 
+class C
     Implements I
 
-Public Function F() As ValueTuple(Of Object) Implements I.F
+    Public Function F() As ValueTuple(Of Object) Implements I.F
         Throw New NotImplementedException()
     End Function
 end class

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/AddParameterCheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/AddParameterCheckTests.vb
@@ -107,7 +107,7 @@ end class",
 Imports System
 
 class C
-    private _s as string
+    private _s as string 
 
     public sub new(s as string)
         If s Is Nothing Then

--- a/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InitializeParameter/InitializeMemberFromParameterTests.vb
@@ -178,7 +178,6 @@ class C
 end class",
 "
 class C
-
     private s As Integer
 
     public sub new(s As String)
@@ -261,6 +260,7 @@ class C
 end class",
 "
 class C
+
     private s As Integer
 
     public sub new([||]s As String)
@@ -293,7 +293,7 @@ class C
 
     public sub new(s As String, t As String)
         Me.s = s
-        Me.t = t
+        Me.t = t   
     end sub
 end class")
         End Function
@@ -343,6 +343,7 @@ class C
     public sub new(s As String)
         if true then
         end if
+
         Me.s = s
     end sub
 end class")
@@ -377,7 +378,6 @@ class C
 end class",
 "
 class C
-
     public sub new(s As String, t As String)
         Me.S = s
         Me.T = t
@@ -402,10 +402,9 @@ class C
 end class",
 "
 class C
-
     public sub new(s As String, t As String)
         Me.S = s
-        Me.T = t
+        Me.T = t   
     end sub
 
     Public ReadOnly Property S As String

--- a/src/EditorFeatures/VisualBasicTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.vb
@@ -71,8 +71,8 @@ end class")
 end class",
 "class C
     sub M()
-
         Console.WriteLine()
+
         dim x as integer
         if true
             Console.WriteLine(x)
@@ -123,7 +123,8 @@ end class",
 "class C
     sub M()
         if true
-            dim x as integer = 5
+            dim x as integer
+= 5
             Console.WriteLine(x)
         end if
     end sub
@@ -255,7 +256,7 @@ using System.Linq
 class Program
     sub M()
         for each (v in x)
-            {|Warning:dim i = CInt(0)|}
+        {|Warning:dim i = CInt(0)|}
             Console.Write(i)
             i = i + 1
         next

--- a/src/EditorFeatures/VisualBasicTest/OrderModifiers/OrderModifiersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/OrderModifiers/OrderModifiersTests.vb
@@ -21,7 +21,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.OrderModifiers
 end class
 ",
 "protected friend class C
-end class")
+end class
+")
         End Function
 
                 <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)>
@@ -30,8 +31,7 @@ end class")
 "[|friend|] protected structure C
 
 end structure",
-"
-protected friend structure C
+"protected friend structure C
 
 end structure")
         End Function
@@ -41,10 +41,8 @@ end structure")
             Await TestInRegularAndScript1Async(
 "[|friend|] protected interface C
 end interface",
-"
-protected friend interface C
-end interface
-")
+"protected friend interface C
+end interface")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)>
@@ -52,8 +50,7 @@ end interface
             Await TestInRegularAndScript1Async(
 "[|friend|] protected enum C
 end enum",
-"
-protected friend enum C
+"protected friend enum C
 end enum")
         End Function
 
@@ -70,8 +67,7 @@ end enum")
 "class C
     [|mustoverride|] protected sub M()
 end class",
-"
-class C
+"class C
     protected mustoverride sub M()
 end class")
         End Function
@@ -83,8 +79,7 @@ end class")
     [|friend|] protected sub M()
     end sub
 end class",
-"
-class C
+"class C
     protected friend sub M()
     end sub
 end class")
@@ -96,8 +91,7 @@ end class")
 "class C
     [|friend|] protected dim a as integer
 end class",
-"
-class C
+"class C
     protected friend dim a as integer
 end class")
         End Function
@@ -109,8 +103,7 @@ end class")
     [|friend|] protected sub new()
     end sub
 end class",
-"
-class C
+"class C
     protected friend sub new()
     end sub
 end class")
@@ -122,8 +115,7 @@ end class")
 "class C
     [|readonly|] protected property P as integer
 end class",
-"
-class C
+"class C
     protected readonly property P as integer
 end class")
         End Function
@@ -137,8 +129,7 @@ end class")
         end get
     end property
 end class",
-"
-class C
+"class C
     protected readonly property P as integer
         get
         end get
@@ -172,9 +163,8 @@ end class
     [|friend|] protected custom event E as Action 
     end event
 end class",
-"
-class C
-    protected friend custom event E as Action
+"class C
+    protected friend custom event E as Action 
     end event
 end class")
         End Function
@@ -185,8 +175,7 @@ end class")
 "class C
     [|friend|] protected event E as Action
 end class",
-"
-class C
+"class C
     protected friend event E as Action
 end class")
         End Function
@@ -199,11 +188,11 @@ end class")
     end operator
 end class
 ",
-"
-class C
+"class C
     public shared operator +(c1 as integer, c2 as integer) as integer
     end operator
-end class")
+end class
+")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)>
@@ -213,8 +202,7 @@ end class")
     [|shared|] public widening operator CType(x as integer) as boolean
     end operator
 end class",
-"
-class C
+"class C
     public shared widening operator CType(x as integer) as boolean
     end operator
 end class")
@@ -227,12 +215,10 @@ end class")
     friend protected class Nested
     end class
 end class",
-"
-protected friend class C
+"protected friend class C
     protected friend class Nested
     end class
-end class
-")
+end class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)>
@@ -243,8 +229,7 @@ end class
     end class
 end class
 ",
-"
-protected friend class C
+"protected friend class C
     protected friend class Nested
     end class
 end class

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnnecessaryImports/RemoveUnnecessaryImportsTests.vb
@@ -417,8 +417,7 @@ Namespace goo
     Class bar
     End Class
 End Namespace|]",
-"Imports System, System.Collections.Generic
-Module Program
+"Imports System, System.Collections.Generic Module Program
     Sub Main(args As String())
         Console.WriteLine(""TEST"")
         Dim q As List(Of Integer)
@@ -516,7 +515,7 @@ Namespace B
     Public Class CB
     End Class
 End Namespace|]",
-"Imports A
+"Imports A _
 Module Program
     Sub Main(args As String())
         Dim q As CA

--- a/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionForNullableTests.vb
@@ -26,7 +26,8 @@ Class C
         Dim z = [||]If (Not x.HasValue, y, x.Value)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
@@ -46,7 +47,8 @@ Class C
         Dim z = [||]If(x.HasValue, x.Value, y)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
@@ -66,7 +68,8 @@ Class C
         Dim z = [||]If (Not (x + y).HasValue, y, (x + y).Value)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
@@ -86,7 +89,8 @@ Class C
         Dim z = [||]If ((Not x.HasValue), y, x.Value)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
@@ -107,7 +111,8 @@ Class C
         Dim z2 = If(x.HasValue, x.Value, y)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?)
@@ -128,7 +133,8 @@ Class C
         dim w = {|FixAllInDocument:If|} (x.HasValue, x.Value, If(y.HasValue, y.Value, z))
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as Integer?, y as Integer?, z as Integer?)
@@ -156,7 +162,7 @@ Imports System.Linq.Expressions
 
 Class C
     Sub M(x as integer?, y as integer)
-        dim e as Expression(of Func(of integer)) = function() {|Warning:If (x, y)|}
+        dim e as Expression(of Func(of integer)) = function() {|Warning:If(x, y)|}
     End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCoalesceExpression/UseCoalesceExpressionTests.vb
@@ -26,7 +26,8 @@ Class C
         Dim z = [||]If (x Is Nothing, y, x)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -46,7 +47,8 @@ Class C
         Dim z = [||]If(x IsNot Nothing, x, y)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -66,7 +68,8 @@ Class C
         Dim z = [||]If(Nothing Is x, y, x)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -86,7 +89,8 @@ Class C
         Dim z = [||]If(Nothing IsNot x, x, y)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -106,7 +110,8 @@ Class C
         Dim z = [||]If (x.ToString() is Nothing, y, x.ToString())
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -126,7 +131,8 @@ Class C
         Dim z = [||]If ((x Is Nothing), y, x)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -146,7 +152,8 @@ Class C
         Dim z = [||]If ((x) Is Nothing, y, x)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -166,7 +173,8 @@ Class C
         Dim z = [||]If (x Is Nothing, y, (x))
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -186,7 +194,8 @@ Class C
         Dim z = [||]If (x Is Nothing, (y), x)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -207,7 +216,8 @@ Class C
         Dim z2 = If(x IsNot Nothing, x, y)
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string)
@@ -228,7 +238,8 @@ Class C
         dim w = {|FixAllInDocument:If|} (x isnot Nothing, x, If(y isnot Nothing, y, z))
     End Sub
 End Class",
-"Imports System
+"
+Imports System
 
 Class C
     Sub M(x as string, y as string, z as string)
@@ -256,7 +267,7 @@ Imports System.Linq.Expressions
 
 Class C
     Sub M(x as string, y as string)
-        dim e as Expression(of Func(of string)) = function() {|Warning:If (x, y)|}
+        dim e as Expression(of Func(of string)) = function() {|Warning:If(x, y)|}
     End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -121,7 +121,7 @@ Class C
     Sub M()
         Dim a As Integer = 1
         Dim b As Integer = 2
-        Dim t = New With { a, b }
+        Dim t = New With {a, b}
     End Sub
 End Class
 ", parseOptions:=s_parseOptions)

--- a/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
@@ -378,7 +378,8 @@ Class C
         }
         z.y = 2
     End Sub
-End Class")
+End Class
+")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Utils.vb
+++ b/src/EditorFeatures/VisualBasicTest/Utils.vb
@@ -327,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests
                         "End Structure"
 
                 Case "File"
-                    Return String.Join(vbCrLf, lines)
+                    Return testSource.NormalizedValue
 
                 Case Else
                     Throw New ArgumentException("Unexpected testSource XML tag.", NameOf(testSource))


### PR DESCRIPTION
* Change `ignoreTrivia` to default to false
* Fix tests so the expected test results accurately reflect reality, including trivia

**Reviewers:** The main item to verify is that this pull request only changes expected test outputs. Test inputs should remain the same. One (seemingly unavoidable) exception is indicated with a ⚠️ comment.

:memo: The changes to expected test results reveal a large number of bugs. These will be identified in comments in this PR, and bugs filed so they can be fixed later.