### PR TITLE
Refactor comments in local function binder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -631,8 +631,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to be dispatched as dynamic invocations since they cannot be
             // overloaded. Instead, we'll just emit a standard call with
             // dynamic implicit conversions for any dynamic arguments. There
-            // are two exceptions: "params", and unconstructed generics. See
-            // comments below for the exact semantics in these cases.
+            // are two exceptions: "params", and unconstructed generics. While
+            // implementing those cases with dynamic invocations is possible,
+            // we have decided the implementation complexity is not worth it.
+            // Refer to the comments below for the exact semantics.
 
             Debug.Assert(resolution.IsLocalFunctionInvocation);
             Debug.Assert(resolution.OverloadResolutionResult.Succeeded);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -627,15 +627,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpSyntaxNode queryClause,
             MethodGroupResolution resolution)
         {
-            // Invocations of local functions with dynamic arguments
-            // don't need to be dispatched as dynamic invocations
-            // since they cannot be overloaded.  Instead, we'll just
-            // emit a standard call with dynamic implicit conversions
-            // for any dynamic arguments. The one exception is params
-            // arguments which cannot be targeted by dynamic arguments
-            // because there is an ambiguity between an array target
-            // and the params element target. See
-            // https://github.com/dotnet/roslyn/issues/10708
+            // Invocations of local functions with dynamic arguments don't need
+            // to be dispatched as dynamic invocations since they cannot be
+            // overloaded. Instead, we'll just emit a standard call with
+            // dynamic implicit conversions for any dynamic arguments. There
+            // are two exceptions: "params", and unconstructed generics. See
+            // comments below for the exact semantics in these cases.
 
             Debug.Assert(resolution.IsLocalFunctionInvocation);
             Debug.Assert(resolution.OverloadResolutionResult.Succeeded);
@@ -650,9 +647,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             var methodResult = validResult.Result;
 
             // We're only in trouble if a dynamic argument is passed to the
-            // params parameter and is ambiguous at compile time between
-            // normal and expanded form i.e., there is exactly one dynamic
-            // argument to a params parameter
+            // params parameter and is ambiguous at compile time between normal
+            // and expanded form i.e., there is exactly one dynamic argument to
+            // a params parameter
+            // See https://github.com/dotnet/roslyn/issues/10708
             if (OverloadResolution.IsValidParams(localFunction) &&
                 methodResult.Kind == MemberResolutionKind.ApplicableInNormalForm)
             {
@@ -682,14 +680,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // If we call an unconstructed generic local function with a dynamic argument in
-            // a place where it influences the type parameters, we need to dynamically dispatch the call
-            // (as the function must be constructed at runtime). We cannot do that, so disallow that.
-            // However, doing a specific analysis of each argument and its corresponding parameter
-            // to check if it's generic (and allow dynamic in non-generic parameters) may break
-            // overload resolution in the future, if we ever allow overloaded local functions.
-            // So, just disallow any mixing of dynamic and inferred generics.
-            // (Explicitly-provided generic arguments are fine)
+            // If we call an unconstructed generic local function with a
+            // dynamic argument in a place where it influences the type
+            // parameters, we need to dynamically dispatch the call (as the
+            // function must be constructed at runtime). We cannot do that, so
+            // disallow that. However, doing a specific analysis of each
+            // argument and its corresponding parameter to check if it's
+            // generic (and allow dynamic in non-generic parameters) may break
+            // overload resolution in the future, if we ever allow overloaded
+            // local functions. So, just disallow any mixing of dynamic and
+            // inferred generics. (Explicit generic arguments are fine)
+            // See https://github.com/dotnet/roslyn/issues/21317
             if (boundMethodGroup.TypeArgumentsOpt.IsDefaultOrEmpty && localFunction.IsGenericMethod)
             {
                 Error(diagnostics,


### PR DESCRIPTION
Resolves @AlekseyTs's [comment on my previous PR](https://github.com/dotnet/roslyn/pull/21450#issuecomment-322312821) in this area.

@dotnet/roslyn-compiler This is a really easy review, as it's a comment-only change.

I also discovered that vim can reflow text really easily (it even preserves `//` comments!), so I couldn't help but reflow the comments to 80 columns 🙂