### PR TITLE
Be resilient to the document being shorter than when it started when we get a completoin item description.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -319,6 +321,39 @@ class C { void M() { B.$$ } }
 ";
             await VerifyItemExistsAsync(code, "X");
             await VerifyItemExistsAsync(code, "Y");
+        }
+
+        [WorkItem(209299, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TestDescriptionWhenDocumentLengthChanges()
+        {
+            var code = @"using System;
+
+class C 
+{
+    string Property
+    {
+        get 
+        {
+            Console.$$";//, @"Beep"
+
+            using (var workspace = TestWorkspace.CreateCSharp(code))
+            {
+                var testDocument = workspace.Documents.Single();
+                var position = testDocument.CursorPosition.Value;
+
+                var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+                var service = CompletionService.GetService(document);
+                var completions = await service.GetCompletionsAsync(document, position);
+
+                var item = completions.Items.First(i => i.DisplayText == "Beep");
+                var edit = testDocument.GetTextBuffer().CreateEdit();
+                edit.Delete(Span.FromBounds(position - 10, position));
+                edit.Apply();
+
+                document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+                var description = service.GetDescriptionAsync(document, item);
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractCrefCompletionProvider.cs
@@ -11,9 +11,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     {
         protected const string HideAdvancedMembers = nameof(HideAdvancedMembers);
 
-        protected override async Task<CompletionDescription> GetDescriptionWorkerAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+        protected override async Task<CompletionDescription> GetDescriptionWorkerAsync(
+            Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            var position = SymbolCompletionItem.GetContextPosition(item);
+            var position = await SymbolCompletionItem.GetContextPositionAsync(document, item, cancellationToken).ConfigureAwait(false);
 
             // What EditorBrowsable settings were we previously passed in (if it mattered)?
             bool hideAdvancedMembers = false;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected override async Task<CompletionDescription> GetDescriptionWorkerAsync(
             Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            var position = SymbolCompletionItem.GetContextPosition(item);
+            var position = await SymbolCompletionItem.GetContextPositionAsync(document, item, cancellationToken).ConfigureAwait(false);
             var name = SymbolCompletionItem.GetSymbolName(item);
             var kind = SymbolCompletionItem.GetKind(item);
             var relatedDocumentIds = document.Project.Solution.GetRelatedDocumentIds(document.Id).Concat(document.Id);


### PR DESCRIPTION
**Customer scenario**

Typing near the end of a file (very common in the interactive window) may crash if the user does something that triggers completion, but then deletes code quickly.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=480573

**Workarounds, if any**

None

**Risk**

Low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

We did a rewrite of our completion system a while back in order to move it down the Roslyn stack and expose it as a public API.  As part of that rewrite, we changed how we computed descriptions for items in the list.  Namely, items in the list would lazily compute their descriptions, using their original creation positoin against the current state of the document they were in.  If that original creation positoin was now out of bounds for the current document (because they were typing near the end, but deletions happened) a crash happens.  

This is rare in normal C# code (as you're generally inside something like a class/method, and you're not at the end of the file), but can happen far more inside the interactive window.

**How was the bug found?**

Watsons.
