### PR TITLE
removed ImmutableArray from json.net usage. and moved to IList

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
@@ -240,6 +242,19 @@ namespace Roslyn.Utilities
             }
 
             return source.Where((Func<T, bool>)s_notNullTest);
+        }
+
+        public static ImmutableArray<TResult> SelectAsArray<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
+        {
+            if (source == null)
+            {
+                return ImmutableArray<TResult>.Empty;
+            }
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            builder.AddRange(source.Select(selector));
+
+            return builder.ToImmutableAndFree();
         }
 
         public static bool All(this IEnumerable<bool> source)

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -257,7 +257,7 @@ class C
             installerServiceMock.Verify();
         }
 
-        private Task<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(
+        private Task<IList<PackageWithTypeResult>> CreateSearchResult(
             string packageName, string typeName, ImmutableArray<string> containingNamespaceNames)
         {
             return CreateSearchResult(new PackageWithTypeResult(
@@ -265,8 +265,8 @@ class C
                 rank: 0, containingNamespaceNames: containingNamespaceNames));
         }
 
-        private Task<ImmutableArray<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
-            => Task.FromResult(ImmutableArray.Create(results));
+        private Task<IList<PackageWithTypeResult>> CreateSearchResult(params PackageWithTypeResult[] results)
+            => Task.FromResult<IList<PackageWithTypeResult>>(ImmutableArray.Create(results));
 
         private ImmutableArray<string> CreateNameParts(params string[] parts) => parts.ToImmutableArray();
     }

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             }
         }
 
-        private async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        private async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
             var service = document.GetLanguageService<ITodoCommentService>();
             if (service == null)

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -122,11 +123,11 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                     return ImmutableArray<PackageWithTypeResult>.Empty;
                 }
 
-                var results = await session.InvokeAsync<ImmutableArray<PackageWithTypeResult>>(
+                var results = await session.InvokeAsync<IList<PackageWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithTypeAsync),
                     source, name, arity).ConfigureAwait(false);
 
-                return results;
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
@@ -139,11 +140,11 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                     return ImmutableArray<PackageWithAssemblyResult>.Empty;
                 }
 
-                var results = await session.InvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
+                var results = await session.InvokeAsync<IList<PackageWithAssemblyResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithAssemblyAsync),
                     source, assemblyName).ConfigureAwait(false);
 
-                return results;
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
@@ -156,11 +157,11 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                     return ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty;
                 }
 
-                var results = await session.InvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
+                var results = await session.InvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindReferenceAssembliesWithTypeAsync),
                     name, arity).ConfigureAwait(false);
 
-                return results;
+                return results.ToImmutableArrayOrEmpty();
             }
 
             public async Task UpdateContinuouslyAsync(

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -239,7 +239,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
             installerServiceMock.Verify()
         End Function
 
-        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of ImmutableArray(Of PackageWithTypeResult))
+        Private Function CreateSearchResult(packageName As String, typeName As String, nameParts As ImmutableArray(Of String)) As Task(Of IList(Of PackageWithTypeResult))
             Return CreateSearchResult(New PackageWithTypeResult(
                 packageName:=packageName,
                 typeName:=typeName,
@@ -248,8 +248,8 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 containingNamespaceNames:=nameParts))
         End Function
 
-        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of ImmutableArray(Of PackageWithTypeResult))
-            Return Task.FromResult(ImmutableArray.Create(results))
+        Private Function CreateSearchResult(ParamArray results As PackageWithTypeResult()) As Task(Of IList(Of PackageWithTypeResult))
+            Return Task.FromResult(Of IList(Of PackageWithTypeResult))(ImmutableArray.Create(results))
         End Function
 
         Private Function CreateNameParts(ParamArray parts As String()) As ImmutableArray(Of String)

--- a/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
+++ b/src/Features/CSharp/Portable/TodoComments/CSharpTodoCommentIncrementalAnalyzerProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TodoComments
         private static readonly int s_multilineCommentPostfixLength = "*/".Length;
         private const string SingleLineCommentPrefix = "//";
 
