### PR TITLE
Adds feature that helps convert keywords and symbols in doc comments to the appropriate tags.

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -2,7 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithSeeElement;
+using Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -1,0 +1,373 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithSeeElement;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ReplaceDocCommentTextWithTag
+{
+    public class ReplaceDocCommentTextWithTagTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable [||]interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestEndOfKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable interface[||].
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestEndOfKeyword_NewLineFollowing()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable interface[||]
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the System.IDisposable <see langword=""interface""/>
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestSelectedKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable [|interface|].
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestInsideKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable int[||]erface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestNotInsideKeywordIfNonEmptySpan()
+        {
+            await TestMissingAsync(
+@"
+/// TKey must implement the System.IDisposable int[|erf|]ace
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfFullyQualifiedTypeName_Start()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the [||]System.IDisposable interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfFullyQualifiedTypeName_Mid1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System[||].IDisposable interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfFullyQualifiedTypeName_Mid2()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.[||]IDisposable interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfFullyQualifiedTypeName_End()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the System.IDisposable[||] interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestStartOfFullyQualifiedTypeName_Selected()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// TKey must implement the [|System.IDisposable|] interface.
+class C<TKey>
+{
+}",
+
+@"
+/// TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestTypeParameterReference()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// [||]TKey must implement the System.IDisposable interface.
+class C<TKey>
+{
+}",
+
+@"
+/// <typeparamref name=""TKey""/> must implement the System.IDisposable interface.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestTypeParameterReference_EmptyClassBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// [||]TKey must implement the System.IDisposable interface.
+class C<TKey>{}",
+
+@"
+/// <typeparamref name=""TKey""/> must implement the System.IDisposable interface.
+class C<TKey>{}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestCanSeeInnerMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// Use WriteLine[||] as a Console.WriteLine replacement
+class C
+{
+    void WriteLine<TKey>(TKey value) { }
+}",
+
+@"
+/// Use <see cref=""WriteLine""/> as a Console.WriteLine replacement
+class C
+{
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestNotOnMispelledName()
+        {
+            await TestMissingAsync(
+@"
+/// Use WriteLine1[||] as a Console.WriteLine replacement
+class C
+{
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodTypeParameterSymbol()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value has type TKey[||] so we don't box primitives.
+    void WriteLine<TKey>(TKey value) { }
+}",
+
+@"
+class C
+{
+    /// value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodTypeParameterSymbol_EmptyBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value has type TKey[||] so we don't box primitives.
+    void WriteLine<TKey>(TKey value){}
+}",
+
+@"
+class C
+{
+    /// value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    void WriteLine<TKey>(TKey value){}
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodTypeParameterSymbol_ExpressionBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value has type TKey[||] so we don't box primitives.
+    object WriteLine<TKey>(TKey value) => null;
+}",
+
+@"
+class C
+{
+    /// value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    object WriteLine<TKey>(TKey value) => null;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodParameterSymbol()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value[||] has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value) { }
+}",
+
+@"
+class C
+{
+    /// <paramref name=""value""/> has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodParameterSymbol_EmptyBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value[||] has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value){}
+}",
+
+@"
+class C
+{
+    /// <paramref name=""value""/> has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value){}
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodParameterSymbol_ExpressionBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value[||] has type TKey so we don't box primitives.
+    object WriteLine<TKey>(TKey value) => null;
+}",
+
+@"
+class C
+{
+    /// <paramref name=""value""/> has type TKey so we don't box primitives.
+    object WriteLine<TKey>(TKey value) => null;
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -314,6 +314,25 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodTypeParameter_SemicolonBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value has type TKey[||] so we don't box primitives.
+    void WriteLine<TKey>(TKey value);
+}",
+
+@"
+class C
+{
+    /// value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    void WriteLine<TKey>(TKey value);
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
         public async Task TestMethodParameterSymbol()
         {
             await TestInRegularAndScriptAsync(
@@ -369,5 +388,25 @@ class C
     object WriteLine<TKey>(TKey value) => null;
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestMethodParameterSymbol_SemicolonBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// value[||] has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value);
+}",
+
+@"
+class C
+{
+    /// <paramref name=""value""/> has type TKey so we don't box primitives.
+    void WriteLine<TKey>(TKey value);
+}");
+        }
+
     }
 }

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -85,6 +85,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsOrderModifiers = "CodeActions.OrderModifiers";
             public const string CodeActionsPopulateSwitch = "CodeActions.PopulateSwitch";
             public const string CodeActionsQualifyMemberAccess = "CodeActions.QualifyMemberAccess";
+            public const string CodeActionsReplaceDocCommentTextWithTag = "CodeActions.ReplaceDocCommentTextWithTag";
             public const string CodeActionsReplaceMethodWithProperty = "CodeActions.ReplaceMethodWithProperty";
             public const string CodeActionsReplacePropertyWithMethods = "CodeActions.ReplacePropertyWithMethods";
             public const string CodeActionsRemoveByVal = "CodeActions.RemoveByVal";

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -1,0 +1,319 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
+Imports Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ReplaceDocCommentTextWithTag
+    Public Class ReplaceDocCommentTextWithTagTests
+        Inherits AbstractVisualBasicCodeActionTest
+
+        Protected Overrides Function CreateCodeRefactoringProvider(Workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+            Return New VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfKeyword() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable [||]interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfKeywordCapitalized() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable [||]Interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""Interface""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestEndOfKeyword() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable interface[||].
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestEndOfKeyword_NewLineFollowing() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable interface[||]
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""interface""/>
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestSelectedKeyword() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable [|interface|].
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestInsideKeyword() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable int[||]erface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestNotInsideKeywordIfNonEmptySpan() As Task
+            Await TestMissingAsync(
+"
+''' TKey must implement the System.IDisposable int[|erf|]ace
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_Start() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the [||]System.IDisposable interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_Mid1() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System[||].IDisposable interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_Mid2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.[||]IDisposable interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_End() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the System.IDisposable[||] interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_CaseInsensitive() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the [||]system.idisposable interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""system.idisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestStartOfFullyQualifiedTypeName_Selected() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' TKey must implement the [|System.IDisposable|] interface.
+class C(Of TKey)
+end class",
+"
+''' TKey must implement the <see cref=""System.IDisposable""/> interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestTypeParameterReference() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' [||]TKey must implement the System.IDisposable interface.
+class C(Of TKey)
+end class",
+"
+''' <typeparamref name=""TKey""/> must implement the System.IDisposable interface.
+class C(Of TKey)
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestCanSeeInnerMethod() As Task
+            Await TestInRegularAndScriptAsync(
+"
+''' Use WriteLine[||] as a Console.WriteLine replacement
+class C
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class",
+"
+''' Use <see cref=""WriteLine""/> as a Console.WriteLine replacement
+class C
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestNotOnMispelledName() As Task
+            Await TestMissingAsync(
+"
+''' Use WriteLine1[||] as a Console.WriteLine replacement
+class C
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodTypeParameterSymbol() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    ''' value has type TKey[||] so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class",
+"
+class C
+    ''' value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodTypeParameterSymbol_CaseInsensitive() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    ''' value has type TKey[||] so we don't box primitives.
+    sub WriteLine(Of tkey)(value as TKey)
+    end sub
+end class",
+"
+class C
+    ''' value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    sub WriteLine(Of tkey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodTypeParameterSymbol_EmptyBody() As Task
+            Await TestInRegularAndScriptAsync(
+"
+interface I
+    ''' value has type TKey[||] so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+end interface",
+"
+interface I
+    ''' value has type <typeparamref name=""TKey""/> so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+end interface")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodParameterSymbol() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    ''' value[||] has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class",
+"
+class C
+    ''' <paramref name=""value""/> has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodParameterSymbol_CaseInsensitive() As Task
+            Await TestInRegularAndScriptAsync(
+"
+class C
+    ''' value[||] has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(Value as TKey)
+    end sub
+end class",
+"
+class C
+    ''' <paramref name=""value""/> has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(Value as TKey)
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestMethodParameterSymbol_EmptyBody() As Task
+            Await TestInRegularAndScriptAsync(
+"
+interface I
+    ''' value[||] has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+end interface",
+"
+interface I
+    ''' <paramref name=""value""/> has type TKey so we don't box primitives.
+    sub WriteLine(Of TKey)(value as TKey)
+end interface")
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithSeeElement/ReplaceDocCommentTextWithSeeTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithSeeElement/ReplaceDocCommentTextWithSeeTagCodeRefactoringProvider.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithSeeElement
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
+    internal class ReplaceDocCommentTextWithSeeTagCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var span = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var token = root.FindToken(span.Start, findInsideTrivia: true);
+
+            if (token.Kind() != SyntaxKind.XmlTextLiteralToken &&
+                token.Kind() != SyntaxKind.XmlTextLiteralNewLineToken)
+            {
+                return;
+            }
+
+            if (!token.FullSpan.Contains(span))
+            {
+                return;
+            }
+
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            var expandedSpan = ExpandSpan(sourceText, span, includeDots: false);
+            var text = sourceText.ToString(expandedSpan);
+
+            if (SyntaxFacts.GetKeywordKind(text) != SyntaxKind.None ||
+                SyntaxFacts.GetContextualKeywordKind(text) != SyntaxKind.None)
+            {
+                RegisterRefactoring(context, expandedSpan, $@"<see langword=""{text}""/>");
+                return;
+            }
+
+            var memberDecl = token.Parent.GetAncestorOrThis<MemberDeclarationSyntax>();
+            if (memberDecl == null)
+            {
+                return;
+            }
+
+            expandedSpan = ExpandSpan(sourceText, span, includeDots: true);
+            text = sourceText.ToString(expandedSpan);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            var speculativePosition = memberDecl.GetLastToken().FullSpan.Start - 1;
+            if (!TryMatchTextAsSymbol(context, expandedSpan, text, semanticModel, speculativePosition, SpeculativeBindingOption.BindAsTypeOrNamespace) &&
+                !TryMatchTextAsSymbol(context, expandedSpan, text, semanticModel, speculativePosition, SpeculativeBindingOption.BindAsExpression))
+            {
+                return;
+            }
+        }
+
+        private void RegisterRefactoring(
+            CodeRefactoringContext context, TextSpan expandedSpan, string replacement)
+        {
+            context.RegisterRefactoring(new MyCodeAction(
+                string.Format(FeaturesResources.Use_0, replacement),
+                c => ReplaceTextAsync(context.Document, expandedSpan, replacement, c)));
+        }
+
+        private bool TryMatchTextAsSymbol(
+            CodeRefactoringContext context, TextSpan expandedSpan, 
+            string text, SemanticModel semanticModel, 
+            int speculativePosition, SpeculativeBindingOption binding)
+        {
+            var parsed = SyntaxFactory.ParseExpression(text);
+
+            var symbolInfo = semanticModel.GetSpeculativeSymbolInfo(speculativePosition, parsed, binding);
+            switch (symbolInfo.GetAnySymbol())
+            {
+                case IParameterSymbol parameter:
+                    RegisterRefactoring(context, expandedSpan, $@"<paramref name=""{text}""/>");
+                    return true;
+                case ITypeParameterSymbol typeParameter:
+                    RegisterRefactoring(context, expandedSpan, $@"<typeparamref name=""{text}""/>");
+                    return true;
+                case ISymbol symbol:
+                    RegisterRefactoring(context, expandedSpan, $@"<see cref=""{text}""/>");
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private async Task<Document> ReplaceTextAsync(
+            Document document, TextSpan span, string replacement, CancellationToken cancellationToken)
+        {
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var newText = text.Replace(span, replacement);
+
+            return document.WithText(newText);
+        }
+
+        private TextSpan ExpandSpan(SourceText sourceText, TextSpan span, bool includeDots)
+        {
+            if (span.Length != 0)
+            {
+                return span;
+            }
+
+            var start = span.Start;
+            var end = span.Start;
+            while (start > 0 && ExpandBackward(sourceText, start, includeDots))
+            {
+                start--;
+            }
+
+            while (end < sourceText.Length && ExpandForward(sourceText, end, includeDots))
+            {
+                end++;
+            }
+
+            return TextSpan.FromBounds(start, end);
+        }
+
+        private bool ExpandForward(SourceText sourceText, int end, bool includeDots)
+        {
+            var currentChar = sourceText[end];
+
+            if (char.IsLetterOrDigit(currentChar))
+            {
+                return true;
+            }
+
+            // Only consume a dot in front of the current word if it is part of a dotted
+            // word chain, and isn't just the end of a sentence.
+            if (includeDots && currentChar == '.' &&
+                end + 1 < sourceText.Length && char.IsLetterOrDigit(sourceText[end + 1]))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ExpandBackward(
+            SourceText sourceText, int start, bool includeDots)
+        {
+            var previousCharacter = sourceText[start - 1];
+            if (char.IsLetterOrDigit(previousCharacter))
+            {
+                return true;
+            }
+
+            if (includeDots && previousCharacter == '.')
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) 
+                : base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -12,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithSeeElement
+namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
     internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider : CodeRefactoringProvider

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
     internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
-        AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider<MemberDeclarationSyntax>
+        AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
     {
         protected override bool IsXmlTextToken(SyntaxToken token)
             => token.Kind() == SyntaxKind.XmlTextLiteralToken ||

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -1,177 +1,25 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag;
 
 namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
-    internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider : CodeRefactoringProvider
+    internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
+        AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider<MemberDeclarationSyntax>
     {
-        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
-        {
-            var document = context.Document;
-            var span = context.Span;
-            var cancellationToken = context.CancellationToken;
+        protected override bool IsXmlTextToken(SyntaxToken token)
+            => token.Kind() == SyntaxKind.XmlTextLiteralToken ||
+               token.Kind() == SyntaxKind.XmlTextLiteralNewLineToken;
 
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var token = root.FindToken(span.Start, findInsideTrivia: true);
+        protected override bool IsAnyKeyword(string text)
+            => SyntaxFacts.GetKeywordKind(text) != SyntaxKind.None ||
+               SyntaxFacts.GetContextualKeywordKind(text) != SyntaxKind.None;
 
-            if (token.Kind() != SyntaxKind.XmlTextLiteralToken &&
-                token.Kind() != SyntaxKind.XmlTextLiteralNewLineToken)
-            {
-                return;
-            }
-
-            if (!token.FullSpan.Contains(span))
-            {
-                return;
-            }
-
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            var expandedSpan = ExpandSpan(sourceText, span, fullyQualifiedName: false);
-            var text = sourceText.ToString(expandedSpan);
-
-            if (SyntaxFacts.GetKeywordKind(text) != SyntaxKind.None ||
-                SyntaxFacts.GetContextualKeywordKind(text) != SyntaxKind.None)
-            {
-                RegisterRefactoring(context, expandedSpan, $@"<see langword=""{text}""/>");
-                return;
-            }
-
-            var memberDecl = token.Parent.GetAncestorOrThis<MemberDeclarationSyntax>();
-            if (memberDecl == null)
-            {
-                return;
-            }
-
-            expandedSpan = ExpandSpan(sourceText, span, fullyQualifiedName: true);
-            text = sourceText.ToString(expandedSpan);
-
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            var speculativePosition = memberDecl.GetLastToken().FullSpan.Start - 1;
-            if (!TryMatchTextAsSymbol(context, expandedSpan, text, semanticModel, speculativePosition, SpeculativeBindingOption.BindAsTypeOrNamespace) &&
-                !TryMatchTextAsSymbol(context, expandedSpan, text, semanticModel, speculativePosition, SpeculativeBindingOption.BindAsExpression))
-            {
-                return;
-            }
-        }
-
-        private void RegisterRefactoring(
-            CodeRefactoringContext context, TextSpan expandedSpan, string replacement)
-        {
-            context.RegisterRefactoring(new MyCodeAction(
-                string.Format(FeaturesResources.Use_0, replacement),
-                c => ReplaceTextAsync(context.Document, expandedSpan, replacement, c)));
-        }
-
-        private bool TryMatchTextAsSymbol(
-            CodeRefactoringContext context, TextSpan expandedSpan, 
-            string text, SemanticModel semanticModel, 
-            int speculativePosition, SpeculativeBindingOption binding)
-        {
-            var parsed = SyntaxFactory.ParseExpression(text);
-
-            var symbolInfo = semanticModel.GetSpeculativeSymbolInfo(speculativePosition, parsed, binding);
-            switch (symbolInfo.GetAnySymbol())
-            {
-                case IParameterSymbol parameter:
-                    RegisterRefactoring(context, expandedSpan, $@"<paramref name=""{text}""/>");
-                    return true;
-                case ITypeParameterSymbol typeParameter:
-                    RegisterRefactoring(context, expandedSpan, $@"<typeparamref name=""{text}""/>");
-                    return true;
-                case ISymbol symbol:
-                    RegisterRefactoring(context, expandedSpan, $@"<see cref=""{text}""/>");
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        private async Task<Document> ReplaceTextAsync(
-            Document document, TextSpan span, string replacement, CancellationToken cancellationToken)
-        {
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var newText = text.Replace(span, replacement);
-
-            return document.WithText(newText);
-        }
-
-        private TextSpan ExpandSpan(SourceText sourceText, TextSpan span, bool fullyQualifiedName)
-        {
-            if (span.Length != 0)
-            {
-                return span;
-            }
-
-            var start = span.Start;
-            var end = span.Start;
-            while (start > 0 && ExpandBackward(sourceText, start, fullyQualifiedName))
-            {
-                start--;
-            }
-
-            while (end < sourceText.Length && ExpandForward(sourceText, end, fullyQualifiedName))
-            {
-                end++;
-            }
-
-            return TextSpan.FromBounds(start, end);
-        }
-
-        private bool ExpandForward(SourceText sourceText, int end, bool fullyQualifiedName)
-        {
-            var currentChar = sourceText[end];
-
-            if (char.IsLetterOrDigit(currentChar))
-            {
-                return true;
-            }
-
-            // Only consume a dot in front of the current word if it is part of a dotted
-            // word chain, and isn't just the end of a sentence.
-            if (fullyQualifiedName && currentChar == '.' &&
-                end + 1 < sourceText.Length && char.IsLetterOrDigit(sourceText[end + 1]))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool ExpandBackward(
-            SourceText sourceText, int start, bool fullyQualifiedName)
-        {
-            var previousCharacter = sourceText[start - 1];
-            if (char.IsLetterOrDigit(previousCharacter))
-            {
-                return true;
-            }
-
-            if (fullyQualifiedName && previousCharacter == '.')
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private class MyCodeAction : CodeAction.DocumentChangeAction
-        {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) 
-                : base(title, createChangedDocument)
-            {
-            }
-        }
+        protected override SyntaxNode ParseExpression(string text)
+            => SyntaxFactory.ParseExpression(text);
     }
 }

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithSeeElement
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
-    internal class ReplaceDocCommentTextWithSeeTagCodeRefactoringProvider : CodeRefactoringProvider
+    internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider : CodeRefactoringProvider
     {
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -3355,6 +3355,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use {0}.
+        /// </summary>
+        internal static string Use_0 {
+            get {
+                return ResourceManager.GetString("Use_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use auto property.
         /// </summary>
         internal static string Use_auto_property {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1301,4 +1301,7 @@ This version used in: {2}</value>
   <data name="Warning_Method_overrides_symbol_from_metadata" xml:space="preserve">
     <value>Warning: Method overrides symbol from metadata</value>
   </data>
+  <data name="Use_0" xml:space="preserve">
+    <value>Use {0}</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -93,7 +93,8 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
                 return;
             }
 
-            // Look up the term inside the named type if we're inside of one.
+            // Doc comments on a named type can see the members inside of it.  So check
+            // inside the named type for a member that matches.
             if (symbol is INamedTypeSymbol namedType)
             {
                 var childMember = namedType.GetMembers().FirstOrDefault(m => syntaxFacts.StringComparer.Equals(m.Name, singleWordText));

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -171,12 +172,14 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 
             var start = span.Start;
             var end = span.Start;
-            while (start > 0 && ExpandBackward(sourceText, start, fullyQualifiedName))
+            while (start > 0 &&
+                   ShouldExpandSpanBackwardOneCharacter(sourceText, start, fullyQualifiedName))
             {
                 start--;
             }
 
-            while (end < sourceText.Length && ExpandForward(sourceText, end, fullyQualifiedName))
+            while (end < sourceText.Length && 
+                   ShouldExpandSpanForwardOneCharacter(sourceText, end, fullyQualifiedName))
             {
                 end++;
             }
@@ -184,7 +187,7 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             return TextSpan.FromBounds(start, end);
         }
 
-        private bool ExpandForward(SourceText sourceText, int end, bool fullyQualifiedName)
+        private bool ShouldExpandSpanForwardOneCharacter(SourceText sourceText, int end, bool fullyQualifiedName)
         {
             var currentChar = sourceText[end];
 
@@ -204,9 +207,11 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             return false;
         }
 
-        private bool ExpandBackward(
+        private bool ShouldExpandSpanBackwardOneCharacter(
             SourceText sourceText, int start, bool fullyQualifiedName)
         {
+            Debug.Assert(start > 0);
+
             var previousCharacter = sourceText[start - 1];
             if (char.IsLetterOrDigit(previousCharacter))
             {

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -170,26 +170,27 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
                 return span;
             }
 
-            var start = span.Start;
-            var end = span.Start;
-            while (start > 0 &&
-                   ShouldExpandSpanBackwardOneCharacter(sourceText, start, fullyQualifiedName))
+            var startInclusive = span.Start;
+            var endExclusive = span.Start;
+            while (startInclusive > 0 &&
+                   ShouldExpandSpanBackwardOneCharacter(sourceText, startInclusive, fullyQualifiedName))
             {
-                start--;
+                startInclusive--;
             }
 
-            while (end < sourceText.Length && 
-                   ShouldExpandSpanForwardOneCharacter(sourceText, end, fullyQualifiedName))
+            while (endExclusive < sourceText.Length && 
+                   ShouldExpandSpanForwardOneCharacter(sourceText, endExclusive, fullyQualifiedName))
             {
-                end++;
+                endExclusive++;
             }
 
-            return TextSpan.FromBounds(start, end);
+            return TextSpan.FromBounds(startInclusive, endExclusive);
         }
 
-        private bool ShouldExpandSpanForwardOneCharacter(SourceText sourceText, int end, bool fullyQualifiedName)
+        private bool ShouldExpandSpanForwardOneCharacter(
+            SourceText sourceText, int endExclusive, bool fullyQualifiedName)
         {
-            var currentChar = sourceText[end];
+            var currentChar = sourceText[endExclusive];
 
             if (char.IsLetterOrDigit(currentChar))
             {
@@ -199,7 +200,7 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             // Only consume a dot in front of the current word if it is part of a dotted
             // word chain, and isn't just the end of a sentence.
             if (fullyQualifiedName && currentChar == '.' &&
-                end + 1 < sourceText.Length && char.IsLetterOrDigit(sourceText[end + 1]))
+                endExclusive + 1 < sourceText.Length && char.IsLetterOrDigit(sourceText[endExclusive + 1]))
             {
                 return true;
             }
@@ -208,11 +209,11 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
         }
 
         private bool ShouldExpandSpanBackwardOneCharacter(
-            SourceText sourceText, int start, bool fullyQualifiedName)
+            SourceText sourceText, int startInclusive, bool fullyQualifiedName)
         {
-            Debug.Assert(start > 0);
+            Debug.Assert(startInclusive > 0);
 
-            var previousCharacter = sourceText[start - 1];
+            var previousCharacter = sourceText[startInclusive - 1];
             if (char.IsLetterOrDigit(previousCharacter))
             {
                 return true;

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -147,29 +147,6 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
                 c => ReplaceTextAsync(context.Document, expandedSpan, replacement, c)));
         }
 
-        //private bool TryMatchTextAsSymbol(
-        //    CodeRefactoringContext context, TextSpan expandedSpan, 
-        //    string text, SemanticModel semanticModel, 
-        //    int speculativePosition, SpeculativeBindingOption binding)
-        //{
-        //    var parsed = ParseExpression(text);
-
-        //    var symbolInfo = semanticModel.GetSpeculativeSymbolInfo(speculativePosition, parsed, binding);
-        //    switch (symbolInfo.GetAnySymbol())
-        //    {
-        //        case IParameterSymbol parameter:
-                    
-        //            return true;
-        //        case ITypeParameterSymbol typeParameter:
-        //            return true;
-        //        case ISymbol symbol:
-        //            RegisterRefactoring(context, expandedSpan, $@"<see cref=""{text}""/>");
-        //            return true;
-        //        default:
-        //            return false;
-        //    }
-        //}
-
         private async Task<Document> ReplaceTextAsync(
             Document document, TextSpan span, string replacement, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -13,9 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 {
-    internal abstract class AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider<TMemberDeclarationSyntax>
-        : CodeRefactoringProvider
-        where TMemberDeclarationSyntax : SyntaxNode
+    internal abstract class AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider : CodeRefactoringProvider
     {
         protected abstract bool IsAnyKeyword(string text);
         protected abstract bool IsXmlTextToken(SyntaxToken token);

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
+{
+    internal abstract class AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider<TMemberDeclarationSyntax>
+        : CodeRefactoringProvider
+        where TMemberDeclarationSyntax : SyntaxNode
+    {
+        protected abstract bool IsAnyKeyword(string text);
+        protected abstract bool IsXmlTextToken(SyntaxToken token);
+        protected abstract SyntaxNode ParseExpression(string text);
+
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var span = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var token = root.FindToken(span.Start, findInsideTrivia: true);
+
+            if (!IsXmlTextToken(token))
+            {
+                return;
+            }
+
+            if (!token.FullSpan.Contains(span))
+            {
+                return;
+            }
+
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            var singleWordSpan = ExpandSpan(sourceText, span, fullyQualifiedName: false);
+            var singleWordText = sourceText.ToString(singleWordSpan);
+            if (singleWordText == "")
+            {
+                return;
+            }
+
+            // First see if they're on a keyword. 
+            if (IsAnyKeyword(singleWordText))
+            {
+                RegisterRefactoring(context, singleWordSpan, $@"<see langword=""{singleWordText}""/>");
+                return;
+            }
+
+            // Not a keyword, see if it semantically means anything in the current context.
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var symbol = GetEnclosingSymbol(semanticModel, span.Start, cancellationToken);
+            if (symbol == null)
+            {
+                return;
+            }
+
+            // See if we can expand the term out to a fully qualified name. Do this
+            // first in case the user has something like X.memberName.  We don't want 
+            // to try to bind "memberName" first as it might bind to something like 
+            // a parameter, which is not what the user intends
+            var fullyQualifiedSpan = ExpandSpan(sourceText, span, fullyQualifiedName: true);
+            if (fullyQualifiedSpan != singleWordSpan)
+            {
+                var fullyQualifiedText = sourceText.ToString(fullyQualifiedSpan);
+                if (TryParseAndBindText(context, semanticModel, token, fullyQualifiedSpan, fullyQualifiedText))
+                {
+                    return;
+                }
+            }
+
+            // Check if the single word could be binding to a type parameter or parameter
+            // for the current symbol.
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var parameter = symbol.GetParameters().FirstOrDefault(p => syntaxFacts.StringComparer.Equals(p.Name, singleWordText));
+            if (parameter != null)
+            {
+                RegisterRefactoring(context, singleWordSpan, $@"<paramref name=""{singleWordText}""/>");
+                return;
+            }
+
+            var typeParameter = symbol.GetTypeParameters().FirstOrDefault(t => syntaxFacts.StringComparer.Equals(t.Name, singleWordText));
+            if (typeParameter != null)
+            {
+                RegisterRefactoring(context, singleWordSpan, $@"<typeparamref name=""{singleWordText}""/>");
+                return;
+            }
+
+            // Look up the term inside the named type if we're inside of one.
+            if (symbol is INamedTypeSymbol namedType)
+            {
+                var childMember = namedType.GetMembers().FirstOrDefault(m => syntaxFacts.StringComparer.Equals(m.Name, singleWordText));
+                if (childMember != null)
+                {
+                    RegisterRefactoring(context, singleWordSpan, $@"<see cref=""{singleWordText}""/>");
+                    return;
+                }
+            }
+
+            // Finally, try to speculatively bind the name and see if it binds to anything
+            // in the surrounding context.
+            TryParseAndBindText(context, semanticModel, token, singleWordSpan, singleWordText);
+        }
+
+        private bool TryParseAndBindText(
+            CodeRefactoringContext context, SemanticModel semanticModel, SyntaxToken token, TextSpan replacementSpan, string text)
+        {
+            var parsed = ParseExpression(text);
+            var foundSymbol = semanticModel.GetSpeculativeSymbolInfo(token.SpanStart, parsed, SpeculativeBindingOption.BindAsExpression).GetAnySymbol();
+            if (foundSymbol == null)
+            {
+                return false;
+            }
+
+            RegisterRefactoring(context, replacementSpan, $@"<see cref=""{text}""/>");
+            return true;
+        }
+
+        private ISymbol GetEnclosingSymbol(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
+        {
+            var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
+            var token = root.FindToken(position);
+
+            for (var node = token.Parent; node != null; node = node.Parent)
+            {
+                if (semanticModel.GetDeclaredSymbol(node) is ISymbol declaration)
+                {
+                    return declaration;
+                }
+            }
+
+            return null;
+        }
+
+        private void RegisterRefactoring(
+            CodeRefactoringContext context, TextSpan expandedSpan, string replacement)
+        {
+            context.RegisterRefactoring(new MyCodeAction(
+                string.Format(FeaturesResources.Use_0, replacement),
+                c => ReplaceTextAsync(context.Document, expandedSpan, replacement, c)));
+        }
+
+        //private bool TryMatchTextAsSymbol(
+        //    CodeRefactoringContext context, TextSpan expandedSpan, 
+        //    string text, SemanticModel semanticModel, 
+        //    int speculativePosition, SpeculativeBindingOption binding)
+        //{
+        //    var parsed = ParseExpression(text);
+
+        //    var symbolInfo = semanticModel.GetSpeculativeSymbolInfo(speculativePosition, parsed, binding);
+        //    switch (symbolInfo.GetAnySymbol())
+        //    {
+        //        case IParameterSymbol parameter:
+                    
+        //            return true;
+        //        case ITypeParameterSymbol typeParameter:
+        //            return true;
+        //        case ISymbol symbol:
+        //            RegisterRefactoring(context, expandedSpan, $@"<see cref=""{text}""/>");
+        //            return true;
+        //        default:
+        //            return false;
+        //    }
+        //}
+
+        private async Task<Document> ReplaceTextAsync(
+            Document document, TextSpan span, string replacement, CancellationToken cancellationToken)
+        {
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var newText = text.Replace(span, replacement);
+
+            return document.WithText(newText);
+        }
+
+        private TextSpan ExpandSpan(SourceText sourceText, TextSpan span, bool fullyQualifiedName)
+        {
+            if (span.Length != 0)
+            {
+                return span;
+            }
+
+            var start = span.Start;
+            var end = span.Start;
+            while (start > 0 && ExpandBackward(sourceText, start, fullyQualifiedName))
+            {
+                start--;
+            }
+
+            while (end < sourceText.Length && ExpandForward(sourceText, end, fullyQualifiedName))
+            {
+                end++;
+            }
+
+            return TextSpan.FromBounds(start, end);
+        }
+
+        private bool ExpandForward(SourceText sourceText, int end, bool fullyQualifiedName)
+        {
+            var currentChar = sourceText[end];
+
+            if (char.IsLetterOrDigit(currentChar))
+            {
+                return true;
+            }
+
+            // Only consume a dot in front of the current word if it is part of a dotted
+            // word chain, and isn't just the end of a sentence.
+            if (fullyQualifiedName && currentChar == '.' &&
+                end + 1 < sourceText.Length && char.IsLetterOrDigit(sourceText[end + 1]))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ExpandBackward(
+            SourceText sourceText, int start, bool fullyQualifiedName)
+        {
+            var previousCharacter = sourceText[start - 1];
+            if (char.IsLetterOrDigit(previousCharacter))
+            {
+                return true;
+            }
+
+            if (fullyQualifiedName && previousCharacter == '.')
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) 
+                : base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -1,0 +1,26 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
+    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
+        Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
+
+        Protected Overrides Function IsXmlTextToken(token As SyntaxToken) As Boolean
+            Return token.Kind() = SyntaxKind.XmlTextLiteralToken OrElse
+                   token.Kind() = SyntaxKind.DocumentationCommentLineBreakToken
+        End Function
+
+        Protected Overrides Function IsAnyKeyword(text As String) As Boolean
+            Return SyntaxFacts.GetKeywordKind(text) <> SyntaxKind.None OrElse
+                   SyntaxFacts.GetContextualKeywordKind(text) <> SyntaxKind.None
+        End Function
+
+        Protected Overrides Function ParseExpression(text As String) As SyntaxNode
+            Return SyntaxFactory.ParseExpression(text)
+        End Function
+    End Class
+End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             {
                 case IMethodSymbol m: return m.Parameters;
                 case IPropertySymbol nt: return nt.Parameters;
-                default: return ImmutableArray.Create<IParameterSymbol>();
+                default: return ImmutableArray<IParameterSymbol>.Empty;
             }
         }
 
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             {
                 case IMethodSymbol m: return m.TypeParameters;
                 case INamedTypeSymbol nt: return nt.TypeParameters;
-                default: return ImmutableArray.Create<ITypeParameterSymbol>();
+                default: return ImmutableArray<ITypeParameterSymbol>.Empty;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21469