### PR TITLE
Improve find-refs behavior when the user invokes it with a symbol selected

### DIFF
--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -53,15 +53,23 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
 
         public void ExecuteCommand(FindReferencesCommandArgs args, Action nextHandler)
         {
-            var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer) ?? -1;
-
-            if (caretPosition >= 0)
+            // Get the selection that user has in our buffer (this also works if there
+            // is no selection and the caret is just at a single position).  If we 
+            // can't get the selection, or there are multiple spans for it (i.e. a 
+            // box selection), then don't do anything.
+            var snapshotSpans = args.TextView.Selection.GetSnapshotSpansOnBuffer(args.SubjectBuffer);
+            if (snapshotSpans.Count == 1)
             {
+                var selectedSpan = snapshotSpans[0];
                 var snapshot = args.SubjectBuffer.CurrentSnapshot;
                 var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document != null)
                 {
-                    if (TryExecuteCommand(caretPosition, document))
+                    // Do a find-refs at the *start* of the selection.  That way if the
+                    // user has selected a symbol that has another symbol touching it
+                    // on the right (i.e.  Goo++  ), then we'll do the find-refs on the
+                    // symbol selected, not the symbol following.
+                    if (TryExecuteCommand(selectedSpan.Start, document))
                     {
                         return;
                     }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
@@ -1,0 +1,86 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Editor.Commands
+Imports Microsoft.CodeAnalysis.Editor.FindReferences
+Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.FindUsages
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
+    Public Class FindReferencesCommandHandlerTests
+        <WorkItem(47594, "https://developercommunity.visualstudio.com/content/problem/47594/c-postfix-operators-inhibit-find-all-references-sh.html")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSelection() As Task
+            Dim source = "
+class C
+{
+    void M()
+    {
+        int {|Definition:yyy|} = 0;
+        {|Reference:{|Selection:yyy|}|}++;
+        {|Reference:yyy|}++;
+    }
+}"
+            Using workspace = TestWorkspace.CreateCSharp(source)
+                Dim testDocument = workspace.Documents.Single()
+
+                Dim view = testDocument.GetTextView()
+                Dim textBuffer = view.TextBuffer
+                Dim snapshot = textBuffer.CurrentSnapshot
+
+                view.Selection.Select(
+                    testDocument.AnnotatedSpans("Selection").Single().ToSnapshotSpan(snapshot), isReversed:=False)
+
+                Dim waiter = New Waiter()
+
+                Dim context = New FindReferencesTests.TestContext()
+                Dim commandHandler = New FindReferencesCommandHandler(
+                    workspace.GetService(Of IWaitIndicator),
+                    {}, {New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindReferencesPresenter(context))},
+                    {New Lazy(Of IAsynchronousOperationListener, FeatureMetadata)(Function() waiter, New FeatureMetadata(FeatureAttribute.FindReferences))})
+
+                Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)
+                commandHandler.ExecuteCommand(
+                    New FindReferencesCommandArgs(view, textBuffer), Sub()
+                                                                     End Sub)
+
+                ' Wait for the find refs to be done.
+                Await waiter.CreateWaitTask()
+
+                Assert.Equal(1, context.Definitions.Count)
+                Assert.Equal(testDocument.AnnotatedSpans("Definition").Single(),
+                             context.Definitions(0).SourceSpans.Single().SourceSpan)
+                Assert.Equal(testDocument.AnnotatedSpans("Reference").Count,
+                             context.References.Count)
+
+                AssertEx.SetEqual(testDocument.AnnotatedSpans("Reference"),
+                                  context.References.Select(Function(r) r.SourceSpan.SourceSpan))
+            End Using
+        End Function
+
+        Private Class MockStreamingFindReferencesPresenter
+            Implements IStreamingFindUsagesPresenter
+
+            Private ReadOnly _context As FindReferencesTests.TestContext
+
+            Public Sub New(context As FindReferencesTests.TestContext)
+                _context = context
+            End Sub
+
+            Public Sub ClearAll() Implements IStreamingFindUsagesPresenter.ClearAll
+            End Sub
+
+            Public Function StartSearch(title As String, supportsReferences As Boolean) As FindUsagesContext Implements IStreamingFindUsagesPresenter.StartSearch
+                Return _context
+            End Function
+        End Class
+
+        Private Class Waiter
+            Inherits AsynchronousOperationListener
+
+        End Class
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -125,7 +125,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
 
         End Structure
 
-        Private Class TestContext
+        Friend Class TestContext
             Inherits FindUsagesContext
 
             Private ReadOnly gate As Object = New Object()

--- a/src/Features/Core/Portable/Shared/TestHooks/FeatureMetadata.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/FeatureMetadata.cs
@@ -19,8 +19,11 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public string FeatureName { get; }
 
         public FeatureMetadata(IDictionary<string, object> data)
+            : this((string)data.GetValueOrDefault("FeatureName"))
         {
-            this.FeatureName = (string)data.GetValueOrDefault("FeatureName");
         }
+
+        public FeatureMetadata(string featureName)
+            => FeatureName = featureName;
     }
 }


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/content/problem/47594/c-postfix-operators-inhibit-find-all-references-sh.html