### PR TITLE
Fix crash in VisualBasic.Binder.MemberLookup.AddLookupSymbolsInfoInTypeParameter when it is called with Cref TypeParameter.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -1995,6 +1995,10 @@ ExitForFor:
                                                                     typeParameter As TypeParameterSymbol,
                                                                     options As LookupOptions,
                                                                     binder As Binder)
+                If typeParameter.TypeParameterKind = TypeParameterKind.Cref Then
+                    Return
+                End If
+
                 AddLookupSymbolsInfoInTypeParameterNoExtensionMethods(nameSet, typeParameter, options, binder)
 
                 ' Search for extension methods.

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -4992,5 +4992,28 @@ class Program
 }",
                 MainDescription($"({FeaturesResources.local_variable}) ref int i"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(410932, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=410932")]
+        public async Task TestGenericMethodInDocComment()
+        {
+            await TestAsync(
+@"
+class Test
+{
+    T F<T>()
+    {
+        F<T>();
+    }
+
+    /// <summary>
+    /// <see cref=""F$${T}()""/>
+    /// </summary>
+    void S()
+    { }
+}
+",
+            MainDescription("T Test.F<T>()"));
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -2089,5 +2089,25 @@ End Class
 ",
                  Documentation("String http://microsoft.com Nothing cat"))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(410932, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=410932")>
+        Public Async Function TestGenericMethodInDocComment() As Task
+            Await TestWithImportsAsync(<Text><![CDATA[
+Public Class Test
+    Function F(Of T)() As T
+        F(Of T)()
+    End Function
+
+    ''' <summary>
+    ''' <see cref="F$$(Of T)()"/>
+    ''' </summary>
+    Public Sub S()
+    End Sub
+End Class
+                ]]></Text>.NormalizedValue,
+             MainDescription("Function Test.F(Of T)() As T"))
+        End Function
+
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=410932.

The fix mimics the way C# compiler handles Cref TypeParameters in the similar API.

**Customer scenario**

Create new VB class library project 
 Paste the following code in Class1.vb
```
 Public Class FooBar
 Function Bar(Of T)() As T
 End Function

 ''' <summary>
 ''' Foo <see cref="Bar(Of T)()" />
 ''' </summary>
 Public Sub Foo()
 End Sub
 End Class
```
 Hover the cursor over "Bar" (for a couple of seconds) in Foo's see tag. VS crashes.

@dotnet/roslyn-compiler Please review.