### PR TITLE
Align lookup of user-defined operators in interfaces with latest LDM decisions.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -46,7 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol rightOperatorSourceOpt = right.Type?.StrippedType();
             bool leftSourceIsInterface = leftOperatorSourceOpt?.IsInterfaceType() == true;
             bool rightSourceIsInterface = rightOperatorSourceOpt?.IsInterfaceType() == true;
-            BinaryOperatorOverloadResolutionResult resultFromNonInterfaces = null;
 
             // The following is a slight rewording of the specification to emphasize that not all
             // operands of a binary operation need to have a type.
@@ -60,22 +59,60 @@ namespace Microsoft.CodeAnalysis.CSharp
             //   provided by the type of x (if any) and the candidate operators provided by the type of y (if any), 
             //   each determined using the rules of 7.3.5. Candidate operators only occur in the combined set once.
 
-            bool leftHadUserDefinedCandidate = false;
-            bool rightHadUserDefinedCandidate = false;
+            // From https://github.com/dotnet/csharplang/blob/master/meetings/2017/LDM-2017-06-27.md:
+            // - We only even look for operator implementations in interfaces if one of the operands has a type that is
+            // an interface or a type parameter with a non-empty effective base interface list.
+            // - We should look at operators from classes first, in order to avoid breaking changes.
+            // Only if there are no applicable user-defined operators from classes will we look in interfaces.
+            // If there aren't any there either, we go to built-ins.
+            // - If we find an applicable candidate in an interface, that candidate shadows all applicable operators in
+            // base interfaces: we stop looking.
+
+            bool hadUserDefinedCandidate = false;
 
             // In order to preserve backward compatibility, at first we ignore interface sources.
 
             if (!leftSourceIsInterface)
             {
-                leftHadUserDefinedCandidate = GetUserDefinedOperators(kind, leftOperatorSourceOpt, left, right, result.Results, ref useSiteDiagnostics);
+                hadUserDefinedCandidate = GetUserDefinedOperators(kind, leftOperatorSourceOpt, left, right, result.Results, ref useSiteDiagnostics);
             }
 
             if (!rightSourceIsInterface && rightOperatorSourceOpt != leftOperatorSourceOpt)
             {
                 var rightOperators = ArrayBuilder<BinaryOperatorAnalysisResult>.GetInstance();
-                rightHadUserDefinedCandidate = GetUserDefinedOperators(kind, rightOperatorSourceOpt, left, right, rightOperators, ref useSiteDiagnostics);
+                hadUserDefinedCandidate |= GetUserDefinedOperators(kind, rightOperatorSourceOpt, left, right, rightOperators, ref useSiteDiagnostics);
                 AddDistinctOperators(result.Results, rightOperators);
                 rightOperators.Free();
+            }
+
+            Debug.Assert(result.Results.Count == 0 || hadUserDefinedCandidate);
+
+            // If there are no applicable candidates in classes / stuctures, try with interface sources.
+            // From https://github.com/dotnet/csharplang/blob/master/meetings/2017/LDM-2017-06-27.md:
+            // Let's not allow == and != and see what feedback we get. We'll see from prototype use whether
+            // this is an intolerable limitation, but we believe it is a decent place to land.
+            if (!hadUserDefinedCandidate &&
+                kind != BinaryOperatorKind.Equal && kind != BinaryOperatorKind.NotEqual)
+            {
+                result.Results.Clear();
+
+                string name = OperatorFacts.BinaryOperatorNameFromOperatorKind(kind);
+                var lookedInInterfaces = PooledDictionary<TypeSymbol, bool>.GetInstance();
+
+                hadUserDefinedCandidate = GetUserDefinedBinaryOperatorsFromInterfaces(kind, name,
+                        leftOperatorSourceOpt, leftSourceIsInterface, left, right, ref useSiteDiagnostics, lookedInInterfaces, result.Results);
+
+                if (leftOperatorSourceOpt != rightOperatorSourceOpt)
+                {
+                    var rightOperators = ArrayBuilder<BinaryOperatorAnalysisResult>.GetInstance();
+                    hadUserDefinedCandidate |= GetUserDefinedBinaryOperatorsFromInterfaces(kind, name,
+                        rightOperatorSourceOpt, rightSourceIsInterface, left, right, ref useSiteDiagnostics, lookedInInterfaces, rightOperators);
+
+                    AddDistinctOperators(result.Results, rightOperators);
+                    rightOperators.Free();
+                }
+
+                lookedInInterfaces.Free();
             }
 
             // SPEC: If the set of candidate user-defined operators is not empty, then this becomes the set of candidate 
