### PR TITLE
3 product changes and 1 test change on sqlite persisted storage

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -66,7 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
         }
 
-        private static async Task RegisterWorkspaceHostAsync(Workspace workspace, RemoteHostClient client)
+        // internal for debugging purpose
+        internal static async Task RegisterWorkspaceHostAsync(Workspace workspace, RemoteHostClient client)
         {
             var vsWorkspace = workspace as VisualStudioWorkspaceImpl;
             if (vsWorkspace == null)

--- a/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
@@ -19,7 +19,12 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.Remote
             // this is the point where we can create different kind of remote host client in future (cloud or etc)
             if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
             {
-                return await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var client = await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // register workspace host for in proc remote host client
+                await ServiceHubRemoteHostClient.RegisterWorkspaceHostAsync(workspace, client).ConfigureAwait(false);
+
+                return client;
             }
 
             return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         // SQLITE_OPEN_SUBJOURNAL       = 0x00002000, /* VFS only */
         // SQLITE_OPEN_MASTER_JOURNAL   = 0x00004000, /* VFS only */
         // SQLITE_OPEN_NOMUTEX          = 0x00008000, /* Ok for sqlite3_open_v2() */
-        // SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
-        // SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
+        SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
+        SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_PRIVATECACHE     = 0x00040000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_WAL              = 0x00080000, /* VFS only */
     }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         // SQLITE_OPEN_SUBJOURNAL       = 0x00002000, /* VFS only */
         // SQLITE_OPEN_MASTER_JOURNAL   = 0x00004000, /* VFS only */
         // SQLITE_OPEN_NOMUTEX          = 0x00008000, /* Ok for sqlite3_open_v2() */
-        SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
+        // SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
         SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_PRIVATECACHE     = 0x00040000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_WAL              = 0x00080000, /* VFS only */

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -51,7 +51,10 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         {
             faultInjector?.OnNewConnection();
 
-            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE;
+            // Explicitly set for Serialized mode to be safe.
+            // Also, enable shared cache so that multiple connections inside of same process share cache
+            // see https://sqlite.org/threadsafe.html for more detail
+            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_FULLMUTEX | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
             var result = (Result)raw.sqlite3_open_v2(databasePath, out var handle, (int)flags, vfs: null);
 
             if (result != Result.OK)

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -51,10 +51,9 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         {
             faultInjector?.OnNewConnection();
 
-            // Explicitly set for Serialized mode to be safe.
-            // Also, enable shared cache so that multiple connections inside of same process share cache
+            // Enable shared cache so that multiple connections inside of same process share cache
             // see https://sqlite.org/threadsafe.html for more detail
-            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_FULLMUTEX | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
+            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
             var result = (Result)raw.sqlite3_open_v2(databasePath, out var handle, (int)flags, vfs: null);
 
             if (result != Result.OK)

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -122,6 +122,7 @@ namespace Microsoft.CodeAnalysis.SQLite
 
         private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 
+        private readonly IDisposable _dbOwnershipLock;
         private readonly IPersistentStorageFaultInjector _faultInjectorOpt;
 
         // Accessors that allow us to retrieve/store data into specific DB tables.  The
@@ -146,10 +147,13 @@ namespace Microsoft.CodeAnalysis.SQLite
             string solutionFilePath,
             string databaseFile,
             Action<AbstractPersistentStorage> disposer,
+            IDisposable dbOwnershipLock,
             IPersistentStorageFaultInjector faultInjectorOpt)
             : base(optionService, workingFolderPath, solutionFilePath, databaseFile, disposer)
         {
+            _dbOwnershipLock = dbOwnershipLock;
             _faultInjectorOpt = faultInjectorOpt;
+
             _solutionAccessor = new SolutionAccessor(this);
             _projectAccessor = new ProjectAccessor(this);
             _documentAccessor = new DocumentAccessor(this);
@@ -212,6 +216,9 @@ namespace Microsoft.CodeAnalysis.SQLite
                     connection.Close_OnlyForUseBySqlPersistentStorage();
                 }
             }
+
+            // let the lock go
+            _dbOwnershipLock.Dispose();
         }
 
         private PooledConnection GetPooledConnection()

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -196,6 +196,21 @@ namespace Microsoft.CodeAnalysis.SQLite
             // are definitely persisted to the DB.
             try
             {
+                CloseWorker();
+            }
+            finally
+            {
+                // let the lock go
+                _dbOwnershipLock.Dispose();
+            }
+        }
+
+        private void CloseWorker()
+        {
+            // Flush all pending writes so that all data our features wanted written
+            // are definitely persisted to the DB.
+            try
+            {
                 FlushAllPendingWritesAsync(CancellationToken.None).Wait();
             }
             catch (Exception e)
@@ -216,9 +231,6 @@ namespace Microsoft.CodeAnalysis.SQLite
                     connection.Close_OnlyForUseBySqlPersistentStorage();
                 }
             }
