### PR TITLE
Add fields as members of synthesized structs

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(scope.DeclaredEnvironments.Count == 1);
 
                     var env = scope.DeclaredEnvironments[0];
-                    var frame = MakeFrame(scope, env.IsStruct);
+                    var frame = MakeFrame(scope, env);
                     env.SynthesizedEnvironment = frame;
 
                     CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(ContainingType, frame);
@@ -346,20 +346,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 frame.Constructor));
                     }
 
-                    foreach (var captured in env.CapturedVariables)
-                    {
-                        Debug.Assert(!proxies.ContainsKey(captured));
-
-                        var hoistedField = LambdaCapturedVariable.Create(frame, captured, ref _synthesizedFieldNameIdDispenser);
-                        proxies.Add(captured, new CapturedToFrameSymbolReplacement(hoistedField, isReusable: false));
-                        CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, hoistedField);
-                    }
-
                     _frames.Add(scope.BoundNode, env);
                 }
             });
 
-            SynthesizedClosureEnvironment MakeFrame(Analysis.Scope scope, bool isStruct)
+            SynthesizedClosureEnvironment MakeFrame(Analysis.Scope scope, Analysis.ClosureEnvironment env)
             {
                 var scopeBoundNode = scope.BoundNode;
 
@@ -375,13 +366,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     containingMethod = _substitutedSourceMethod;
                 }
 
-                return new SynthesizedClosureEnvironment(
+                var synthesizedEnv = new SynthesizedClosureEnvironment(
                     _topLevelMethod,
                     containingMethod,
-                    isStruct,
+                    env.IsStruct,
                     syntax,
                     methodId,
                     closureId);
+
+                foreach (var captured in env.CapturedVariables)
+                {
+                    Debug.Assert(!proxies.ContainsKey(captured));
+
+                    var hoistedField = LambdaCapturedVariable.Create(synthesizedEnv, captured, ref _synthesizedFieldNameIdDispenser);
+                    proxies.Add(captured, new CapturedToFrameSymbolReplacement(hoistedField, isReusable: false));
+                    synthesizedEnv.AddHoistedField(hoistedField);
+                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(synthesizedEnv, hoistedField);
+                }
+
+                return synthesizedEnv;
             }
         }
 
@@ -515,8 +518,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     var frame = _lazyStaticLambdaFrame;
 
-                    // add frame type
+                    // add frame type and cache field
                     CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(this.ContainingType, frame);
+                    //CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, frame.SingletonCache);
 
                     // add its ctor (note Constructor can be null if TypeKind.Struct is passed in to LambdaFrame.ctor, but Class is passed in above)
                     AddSynthesizedMethod(
@@ -661,6 +665,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (CompilationState.Emitting)
                     {
                         Debug.Assert(capturedFrame.Type.IsReferenceType); // Make sure we're not accidentally capturing a struct by value
+                        frame.AddHoistedField(capturedFrame);
                         CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, capturedFrame);
                     }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -520,7 +520,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // add frame type and cache field
                     CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(this.ContainingType, frame);
-                    //CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, frame.SingletonCache);
 
                     // add its ctor (note Constructor can be null if TypeKind.Struct is passed in to LambdaFrame.ctor, but Class is passed in above)
                     AddSynthesizedMethod(

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <see cref="CommonPEModuleBuilder" />, so we don't want to duplicate them here.
         /// </summary>
         internal override IEnumerable<FieldSymbol> GetFieldsToEmit()
-            => SingletonCache != null
+            => (object)SingletonCache != null
             ? SpecializedCollections.SingletonEnumerable(SingletonCache)
             : SpecializedCollections.EmptyEnumerable<FieldSymbol>();
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
@@ -5,6 +5,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -24,6 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal readonly MethodSymbol OriginalContainingMethodOpt;
         internal readonly FieldSymbol SingletonCache;
         internal readonly MethodSymbol StaticConstructor;
+
+        private ArrayBuilder<Symbol> _membersBuilder = ArrayBuilder<Symbol>.GetInstance();
+        private ImmutableArray<Symbol> _members;
 
         public override TypeKind TypeKind { get; }
         internal override MethodSymbol Constructor { get; }
@@ -54,6 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             AssertIsClosureScopeSyntax(scopeSyntaxOpt);
             this.ScopeSyntaxOpt = scopeSyntaxOpt;
         }
