### PR TITLE
Fixed IDE0009 suggestion in nameof expression used to initialize static member

### DIFF
--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.GetAccessorDeclaration:
                     {
                         var t = (AccessorDeclarationSyntax)node;
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body, cancellationToken));
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body ?? (SyntaxNode)t.ExpressionBody, cancellationToken));
                         return;
                     }
 

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -183,14 +184,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.GetAccessorDeclaration:
                     {
                         var t = (AccessorDeclarationSyntax)node;
-                        if (t.Body != null && t.ExpressionBody != null)
-                        {
-                            builder.Add(GetDeclarationInfo(model, node, getSymbol, new SyntaxNode[] { t.Body, t.ExpressionBody }, cancellationToken));
-                        }
-                        else
-                        {
-                            builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body ?? (SyntaxNode) t.ExpressionBody, cancellationToken));
-                        }
+                        var blocks = ArrayBuilder<SyntaxNode>.GetInstance();
+                        blocks.AddIfNotNull(t.Body);
+                        blocks.AddIfNotNull(t.ExpressionBody);
+                        builder.Add(GetDeclarationInfo(model, node, getSymbol, blocks, cancellationToken));
+                        blocks.Free();
                         
                         return;
                     }

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -183,7 +183,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.GetAccessorDeclaration:
                     {
                         var t = (AccessorDeclarationSyntax)node;
-                        builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body ?? (SyntaxNode)t.ExpressionBody, cancellationToken));
+                        if (t.Body != null && t.ExpressionBody != null)
+                        {
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, new SyntaxNode[] { t.Body, t.ExpressionBody }, cancellationToken));
+                        }
+                        else
+                        {
+                            builder.Add(GetDeclarationInfo(model, node, getSymbol, t.Body ?? (SyntaxNode) t.ExpressionBody, cancellationToken));
+                        }
+                        
                         return;
                     }
 

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1096,5 +1096,52 @@ class Derived : Base
 }",
 CodeStyleOptions.QualifyEventAccess);
         }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext1()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    public int Foo { get; set; }
+    public static string Bar = nameof([|Foo|]);
+}",
+CodeStyleOptions.QualifyEventAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext2()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    public int Foo { get; set; }
+    static void Main(string[] args)
+    {
+        System.Console.WriteLine(nameof([|Foo|]));
+    }
+}",
+CodeStyleOptions.QualifyEventAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext3()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    public int Foo { get; set; }
+    static string Bar { get; set; }
+
+    static Program()
+    {
+        Bar = nameof([|Foo|]);
+    }
+}",
+CodeStyleOptions.QualifyEventAccess);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1107,7 +1107,7 @@ CodeStyleOptions.QualifyEventAccess);
     public int Foo { get; set; }
     public static string Bar = nameof([|Foo|]);
 }",
-CodeStyleOptions.QualifyEventAccess);
+CodeStyleOptions.QualifyPropertyAccess);
         }
 
         [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
@@ -1118,17 +1118,46 @@ CodeStyleOptions.QualifyEventAccess);
 @"class Program
 {
     public int Foo { get; set; }
-    static void Main(string[] args)
-    {
-        System.Console.WriteLine(nameof([|Foo|]));
-    }
+    public string Bar = nameof([|Foo|]);
 }",