@@ -97,22 +134,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             //
             // Roslyn matches the specification and takes the break from the native compiler.
 
-            if (!leftHadUserDefinedCandidate && !rightHadUserDefinedCandidate)
+            if (!hadUserDefinedCandidate)
             {
                 Debug.Assert(result.Results.Count == 0);
                 result.Results.Clear();
                 GetAllBuiltInOperators(kind, left, right, result.Results, ref useSiteDiagnostics);
-            }
-            else if (kind != BinaryOperatorKind.Equal && kind != BinaryOperatorKind.NotEqual &&
-                     ((!leftHadUserDefinedCandidate && 
-                       ShouldGetUserDefinedBinaryOperatorsFromInterfaces(leftOperatorSourceOpt, leftSourceIsInterface, ref useSiteDiagnostics)) || 
-                      (!rightHadUserDefinedCandidate && leftOperatorSourceOpt != rightOperatorSourceOpt && 
-                       ShouldGetUserDefinedBinaryOperatorsFromInterfaces(rightOperatorSourceOpt, rightSourceIsInterface, ref useSiteDiagnostics))))
-            {
-                Debug.Assert(result.Results.Any(r => r.IsValid));
-                // Copy candidates to avoid repeating lookup in case we need to add operators from interfaces
-                resultFromNonInterfaces = BinaryOperatorOverloadResolutionResult.GetInstance();
-                resultFromNonInterfaces.Results.AddRange(result.Results);
             }
             
             // SPEC: The overload resolution rules of 7.5.3 are applied to the set of candidate operators to select the best 
@@ -121,69 +147,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: error occurs.
 
             BinaryOperatorOverloadResolution(left, right, result, ref useSiteDiagnostics);
