### PR TITLE
Fix ctrl click crash

### DIFF
--- a/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
+++ b/src/EditorFeatures/Core/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
@@ -55,6 +55,10 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 }
 
                 var service = document.GetLanguageService<IGoToSymbolService>();
+                if (service == null)
+                {
+                    return null;
+                }
 
                 var context = new GoToSymbolContext(document, position, cancellationToken);
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -321,6 +321,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                                 if (document != null)
                                 {
+                                    await TrackSemanticVersionsAsync(document, workItem, cancellationToken).ConfigureAwait(false);
+
                                     // if we are called because a document is opened, we invalidate the document so that
                                     // it can be re-analyzed. otherwise, since newly opened document has same version as before
                                     // analyzer will simply return same data back
@@ -368,6 +370,33 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // remove one that is finished running
                             _workItemQueue.RemoveCancellationSource(workItem.DocumentId);
                         }
+                    }
+
+                    private async Task TrackSemanticVersionsAsync(Document document, WorkItem workItem, CancellationToken cancellationToken)
+                    {
+                        if (workItem.IsRetry ||
+                            workItem.InvocationReasons.Contains(PredefinedInvocationReasons.DocumentAdded) ||
+                            !workItem.InvocationReasons.Contains(PredefinedInvocationReasons.SyntaxChanged))
+                        {
+                            return;
+                        }
+
+                        var service = document.Project.Solution.Workspace.Services.GetService<ISemanticVersionTrackingService>();
+                        if (service == null)
+                        {
+                            return;
+                        }
+
+                        // we already reported about this project for same snapshot, don't need to do it again
+                        if (_currentSnapshotVersionTrackingSet.Contains(document.Project.Id))
+                        {
+                            return;
+                        }
+
+                        await service.RecordSemanticVersionsAsync(document.Project, cancellationToken).ConfigureAwait(false);
+
+                        // mark this project as already processed.
+                        _currentSnapshotVersionTrackingSet.Add(document.Project.Id);
                     }
 
                     private async Task ProcessOpenDocumentIfNeeded(ImmutableArray<IIncrementalAnalyzer> analyzers, WorkItem workItem, Document document, bool isOpen, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -296,6 +296,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 switch (e.Kind)
                 {
                     case WorkspaceChangeKind.ProjectAdded:
+                        OnProjectAdded(e.NewSolution.GetProject(e.ProjectId));
                         EnqueueEvent(e.NewSolution, e.ProjectId, InvocationReasons.DocumentAdded, asyncToken);
                         break;
                     case WorkspaceChangeKind.ProjectRemoved:
@@ -315,6 +316,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 switch (e.Kind)
                 {
                     case WorkspaceChangeKind.SolutionAdded:
+                        OnSolutionAdded(e.NewSolution);
                         EnqueueEvent(e.NewSolution, InvocationReasons.DocumentAdded, asyncToken);
                         break;
                     case WorkspaceChangeKind.SolutionRemoved:
@@ -330,6 +332,32 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     default:
                         throw ExceptionUtilities.UnexpectedValue(e.Kind);
                 }
+            }
+
+            private void OnSolutionAdded(Solution solution)
+            {
+                var asyncToken = _listener.BeginAsyncOperation("OnSolutionAdded");
+                _eventProcessingQueue.ScheduleTask(() =>
+                {
+                    var semanticVersionTrackingService = solution.Workspace.Services.GetService<ISemanticVersionTrackingService>();
+                    if (semanticVersionTrackingService != null)
+                    {
+                        semanticVersionTrackingService.LoadInitialSemanticVersions(solution);
+                    }
+                }, _shutdownToken).CompletesAsyncOperation(asyncToken);
+            }
+
+            private void OnProjectAdded(Project project)
+            {
+                var asyncToken = _listener.BeginAsyncOperation("OnProjectAdded");
+                _eventProcessingQueue.ScheduleTask(() =>
+                {
+                    var semanticVersionTrackingService = project.Solution.Workspace.Services.GetService<ISemanticVersionTrackingService>();
+                    if (semanticVersionTrackingService != null)
+                    {
+                        semanticVersionTrackingService.LoadInitialSemanticVersions(project);
+                    }
+                }, _shutdownToken).CompletesAsyncOperation(asyncToken);
             }
 
             private void EnqueueEvent(Solution oldSolution, Solution newSolution, IAsyncToken asyncToken)

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
@@ -7,12 +7,11 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Navigation;
+using EnvDTE;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Editor.Implementation.Preview;
-using IVsUIShell = Microsoft.VisualStudio.Shell.Interop.IVsUIShell;
-using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 {
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 
         private readonly string _id;
         private readonly bool _logIdVerbatimInTelemetry;
-        private readonly IVsUIShell _uiShell;
+        private readonly DTE _dte;
 
         private bool _isExpanded;
         private double _heightForThreeLineTitle;
@@ -40,14 +39,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             string helpLinkToolTipText,
             IReadOnlyList<object> previewContent,
             bool logIdVerbatimInTelemetry,
-            IVsUIShell uiShell,
+            DTE dte,
             Guid optionPageGuid = default(Guid))
         {
             InitializeComponent();
 
             _id = id;
             _logIdVerbatimInTelemetry = logIdVerbatimInTelemetry;
-            _uiShell = uiShell;
+            _dte = dte;
 
             // Initialize header portion.
             if ((severityIcon != null) && !string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(title))
@@ -359,11 +358,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         {
             if (_optionPageGuid != default(Guid))
             {
-                ErrorHandler.ThrowOnFailure(_uiShell.PostExecCommand(
-                    VSConstants.GUID_VSStandardCommandSet97,
-                    (uint)VSConstants.VSStd97CmdID.ToolsOptions,
-                    (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT,
-                    _optionPageGuid.ToString()));
+                _dte.ExecuteCommand("Tools.Options", _optionPageGuid.ToString());
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -18,20 +18,18 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell;
-using IVsUIShell = Microsoft.VisualStudio.Shell.Interop.IVsUIShell;
-using SVsUIShell = Microsoft.VisualStudio.Shell.Interop.SVsUIShell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 {
     [ExportWorkspaceServiceFactory(typeof(IPreviewPaneService), ServiceLayer.Host), Shared]
     internal class PreviewPaneService : ForegroundThreadAffinitizedObject, IPreviewPaneService, IWorkspaceServiceFactory
     {
-        private readonly IVsUIShell _uiShell;
+        private readonly EnvDTE.DTE _dte;
 
         [ImportingConstructor]
         public PreviewPaneService(SVsServiceProvider serviceProvider)
         {
-            _uiShell = serviceProvider.GetService(typeof(SVsUIShell)) as IVsUIShell;
+            _dte = serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
         }
 
         IWorkspaceService IWorkspaceServiceFactory.CreateService(HostWorkspaceServices workspaceServices)
@@ -109,7 +107,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 
                 return new PreviewPane(
                     severityIcon: null, id: null, title: null, description: null, helpLink: null, helpLinkToolTipText: null,
-                    previewContent: previewContent, logIdVerbatimInTelemetry: false, uiShell: _uiShell);
+                    previewContent: previewContent, logIdVerbatimInTelemetry: false, dte: _dte);
             }
 
             var helpLinkToolTipText = string.Empty;
@@ -130,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 helpLinkToolTipText: helpLinkToolTipText,
                 previewContent: previewContent,
                 logIdVerbatimInTelemetry: diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
-                uiShell: _uiShell,
+                dte: _dte,
                 optionPageGuid: optionPageGuid);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/Versions/SemanticVersionTrackingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Versions/SemanticVersionTrackingService.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Versions;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Versions
+{
+    /// <summary>
+    /// this service tracks semantic version changes as solution changes and provide a way to get back to initial project/semantic version
+    /// pairs at the solution load 
+    /// </summary>
+    [ExportWorkspaceService(typeof(ISemanticVersionTrackingService), ServiceLayer.Host), Shared]
+    internal class SemanticVersionTrackingService : ISemanticVersionTrackingService
+    {
+        private const int SerializationFormat = 1;
+        private const string SemanticVersion = nameof(SemanticVersion);
+        private const string DependentSemanticVersion = nameof(DependentSemanticVersion);
+
+        private static readonly ConditionalWeakTable<ProjectId, Versions> s_initialSemanticVersions = new ConditionalWeakTable<ProjectId, Versions>();
+        private static readonly ConditionalWeakTable<ProjectId, Versions> s_initialDependentSemanticVersions = new ConditionalWeakTable<ProjectId, Versions>();
+
+        public VersionStamp GetInitialProjectVersionFromSemanticVersion(Project project, VersionStamp semanticVersion)
+        {
+            if (!TryGetInitialVersions(s_initialSemanticVersions, project, SemanticVersion, out var versions))
+            {
+                return VersionStamp.Default;
+            }
+
+            if (!VersionStamp.CanReusePersistedVersion(semanticVersion, versions.SemanticVersion))
+            {
+                return VersionStamp.Default;
+            }
+
+            return versions.ProjectVersion;
+        }
+
+        public VersionStamp GetInitialDependentProjectVersionFromDependentSemanticVersion(Project project, VersionStamp dependentSemanticVersion)
+        {
+            if (!TryGetInitialVersions(s_initialDependentSemanticVersions, project, DependentSemanticVersion, out var versions))
+            {
+                return VersionStamp.Default;
+            }
+
+            if (!VersionStamp.CanReusePersistedVersion(dependentSemanticVersion, versions.SemanticVersion))
+            {
+                return VersionStamp.Default;
+            }
+
+            return versions.ProjectVersion;
+        }
+
+        private bool TryGetInitialVersions(ConditionalWeakTable<ProjectId, Versions> initialVersionMap, Project project, string keyName, out Versions versions)
+        {
+            // if we already loaded this, return it.
+            if (initialVersionMap.TryGetValue(project.Id, out versions))
+            {
+                return true;
+            }
+
+            // otherwise, load it
+            return TryLoadInitialVersions(initialVersionMap, project, keyName, out versions);
+        }
+
+        public void LoadInitialSemanticVersions(Solution solution)
+        {
+            foreach (var project in solution.Projects)
+            {
+                LoadInitialSemanticVersions(project);
+            }
+        }
+
+        public void LoadInitialSemanticVersions(Project project)
+        {
+            if (!s_initialSemanticVersions.TryGetValue(project.Id, out var unused))
+            {
+                PersistedVersionStampLogger.LogProject();
+
+                if (TryLoadInitialVersions(s_initialSemanticVersions, project, SemanticVersion, out unused))
+                {
+                    PersistedVersionStampLogger.LogInitialSemanticVersion();
+                }
+            }
+
+            if (!s_initialDependentSemanticVersions.TryGetValue(project.Id, out unused) &&
+                TryLoadInitialVersions(s_initialDependentSemanticVersions, project, DependentSemanticVersion, out unused))
+            {
+                PersistedVersionStampLogger.LogInitialDependentSemanticVersion();
+            }
+        }
+
+        private bool TryLoadInitialVersions(ConditionalWeakTable<ProjectId, Versions> initialVersionMap, Project project, string keyName, out Versions versions)
+        {
+            var result = TryReadFrom(project, keyName, out versions);
+            if (result)
+            {
+                Versions save = versions;
+                initialVersionMap.GetValue(project.Id, _ => save);
+                return true;
+            }
+
+            initialVersionMap.GetValue(project.Id, _ => Versions.Default);
+            return false;
+        }
+
+        private static bool TryReadFrom(Project project, string keyName, out Versions versions)
+        {
+            versions = default(Versions);
+
+            var service = project.Solution.Workspace.Services.GetService<IPersistentStorageService>();
+            if (service == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                using (var storage = service.GetStorage(project.Solution))
+                using (var stream = storage.ReadStreamAsync(keyName, CancellationToken.None).WaitAndGetResult(CancellationToken.None))
+                using (var reader = ObjectReader.TryGetReader(stream))
+                {
+                    if (reader != null)
+                    {
+                        var formatVersion = reader.ReadInt32();
+                        if (formatVersion == SerializationFormat)
+                        {
+                            var persistedProjectVersion = VersionStamp.ReadFrom(reader);
+                            var persistedSemanticVersion = VersionStamp.ReadFrom(reader);
+
+                            versions = new Versions(persistedProjectVersion, persistedSemanticVersion);
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (Exception e) when (IOUtilities.IsNormalIOException(e))
+            {
+            }
+
+            return false;
+        }
+
+        public async Task RecordSemanticVersionsAsync(Project project, CancellationToken cancellationToken)
+        {
+            var service = project.Solution.Workspace.Services.GetService<IPersistentStorageService>();
+            if (service == null)
+            {
+                return;
+            }
+
+            using (var storage = service.GetStorage(project.Solution))
+            {
+                // first update semantic and dependent semantic version of this project
+                await WriteToSemanticVersionAsync(storage, project, cancellationToken).ConfigureAwait(false);
+                await WriteToDependentSemanticVersionAsync(storage, project, cancellationToken).ConfigureAwait(false);
+
+                // next update dependent semantic version fo all projects that depend on this project.
+                var projectIds = project.Solution.GetProjectDependencyGraph().GetProjectsThatTransitivelyDependOnThisProject(project.Id);
+                foreach (var projectId in projectIds)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var currentProject = project.Solution.GetProject(projectId);
+                    if (currentProject == null)
+                    {
+                        continue;
+                    }
+
+                    await WriteToDependentSemanticVersionAsync(storage, currentProject, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private static async Task WriteToSemanticVersionAsync(IPersistentStorage storage, Project project, CancellationToken cancellationToken)
+        {
+            var projectVersion = await project.GetVersionAsync(cancellationToken).ConfigureAwait(false);
+            var semanticVersion = await project.GetSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            await WriteToVersionAsync(storage, SemanticVersion, projectVersion, semanticVersion, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task WriteToDependentSemanticVersionAsync(IPersistentStorage storage, Project project, CancellationToken cancellationToken)
+        {
+            var projectVersion = await project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false);
+            var semanticVersion = await project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            await WriteToVersionAsync(storage, DependentSemanticVersion, projectVersion, semanticVersion, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task WriteToVersionAsync(
+            IPersistentStorage storage, string keyName, VersionStamp projectVersion, VersionStamp semanticVersion, CancellationToken cancellationToken)
+        {
+            using (var stream = SerializableBytes.CreateWritableStream())
+            using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
+            {
+                writer.WriteInt32(SerializationFormat);
+                projectVersion.WriteTo(writer);
+                semanticVersion.WriteTo(writer);
+
+                stream.Position = 0;
+                await storage.WriteStreamAsync(keyName, stream, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private class Versions
+        {
+            public static readonly Versions Default = new Versions(VersionStamp.Default, VersionStamp.Default);
+
+            public readonly VersionStamp ProjectVersion;
+            public readonly VersionStamp SemanticVersion;
+
+            public Versions(VersionStamp projectVersion, VersionStamp semanticVersion)
+            {
+                this.ProjectVersion = projectVersion;
+                this.SemanticVersion = semanticVersion;
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Implementation\Utilities\AutomationDelegatingListView.cs" />
     <Compile Include="Implementation\Utilities\HyperlinkStyleHelper.cs" />
     <Compile Include="Implementation\Venus\VenusTaskExtensions.cs" />
+    <Compile Include="Implementation\Versions\SemanticVersionTrackingService.cs" />
     <Compile Include="Implementation\ContainedLanguageRefactorNotifyService.cs" />
     <Compile Include="Implementation\VirtualMemoryNotificationListener.cs" />
     <Compile Include="Implementation\Watson\WatsonReporter.cs" />
@@ -345,7 +346,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime">
       <Version>$(MicrosoftVisualStudioShellInterop150DesignTimeVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
+	 <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
       <Version>$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
@@ -450,9 +451,9 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>$(NewtonsoftJsonVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
-      <Version>$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)</Version>
-    </PackageReference>
+	<PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
+		<Version>$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)</Version>
+	</PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeMarkers\ManagedCodeMarkers.cs" />

--- a/src/Workspaces/Core/Portable/Versions/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Versions/Extensions.cs
@@ -37,5 +37,40 @@ namespace Microsoft.CodeAnalysis.Versions
             PersistedVersionStampLogger.LogPersistedDependentProjectVersionUsage(canReuse);
             return canReuse;
         }
+
+        public static bool CanReusePersistedSemanticVersion(
+            this Project project, VersionStamp projectVersion, VersionStamp semanticVersion, VersionStamp persistedVersion)
+        {
+            var canReuse = CanReusePersistedSemanticVersionInternal(
+                project, projectVersion, semanticVersion, persistedVersion, (s, p, v) => s.GetInitialProjectVersionFromSemanticVersion(p, v));
+
+            PersistedVersionStampLogger.LogPersistedSemanticVersionUsage(canReuse);
+            return canReuse;
+        }
+
+        public static bool CanReusePersistedDependentSemanticVersion(
+            this Project project, VersionStamp dependentProjectVersion, VersionStamp dependentSemanticVersion, VersionStamp persistedVersion)
+        {
+            var canReuse = CanReusePersistedSemanticVersionInternal(
+                project, dependentProjectVersion, dependentSemanticVersion, persistedVersion, (s, p, v) => s.GetInitialDependentProjectVersionFromDependentSemanticVersion(p, v));
+
+            PersistedVersionStampLogger.LogPersistedDependentSemanticVersionUsage(canReuse);
+            return canReuse;
+        }
+
+        private static bool CanReusePersistedSemanticVersionInternal(
+            Project project,
+            VersionStamp projectVersion,
+            VersionStamp semanticVersion,
+            VersionStamp persistedVersion,
+            Func<ISemanticVersionTrackingService, Project, VersionStamp, VersionStamp> versionGetter)
+        {
+            // * NOTE * 
+            // Disabled semantic version tracking
+            // we need better version for it to reliably work.
+            //
+            // see tracking issue here : https://github.com/dotnet/roslyn/issues/2311
+            return VersionStamp.CanReusePersistedVersion(semanticVersion, persistedVersion);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Versions/ISemanticVersionTrackingService.cs
+++ b/src/Workspaces/Core/Portable/Versions/ISemanticVersionTrackingService.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Versions
+{
+    /// <summary>
+    /// A service that knows how to convert semantic version to project version
+    /// </summary>
+    internal interface ISemanticVersionTrackingService : IWorkspaceService
+    {
+        VersionStamp GetInitialProjectVersionFromSemanticVersion(Project project, VersionStamp semanticVersion);
+        VersionStamp GetInitialDependentProjectVersionFromDependentSemanticVersion(Project project, VersionStamp dependentSemanticVersion);
+
+        void LoadInitialSemanticVersions(Solution solution);
+        void LoadInitialSemanticVersions(Project project);
+        Task RecordSemanticVersionsAsync(Project project, CancellationToken cancellationToken);
+    }
+}

--- a/src/Workspaces/Core/Portable/Versions/PersistedVersionStampLogger.cs
+++ b/src/Workspaces/Core/Portable/Versions/PersistedVersionStampLogger.cs
@@ -11,6 +11,12 @@ namespace Microsoft.CodeAnalysis.Versions
         private const string SyntaxTree = nameof(SyntaxTree);
         private const string Project = nameof(Project);
         private const string DependentProject = nameof(DependentProject);
+        private const string Semantic = nameof(Semantic);
+        private const string DependentSemantic = nameof(DependentSemantic);
+
+        private const string ProjectCount = nameof(ProjectCount);
+        private const string InitialSemanticVersionCount = nameof(InitialSemanticVersionCount);
+        private const string InitialDependentSemanticVersionCount = nameof(InitialDependentSemanticVersionCount);
 
         private static readonly LogAggregator s_logAggregator = new LogAggregator();
 
@@ -54,14 +60,55 @@ namespace Microsoft.CodeAnalysis.Versions
             s_logAggregator.IncreaseCount(DependentProject);
         }
 
+        public static void LogPersistedSemanticVersionUsage(bool succeeded)
+        {
+            if (!succeeded)
+            {
+                return;
+            }
+
+            s_logAggregator.IncreaseCount(Semantic);
+        }
+
+        public static void LogPersistedDependentSemanticVersionUsage(bool succeeded)
+        {
+            if (!succeeded)
+            {
+                return;
+            }
+
+            s_logAggregator.IncreaseCount(DependentSemantic);
+        }
+
+        public static void LogProject()
+        {
+            s_logAggregator.IncreaseCount(ProjectCount);
+        }
+
+        public static void LogInitialSemanticVersion()
+        {
+            s_logAggregator.IncreaseCount(InitialSemanticVersionCount);
+        }
+
+        public static void LogInitialDependentSemanticVersion()
+        {
+            s_logAggregator.IncreaseCount(InitialDependentSemanticVersionCount);
+        }
+
         public static void LogSummary()
         {
             Logger.Log(FunctionId.PersistedSemanticVersion_Info, KeyValueLogMessage.Create(m =>
             {
+                m[ProjectCount] = s_logAggregator.GetCount(ProjectCount);
+                m[InitialSemanticVersionCount] = s_logAggregator.GetCount(InitialSemanticVersionCount);
+                m[InitialDependentSemanticVersionCount] = s_logAggregator.GetCount(InitialDependentSemanticVersionCount);
+
                 m[Text] = s_logAggregator.GetCount(Text);
                 m[SyntaxTree] = s_logAggregator.GetCount(SyntaxTree);
                 m[Project] = s_logAggregator.GetCount(Project);
                 m[DependentProject] = s_logAggregator.GetCount(DependentProject);
+                m[Semantic] = s_logAggregator.GetCount(Semantic);
+                m[DependentSemantic] = s_logAggregator.GetCount(DependentSemantic);
             }));
         }
     }

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -636,6 +636,7 @@
     <Compile Include="Utilities\ValuesSources\CachedWeakValueSource.cs" />
     <Compile Include="Utilities\WeakEventHandler.cs" />
     <Compile Include="Versions\Extensions.cs" />
+    <Compile Include="Versions\ISemanticVersionTrackingService.cs" />
     <Compile Include="Versions\PersistedVersionStampLogger.cs" />
     <Compile Include="Workspace\AdhocWorkspace.cs" />
     <Compile Include="Workspace\DocumentActiveContextChangedEventArgs.cs" />


### PR DESCRIPTION
**Customer scenario**

Customer holds CTRL key in a JS/TS file and Visual Studio crashes.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=479492

**Workarounds, if any**

Disable Ctrl-Click Go To Definition for all languages (the editor doesn't provide a per-language option for this). This is not a good workaround because it also disables the feature in languages where it does work.

**Risk**
Low--adds a null check.

**Performance impact**
Low--adds a null check.

**Is this a regression from a previous update?**
Yes--our implementation of the Editor's "Ctrl-Click Go To Definition" feature allows all languages using Roslyn to opt into the feature at the Roslyn layer. However, we crash in languages that don't implement it.

**Root cause analysis:**

Didn't test languages other than C#/VB to validate that the feature was simply disabled without crashing. When adding extension points like this in the future, we should test them in other languages to verify that not implementing the feature doesn't cause any issues.

**How was the bug found?**

Dogfooding.
