### PR TITLE
make SupportedDiagnosticId for build error thread safe

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -420,26 +420,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
             public bool SupportedDiagnosticId(ProjectId projectId, string id)
             {
-                if (_diagnosticIdMap.TryGetValue(projectId, out var ids))
+                lock (_diagnosticIdMap)
                 {
-                    return ids.Contains(id);
+                    if (_diagnosticIdMap.TryGetValue(projectId, out var ids))
+                    {
+                        return ids.Contains(id);
+                    }
+
+                    // set ids set
+                    var map = new HashSet<string>();
+                    _diagnosticIdMap.Add(projectId, map);
+
+                    var project = _solution.GetProject(projectId);
+                    if (project == null)
+                    {
+                        // projectId no longer exist, return false;
+                        return false;
+                    }
+
+                    var descriptorMap = _owner._diagnosticService.GetDiagnosticDescriptors(project);
+                    map.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
+
+                    return map.Contains(id);
                 }
-
-                // set ids set
-                var map = new HashSet<string>();
-                _diagnosticIdMap.Add(projectId, map);
-
-                var project = _solution.GetProject(projectId);
-                if (project == null)
-                {
-                    // projectId no longer exist, return false;
-                    return false;
-                }
-
-                var descriptorMap = _owner._diagnosticService.GetDiagnosticDescriptors(project);
-                map.UnionWith(descriptorMap.Values.SelectMany(v => v.Select(d => d.Id)));
-
-                return map.Contains(id);
             }
 
             public ImmutableArray<DiagnosticData> GetBuildDiagnostics()

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim project = workspace.CurrentSolution.Projects.First()
                 source.OnSolutionBuild(Me, Shell.UIContextChangedEventArgs.From(True))
 
-                Parallel.For(0, 100, Sub() source.SupportedDiagnosticId(project.Id, "CS1002"))
+                Parallel.For(0, 100, Sub(i As Integer) source.SupportedDiagnosticId(project.Id, "CS1002"))
             End Using
         End Sub
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -69,6 +69,20 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         End Sub
 
         <Fact>
+        Public Sub TestExternalDiagnostics_SupportedDiagnosticId_Concurrent()
+            Using workspace = TestWorkspace.CreateCSharp(String.Empty)
+                Dim waiter = New Waiter()
+                Dim service = New TestDiagnosticAnalyzerService()
+                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, New MockDiagnosticUpdateSourceRegistrationService(), waiter)
+
+                Dim project = workspace.CurrentSolution.Projects.First()
+                source.OnSolutionBuild(Me, Shell.UIContextChangedEventArgs.From(True))
+
+                Parallel.For(0, 100, Sub() source.SupportedDiagnosticId(project.Id, "CS1002"))
+            End Using
+        End Sub
+
+        <Fact>
         Public Async Function TestExternalDiagnostics_DuplicatedError() As Task
             Using workspace = TestWorkspace.CreateCSharp(String.Empty)
                 Dim waiter = New Waiter()


### PR DESCRIPTION
**Customer scenario**

Customer builds CPS project such as .Net Core project in VS and VS Crashes.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/384036

**Workarounds, if any**

There is no workaround

**Risk**

I don't see any risk. it can't cause any dead lock.

**Performance impact**

I don't believe it can cause any user perceivable performance impact. only perf impact it can have is lock contention but operation should be very fast.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

the code originally written for legacy project system which calls this only from UI thread. no concurrency. in CPS world, this method is now called from background thread and concurrently. 

**How was the bug found?**

Watson. and customer feedback.

**Test documentation updated?**

Test Added.
