### PR TITLE
Do not offer 'use throw expression' if value is accessed before being checked for null.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
@@ -430,5 +430,29 @@ class C
     }
 }");
         }
+
+        [WorkItem(21612, "https://github.com/dotnet/roslyn/issues/21612")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TestNotWhenAccessedOnLeftOfAssignment()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+using System.Collections.Generic;
+
+class A
+{
+    public string Id;
+}
+
+class B
+{
+    private Dictionary<string, A> map = new Dictionary<string, A>();
+    public B(A a)
+    {
+        if (a == null) [|throw|] new ArgumentNullException();
+        map[a.Id] = a;
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             {
                 return;
             }
-            
+
             var option = optionSet.GetOption(CodeStyleOptions.PreferThrowExpression, throwStatement.Language);
             if (!option.Value)
             {
@@ -129,37 +129,16 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             }
 
             if (!TryFindAssignmentExpression(containingBlock, ifOperation, localOrParameter,
-                out var expressionStatement, out var assignmentExpression))
+                    out var expressionStatement, out var assignmentExpression))
             {
                 return;
             }
 
             // We found an assignment using this local/parameter.  Now, just make sure there
             // were no intervening accesses between the check and the assignment.
-            var statements = containingBlock.Statements;
-            var ifOperationIndex = statements.IndexOf(ifOperation);
-            var expressionStatementIndex = statements.IndexOf(expressionStatement);
-
-            if (expressionStatementIndex > ifOperationIndex + 1)
-            {
-                // There are intermediary statements between the check and the assignment.
-                // Make sure they don't try to access the local.
-                var dataFlow = semanticModel.AnalyzeDataFlow(
-                    statements[ifOperationIndex + 1].Syntax,
-                    statements[expressionStatementIndex - 1].Syntax);
-
-                if (dataFlow.ReadInside.Contains(localOrParameter) ||
-                    dataFlow.WrittenInside.Contains(localOrParameter))
-                {
-                    return;
-                }
-            }
-
-            // Also, have to make sure there is no read/write of the local/parameter on the left
-            // of the assignment.  For example: map[val.Id] = val;
-            var exprDataFlow = semanticModel.AnalyzeDataFlow(assignmentExpression.Target.Syntax);
-            if (exprDataFlow.ReadInside.Contains(localOrParameter) ||
-                exprDataFlow.WrittenInside.Contains(localOrParameter))
+            if (ValueIsAccessed(
+                    semanticModel, ifOperation, containingBlock,
+                    localOrParameter, expressionStatement, assignmentExpression))
             {
                 return;
             }
@@ -195,6 +174,34 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                             ifOperation.Syntax.Span.End)),
                         additionalLocations: allLocations));
             }
+        }
+
+        private static bool ValueIsAccessed(SemanticModel semanticModel, IIfStatement ifOperation, IBlockStatement containingBlock, ISymbol localOrParameter, IExpressionStatement expressionStatement, IAssignmentExpression assignmentExpression)
+        {
+            var statements = containingBlock.Statements;
+            var ifOperationIndex = statements.IndexOf(ifOperation);
+            var expressionStatementIndex = statements.IndexOf(expressionStatement);
+
+            if (expressionStatementIndex > ifOperationIndex + 1)
+            {
+                // There are intermediary statements between the check and the assignment.
+                // Make sure they don't try to access the local.
+                var dataFlow = semanticModel.AnalyzeDataFlow(
+                    statements[ifOperationIndex + 1].Syntax,
+                    statements[expressionStatementIndex - 1].Syntax);
+
+                if (dataFlow.ReadInside.Contains(localOrParameter) ||
+                    dataFlow.WrittenInside.Contains(localOrParameter))
+                {
+                    return true;
+                }
+            }
+
+            // Also, have to make sure there is no read/write of the local/parameter on the left
+            // of the assignment.  For example: map[val.Id] = val;
+            var exprDataFlow = semanticModel.AnalyzeDataFlow(assignmentExpression.Target.Syntax);
+            return exprDataFlow.ReadInside.Contains(localOrParameter) ||
+                   exprDataFlow.WrittenInside.Contains(localOrParameter);
         }
 
         protected abstract ISyntaxFactsService GetSyntaxFactsService();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21612