-
-            // let the lock go
-            _dbOwnershipLock.Dispose();
         }
 
         private PooledConnection GetPooledConnection()

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SolutionSize;
 using Microsoft.CodeAnalysis.Storage;
 using Roslyn.Utilities;
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.SQLite
 
         private static IDisposable TryGetDatabaseOwnership(string databaseFilePath)
         {
-            try
+            return IOUtilities.PerformIO<IDisposable>(() =>
             {
                 // make sure directory exist first.
                 EnsureDirectory(databaseFilePath);
@@ -65,11 +66,7 @@ namespace Microsoft.CodeAnalysis.SQLite
                 return File.Open(
                     Path.Combine(Path.GetDirectoryName(databaseFilePath), LockFile),
                     FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            });
         }
 
         private static void EnsureDirectory(string databaseFilePath)

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
@@ -37,13 +37,22 @@ namespace Microsoft.CodeAnalysis.SQLite
             return Path.Combine(workingFolderPath, StorageExtension, PersistentStorageFileName);
         }
 
-        protected override AbstractPersistentStorage OpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath)
+        protected override bool TryOpenDatabase(
+            Solution solution, string workingFolderPath, string databaseFilePath, out AbstractPersistentStorage storage)
         {
+            storage = null;
+
             // try to get db ownership lock. if someone else already has the lock. it will throw
             var dbOwnershipLock = TryGetDatabaseOwnership(databaseFilePath);
+            if (dbOwnershipLock == null)
+            {
+                return false;
+            }
 
-            return new SQLitePersistentStorage(
+            storage = new SQLitePersistentStorage(
                 OptionService, workingFolderPath, solution.FilePath, databaseFilePath, this.Release, dbOwnershipLock, _faultInjectorOpt);
+
+            return true;
         }
 
         private static IDisposable TryGetDatabaseOwnership(string databaseFilePath)
@@ -57,9 +66,9 @@ namespace Microsoft.CodeAnalysis.SQLite
                     Path.Combine(Path.GetDirectoryName(databaseFilePath), LockFile),
                     FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                throw new InvalidOperationException("can't get the ownership", ex);
+                return null;
             }
         }
 
@@ -76,12 +85,6 @@ namespace Microsoft.CodeAnalysis.SQLite
 
         protected override bool ShouldDeleteDatabase(Exception exception)
         {
-            if (exception is InvalidOperationException)
-            {
-                // db is owned by another process
-                return false;
-            }
-
             // Error occurred when trying to open this DB.  Try to remove it so we can create a good dB.
             return true;
         }

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Storage
         }
 
         protected abstract string GetDatabaseFilePath(string workingFolderPath);
-        protected abstract AbstractPersistentStorage OpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath);
+        protected abstract bool TryOpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath, out AbstractPersistentStorage storage);
         protected abstract bool ShouldDeleteDatabase(Exception exception);
 
         public IPersistentStorage GetStorage(Solution solution)
@@ -235,7 +235,11 @@ namespace Microsoft.CodeAnalysis.Storage
             var databaseFilePath = GetDatabaseFilePath(workingFolderPath);
             try
             {
-                database = OpenDatabase(solution, workingFolderPath, databaseFilePath);
+                if (!TryOpenDatabase(solution, workingFolderPath, databaseFilePath, out database))
+                {
+                    return false;
+                }
+
                 database.Initialize(solution);
 
                 persistentStorage = database;

--- a/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
+++ b/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.Remote.Storage
                 }
                 else
                 {
-                    _idToStorageLocation[id] = storageLocation;
+                    // Store the esent database in a different location for the out of proc server.
+                    _idToStorageLocation[id] = Path.Combine(storageLocation, "Server");
                 }
             }
         }


### PR DESCRIPTION
#1. made persisted storage exclusive to 1 process. like before, second VS with same solution will not use persisted storage.
#2, tweaked sqlite to share cache between connections like esent. (this is supposed to use less memory since same cache will be re-used by all connection rather than each connection having its own cache)
#3, made VS and OOP to use different db files (we can make them to share if we want to, but for now, nobody requires it so we create 2 different db)

..

made OOP mock to enable persisted service.
