### PR TITLE
EnC: Retrieve baseline metadata from the debugger

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -67,8 +67,8 @@
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26606</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.0.71</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>15.0.26606</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26725-gamma</MicrosoftVisualStudioDebuggerEngineVersion>
-    <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26725-gamma</MicrosoftVisualStudioDebuggerMetadataVersion>
+    <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26725-vsucorediag</MicrosoftVisualStudioDebuggerEngineVersion>
+    <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26725-vsucorediag</MicrosoftVisualStudioDebuggerMetadataVersion>
     <MicrosoftVisualStudioDebuggerInterop100Version>10.0.30319</MicrosoftVisualStudioDebuggerInterop100Version>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.0.26606-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -67,8 +67,8 @@
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26606</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.0.71</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>15.0.26606</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26725-vsucorediag</MicrosoftVisualStudioDebuggerEngineVersion>
-    <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26725-vsucorediag</MicrosoftVisualStudioDebuggerMetadataVersion>
+    <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerEngineVersion>
+    <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerMetadataVersion>
     <MicrosoftVisualStudioDebuggerInterop100Version>10.0.30319</MicrosoftVisualStudioDebuggerInterop100Version>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.0.26606-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <exception cref="IOException">Error reading module metadata.</exception>
         /// <exception cref="BadImageFormatException">Module metadata is invalid.</exception>
         /// <exception cref="ObjectDisposedException">Module has been disposed.</exception>
