### PR TITLE
DesktopShim throws on .NET Core

### DIFF
--- a/src/Compilers/Shared/DesktopShim.cs
+++ b/src/Compilers/Shared/DesktopShim.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Utilities
 
             private static PropertyInfo s_fusionLog = Type?.GetTypeInfo().GetDeclaredProperty("FusionLog");
 
-            internal static string TryGetFusionLog(object obj) => s_fusionLog.GetValue(obj) as string;
+            internal static string TryGetFusionLog(object obj) => s_fusionLog?.GetValue(obj) as string;
         }
     }
 }


### PR DESCRIPTION
On .NET Core this method throws a `NullReferenceException` since `Type` (and thus `s_fusionLog`) is null.