-CodeStyleOptions.QualifyEventAccess);
+CodeStyleOptions.QualifyPropertyAccess);
         }
 
         [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task DoNotReportToQualify_IfInStaticContext3()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    public int Foo { get; set; }
+    static void Main(string[] args)
+    {
+        System.Console.WriteLine(nameof([|Foo|]));
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext4()
+        {
+            await TestMissingAsyncWithOption(
+@"class Program
+{
+    public int Foo;
+    static void Main(string[] args)
+    {
+        System.Console.WriteLine(nameof([|Foo|]));
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext5()
         {
             await TestMissingAsyncWithOption(
 @"class Program
@@ -1141,23 +1170,37 @@ CodeStyleOptions.QualifyEventAccess);
         Bar = nameof([|Foo|]);
     }
 }",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfInStaticContext6()
+        {
+            await TestMissingAsyncWithOption(
+@"public class Foo
+{
+    public event EventHandler Bar;
+
+    private string Field = nameof([|Bar|]);
+}",
 CodeStyleOptions.QualifyEventAccess);
         }
 
         [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_NameofArgument()
+        public async Task QualifyPropertyAccess_InAccessorExpressionBody()
         {
             await TestAsyncWithOption(
-@"class Program
+@"public class C
 {
-    public int Foo { get; set; }
-    public string Bar = nameof([|Foo|]);
+    public string Foo { get; set; }
+    public string Bar { get => [|Foo|]; }
 }",
-@"class Program
+@"public class C
 {
-    public int Foo { get; set; }
-    public string Bar = nameof(this.Foo);
+    public string Foo { get; set; }
+    public string Bar { get => this.Foo; }
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1204,5 +1204,41 @@ CodeStyleOptions.QualifyEventAccess);
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_InAccessorWithBodyAndExpressionBody1()
+        {
+            await TestAsyncWithOption(
+@"public class C
+{
+    public string Foo { get; set; }
+    public string Bar { get { return [|Foo|]; } => Foo; }
+}",
+@"public class C
+{
+    public string Foo { get; set; }
+    public string Bar { get { return this.Foo; } => Foo; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_InAccessorWithBodyAndExpressionBody2()
+        {
+            await TestAsyncWithOption(
+@"public class C
+{
+    public string Foo { get; set; }
+    public string Bar { get { return Foo; } => [|Foo|]; }
+}",
+@"public class C
+{
+    public string Foo { get; set; }
+    public string Bar { get { return Foo; } => this.Foo; }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1143,5 +1143,23 @@ CodeStyleOptions.QualifyEventAccess);
 }",
 CodeStyleOptions.QualifyEventAccess);
         }
+
+        [WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_NameofArgument()
+        {
+            await TestAsyncWithOption(
+@"class Program
+{
+    public int Foo { get; set; }
+    public string Bar = nameof([|Foo|]);
+}",
+@"class Program
+{
+    public int Foo { get; set; }
+    public string Bar = nameof(this.Foo);
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -561,5 +561,32 @@ End Class
 ",
 CodeStyleOptions.QualifyMethodAccess)
         End Function
+
+        <WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfInStaticContext1() As Task
+            Await TestMissingAsyncWithOption("
+Class C
+    Private Value As String
+
+    Shared Sub Test()
+        Console.WriteLine([|Value|])
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(21519, "https://github.com/dotnet/roslyn/issues/21519")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfInStaticContext2() As Task
+            Await TestMissingAsyncWithOption("
+Class C
+    Private Value As String
+    Private Shared Field As String = NameOf([|Value|])
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.QualifyMemberAccess;
 
@@ -15,7 +17,21 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
             => node.IsKind(SyntaxKind.ThisExpression);
 
         // If the member is already qualified with `base.`, it cannot be further qualified.
-        protected override bool CanMemberAccessBeQualified(SyntaxNode node)
-            => !node.IsKind(SyntaxKind.BaseExpression);
+        protected override bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node)
+            => !(node.IsKind(SyntaxKind.BaseExpression) || IsInPropertyOrFieldInitialization(containingSymbol, node));
+
+        private bool IsInPropertyOrFieldInitialization(ISymbol containingSymbol, SyntaxNode node)
+        {
+            return (containingSymbol.Kind == SymbolKind.Field || containingSymbol.Kind == SymbolKind.Property) &&
+                containingSymbol.DeclaringSyntaxReferences
+                    .Select(declaringSyntaxReferences => declaringSyntaxReferences.GetSyntax())
+                    .Any(declaringSyntax => IsInPropertyInitialization(declaringSyntax, node) || IsInFieldInitialization(declaringSyntax, node));
+        }
+
+        private bool IsInPropertyInitialization(SyntaxNode declarationSyntax, SyntaxNode node)
+            => declarationSyntax.IsKind(SyntaxKind.PropertyDeclaration) && declarationSyntax.Contains(node);
+
+        private bool IsInFieldInitialization(SyntaxNode declarationSyntax, SyntaxNode node)
+            => declarationSyntax.GetAncestorsOrThis(n => n.IsKind(SyntaxKind.FieldDeclaration) && n.Contains(node)).Any();
     }
 }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
         /// <c>MyBase.</c>, or <c>MyClass.</c>.
         /// </summary>
         /// <returns>True if the member access can be qualified; otherwise, False.</returns>
-        protected abstract bool CanMemberAccessBeQualified(SyntaxNode node);
+        protected abstract bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node);
 
         protected abstract bool IsAlreadyQualifiedMemberAccess(SyntaxNode node);
 
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
             }
 
             // If we can't be qualified (e.g., because we're already qualified with `base.`), we're done.
-            if (!CanMemberAccessBeQualified(memberReference.Instance.Syntax))
+            if (!CanMemberAccessBeQualified(context.ContainingSymbol, memberReference.Instance.Syntax))
             {
                 return;
             }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
 
         private void AnalyzeOperation(OperationAnalysisContext context)
         {
+            if (context.ContainingSymbol.IsStatic)
+            {
+                return;
+            }
+
             var memberReference = (IMemberReferenceExpression)context.Operation;
 
             // this is a static reference so we don't care if it's qualified

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
             Return node.IsKind(SyntaxKind.MeExpression)
         End Function
 
-        Protected Overrides Function CanMemberAccessBeQualified(node As SyntaxNode) As Boolean
+        Protected Overrides Function CanMemberAccessBeQualified(containingSymbol As ISymbol, node As SyntaxNode) As Boolean
             ' If the member is already qualified with `MyBase.`, or `MyClass.`, it cannot be further qualified.
             Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression))
         End Function


### PR DESCRIPTION
**Customer scenario**
IDE0009 suggested incorrectly in nameof expression used to initialize static member in VS 15.3

**Bugs this fixes:**
Fixes #21519

**Risk**
Low

**Performance impact**
Low

**How was the bug found?**
customer reported
