### PR TITLE
Don't offer to use pattern matching if a user defined operator was involved.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -745,5 +745,25 @@ public static class C
     }
 }");
         }
+
+        [WorkItem(21551, "https://github.com/dotnet/roslyn/issues/21551")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestOverloadedUserOperator()
+        {
+            await TestMissingAsync(
+@"class C
+{
+  public static void Main()
+  {
+    object o = new C();
+    [|var|] c = o as C;
+    if (c != null)
+      System.Console.WriteLine();
+  }
+
+  public static bool operator ==(C c1, C c2) => false;
+  public static bool operator !=(C c1, C c2) => false;
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -95,6 +95,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             }
 
             var semanticModel = syntaxContext.SemanticModel;
+            if (semanticModel.GetSymbolInfo(comparison).GetAnySymbol().IsUserDefinedOperator())
+            {
+                return;
+            }
+
             var typeNode = ((BinaryExpressionSyntax)asExpression).Right;
             var asType = semanticModel.GetTypeInfo(typeNode, cancellationToken).Type;
             if (asType.IsNullable())


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21551