-        protected override void AppendTodoComments(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
+        protected override void AppendTodoComments(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList)
         {
             if (PreprocessorHasComment(trivia))
             {

--- a/src/Features/Core/Portable/AddImport/AddImportFixData.cs
+++ b/src/Features/Core/Portable/AddImport/AddImportFixData.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// May be empty for fixes that don't need to add an import and only do something like
         /// add a project/metadata reference.
         /// </summary>
-        public ImmutableArray<TextChange> TextChanges { get; }
+        public IList<TextChange> TextChanges { get; }
 
         /// <summary>
         /// String to display in the lightbulb menu.
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// <summary>
         /// Tags that control what glyph is displayed in the lightbulb menu.
         /// </summary>
-        public ImmutableArray<string> Tags { get; private set; }
+        public IList<string> Tags { get; private set; }
 
         /// <summary>
         /// The priority this item should have in the lightbulb list.

--- a/src/Features/Core/Portable/AddImport/CodeActions/AddImportCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AddImportCodeAction.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
 {
@@ -44,9 +45,9 @@ namespace Microsoft.CodeAnalysis.AddImport
                 FixData = fixData;
 
                 Title = fixData.Title;
-                Tags = fixData.Tags;
+                Tags = fixData.Tags.ToImmutableArrayOrEmpty();
                 Priority = fixData.Priority;
-                _textChanges = fixData.TextChanges;
+                _textChanges = fixData.TextChanges.ToImmutableArrayOrEmpty();
             }
 
             protected async Task<Document> GetUpdatedDocumentAsync(CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -19,12 +20,12 @@ namespace Microsoft.CodeAnalysis.AddImport
             string diagnosticId, bool placeSystemNamespaceFirst,
             bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources)
         {
-            var result = await session.InvokeAsync<ImmutableArray<AddImportFixData>>(
+            var result = await session.InvokeAsync<IList<AddImportFixData>>(
                 nameof(IRemoteAddImportFeatureService.GetFixesAsync),
                 document.Id, span, diagnosticId, placeSystemNamespaceFirst, 
                 searchReferenceAssemblies, packageSources).ConfigureAwait(false);
 
-            return result;
+            return result.AsImmutableOrEmpty();
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 throw new NotImplementedException();
             }
 
-            public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity)
             {
                 var result = await _symbolSearchService.FindPackagesWithTypeAsync(
@@ -65,7 +66,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 return result;
             }
 
-            public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string name)
             {
                 var result = await _symbolSearchService.FindPackagesWithAssemblyAsync(
@@ -74,7 +75,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 return result;
             }
 
-            public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity)
             {
                 var result = await _symbolSearchService.FindReferenceAssembliesWithTypeAsync(

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Packaging;
@@ -9,8 +10,8 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     internal interface IRemoteAddImportFeatureService
     {
-        Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
+        Task<IList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources);
+            bool searchReferenceAssemblies, IList<PackageSource> packageSources);
     }
 }

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.SymbolSearch;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 cancellationToken.ThrowIfCancellationRequested();
                 var results = await _symbolSearchService.FindReferenceAssembliesWithTypeAsync(
                     name, arity, cancellationToken).ConfigureAwait(false);
-                if (results.IsDefault)
+                if (results == null)
                 {
                     return;
                 }
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 cancellationToken.ThrowIfCancellationRequested();
                 var results = await _symbolSearchService.FindPackagesWithTypeAsync(
                     source.Name, name, arity, cancellationToken).ConfigureAwait(false);
-                if (results.IsDefault)
+                if (results == null)
                 {
                     return;
                 }
@@ -160,7 +161,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 var desiredName = GetDesiredName(isAttributeSearch, result.TypeName);
                 allReferences.Add(new AssemblyReference(
-                    _owner, new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames, weight), result));
+                    _owner, new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight), result));
             }
 
             private void HandleNugetReference(
@@ -174,7 +175,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 var desiredName = GetDesiredName(isAttributeSearch, result.TypeName);
                 allReferences.Add(new PackageReference(_owner,
-                    new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames, weight),
+                    new SearchResult(desiredName, nameNode, result.ContainingNamespaceNames.ToReadOnlyList(), weight),
                     source, result.PackageName, result.Version));
             }
 

