### PR TITLE
Remove Release subdir from template output path

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -102,7 +102,7 @@
         "Vsix\\VisualStudioSetup.Next\\Roslyn.VisualStudio.Setup.Next.vsix",
         "Vsix\\VisualStudioSetup\\Roslyn.VisualStudio.Setup.vsix",
         "Vsix\\Roslyn\\RoslynDeployment.vsix",
-        "Vsix\\Templates\\Roslyn Templates\\Release\\Roslyn SDK.vsix"
+        "Vsix\\Templates\\Roslyn SDK.vsix"
       ]
     }
   ],

--- a/src/Setup/Templates/Templates.csproj
+++ b/src/Setup/Templates/Templates.csproj
@@ -17,9 +17,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <DeployVSTemplates>false</DeployVSTemplates>
     <CopyZipOutputToOutputDirectory>false</CopyZipOutputToOutputDirectory>
-    <BaseIntermediateOutputPath>$(BaseIntermediateOutputPath)\$(VersionType)\</BaseIntermediateOutputPath>
-    <VsixOutDirSuffix>Roslyn Templates\$(VersionType)</VsixOutDirSuffix>
-    <TargetVsixContainerName>$(VsixOutDirSuffix)\Roslyn SDK.vsix</TargetVsixContainerName>
+    <TargetVsixContainerName>Roslyn SDK.vsix</TargetVsixContainerName>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>


### PR DESCRIPTION
Having "Release" hardcoded in SignToolData.json breaks Debug builds.