+
+        internal void AddHoistedField(LambdaCapturedVariable captured) => _membersBuilder.Add(captured);
 
         private static string MakeName(SyntaxNode scopeSyntaxOpt, DebugId methodId, DebugId closureId)
         {
@@ -89,14 +96,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override ImmutableArray<Symbol> GetMembers()
         {
-            var members = base.GetMembers();
-            if ((object)StaticConstructor != null)
+            if (_members.IsDefault)
             {
-                members = ImmutableArray.Create<Symbol>(StaticConstructor, SingletonCache).AddRange(members);
+                var builder = _membersBuilder;
+                if ((object)StaticConstructor != null)
+                {
+                    builder.Add(StaticConstructor);
+                    builder.Add(SingletonCache);
+                }
+                builder.AddRange(base.GetMembers());
+                _members = builder.ToImmutableAndFree();
+                _membersBuilder = null;
             }
 
-            return members;
+            return _members;
         }
+
+        /// <summary>
+        /// All fields should have already been added as synthesized members on the
+        /// <see cref="CommonPEModuleBuilder" />, so we don't want to duplicate them here.
+        /// </summary>
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit()
+            => SingletonCache != null
+            ? SpecializedCollections.SingletonEnumerable(SingletonCache)
+            : SpecializedCollections.EmptyEnumerable<FieldSymbol>();
 
         // display classes for static lambdas do not have any data and can be serialized.
         internal override bool IsSerializable => (object)SingletonCache != null;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -249,7 +249,7 @@ class C
         yield return L();
         x = 5;
         y = 7;
-        yield return L();;
+        yield return L();
     }
 }", expectedOutput: @"5
 12");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -31,6 +31,306 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenLocalFunctionTests : CSharpTestBase
     {
         [Fact]
+        [WorkItem(472056, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=472056")]
+        public void Repro472056()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ConsoleApp2
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var task = WhyYouBreaky(new List<string>());
+
+            Console.WriteLine(task.Result);
+        }
+
+        static async Task<string> WhyYouBreaky(List<string> words)
+        {
+            await Task.Delay(1);
+            var word = """"; // moving me before the 'await' will make it work
+
+            words.Add(""Oh No!""); // I will crash here :(
+
+            return ""Great success!""; // Not so much.
+
+            void IDontEvenGetCalled()
+            {
+                // commenting out either of these lines will make it work
+                var a = word;
+                var b = words[0];
+            }
+        }
+    }
+}", options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(comp, expectedOutput: "Great success!");
+        }
+
+        [Fact]
+        public void AsyncStructClosure()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main() => M().Wait();
+
+    static async Task M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        Console.WriteLine(L());
+        await Task.FromResult(false);
+    }
+}", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput: "5");
+            // No field captures
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "System.Runtime.CompilerServices.AsyncTaskMethodBuilder <>t__builder",
+                "System.Runtime.CompilerServices.TaskAwaiter<bool> <>u__1");
+
+            comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main() => M().Wait();
+
+    static async Task M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        Console.WriteLine(L());
+        await Task.FromResult(false);
+        x++;
+        Console.WriteLine(x);
+    }
+}", options: TestOptions.ReleaseExe);
+            verifier = CompileAndVerify(comp, expectedOutput: @"5
+3");
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "System.Runtime.CompilerServices.AsyncTaskMethodBuilder <>t__builder",
+                // Display class capture
+                "C.<>c__DisplayClass1_0 <>8__1",
+                "System.Runtime.CompilerServices.TaskAwaiter<bool> <>u__1");
+
+            verifier.VerifySynthesizedFields("C.<>c__DisplayClass1_0",
+                "int x",
+                "int y");
+
+            comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main() => M().Wait();
+
+    static async Task M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        Console.WriteLine(L());
+        await Task.FromResult(false);
+        x = 5;
+        y = 7;
+        Console.WriteLine(L());
+    }
+}", options: TestOptions.ReleaseExe);
+            verifier = CompileAndVerify(comp, expectedOutput: @"5
+12");
+            // Nothing captured across await
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "System.Runtime.CompilerServices.AsyncTaskMethodBuilder <>t__builder",
+                "System.Runtime.CompilerServices.TaskAwaiter<bool> <>u__1");
+        }
+
+        [Fact]
+        public void IteratorStructClosure()
+        {
+            var verifier = CompileAndVerify(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main()
+    {
+        foreach (var m in M())
+        {
+            Console.WriteLine(m);
+        }
+    }
+
+    static IEnumerable<int> M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        yield return L();
+    }
+}", expectedOutput: "5");
+            // No field captures
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "int <>2__current",
+                "int <>l__initialThreadId");
+
+            verifier = CompileAndVerify(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main()
+    {
+        foreach (var m in M())
+        {
+            Console.WriteLine(m);
+        }
+    }
+
+    static IEnumerable<int> M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        yield return L();
+        x++;
+        yield return x;
+    }
+}", expectedOutput: @"5
+3");
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "int <>2__current",
+                "int <>l__initialThreadId",
+                // Display class capture
+                "C.<>c__DisplayClass1_0 <>8__1");
+
+            verifier.VerifySynthesizedFields("C.<>c__DisplayClass1_0",
+                "int x",
+                "int y");
+
+            verifier = CompileAndVerify(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    static void Main()
+    {
+        foreach (var m in M())
+        {
+            Console.WriteLine(m);
+        }
+    }
+
+    static IEnumerable<int> M()
+    {
+        int x = 2;
+        int y = 3;
+        int L() => x + y;
+        yield return L();
+        x = 5;
+        y = 7;
+        yield return L();;
+    }
+}", expectedOutput: @"5
+12");
+            // No captures
+            verifier.VerifySynthesizedFields("C.<M>d__1",
+                "int <>1__state",
+                "int <>2__current",
+                "int <>l__initialThreadId");
+        }
+
+        [Fact]
+        [WorkItem(21409, "https://github.com/dotnet/roslyn/issues/21409")]
+        public void Repro21409()
+        {
+            CompileAndVerify(
+@"
+using System;
+using System.Collections.Generic;
+
+namespace Buggles
+{
+    class Program
+    {
+        private static IEnumerable<int> Problem(IEnumerable<int> chunks)
+        {
+            var startOfChunk = 0;
+            var pendingChunks = new List<int>();
+
+            int GenerateChunk()
+            {
+                if (pendingChunks == null)
+                {
+                    Console.WriteLine(""impossible in local function"");
+                    return -1;
+                }
+                while (pendingChunks.Count > 0)
+                {
+                    pendingChunks.RemoveAt(0);
+                }
+                return startOfChunk;
+            }
+
+            foreach (var chunk in chunks)
+            {
+                if (chunk - startOfChunk <= 0)
+                {
+                    pendingChunks.Insert(0, chunk);
+                }
+                else
+                {
+                    yield return GenerateChunk();
+                }
+                startOfChunk = chunk;
+                if (pendingChunks == null)
+                {
+                    Console.WriteLine(""impossible in outer function"");
+                }
+                else
+                {
+                    pendingChunks.Insert(0, chunk);
+                }
+            }
+        }
+
+        private static void Main()
+        {
+            var xs = Problem(new[] { 0, 1, 2, 3 });
+            foreach (var x in xs)
+            {
+                Console.WriteLine(x);
+            }
+        }
+    }
+}
+", expectedOutput: @"
+0
+1
+2");
+        }
+
+        [Fact]
         [WorkItem(294554, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=294554")]
         public void ThisOnlyClosureBetweenStructCaptures()
         {

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -285,5 +285,22 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             _compilation.VerifyOperationTree(symbolToVerify, expectedOperationTree, skipImplicitlyDeclaredSymbols);
         }
+
+        /// <summary>
+        /// Useful for verifying the expected variables are hoisted for closures, async, and iterator methods.
+        /// </summary>
+        public void VerifySynthesizedFields(string containingTypeName, params string[] expectedFields)
+        {
+            var types = TestData.Module.GetSynthesizedMembers();
+            Assert.Contains(types.Keys, t => containingTypeName == t.ToString());
+            var members = TestData.Module.GetSynthesizedMembers()
+                .Where(e => e.Key.ToString() == containingTypeName)
+                .Single()
+                .Value
+                .OfType<IFieldSymbol>()
+                .Select(f => $"{f.Type.ToString()} {f.Name}")
+                .ToList();
+            AssertEx.SetEqual(expectedFields, members);
+        }
     }
 }


### PR DESCRIPTION
In order for EnC and other mechanisms to work we have to add synthesized
members to a list in the CommonPEModuleBuilder for a compilation (these
synthesized members are then queried as part of compilation stages).
If those members are struct fields, we don't add them to the struct
definition, only to the list of synthesized members. This works for
emit, since we explicitly emit everything in the synthesized list, but
it doesn't work for any compiler pass that examines the members of the
struct for semantically meaningful reasons.

This is the case for the CaptureWalker for async and iterator
expressions. The walker checks the members of structs when a field of a
struct is assigned to see if the struct has been assigned piecewise
(each of its members has been assigned individually). If so, it will
mark the entire struct as assigned. By not including synthesized fields
as proper members of the struct type, the assignment pass believes that
many fields have been assigned that have not, and thus marks the full
struct as assigned, leading to losing track of variables captured across
await/yield statements.

This PR fixes the problem by adding the fields to the
SynthesizedContainer, but exlcuding them from emit, since we should
continue to use the emit mechanism used for CommonPEModuleBuilder.

Fixes #21409