--- a/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
@@ -7,6 +8,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
 {
     internal interface IRemoteDesignerAttributeService
     {
-        Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId);
+        Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId);
     }
 }

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                     return (succeeded: false, ImmutableArray<DocumentHighlights>.Empty);
                 }
 
-                var result = await session.InvokeAsync<ImmutableArray<SerializableDocumentHighlights>>(
+                var result = await session.InvokeAsync<IList<SerializableDocumentHighlights>>(
                     nameof(IRemoteDocumentHighlights.GetDocumentHighlightsAsync),
                     document.Id,
                     position,

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,14 +9,14 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
 {
     internal interface IRemoteDocumentHighlights
     {
-        Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        Task<IList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch);
     }
 
     internal struct SerializableDocumentHighlights
     {
         public DocumentId DocumentId;
-        public ImmutableArray<HighlightSpan> HighlightSpans;
+        public IList<HighlightSpan> HighlightSpans;
 
         public DocumentHighlights Rehydrate(Solution solution)
             => new DocumentHighlights(solution.GetDocument(DocumentId), HighlightSpans.ToImmutableArray());

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.NavigateTo
 {
@@ -12,7 +14,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentInRemoteProcessAsync(
             RemoteHostClient.Session session, Document document, string searchPattern, CancellationToken cancellationToken)
         {
-            var serializableResults = await session.InvokeAsync<ImmutableArray<SerializableNavigateToSearchResult>>(
+            var serializableResults = await session.InvokeAsync<IList<SerializableNavigateToSearchResult>>(
                 nameof(IRemoteNavigateToSearchService.SearchDocumentAsync),
                 document.Id, searchPattern).ConfigureAwait(false);
 
@@ -22,7 +24,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
             RemoteHostClient.Session session, Project project, string searchPattern, CancellationToken cancellationToken)
         {
-            var serializableResults = await session.InvokeAsync<ImmutableArray<SerializableNavigateToSearchResult>>(
+            var serializableResults = await session.InvokeAsync<IList<SerializableNavigateToSearchResult>>(
                 nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
                 project.Id, searchPattern).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
@@ -8,7 +9,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface IRemoteNavigateToSearchService
     {
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern);
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern);
+        Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern);
+        Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern);
     }
 }

--- a/src/Features/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Features/Core/Portable/Remote/RemoteArguments.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -17,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public NavigateToMatchKind MatchKind;
         public bool IsCaseSensitive;
         public string Name;
-        public ImmutableArray<TextSpan> NameMatchSpans;
+        public IList<TextSpan> NameMatchSpans;
         public string SecondarySort;
         public string Summary;
 
@@ -82,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         public Glyph Glyph;
 
-        public ImmutableArray<TaggedText> DisplayTaggedParts;
+        public IList<TaggedText> DisplayTaggedParts;
 
         public bool DisplayFileLocation;
 
@@ -91,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public DocumentId Document;
         public TextSpan SourceSpan;
 
-        ImmutableArray<SerializableNavigableItem> ChildItems;
+        public IList<SerializableNavigableItem> ChildItems;
 
         public static SerializableNavigableItem Dehydrate(INavigableItem item)
         {

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
         protected abstract string GetNormalizedText(string message);
         protected abstract int GetCommentStartingIndex(string message);
-        protected abstract void AppendTodoComments(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
+        protected abstract void AppendTodoComments(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, List<TodoComment> todoList);
 
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             // same service run in both inproc and remote host, but remote host will not have RemoteHostClient service, 
             // so inproc one will always run
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
         }
 
         private async Task<IList<TodoComment>> GetTodoCommentsInRemoteHostAsync(
-            RemoteHostClient client, Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+            RemoteHostClient client, Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             return await client.RunCodeAnalysisServiceOnRemoteHostAsync<IList<TodoComment>>(
                 document.Project.Solution, nameof(IRemoteTodoCommentService.GetTodoCommentsAsync),
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
         }
 
         private async Task<IList<TodoComment>> GetTodoCommentsInCurrentProcessAsync(
-            Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
+            Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             return PreprocessorHasComment(trivia) || IsSingleLineComment(trivia) || IsMultilineComment(trivia);
         }
 
-        protected void AppendTodoCommentInfoFromSingleLine(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
+        protected void AppendTodoCommentInfoFromSingleLine(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, string message, int start, List<TodoComment> todoList)
         {
             var index = GetCommentStartingIndex(message);
             if (index >= message.Length)
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             }
         }
 
-        protected void ProcessMultilineComment(ImmutableArray<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
+        protected void ProcessMultilineComment(IList<TodoCommentDescriptor> commentDescriptors, SyntacticDocument document, SyntaxTrivia trivia, int postfixLength, List<TodoComment> todoList)
         {
             // this is okay since we know it is already alive
             var text = document.Text;

--- a/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
     /// </summary>
     internal interface IRemoteTodoCommentService
     {
-        Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> commentDescriptors);
+        Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, IList<TodoCommentDescriptor> commentDescriptors);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/ITodoCommentService.cs
@@ -42,6 +42,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
 
     internal interface ITodoCommentService : ILanguageService
     {
-        Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
+        Task<IList<TodoComment>> GetTodoCommentsAsync(Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
+++ b/src/Features/VisualBasic/Portable/TodoComments/BasicTodoCommentIncrementalAnalyzerProvider.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.TodoComments
     Friend Class VisualBasicTodoCommentService
         Inherits AbstractTodoCommentService
 
-        Protected Overrides Sub AppendTodoComments(commentDescriptors As ImmutableArray(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
+        Protected Overrides Sub AppendTodoComments(commentDescriptors As IList(Of TodoCommentDescriptor), document As SyntacticDocument, trivia As SyntaxTrivia, todoList As List(Of TodoComment))
             If PreprocessorHasComment(trivia) Then
                 Dim commentTrivia = trivia.GetStructure().DescendantTrivia().First(Function(t) t.RawKind = SyntaxKind.CommentTrivia)
 

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                     return null;
                 }
 
-                var serializedResults = await session.InvokeAsync<ImmutableArray<DesignerAttributeDocumentData>>(
+                var serializedResults = await session.InvokeAsync<IList<DesignerAttributeDocumentData>>(
                     nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), project.Id).ConfigureAwait(false);
 
                 var data = serializedResults.ToImmutableDictionary(kvp => kvp.FilePath);

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             await engine.UpdateContinuouslyAsync(sourceName, _localSettingsDirectory).ConfigureAwait(false);
         }
 
-        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return FilterAndOrderPackages(allPackagesWithType);
         }
 
-        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             return result.ToImmutableAndFree();
         }
 
-        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -100,7 +101,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     if (session != null)
                     {
-                        var result = await session.InvokeAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+                        var result = await session.InvokeAsync<IList<SerializableSymbolAndProjectId>>(
                             nameof(IRemoteSymbolFinder.FindAllDeclarationsWithNormalQueryAsync),
                             project.Id, query.Name, query.Kind, criteria).ConfigureAwait(false);
 
@@ -116,9 +117,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static async Task<ImmutableArray<SymbolAndProjectId>> RehydrateAsync(
-            Solution solution, ImmutableArray<SerializableSymbolAndProjectId> array, CancellationToken cancellationToken)
+            Solution solution, IList<SerializableSymbolAndProjectId> array, CancellationToken cancellationToken)
         {
-            var result = ArrayBuilder<SymbolAndProjectId>.GetInstance(array.Length);
+            var result = ArrayBuilder<SymbolAndProjectId>.GetInstance(array.Count);
 
             foreach (var dehydrated in array)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 if (session != null)
                 {
-                    var result = await session.InvokeAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+                    var result = await session.InvokeAsync<IList<SerializableSymbolAndProjectId>>(
                         nameof(IRemoteSymbolFinder.FindSolutionSourceDeclarationsWithNormalQueryAsync),
                         name, ignoreCase, criteria).ConfigureAwait(false);
 
@@ -141,7 +142,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     if (session != null)
                     {
-                        var result = await session.InvokeAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+                        var result = await session.InvokeAsync<IList<SerializableSymbolAndProjectId>>(
                             nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithNormalQueryAsync),
                             project.Id, name, ignoreCase, criteria).ConfigureAwait(false);
 
@@ -165,7 +166,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 {
                     if (session != null)
                     {
-                        var result = await session.InvokeAsync<ImmutableArray<SerializableSymbolAndProjectId>>(
+                        var result = await session.InvokeAsync<IList<SerializableSymbolAndProjectId>>(
                             nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithPatternAsync),
                             project.Id, pattern, criteria).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
@@ -12,16 +13,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs);
         Task FindLiteralReferencesAsync(object value, TypeCode typeCode);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria);
 
-        Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
@@ -9,8 +10,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     {
         Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory);
 
-        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity);
-        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name);
-        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity);
+        Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity);
+        Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name);
+        Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken);
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         /// Implementations should return results in order from best to worst (from their
         /// perspective).
         /// </summary>
-        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken);
     }
 
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class PackageWithTypeResult : PackageResult
     {
-        public readonly ImmutableArray<string> ContainingNamespaceNames;
+        public readonly IList<string> ContainingNamespaceNames;
         public readonly string TypeName;
         public readonly string Version;
 
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             string typeName,
             string version,
             int rank,
-            ImmutableArray<string> containingNamespaceNames)
+            IList<string> containingNamespaceNames)
             : base(packageName, rank)
         {
             TypeName = typeName;
@@ -118,14 +118,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
     internal class ReferenceAssemblyWithTypeResult
     {
-        public readonly ImmutableArray<string> ContainingNamespaceNames;
+        public readonly IList<string> ContainingNamespaceNames;
         public readonly string AssemblyName;
         public readonly string TypeName;
 
         public ReferenceAssemblyWithTypeResult(
             string assemblyName,
             string typeName,
-            ImmutableArray<string> containingNamespaceNames)
+            IList<string> containingNamespaceNames)
         {
             AssemblyName = assemblyName;
             TypeName = typeName;
@@ -136,22 +136,22 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     [ExportWorkspaceService(typeof(ISymbolSearchService)), Shared]
     internal class DefaultSymbolSearchService : ISymbolSearchService
     {
-        public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+        public Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
             string source, string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<PackageWithTypeResult>();
+            return SpecializedTasks.EmptyList<PackageWithTypeResult>();
         }
 
-        public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
             string source, string assemblyName, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<PackageWithAssemblyResult>();
+            return SpecializedTasks.EmptyList<PackageWithAssemblyResult>();
         }
 
-        public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+        public Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
             string name, int arity, CancellationToken cancellationToken)
         {
-            return SpecializedTasks.EmptyImmutableArray<ReferenceAssemblyWithTypeResult>();
+            return SpecializedTasks.EmptyList<ReferenceAssemblyWithTypeResult>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/IReadOnlyListExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IReadOnlyListExtensions.cs
@@ -1,12 +1,38 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
     internal static class IReadOnlyListExtensions
     {
+        public static IReadOnlyList<T> ToReadOnlyList<T>(this IList<T> list)
+        {
+            if (list is IReadOnlyList<T> readOnlyList)
+            {
+                return readOnlyList;
+            }
+
+            return new ReadOnlyList<T>(list);
+        }
+
         public static T Last<T>(this IReadOnlyList<T> list)
         {
             return list[list.Count - 1];
+        }
+
+        private class ReadOnlyList<T> : IReadOnlyList<T>
+        {
+            private readonly IList<T> _list;
+
+            public ReadOnlyList(IList<T> list)
+            {
+                _list = list;
+            }
+
+            public T this[int index] => _list[index];
+            public int Count => _list.Count;
+            public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
@@ -28,6 +28,16 @@ namespace Roslyn.Utilities
             return Task.FromResult(value);
         }
 
+        public static Task<IReadOnlyList<T>> EmptyReadOnlyList<T>()
+        {
+            return Empty<T>.EmptyReadOnlyList;
+        }
+
+        public static Task<IList<T>> EmptyList<T>()
+        {
+            return Empty<T>.EmptyList;
+        }
+
         public static Task<ImmutableArray<T>> EmptyImmutableArray<T>()
         {
             return Empty<T>.EmptyImmutableArray;
@@ -48,6 +58,8 @@ namespace Roslyn.Utilities
             public static readonly Task<T> Default = Task.FromResult<T>(default(T));
             public static readonly Task<IEnumerable<T>> EmptyEnumerable = Task.FromResult<IEnumerable<T>>(SpecializedCollections.EmptyEnumerable<T>());
             public static readonly Task<ImmutableArray<T>> EmptyImmutableArray = Task.FromResult(ImmutableArray<T>.Empty);
+            public static readonly Task<IList<T>> EmptyList = Task.FromResult(SpecializedCollections.EmptyList<T>());
+            public static readonly Task<IReadOnlyList<T>> EmptyReadOnlyList = Task.FromResult(SpecializedCollections.EmptyReadOnlyList<T>());
         }
 
         private static class FromResultCache<T> where T : class

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteAddImportFeatureService
     {
-        public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
+        public async Task<IList<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources)
+            bool searchReferenceAssemblies, IList<PackageSource> packageSources)
         {
             using (UserOperationBooster.Boost())
             {
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var result = await service.GetFixesAsync(
                     document, span, diagnosticId, placeSystemNamespaceFirst,
                     symbolSearchService, searchReferenceAssemblies,
-                    packageSources, CancellationToken).ConfigureAwait(false);
+                    packageSources.ToImmutableArray(), CancellationToken).ConfigureAwait(false);
 
                 return result;
             }
@@ -54,28 +55,28 @@ namespace Microsoft.CodeAnalysis.Remote
                 this.codeAnalysisService = codeAnalysisService;
             }
 