-
-            // If resolution failed, try with interface sources
-            if (!result.Best.HasValue && 
-                (!leftHadUserDefinedCandidate || !rightHadUserDefinedCandidate) &&
-                kind != BinaryOperatorKind.Equal && kind != BinaryOperatorKind.NotEqual)
-            {
-                var resultFromInterfaces = BinaryOperatorOverloadResolutionResult.GetInstance();
-                bool leftHadUserDefinedCandidateFromInterfaces = false;
-                bool rightHadUserDefinedCandidateFromInterfaces = false;
-                string name = OperatorFacts.BinaryOperatorNameFromOperatorKind(kind);
-                var lookedInInterfaces = PooledDictionary<TypeSymbol, bool>.GetInstance();
-
-                if (!leftHadUserDefinedCandidate)
-                {
-                    leftHadUserDefinedCandidateFromInterfaces = GetUserDefinedBinaryOperatorsFromInterfaces(kind, name,
-                        leftOperatorSourceOpt, leftSourceIsInterface, left, right, ref useSiteDiagnostics, lookedInInterfaces, resultFromInterfaces.Results);
-                }
-
-                if (!rightHadUserDefinedCandidate && leftOperatorSourceOpt != rightOperatorSourceOpt)
-                {
-                    var rightOperators = ArrayBuilder<BinaryOperatorAnalysisResult>.GetInstance();
-                    rightHadUserDefinedCandidateFromInterfaces = GetUserDefinedBinaryOperatorsFromInterfaces(kind, name, 
-                        rightOperatorSourceOpt, rightSourceIsInterface, left, right, ref useSiteDiagnostics, lookedInInterfaces, rightOperators);
-
-                    AddDistinctOperators(resultFromInterfaces.Results, rightOperators);
-                    rightOperators.Free();
-                }
-
-                Debug.Assert(resultFromNonInterfaces != null || 
-                             lookedInInterfaces.Count == 0 ||
-                             (!leftHadUserDefinedCandidate && !rightHadUserDefinedCandidate));
-
-                if (leftHadUserDefinedCandidateFromInterfaces || rightHadUserDefinedCandidateFromInterfaces)
-                {
-                    result.Clear();
-
-                    if (resultFromNonInterfaces != null)
-                    {
-                        result.Results.AddRange(resultFromNonInterfaces.Results);
-                    }
-
-                    result.Results.AddRange(resultFromInterfaces.Results);
-                    BinaryOperatorOverloadResolution(left, right, result, ref useSiteDiagnostics);
-                }
-
-                resultFromInterfaces.Free();
-                lookedInInterfaces.Free();
-            }
-
-            if (resultFromNonInterfaces != null)
-            {
-                resultFromNonInterfaces.Free();
-            }
-        }
-
-        private static bool ShouldGetUserDefinedBinaryOperatorsFromInterfaces(
-            TypeSymbol operatorSourceOpt, bool sourceIsInterface,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-        {
-            return (object)operatorSourceOpt != null &&
-                   (sourceIsInterface ||
-                    (operatorSourceOpt.IsTypeParameter() &&
-                     !((TypeParameterSymbol)operatorSourceOpt).AllEffectiveInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics).IsEmpty));
         }
 
         private bool GetUserDefinedBinaryOperatorsFromInterfaces(BinaryOperatorKind kind, string name, 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -355,6 +355,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: base class of T0 if T0 is a type parameter.
 
             // PROTOTYPE(DefaultInterfaceImplementation): The spec quote should be adjusted to cover operators from interfaces as well.
+            // From https://github.com/dotnet/csharplang/blob/master/meetings/2017/LDM-2017-06-27.md:
+            // - We only even look for operator implementations in interfaces if one of the operands has a type that is an interface or
+            // a type parameter with a non-empty effective base interface list.
+            // - The applicable operators from classes / structs shadow those in interfaces.This matters for constrained type parameters:
+            // the effective base class can shadow operators from effective base interfaces.
+            // - If we find an applicable candidate in an interface, that candidate shadows all applicable operators in base interfaces:
+            // we stop looking.
 
             TypeSymbol type0 = operand.Type.StrippedType();
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -32034,12 +32034,12 @@ public interface I3 :  I1, I2
             var compilation7 = CreateStandardCompilation(source3, new[] { compilationReference6 }, options: TestOptions.DebugExe,
                                                          parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
             Assert.True(compilation7.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
-            CompileAndVerify(compilation7, expectedOutput: "I3.+");
+            compilation7.VerifyDiagnostics(expected);
 
             var compilation8 = CreateStandardCompilation(source3, new[] { metadataReference6 }, options: TestOptions.DebugExe,
                                                          parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
             Assert.True(compilation8.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
-            CompileAndVerify(compilation8, expectedOutput: "I3.+");
+            compilation8.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -32167,12 +32167,12 @@ public interface I3 :  I1, I2
             var compilation7 = CreateStandardCompilation(source3, new[] { compilationReference6 }, options: TestOptions.DebugExe,
                                                          parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
             Assert.True(compilation7.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
-            CompileAndVerify(compilation7, expectedOutput: "I3.+");
+            compilation7.VerifyDiagnostics(expected);
 
             var compilation8 = CreateStandardCompilation(source3, new[] { metadataReference6 }, options: TestOptions.DebugExe,
                                                          parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
             Assert.True(compilation8.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
-            CompileAndVerify(compilation8, expectedOutput: "I3.+");
+            compilation8.VerifyDiagnostics(expected);
         }
 
         [Fact]


### PR DESCRIPTION
Here is the link to the notes https://github.com/dotnet/csharplang/blob/master/meetings/2017/LDM-2017-06-27.md.

@dotnet/roslyn-compiler Please review.