### PR TITLE
Move to GitLink 3.0.0

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -8,7 +8,7 @@
     <EnvDTEVersion>8.0.1</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
     <FakeSignVersion>0.9.2</FakeSignVersion>
-    <GitLinkVersion>3.0.0-unstable0090</GitLinkVersion>
+    <GitLinkVersion>3.0.0</GitLinkVersion>
     <LibGit2SharpVersion>0.22.0</LibGit2SharpVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
     <MicroBuildCoreSentinelVersion>1.0.0</MicroBuildCoreSentinelVersion>


### PR DESCRIPTION
This will fix the issue that backtick files are not being included in git linking. 