-            public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
+            public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<PackageWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithTypeResult>>(
                     nameof(FindPackagesWithTypeAsync), source, name, arity).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<PackageWithAssemblyResult>>(
                     nameof(FindPackagesWithAssemblyAsync), source, assemblyName).ConfigureAwait(false);
 
                 return result;
             }
 
-            public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
+            public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity, CancellationToken cancellationToken)
             {
-                var result = await codeAnalysisService.Rpc.InvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
+                var result = await codeAnalysisService.Rpc.InvokeAsync<IList<ReferenceAssemblyWithTypeResult>>(
                     nameof(FindReferenceAssembliesWithTypeAsync), name, arity).ConfigureAwait(false);
 
                 return result;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId)
+        public async Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, CancellationToken))
             {
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var data = await AbstractDesignerAttributeService.TryAnalyzeProjectInCurrentProcessAsync(
                     project, CancellationToken).ConfigureAwait(false);
 
-                return data.Values.ToImmutableArray();
+                return data.Values.ToList();
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : IRemoteDocumentHighlights
     {
-        public async Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
+        public async Task<IList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch)
         {
             // NOTE: In projection scenarios, we might get a set of documents to search

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService : IRemoteNavigateToSearchService
     {
-        public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(
+        public async Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(
             DocumentId documentId, string searchPattern)
         {
             using (UserOperationBooster.Boost())
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(
+        public async Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(
             ProjectId projectId, string searchPattern)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria)
         {
             using (UserOperationBooster.Boost())
@@ -76,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria)
         {
             using (UserOperationBooster.Boost())
@@ -89,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria)
         {
             using (UserOperationBooster.Boost())
@@ -104,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
+        public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria)
         {
             using (UserOperationBooster.Boost())

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> tokens)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, IList<TodoCommentDescriptor> tokens)
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, CancellationToken))
             {

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
         }
 
-        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity)
+        public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity)
         {
             var results = await _updateEngine.FindPackagesWithTypeAsync(
                 source, name, arity).ConfigureAwait(false);
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName)
+        public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName)
         {
             var results = await _updateEngine.FindPackagesWithAssemblyAsync(
                 source, assemblyName).ConfigureAwait(false);
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return results;
         }
 