-        internal static EmitBaseline CreateInitialBaseline(
+        public static EmitBaseline CreateInitialBaseline(
             ModuleMetadata module, 
             Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider,
             Func<MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider,

--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -229,7 +229,10 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal bool IsDisposed
+        /// <summary>
+        /// True if the module has been disposed.
+        /// </summary>
+        public bool IsDisposed
         {
             get { return _isDisposed || _module.IsDisposed; }
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -41,6 +41,7 @@ Microsoft.CodeAnalysis.IOperation.IsInvalid.get -> bool
 Microsoft.CodeAnalysis.IOperation.Kind.get -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.IOperation.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.IOperation.Type.get -> Microsoft.CodeAnalysis.ITypeSymbol
+Microsoft.CodeAnalysis.ModuleMetadata.IsDisposed.get -> bool
 Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.AddressOfExpression = 515 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.Argument = 1031 -> Microsoft.CodeAnalysis.OperationKind
@@ -740,6 +741,7 @@ override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitVariableDeclarati
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWhileUntilLoopStatement(Microsoft.CodeAnalysis.Semantics.IWhileUntilLoopStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWithStatement(Microsoft.CodeAnalysis.Semantics.IWithStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitYieldBreakStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation) -> void
+static Microsoft.CodeAnalysis.Emit.EmitBaseline.CreateInitialBaseline(Microsoft.CodeAnalysis.ModuleMetadata module, System.Func<System.Reflection.Metadata.MethodDefinitionHandle, Microsoft.CodeAnalysis.Emit.EditAndContinueMethodDebugInformation> debugInformationProvider, System.Func<System.Reflection.Metadata.MethodDefinitionHandle, System.Reflection.Metadata.StandaloneSignatureHandle> localSignatureProvider, bool hasPortableDebugInformation) -> Microsoft.CodeAnalysis.Emit.EmitBaseline
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.Descendants(this Microsoft.CodeAnalysis.IOperation operation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.DescendantsAndSelf(this Microsoft.CodeAnalysis.IOperation operation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.GetDeclaredVariables(this Microsoft.CodeAnalysis.Semantics.IVariableDeclarationStatement declarationStatement) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ILocalSymbol>

--- a/src/EditorFeatures/Test/EditAndContinue/DebuggeeModuleMetadataCacheTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/DebuggeeModuleMetadataCacheTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
+{
+    public sealed class DebuggeeModuleMetadataCacheTests
+    {
+        [Fact]
+        public void GetOrAddNull()
+        {
+            var cache = new DebuggeeModuleMetadataCache();
+            var mvid = Guid.NewGuid();
+
+            Assert.Null(cache.GetOrAdd(mvid, m => { Assert.Equal(mvid, m); return default; }));
+        }
+
+        [Fact]
+        public void GetOrAdd()
+        {
+            var cache = new DebuggeeModuleMetadataCache();
+
+            var metadata1 = ModuleMetadata.CreateFromImage((IntPtr)1, 1);
+            var metadata2 = ModuleMetadata.CreateFromImage((IntPtr)2, 1);
+
+            var mvid1 = Guid.NewGuid();
+            var mvid2 = Guid.NewGuid();
+            var mvid3 = Guid.NewGuid();
+
+            Assert.Same(metadata1, cache.GetOrAdd(mvid1, _ => metadata1));
+            Assert.Same(metadata2, cache.GetOrAdd(mvid2, _ => metadata2));
+
+            Assert.Same(metadata1, cache.GetOrAdd(mvid1, _ => throw null));
+            Assert.Same(metadata2, cache.GetOrAdd(mvid2, _ => throw null));
+        }
+
+        [Fact]
+        public void Remove()
+        {
+            var cache = new DebuggeeModuleMetadataCache();
+            Assert.False(cache.Remove(Guid.NewGuid()));
+
+            var mvid1 = Guid.NewGuid();
+
+            cache.GetOrAdd(mvid1, _ => ModuleMetadata.CreateFromImage((IntPtr)1, 1));
+
+            Assert.True(cache.Remove(mvid1));
+            Assert.False(cache.Remove(mvid1));
+            Assert.Null(cache.GetOrAdd(mvid1, _ => default));
+        }
+
+        [Fact]
+        public void RemoveAdd()
+        {
+            var cache = new DebuggeeModuleMetadataCache();
+            Assert.False(cache.Remove(Guid.NewGuid()));
+            
+            var mvid1 = Guid.NewGuid();
+
+            var metadata1 = ModuleMetadata.CreateFromImage((IntPtr)1, 1);
+            var metadata2 = ModuleMetadata.CreateFromImage((IntPtr)2, 1);
+
+            Assert.Same(metadata1, cache.GetOrAdd(mvid1, _ => metadata1));
+
+            Assert.True(cache.Remove(mvid1));
+            Assert.Null(cache.GetOrAdd(mvid1, _ => default));
+
+            Assert.Same(metadata2, cache.GetOrAdd(mvid1, _ => metadata2));
+        }
+    }
+}

--- a/src/Features/Core/Portable/EditAndContinue/DebuggeeModuleMetadataCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggeeModuleMetadataCache.cs
@@ -73,8 +73,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 if (cache.TryGetValue(mvid, out var entry))
                 {
-                    entry.Dispose();
                     cache.Remove(mvid);
+                    entry.Dispose();
                     return true;
                 }
             }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggeeModuleMetadataCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggeeModuleMetadataCache.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    /// <summary>
+    /// A cache of metadata blobs loaded into processes being debugged.
+    /// Thread safe.
+    /// </summary>
+    internal sealed class DebuggeeModuleMetadataCache
+    {
+        // Maps MVIDs to metadata blobs loaded to specific processes
+        private Dictionary<Guid, ModuleMetadata> _lazyCache;
+
+        /// <summary>
+        /// May return null if the provider returns null.
+        /// </summary>
+        public ModuleMetadata GetOrAdd(Guid mvid, Func<Guid, ModuleMetadata> provider)
+        {
+            if (_lazyCache == null)
+            {
+                Interlocked.CompareExchange(ref _lazyCache, new Dictionary<Guid, ModuleMetadata>(), null);
+            }
+
+            var cache = _lazyCache;
+
+            lock (cache)
+            {
+                if (cache.TryGetValue(mvid, out var existing))
+                {
+                    return existing;
+                }
+            }
+
+            var newMetadata = provider(mvid);
+            if (newMetadata == null)
+            {
+                return null;
+            }
+
+            lock (cache)
+            {
+                if (cache.TryGetValue(mvid, out var existing))
+                {
+                    newMetadata.Dispose();
+                    return existing;
+                }
+
+                cache.Add(mvid, newMetadata);
+                return newMetadata;
+            }
+        }
+
+        /// <summary>
+        /// Removes metadata of specified module and process.
+        /// </summary>
+        public bool Remove(Guid mvid)
+        {
+            Debug.Assert(mvid != default);
+
+            var cache = _lazyCache;
+            if (cache == null)
+            {
+                return false;
+            }
+
+            lock (cache)
+            {
+                if (cache.TryGetValue(mvid, out var entry))
+                {
+                    entry.Dispose();
+                    cache.Remove(mvid);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Features/Core/Portable/EditAndContinue/IDebuggeeModuleMetadataProvider.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IDebuggeeModuleMetadataProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue
+{
+    /// <summary>
+    /// Provides metadata of modules loaded into processes being debugged.
+    /// </summary>
+    internal interface IDebuggeeModuleMetadataProvider
+    {
+        /// <summary>
+        /// Finds a module of given MVID in one of the processes being debugged and returns its baseline metadata.
+        /// Shall only be called while in debug mode.
+        /// </summary>
+        ModuleMetadata TryGetBaselineMetadata(Guid mvid);
+    }
+}

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -848,6 +848,7 @@ Public Class BuildDevDivInsertionFiles
         add("Dlls\CSharpExpressionCompiler\Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ExpressionCompiler.vsdconfig")
         add("Dlls\CSharpResultProvider.Portable\Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.ResultProvider.vsdconfig")
         add("Dlls\FunctionResolver\Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.vsdconfig")
+        add("Dlls\ServicesVisualStudio\Microsoft.VisualStudio.LanguageServices.vsdconfig")
         add("Dlls\MSBuildTask\Microsoft.CSharp.Core.targets")
         add("Dlls\MSBuildTask\Microsoft.VisualBasic.Core.targets")
         add("Dlls\CSharpCompilerTestUtilities\Roslyn.Compilers.CSharp.Test.Utilities.dll")

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebuggeeModuleMetadataProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebuggeeModuleMetadataProvider.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Debugging;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.VisualStudio.Debugger;
+using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.VisualStudio.Debugger.ComponentInterfaces;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
+{
+    [Export(typeof(IDebuggeeModuleMetadataProvider)), Shared]
+    internal sealed class DebuggeeModuleMetadataProvider : IDebuggeeModuleMetadataProvider
+    {
+        /// <summary>
+        /// Concord component. Singleton created on demand during debugging session and discarded as soon as the session ends.
+        /// </summary>
+        private sealed class DebuggerService : IDkmCustomMessageForwardReceiver
+        {
+            /// <summary>
+            /// Component id as specified in ManagedEditAndContinueService.vsdconfigxml.
+            /// </summary>
+            public static readonly Guid ComponentId = new Guid("A96BBE03-0408-41E3-8613-6086FD494B43");
+
+            /// <summary>
+            /// Message source id as specified in ManagedEditAndContinueService.vsdconfigxml.
+            /// </summary>
+            public static readonly Guid MessageSourceId = new Guid("58CDF976-1923-48F7-8288-B4189F5700B1");
+
+            private sealed class DataItem : DkmDataItem
+            {
+                private readonly DebuggeeModuleMetadataProvider _provider;
+                private readonly Guid _mvid;
+
+                public DataItem(DebuggeeModuleMetadataProvider provider, Guid mvid)
+                {
+                    _provider = provider;
+                    _mvid = mvid;
+                }
+
+                protected override void OnClose() => _provider.OnModuleInstanceUnload(_mvid);
+            }
+
+            DkmCustomMessage IDkmCustomMessageForwardReceiver.SendLower(DkmCustomMessage customMessage)
+            {
+                var provider = (DebuggeeModuleMetadataProvider)customMessage.Parameter1;
+                var clrModuleInstance = (DkmClrModuleInstance)customMessage.Parameter2;
+
+                // Note that this call has to be made in a Concord component.
+                // The debugger tracks what the current component is and associates the data item with it.
+                clrModuleInstance.SetDataItem(DkmDataCreationDisposition.CreateAlways, new DataItem(provider, clrModuleInstance.Mvid));
+                return null;
+            }
+        }
+
+        private readonly DebuggeeModuleMetadataCache _baselineMetadata;
+
+        public DebuggeeModuleMetadataProvider()
+        {
+            _baselineMetadata = new DebuggeeModuleMetadataCache();
+        }
+
+        private void OnModuleInstanceUnload(Guid mvid)
+            => _baselineMetadata.Remove(mvid);
+
+        /// <summary>
+        /// Finds a module of given MVID in one of the processes being debugged and returns its baseline metadata.
+        /// Shall only be called while in debug mode.
+        /// </summary>
+        public ModuleMetadata TryGetBaselineMetadata(Guid mvid)
+        {
+            return _baselineMetadata.GetOrAdd(mvid, m =>
+            {
+                DkmComponentManager.InitializeThread(DebuggerService.ComponentId);
+
+                try
+                {
+                    var clrModuleInstance = FindClrModuleInstance(m);
+                    if (clrModuleInstance == null)
+                    {
+                        return default;
+                    }
+
+                    var metadata = GetBaselineModuleMetadata(clrModuleInstance);
+                    if (metadata == null)
+                    {
+                        return default;
+                    }
+
+                    // hook up a callback on module unload (the call blocks until the message is processed):
+                    DkmCustomMessage.Create(
+                        Connection: clrModuleInstance.Process.Connection,
+                        Process: clrModuleInstance.Process,
+                        SourceId: DebuggerService.MessageSourceId,
+                        MessageCode: 0,
+                        Parameter1: this,
+                        Parameter2: clrModuleInstance).SendLower();
+
+                    return metadata;
+                }
+                finally
+                {
+                    DkmComponentManager.UninitializeThread(DebuggerService.ComponentId);
+                }
+            });
+        }
+
+        private static ModuleMetadata GetBaselineModuleMetadata(DkmClrModuleInstance module)
+        {
+            IntPtr metadataPtr;
+            uint metadataSize;
+            try
+            {
+                metadataPtr = module.GetBaselineMetaDataBytesPtr(out metadataSize);
+            }
+            catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
+            {
+                return null;
+            }
+
+            return ModuleMetadata.CreateFromMetadata(metadataPtr, (int)metadataSize);
+        }
+
+        private static DkmClrModuleInstance FindClrModuleInstance(Guid mvid)
+        {
+            foreach (var process in DkmProcess.GetProcesses())
+            {
+                foreach (var runtimeInstance in process.GetRuntimeInstances())
+                {
+                    if (runtimeInstance.TagValue == DkmRuntimeInstance.Tag.ClrRuntimeInstance)
+                    {
+                        foreach (var moduleInstance in runtimeInstance.GetModuleInstances())
+                        {
+                            if (moduleInstance.TagValue == DkmModuleInstance.Tag.ClrModuleInstance &&
+                                moduleInstance is DkmClrModuleInstance clrModuleInstance &&
+                                clrModuleInstance.Mvid == mvid)
+                            {
+                                return clrModuleInstance;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ManagedEditAndContinueService.vsdconfigxml
+++ b/src/VisualStudio/Core/Def/ManagedEditAndContinueService.vsdconfigxml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Configuration xmlns="http://schemas.microsoft.com/vstudio/vsdconfig/2008">
+  <DefineGuid Name="ManagedEditAndContinueServiceId" Value="A96BBE03-0408-41E3-8613-6086FD494B43"/>
+  <DefineGuid Name="ManagedEditAndContinueMessageSourceId" Value="58CDF976-1923-48F7-8288-B4189F5700B1"/>
+  <ManagedComponent
+    ComponentId="ManagedEditAndContinueServiceId"
+    ComponentLevel="9991500"
+    Synchronized="true"
+    AssemblyName="Microsoft.VisualStudio.LanguageServices">
+    <Class Name="Microsoft.VisualStudio.LanguageServices.EditAndContinue.DebuggeeModuleMetadataProvider+DebuggerService">
+      <Implements>
+        <InterfaceGroup>
+          <Filter>
+            <SourceId RequiredValue="ManagedEditAndContinueMessageSourceId"/>
+          </Filter>
+          <Interface Name="IDkmCustomMessageForwardReceiver"/>
+        </InterfaceGroup>
+      </Implements>
+    </Class>
+  </ManagedComponent>
+</Configuration>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -380,6 +380,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t apply changes -- module &apos;{0}&apos; has been unloaded..
+        /// </summary>
+        internal static string CantApplyChangesModuleHasBeenUnloaded {
+            get {
+                return ResourceManager.GetString("CantApplyChangesModuleHasBeenUnloaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Capitalization:.
         /// </summary>
         internal static string Capitalization_colon {
@@ -749,6 +758,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Error_while_reading_0_colon_1 {
             get {
                 return ResourceManager.GetString("Error_while_reading_0_colon_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while reading a file.
+        /// </summary>
+        internal static string ErrorReadingFile {
+            get {
+                return ResourceManager.GetString("ErrorReadingFile", resourceCulture);
             }
         }
         
@@ -1212,6 +1230,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Modifiers_must_match_all {
             get {
                 return ResourceManager.GetString("Modifiers_must_match_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Module has been unloaded..
+        /// </summary>
+        internal static string ModuleHasBeenUnloaded {
+            get {
+                return ResourceManager.GetString("ModuleHasBeenUnloaded", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -234,6 +234,9 @@
   <data name="Error_while_reading_0_colon_1" xml:space="preserve">
     <value>Error while reading '{0}': {1}</value>
   </data>
+  <data name="ErrorReadingFile" xml:space="preserve">
+    <value>Error while reading a file</value>
+  </data>
   <data name="Assembly" xml:space="preserve">
     <value>Assembly </value>
   </data>
@@ -961,5 +964,11 @@ Additional information: {1}</value>
   </data>
   <data name="Prefer_local_function_over_anonymous_function" xml:space="preserve">
     <value>Prefere local function over anonymous function</value>
+  </data>
+  <data name="ModuleHasBeenUnloaded" xml:space="preserve">
+    <value>Module has been unloaded.</value>
+  </data>
+  <data name="CantApplyChangesModuleHasBeenUnloaded" xml:space="preserve">
+    <value>Can't apply changes -- module '{0}' has been unloaded.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\..\..\Compilers\Shared\ShadowCopyAnalyzerAssemblyLoader.cs">
       <Link>InternalUtilities\ShadowCopyAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\ExpressionEvaluator\Core\Source\ExpressionCompiler\DkmExceptionUtilities.cs" Link="Implementation\EditAndContinue\Interop\DkmExceptionUtilities.cs" />
     <Compile Update="Implementation\PickMembers\PickMembersDialog.xaml.cs">
       <DependentUpon>PickMembersDialog.xaml</DependentUpon>
     </Compile>
@@ -120,6 +121,9 @@
     <InternalsVisibleToFSharp Include="FSharp.LanguageService" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="ManagedEditAndContinueService.vsdconfigxml" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -139,6 +143,7 @@
     <PackageReference Include="EnvDTE" Version="$(EnvDTEVersion)" />
     <PackageReference Include="EnvDTE80" Version="$(EnvDTE80Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="$(MicrosoftVisualStudioDebuggerEngineVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="$(MicrosoftVisualStudioRemoteControlVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
@@ -246,6 +251,10 @@
       <SubType>Designer</SubType>
     </VSCTCompile>
   </ItemGroup>
+  <ItemGroup>
+    <VsdConfigXml Include="ManagedEditAndContinueService.vsdconfigxml" />
+  </ItemGroup>
   <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />
+  <Import Project="..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Debugger_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Debugger_InProc.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 {
     internal class Debugger_InProc : InProcComponent
     {
-        private readonly Debugger _debugger;
+        private readonly EnvDTE.Debugger _debugger;
 
         private Debugger_InProc()
         {

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -139,7 +139,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Core\Def\ServicesVisualStudio.csproj">
       <Name>ServicesVisualStudio</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;PkgDefProjectOutputGroup;VsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Ngen>true</Ngen>
       <NgenArchitecture>All</NgenArchitecture>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -37,6 +37,7 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="CSharpVisualStudio" Path="|CSharpVisualStudio;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="BasicVisualStudio" Path="VisualBasicPackageRegistration.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="CSharpVisualStudio" Path="CSharpPackageRegistration.pkgdef" />
+    <Asset Type="DebuggerEngineExtension" d:Source="Project" d:ProjectName="ServicesVisualStudio" Path="|ServicesVisualStudio;VsdConfigOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.CSharp.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.VisualBasic.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.EditorFeatures.dll" />


### PR DESCRIPTION
Use Concord APIs to retrieve the baseline metadata blob when applying change during debugging. Previously we read the metadata from the PE file in obj directory and had to lock it to maintain consistency. That prevented another VS instance from rebuilding the project (customer scenario https://devdiv.visualstudio.com/DevDiv/_workitems/edit/96078).

Adds new public APIs:

```C#
namespace Microsoft.CodeAnalysis
{
  class ModuleMetadata
  {
    bool IsDisposed { get; }
  }
}

namespace Microsoft.CodeAnalysis.Emit
{
  class EmitBaseline
  {
    static Emit.EmitBaseline CreateInitialBaseline(
      ModuleMetadata module, 
      Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> debugInformationProvider, 
      Func<System.Reflection.Metadata.MethodDefinitionHandle, StandaloneSignatureHandle> localSignatureProvider, 
      bool hasPortableDebugInformation);
  }
}
```

This change requires the latest vsuml VS build.