### PR TITLE
Disallow calling generic local function with dynamic

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2801,7 +2801,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             EffectiveParameters effectiveParameters;
             if (member.Kind == SymbolKind.Method && (method = (MethodSymbol)(Symbol)member).Arity > 0)
             {
-                if (typeArgumentsBuilder.Count == 0 && arguments.HasDynamicArgument && !inferWithDynamic)
+                var isLocalFunction = ((MethodSymbol)(Symbol)member).MethodKind == MethodKind.LocalFunction;
+                if (typeArgumentsBuilder.Count == 0 && arguments.HasDynamicArgument && !inferWithDynamic && !isLocalFunction)
                 {
                     // Spec 7.5.4: Compile-time checking of dynamic overload resolution:
                     // * First, if F is a generic method and type arguments were provided, 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2801,8 +2801,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             EffectiveParameters effectiveParameters;
             if (member.Kind == SymbolKind.Method && (method = (MethodSymbol)(Symbol)member).Arity > 0)
             {
-                var isLocalFunction = ((MethodSymbol)(Symbol)member).MethodKind == MethodKind.LocalFunction;
-                if (typeArgumentsBuilder.Count == 0 && arguments.HasDynamicArgument && !inferWithDynamic && !isLocalFunction)
+                if (typeArgumentsBuilder.Count == 0 && arguments.HasDynamicArgument && !inferWithDynamic)
                 {
                     // Spec 7.5.4: Compile-time checking of dynamic overload resolution:
                     // * First, if F is a generic method and type arguments were provided, 

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3725,7 +3725,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot pass argument with dynamic type to generic local function &apos;{0}&apos;. Try specifying the type arguments explicitly..
+        ///   Looks up a localized string similar to Cannot pass argument with dynamic type to generic local function &apos;{0}&apos; with inferred type arguments..
         /// </summary>
         internal static string ERR_DynamicLocalFunctionTypeParameter {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3725,6 +3725,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot pass argument with dynamic type to generic parameter &apos;{0}&apos; of local function &apos;{1}&apos;..
+        /// </summary>
+        internal static string ERR_DynamicLocalFunctionTypeParameter {
+            get {
+                return ResourceManager.GetString("ERR_DynamicLocalFunctionTypeParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to One or more types required to compile a dynamic expression cannot be found. Are you missing a reference?.
         /// </summary>
         internal static string ERR_DynamicRequiredTypesMissing {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3725,7 +3725,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot pass argument with dynamic type to generic parameter &apos;{0}&apos; of local function &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Cannot pass argument with dynamic type to generic local function &apos;{0}&apos;. Try specifying the type arguments explicitly..
         /// </summary>
         internal static string ERR_DynamicLocalFunctionTypeParameter {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5109,6 +5109,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
-    <value>Cannot pass argument with dynamic type to generic local function '{0}'. Try specifying the type arguments explicitly.</value>
+    <value>Cannot pass argument with dynamic type to generic local function '{0}' with inferred type arguments.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5109,6 +5109,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
   </data>
   <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
-    <value>Cannot pass argument with dynamic type to generic parameter '{0}' of local function '{1}'.</value>
+    <value>Cannot pass argument with dynamic type to generic local function '{0}'. Try specifying the type arguments explicitly.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5108,4 +5108,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InvalidDebugInfo" xml:space="preserve">
     <value>Unable to read debug information of method '{0}' (token 0x{1:X8}) from assembly '{2}'</value>
   </data>
+  <data name="ERR_DynamicLocalFunctionTypeParameter" xml:space="preserve">
+    <value>Cannot pass argument with dynamic type to generic parameter '{0}' of local function '{1}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1496,6 +1496,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics introduced for C# 7.2
         ERR_FeatureNotAvailableInVersion7_2 = 8320,
         WRN_UnreferencedLocalFunction = 8321,
+        ERR_DynamicLocalFunctionTypeParameter = 8322,
         #endregion diagnostics introduced for C# 7.2
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3453,41 +3453,111 @@ class Program
             var src = @"
 void L1<T>(T x)
 {
-    Console.WriteLine(x);
-    Console.WriteLine(typeof(T).ToString());
+    Console.WriteLine($""{x}: {typeof(T)}"");
 }
 dynamic val = 2;
 L1<object>(val);
 L1<int>(val);
+L1<dynamic>(val);
+L1<dynamic>(4);
 
-void L2<T>(int x, T y)
-{
-    Console.WriteLine(x);
-    Console.WriteLine(y);
-    Console.WriteLine(typeof(T).ToString());
-}
-L2(val, 3.0f);
+void L2<T>(int x, T y) => Console.WriteLine($""{x}, {y}: {typeof(T)}"");
+L2<double>(val, 3.0f);
 
 List<dynamic> listOfDynamic = new List<dynamic> { 1, 2, 3 };
-void L3<T>(List<T> x)
-{
-    Console.WriteLine(string.Join("", "", x));
-    Console.WriteLine(typeof(T).ToString());
-}
+void L3<T>(List<T> x) => Console.WriteLine($""{string.Join("", "", x)}: {typeof(T)}"");
 L3(listOfDynamic);
+
+void L4<T>(T x, params int[] y) => Console.WriteLine($""{x}, {string.Join("", "", y)}: {typeof(T)}"");
+L4<dynamic>(val, 3, 4);
+L4<int>(val, 3, 4);
+L4<int>(1, 3, val);
+
+void L5<T>(int x, params T[] y) => Console.WriteLine($""{x}, {string.Join("", "", y)}: {typeof(T)}"");
+L5<int>(val, 3, 4);
+L5<int>(1, 3, val);
+L5<dynamic>(1, 3, val);
 ";
             var output = @"
-2
-System.Object
-2
-System.Int32
-2
-3
-System.Single
-1, 2, 3
-System.Object
+2: System.Object
+2: System.Int32
+2: System.Object
+4: System.Object
+2, 3: System.Single
+1, 2, 3: System.Object
+2, 3, 4: System.Object
+2, 3, 4: System.Int32
+1, 3, 2: System.Int32
+2, 3, 4: System.Int32
+1, 3, 2: System.Int32
+1, 3, 2: System.Object
 ";
             VerifyOutputInMain(src, output, "System", "System.Collections.Generic");
+        }
+
+        [Fact]
+        [WorkItem(21317, "https://github.com/dotnet/roslyn/issues/21317")]
+        [CompilerTrait(CompilerFeature.Dynamic)]
+        public void DynamicGenericClassMethod()
+        {
+            var src = @"
+using System;
+class C1<T1>
+{
+    public static void M1<T2>()
+    {
+        void F(int x)
+        {
+            Console.WriteLine($""C1<{typeof(T1)}>.M1<{typeof(T2)}>.F({x})"");
+        }
+        F((dynamic)2);
+    }
+    public static void M2()
+    {
+        void F(int x)
+        {
+            Console.WriteLine($""C1<{typeof(T1)}>.M2.F({x})"");
+        }
+        F((dynamic)2);
+    }
+}
+class C2
+{
+    public static void M1<T2>()
+    {
+        void F(int x)
+        {
+            Console.WriteLine($""C2.M1<{typeof(T2)}>.F({x})"");
+        }
+        F((dynamic)2);
+    }
+    public static void M2()
+    {
+        void F(int x)
+        {
+            Console.WriteLine($""C2.M2.F({x})"");
+        }
+        F((dynamic)2);
+    }
+}
+class Program
+{
+    static void Main()
+    {
+        C1<int>.M1<float>();
+        C1<int>.M2();
+        C2.M1<float>();
+        C2.M2();
+    }
+}
+";
+            var output = @"
+C1<System.Int32>.M1<System.Single>.F(2)
+C1<System.Int32>.M2.F(2)
+C2.M1<System.Single>.F(2)
+C2.M2.F(2)
+";
+            VerifyOutput(src, output);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3446,6 +3446,51 @@ class Program
         }
 
         [Fact]
+        [WorkItem(21317, "https://github.com/dotnet/roslyn/issues/21317")]
+        [CompilerTrait(CompilerFeature.Dynamic)]
+        public void DynamicGenericArg()
+        {
+            var src = @"
+void L1<T>(T x)
+{
+    Console.WriteLine(x);
+    Console.WriteLine(typeof(T).ToString());
+}
+dynamic val = 2;
+L1<object>(val);
+L1<int>(val);
+
+void L2<T>(int x, T y)
+{
+    Console.WriteLine(x);
+    Console.WriteLine(y);
+    Console.WriteLine(typeof(T).ToString());
+}
+L2(val, 3.0f);
+
+List<dynamic> listOfDynamic = new List<dynamic> { 1, 2, 3 };
+void L3<T>(List<T> x)
+{
+    Console.WriteLine(string.Join("", "", x));
+    Console.WriteLine(typeof(T).ToString());
+}
+L3(listOfDynamic);
+";
+            var output = @"
+2
+System.Object
+2
+System.Int32
+2
+3
+System.Single
+1, 2, 3
+System.Object
+";
+            VerifyOutputInMain(src, output, "System", "System.Collections.Generic");
+        }
+
+        [Fact]
         [CompilerTrait(CompilerFeature.Dynamic, CompilerFeature.Params)]
         public void DynamicArgsAndParams()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3462,7 +3462,7 @@ L1<dynamic>(val);
 L1<dynamic>(4);
 
 void L2<T>(int x, T y) => Console.WriteLine($""{x}, {y}: {typeof(T)}"");
-L2<double>(val, 3.0f);
+L2<float>(val, 3.0f);
 
 List<dynamic> listOfDynamic = new List<dynamic> { 1, 2, 3 };
 void L3<T>(List<T> x) => Console.WriteLine($""{string.Join("", "", x)}: {typeof(T)}"");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3163,5 +3163,56 @@ class C
                 //             => await L(async m => L(async d => await d, m), p);
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "=>").WithLocation(8, 32));
         }
+
+        [Fact]
+        [WorkItem(21317, "https://github.com/dotnet/roslyn/issues/21317")]
+        [CompilerTrait(CompilerFeature.Dynamic)]
+        public void DynamicGenericArg()
+        {
+            var src = @"
+using System;
+using System.Collections.Generic;
+class C
+{
+    static void M()
+    {
+        dynamic val = 2;
+
+        void L1<T>(T x)
+        {
+            Console.Write(x);
+        }
+        L1(val);
+
+        void L2<T>(int x, T y)
+        {
+            Console.Write(x);
+        }
+        L2(1, val);
+
+        dynamic dynamicList = new List<int>();
+        void L3<T>(List<T> x)
+        {
+            Console.Write(x);
+        }
+        L3(dynamicList);
+    }
+}
+";
+            VerifyDiagnostics(src,
+                // (14,9): error CS8322: Cannot pass argument with dynamic type to generic parameter 'x' of local function 'L1'.
+                //         L1(val);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L1(val)").WithArguments("x", "L1").WithLocation(14, 9),
+                // (20,9): error CS8322: Cannot pass argument with dynamic type to generic parameter 'y' of local function 'L2'.
+                //         L2(1, val);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L2(1, val)").WithArguments("y", "L2").WithLocation(20, 9),
+                // (27,9): error CS0411: The type arguments for method 'L3<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         L3(dynamicList);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "L3").WithArguments("L3<T>(System.Collections.Generic.List<T>)").WithLocation(27, 9),
+                // (23,14): warning CS8321: The local function 'L3' is declared but never used
+                //         void L3<T>(List<T> x)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "L3").WithArguments("L3").WithLocation(23, 14)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3170,48 +3170,59 @@ class C
         public void DynamicGenericArg()
         {
             var src = @"
-using System;
 using System.Collections.Generic;
 class C
 {
     static void M()
     {
         dynamic val = 2;
+        dynamic dynamicList = new List<int>();
 
-        void L1<T>(T x)
-        {
-            Console.Write(x);
-        }
+        void L1<T>(T x) { }
         L1(val);
 
-        void L2<T>(int x, T y)
-        {
-            Console.Write(x);
-        }
+        void L2<T>(int x, T y) { }
         L2(1, val);
+        L2(val, 3.0f);
 
-        dynamic dynamicList = new List<int>();
-        void L3<T>(List<T> x)
-        {
-            Console.Write(x);
-        }
+        void L3<T>(List<T> x) { }
         L3(dynamicList);
+
+        void L4<T>(int x, params T[] y) { }
+        L4(1, 2, val);
+        L4(val, 3, 4);
+
+        void L5<T>(T x, params int[] y) { }
+        L5(val, 1, 2);
+        L5(1, 3, val);
     }
 }
 ";
             VerifyDiagnostics(src,
-                // (14,9): error CS8322: Cannot pass argument with dynamic type to generic parameter 'x' of local function 'L1'.
+                // (11,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L1'. Try specifying the type arguments explicitly.
                 //         L1(val);
-                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L1(val)").WithArguments("x", "L1").WithLocation(14, 9),
-                // (20,9): error CS8322: Cannot pass argument with dynamic type to generic parameter 'y' of local function 'L2'.
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L1(val)").WithArguments("L1").WithLocation(11, 9),
+                // (14,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L2'. Try specifying the type arguments explicitly.
                 //         L2(1, val);
-                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L2(1, val)").WithArguments("y", "L2").WithLocation(20, 9),
-                // (27,9): error CS0411: The type arguments for method 'L3<T>(List<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L2(1, val)").WithArguments("L2").WithLocation(14, 9),
+                // (15,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L2'. Try specifying the type arguments explicitly.
+                //         L2(val, 3.0f);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L2(val, 3.0f)").WithArguments("L2").WithLocation(15, 9),
+                // (18,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L3'. Try specifying the type arguments explicitly.
                 //         L3(dynamicList);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "L3").WithArguments("L3<T>(System.Collections.Generic.List<T>)").WithLocation(27, 9),
-                // (23,14): warning CS8321: The local function 'L3' is declared but never used
-                //         void L3<T>(List<T> x)
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "L3").WithArguments("L3").WithLocation(23, 14)
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L3(dynamicList)").WithArguments("L3").WithLocation(18, 9),
+                // (21,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L4'. Try specifying the type arguments explicitly.
+                //         L4(1, 2, val);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L4(1, 2, val)").WithArguments("L4").WithLocation(21, 9),
+                // (22,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L4'. Try specifying the type arguments explicitly.
+                //         L4(val, 3, 4);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L4(val, 3, 4)").WithArguments("L4").WithLocation(22, 9),
+                // (25,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L5'. Try specifying the type arguments explicitly.
+                //         L5(val, 1, 2);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L5(val, 1, 2)").WithArguments("L5").WithLocation(25, 9),
+                // (26,9): error CS8322: Cannot pass argument with dynamic type to generic local function 'L5'. Try specifying the type arguments explicitly.
+                //         L5(1, 3, val);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L5(1, 3, val)").WithArguments("L5").WithLocation(26, 9)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3136,7 +3136,10 @@ class C
             comp.VerifyEmitDiagnostics(
                 // (8,18): error CS1977: Cannot use a lambda expression as an argument to a dynamically dispatched operation without first casting it to a delegate or expression tree type.
                 //         L(m => L(d => d, m), null);
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgLambda, "d => d").WithLocation(8, 18));
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgLambda, "d => d").WithLocation(8, 18),
+                // (8,16): error CS8322: Cannot pass argument with dynamic type to generic local function 'L' with inferred type arguments.
+                //         L(m => L(d => d, m), null);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L(d => d, m)").WithArguments("L").WithLocation(8, 16));
         }
 
         [Fact]
@@ -3159,6 +3162,9 @@ class C
                 // (8,37): error CS1977: Cannot use a lambda expression as an argument to a dynamically dispatched operation without first casting it to a delegate or expression tree type.
                 //             => await L(async m => L(async d => await d, m), p);
                 Diagnostic(ErrorCode.ERR_BadDynamicMethodArgLambda, "async d => await d").WithLocation(8, 37),
+                // (8,35): error CS8322: Cannot pass argument with dynamic type to generic local function 'L' with inferred type arguments.
+                //             => await L(async m => L(async d => await d, m), p);
+                Diagnostic(ErrorCode.ERR_DynamicLocalFunctionTypeParameter, "L(async d => await d, m)").WithArguments("L").WithLocation(8, 35),
                 // (8,32): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //             => await L(async m => L(async d => await d, m), p);
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "=>").WithLocation(8, 32));


### PR DESCRIPTION
Resolves #21317.

After discussion with @agocke, we've decided to ban this scenario - allowing this requires local functions to be constructed dynamically at runtime, something we explicitly decided not to do for local functions.

@dotnet/roslyn-compat-council This is technically a breaking change, as code that used to compile no longer does so. However, the IL generated in this scenario was broken, and the assembly could never load (not even a case of "fails when the code is executed", but "fails immediately when the assembly itself loads")