### PR TITLE
Don't crash in QuickInfo if the search for linked tokens goes out of bounds

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -143,9 +143,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 // Capturing more information for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
                 var originalText = await originalDocument.GetTextAsync().ConfigureAwait(false);
                 var linkedText = await linkedDocument.GetTextAsync().ConfigureAwait(false);
-
                 var linkedFileException = new LinkedFileDiscrepancyException(thrownException, originalText.ToString(), linkedText.ToString());
-                FatalError.Report(linkedFileException);
+
+                // This problem itself does not cause any corrupted state, it just changes the set
+                // of symbols included in QuickInfo, so we report and continue running.
+                FatalError.ReportWithoutCrash(linkedFileException);
             }
 
             return default(SyntaxToken);


### PR DESCRIPTION
Works around 3/4 of the 12 dumps investigated for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299

**Customer scenario**

Unknown. At least one dump has indicated that this happens in linked/shared/multitargeted .cshtml files, where one of the linked documents is fully populated and the other is just a basically empty type.

**Bugs this fixes:**

Works around 3/4 of the 12 dumps investigated for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299

**Workarounds, if any**

None

**Risk**

It's possible that something will crash later on that was being caught by this earlier.

**Performance impact**

None

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We still don't understand it.

**How was the bug found?**

Watsons