### PR TITLE
Optimize performance for LookupSymbols(name)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1564,7 +1564,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void AddMemberLookupSymbolsInfoInNamespace(LookupSymbolsInfo result, NamespaceSymbol ns, LookupOptions options, Binder originalBinder)
         {
-            foreach (var symbol in GetCandidateMembers(ns, options, originalBinder))
+            var candidateMembers = result.FilterName != null ? GetCandidateMembers(ns, result.FilterName, options, originalBinder) : GetCandidateMembers(ns, options, originalBinder);
+            foreach (var symbol in candidateMembers)
             {
                 if (originalBinder.CanAddLookupSymbolInfo(symbol, options, result, null))
                 {
@@ -1575,7 +1576,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void AddMemberLookupSymbolsInfoWithoutInheritance(LookupSymbolsInfo result, TypeSymbol type, LookupOptions options, Binder originalBinder, TypeSymbol accessThroughType)
         {
-            foreach (var symbol in GetCandidateMembers(type, options, originalBinder))
+            var candidateMembers = result.FilterName != null ? GetCandidateMembers(type, result.FilterName, options, originalBinder) : GetCandidateMembers(type, options, originalBinder);
+            foreach (var symbol in candidateMembers)
             {
                 if (originalBinder.CanAddLookupSymbolInfo(symbol, options, result, accessThroughType))
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1240,11 +1240,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>
         /// Does not consider <see cref="Symbol.CanBeReferencedByName"/> - that is left to the caller.
         /// </remarks>
-        internal bool CanAddLookupSymbolInfo(Symbol symbol, LookupOptions options, TypeSymbol accessThroughType)
+        internal bool CanAddLookupSymbolInfo(Symbol symbol, LookupOptions options, LookupSymbolsInfo info, TypeSymbol accessThroughType, AliasSymbol aliasSymbol = null)
         {
             Debug.Assert(symbol.Kind != SymbolKind.Alias, "It is the caller's responsibility to unwrap aliased symbols.");
+            Debug.Assert(aliasSymbol == null || aliasSymbol.GetAliasTarget(basesBeingResolved: null) == symbol);
             Debug.Assert(options.AreValid());
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+
+            var name = aliasSymbol != null ? aliasSymbol.Name : symbol.Name;
+            if (!info.CanBeAdded(name))
+            {
+                return false;
+            }
 
             if ((options & LookupOptions.NamespacesOrTypesOnly) != 0 && !(symbol is NamespaceOrTypeSymbol))
             {
@@ -1559,7 +1566,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var symbol in GetCandidateMembers(ns, options, originalBinder))
             {
-                if (originalBinder.CanAddLookupSymbolInfo(symbol, options, null))
+                if (originalBinder.CanAddLookupSymbolInfo(symbol, options, result, null))
                 {
                     result.AddSymbol(symbol, symbol.Name, symbol.GetArity());
                 }
@@ -1570,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var symbol in GetCandidateMembers(type, options, originalBinder))
             {
-                if (originalBinder.CanAddLookupSymbolInfo(symbol, options, accessThroughType))
+                if (originalBinder.CanAddLookupSymbolInfo(symbol, options, result, accessThroughType))
                 {
                     result.AddSymbol(symbol, symbol.Name, symbol.GetArity());
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -838,7 +838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static void AddAliasSymbolToResult(LookupSymbolsInfo result, AliasSymbol aliasSymbol, LookupOptions options, Binder originalBinder)
         {
             var targetSymbol = aliasSymbol.GetAliasTarget(basesBeingResolved: null);
-            if (originalBinder.CanAddLookupSymbolInfo(targetSymbol, options, null))
+            if (originalBinder.CanAddLookupSymbolInfo(targetSymbol, options, result, accessThroughType: null, aliasSymbol: aliasSymbol))
             {
                 result.AddSymbol(aliasSymbol, aliasSymbol.Name, 0);
             }
@@ -859,7 +859,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var member in namespaceSymbol.NamespaceOrType.GetMembersUnordered())
                 {
-                    if (IsValidLookupCandidateInUsings(member) && originalBinder.CanAddLookupSymbolInfo(member, options, null))
+                    if (IsValidLookupCandidateInUsings(member) && originalBinder.CanAddLookupSymbolInfo(member, options, result, null))
                     {
                         result.AddSymbol(member, member.Name, member.GetArity());
                     }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var parameter in _methodSymbol.Parameters)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     foreach (var local in this.LocalsMap)
                     {
-                        if (originalBinder.CanAddLookupSymbolInfo(local.Value, options, null))
+                        if (originalBinder.CanAddLookupSymbolInfo(local.Value, options, result, null))
                         {
                             result.AddSymbol(local.Value, local.Key, 0);
                         }
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     foreach (var local in this.LocalFunctionsMap)
                     {
-                        if (originalBinder.CanAddLookupSymbolInfo(local.Value, options, null))
+                        if (originalBinder.CanAddLookupSymbolInfo(local.Value, options, result, null))
                         {
                             result.AddSymbol(local.Value, local.Key, 0);
                         }

--- a/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var parameter in _namedType.TypeParameters)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/WithCrefTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithCrefTypeParametersBinder.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     foreach (TypeParameterSymbol typeParameter in kvp.Value)
                     {
                         // In any context where this binder applies, the type parameters are always viable/speakable.
-                        Debug.Assert(originalBinder.CanAddLookupSymbolInfo(typeParameter, options, null));
+                        Debug.Assert(!result.CanBeAdded(typeParameter.Name) || originalBinder.CanAddLookupSymbolInfo(typeParameter, options, result, null));
 
                         result.AddSymbol(typeParameter, kvp.Key, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var parameter in lambdaSymbol.Parameters)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var parameter in _methodSymbol.TypeParameters)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Binder/WithParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithParametersBinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var parameter in _parameters)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1510,6 +1510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var info = LookupSymbolsInfo.GetInstance();
+            info.FilterName = name;
 
             if ((object)container == null)
             {

--- a/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
+++ b/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
@@ -222,12 +222,17 @@ namespace Microsoft.CodeAnalysis
 #endif
         }
 
+        private readonly IEqualityComparer<string> _comparer;
         private readonly Dictionary<string, UniqueSymbolOrArities> _nameMap;
+        internal string FilterName { private get; set; }
 
         protected AbstractLookupSymbolsInfo(IEqualityComparer<string> comparer)
         {
+            _comparer = comparer;
             _nameMap = new Dictionary<string, UniqueSymbolOrArities>(comparer);
         }
+
+        public bool CanBeAdded(string name) => FilterName == null || _comparer.Equals(name, FilterName);
 
         public void AddSymbol(TSymbol symbol, string name, int arity)
         {
@@ -273,6 +278,8 @@ namespace Microsoft.CodeAnalysis
             out IArityEnumerable arities,
             out TSymbol uniqueSymbol)
         {
+            Debug.Assert(CanBeAdded(name));
+
             UniqueSymbolOrArities pair;
             if (!_nameMap.TryGetValue(name, out pair))
             {
@@ -287,6 +294,10 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
-        public void Clear() => _nameMap.Clear();
+        public void Clear()
+        {
+            _nameMap.Clear();
+            FilterName = null;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
+++ b/src/Compilers/Core/Portable/Binding/AbstractLookupSymbolsInfo.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis
 
         private readonly IEqualityComparer<string> _comparer;
         private readonly Dictionary<string, UniqueSymbolOrArities> _nameMap;
-        internal string FilterName { private get; set; }
+        internal string FilterName { get; set; }
 
         protected AbstractLookupSymbolsInfo(IEqualityComparer<string> comparer)
         {

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -274,11 +274,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </remarks>
         Friend Function CanAddLookupSymbolInfo(sym As Symbol,
                                                     options As LookupOptions,
+                                                    nameSet As LookupSymbolsInfo,
                                                     accessThroughType As TypeSymbol) As Boolean
+            Debug.Assert(sym IsNot Nothing)
+
+            If Not nameSet.CanBeAdded(sym.Name) Then
+                Return False
+            End If
+
             Dim singleResult = CheckViability(sym, -1, options, accessThroughType, useSiteDiagnostics:=Nothing)
 
-            If sym IsNot Nothing AndAlso
-               (options And LookupOptions.MethodsOnly) <> 0 AndAlso
+            If (options And LookupOptions.MethodsOnly) <> 0 AndAlso
                sym.Kind <> SymbolKind.Method Then
                 Return False
             End If
@@ -524,7 +530,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Add names from the namespace
                 For Each sym In container.GetMembersUnordered()
                     ' UNDONE: filter by options
-                    If binder.CanAddLookupSymbolInfo(sym, options, Nothing) Then
+                    If binder.CanAddLookupSymbolInfo(sym, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(sym, sym.Name, sym.GetArity())
                     End If
                 Next
@@ -2081,7 +2087,7 @@ ExitForFor:
                     ' validate them.
                     If TypeOf container Is NamedTypeSymbol Then
                         For Each sym In container.GetTypeMembersUnordered()
-                            If binder.CanAddLookupSymbolInfo(sym, options, accessThroughType) Then
+                            If binder.CanAddLookupSymbolInfo(sym, options, nameSet, accessThroughType) Then
                                 nameSet.AddSymbol(sym, sym.Name, sym.Arity)
                             End If
                         Next
@@ -2089,7 +2095,7 @@ ExitForFor:
                 ElseIf (options And LookupOptions.LabelsOnly) = 0 Then
                     ' Go through each member of the type.
                     For Each sym In container.GetMembersUnordered()
-                        If binder.CanAddLookupSymbolInfo(sym, options, accessThroughType) Then
+                        If binder.CanAddLookupSymbolInfo(sym, options, nameSet, accessThroughType) Then
                             nameSet.AddSymbol(sym, sym.Name, sym.GetArity())
                         End If
                     Next

--- a/src/Compilers/VisualBasic/Portable/Binding/BlockBaseBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BlockBaseBinder.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim locals = Me.Locals
             If Not locals.IsEmpty AndAlso (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly)) = 0 Then
                 For Each localSymbol In locals
-                    If originalBinder.CanAddLookupSymbolInfo(localSymbol, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(localSymbol, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(localSymbol, localSymbol.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_TypeParameters.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_TypeParameters.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                        originalBinder As Binder)
 
                 For Each typeParameter In _typeParameters.Values
-                    If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(typeParameter, typeParameter.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentParamBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentParamBinder.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             For Each parameter In Me.Parameters
-                If originalBinder.CanAddLookupSymbolInfo(parameter, options, Nothing) Then
+                If originalBinder.CanAddLookupSymbolInfo(parameter, options, nameSet, Nothing) Then
                     nameSet.AddSymbol(parameter, parameter.Name, 0)
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamBinder.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If Not typeParameters.IsEmpty Then
                 For Each typeParameter In typeParameters
-                    If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(typeParameter, typeParameter.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/ImplicitVariableBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImplicitVariableBinder.vb
@@ -231,7 +231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly)) = 0 Then
 
                 For Each localSymbol In _implicitLocals.Values
-                    If originalBinder.CanAddLookupSymbolInfo(localSymbol, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(localSymbol, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(localSymbol, localSymbol.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/MethodTypeParametersBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MethodTypeParametersBinder.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                     originalBinder As Binder)
             ' UNDONE: check options to see if type parameters should be found.
             For Each typeParameter In _typeParameters
-                If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, Nothing) Then
+                If originalBinder.CanAddLookupSymbolInfo(typeParameter, options, nameSet, Nothing) Then
                     nameSet.AddSymbol(typeParameter, typeParameter.Name, 0)
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' UNDONE: filter using options.
             If _typeSymbol.Arity > 0 Then
                 For Each tp In _typeSymbol.TypeParameters
-                    If originalBinder.CanAddLookupSymbolInfo(tp, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(tp, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(tp, tp.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
@@ -75,7 +75,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' UNDONE: additional filtering based on options?
             If (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly)) = 0 Then
                 For Each param In _parameterMap.Values
-                    If originalBinder.CanAddLookupSymbolInfo(param, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(param, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(param, param.Name, 0)
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -1890,6 +1890,8 @@ _Default:
             Else
                 ' They provided a name.  Find all the arities for that name, and then look all of those up.
                 Dim info = LookupSymbolsInfo.GetInstance()
+                info.FilterName = name
+
                 Me.AddLookupSymbolsInfo(position, info, container, options)
 
                 Dim results = ArrayBuilder(Of Symbol).GetInstance(info.Count)

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamespaceOrTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamespaceOrTypeSymbol.vb
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         If method.MayBeReducibleExtensionMethod Then
                             haveSeenExtensionMethod = True
 
-                            If AddExtensionMethodLookupSymbolsInfoViabilityCheck(method, options, originalBinder) Then
+                            If AddExtensionMethodLookupSymbolsInfoViabilityCheck(method, options, nameSet, originalBinder) Then
                                 nameSet.AddSymbol(member, member.Name, member.GetArity())
 
                                 ' Move to the next name.
@@ -239,9 +239,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overridable Function AddExtensionMethodLookupSymbolsInfoViabilityCheck(
             method As MethodSymbol,
             options As LookupOptions,
+            nameSet As LookupSymbolsInfo,
             originalBinder As Binder
         ) As Boolean
-            Return originalBinder.CanAddLookupSymbolInfo(method, options, accessThroughType:=method.ContainingType)
+            Return originalBinder.CanAddLookupSymbolInfo(method, options, nameSet, accessThroughType:=method.ContainingType)
         End Function
 
         ''' <summary> 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
@@ -214,8 +214,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         ''' <summary>
         ''' Make sure we retarget methods when underlying type checks their viability.
         ''' </summary>
-        Friend Overrides Function AddExtensionMethodLookupSymbolsInfoViabilityCheck(method As MethodSymbol, options As LookupOptions, originalBinder As Binder) As Boolean
-            Return MyBase.AddExtensionMethodLookupSymbolsInfoViabilityCheck(RetargetingTranslator.Retarget(method), options, originalBinder)
+        Friend Overrides Function AddExtensionMethodLookupSymbolsInfoViabilityCheck(method As MethodSymbol, options As LookupOptions, nameSet As LookupSymbolsInfo, originalBinder As Binder) As Boolean
+            Return MyBase.AddExtensionMethodLookupSymbolsInfoViabilityCheck(RetargetingTranslator.Retarget(method), options, nameSet, originalBinder)
         End Function
 
         Friend Overrides Sub AddExtensionMethodLookupSymbolsInfo(nameSet As LookupSymbolsInfo,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.vb
@@ -270,8 +270,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         ''' <summary>
         ''' Make sure we retarget methods when underlying namespace checks their viability.
         ''' </summary>
-        Friend Overrides Function AddExtensionMethodLookupSymbolsInfoViabilityCheck(method As MethodSymbol, options As LookupOptions, originalBinder As Binder) As Boolean
-            Return MyBase.AddExtensionMethodLookupSymbolsInfoViabilityCheck(RetargetingTranslator.Retarget(method), options, originalBinder)
+        Friend Overrides Function AddExtensionMethodLookupSymbolsInfoViabilityCheck(method As MethodSymbol, options As LookupOptions, nameSet As LookupSymbolsInfo, originalBinder As Binder) As Boolean
+            Return MyBase.AddExtensionMethodLookupSymbolsInfoViabilityCheck(RetargetingTranslator.Retarget(method), options, nameSet, originalBinder)
         End Function
 
         Friend Overrides Sub AddExtensionMethodLookupSymbolsInfo(nameSet As LookupSymbolsInfo,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/WithTypeArgumentsBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/WithTypeArgumentsBinder.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             {
                 foreach (var parameter in _typeArguments)
                 {
-                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, null))
+                    if (originalBinder.CanAddLookupSymbolInfo(parameter, options, result, null))
                     {
                         result.AddSymbol(parameter, parameter.Name, 0);
                     }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
@@ -91,7 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' UNDONE: additional filtering based on options?
             If (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly Or LookupOptions.MustNotBeLocalOrParameter)) = 0 Then
                 For Each symbol In _nameToSymbolMap.Values
-                    If originalBinder.CanAddLookupSymbolInfo(symbol, options, Nothing) Then
+                    If originalBinder.CanAddLookupSymbolInfo(symbol, options, nameSet, Nothing) Then
                         nameSet.AddSymbol(symbol, symbol.Name, 0)
                     End If
                 Next


### PR DESCRIPTION
A customer trace on recent 15.3 release shows that `Microsoft.CodeAnalysis.CSharp!Binder.IsAccessibleHelper` is taking up large amount of CPU stacks for LookupSymbols(name) calls from IDE analyzers. This change optimizes the performance of this code path by adding a name check before doing accessibilty checks.

Addresses VS Feedback item https://developercommunity.visualstudio.com/content/problem/94142/start-a-debug-session-kicks-off-high-cpu-thread.html tracked with VSO [479758](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=479758&_a=edit)