-        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity)
+        public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity)
         {
             var results = await _updateEngine.FindReferenceAssembliesWithTypeAsync(
                 name, arity).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.RoslynOnly.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.RoslynOnly.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.AddImport;
@@ -165,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var typeName = ReadProperty<string>(reader);
                 var version = ReadProperty<string>(reader);
                 var rank = (int)ReadProperty<long>(reader);
-                var containingNamespaceNames = ReadProperty<ImmutableArray<string>>(serializer, reader);
+                var containingNamespaceNames = ReadProperty<IList<string>>(serializer, reader);
 
                 Contract.ThrowIfFalse(reader.Read());
                 Contract.ThrowIfFalse(reader.TokenType == JsonToken.EndObject);
@@ -237,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var assemblyName = ReadProperty<string>(reader);
                 var typeName = ReadProperty<string>(reader);
-                var containingNamespaceNames = ReadProperty<ImmutableArray<string>>(serializer, reader);
+                var containingNamespaceNames = ReadProperty<IList<string>>(serializer, reader);
 
                 Contract.ThrowIfFalse(reader.Read());
                 Contract.ThrowIfFalse(reader.TokenType == JsonToken.EndObject);
@@ -298,9 +299,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 Contract.ThrowIfFalse(reader.TokenType == JsonToken.StartObject);
 
                 var kind = (AddImportFixKind)ReadProperty<long>(reader);
-                var textChanges = ReadProperty<ImmutableArray<TextChange>>(serializer, reader);
+                var textChanges = ReadProperty<IList<TextChange>>(serializer, reader).ToImmutableArrayOrEmpty();
                 var title = ReadProperty<string>(reader);
-                var tags = ReadProperty<ImmutableArray<string>>(serializer, reader);
+                var tags = ReadProperty<IList<string>>(serializer, reader).ToImmutableArrayOrEmpty();
                 var priority = (CodeActionPriority)ReadProperty<long>(reader);
 
                 var projectReferenceToAdd = ReadProperty<ProjectId>(serializer, reader);
@@ -344,13 +345,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 writer.WriteValue((int)source.Kind);
 
                 writer.WritePropertyName(nameof(AddImportFixData.TextChanges));
-                serializer.Serialize(writer, source.TextChanges);
+                serializer.Serialize(writer, source.TextChanges ?? SpecializedCollections.EmptyList<TextChange>());
 
                 writer.WritePropertyName(nameof(AddImportFixData.Title));
                 writer.WriteValue(source.Title);
 
                 writer.WritePropertyName(nameof(AddImportFixData.Tags));
-                serializer.Serialize(writer, source.Tags.NullToEmpty());
+                serializer.Serialize(writer, source.Tags ?? SpecializedCollections.EmptyList<string>());
 
                 writer.WritePropertyName(nameof(AddImportFixData.Priority));
                 writer.WriteValue((int)source.Priority);


### PR DESCRIPTION
this is port of https://github.com/dotnet/roslyn/pull/21395 to dev15.3.x branch.

**Customer scenario**

VS crashes at random point when C#/VB proects are loaded to VS.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=473979&fullScreen=false&_a=edit

**Workarounds, if any**

Make sure VS uses newtonsoft.json shipped with VS not one in the GAC or one in some VS extensions by deleting those.

**Risk**

low. There should be no behavior or noticeable perf changes. it just changes collection type we use to marshal collections between 2 processes.

**Performance impact**

there could be some allocations differences due to creating different kinds of collections (List vs ImmutableArray) but not significant.

**Is this a regression from a previous update?**

Kind of yes. in RTM, we used old version of newtonsoft.json to build, so didn't try to use ImmutableArray, after RTM, we moved all dependencies to current (what VS uses) which support ImmutableArray, so we changed all code to use ImmutableArray.

**Root cause analysis:**

This is general problem for any dll that are not specific to VS but VS depends on. we just encountered it since newstonsoft.json is such a popular one. and some other software GACed the dll that happened to be same version as VS uses but target different framework.

**How was the bug found?**

Watson. feedbacks.
