### PR TITLE
Better error reporting for VsLanguageDebugInfo

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Debugging/IBreakpointResolutionService.cs
+++ b/src/EditorFeatures/Core/Implementation/Debugging/IBreakpointResolutionService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -12,6 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Debugging
     {
         Task<BreakpointResolutionResult> ResolveBreakpointAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<BreakpointResolutionResult>> ResolveBreakpointsAsync(Solution solution, string name, CancellationToken cancellationToken = default);
+        Task<ImmutableArray<BreakpointResolutionResult>> ResolveBreakpointsAsync(Solution solution, string name, CancellationToken cancellationToken = default);
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Debugging/CSharpBreakpointResolutionService.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/CSharpBreakpointResolutionService.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Implementation.Debugging;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
@@ -15,29 +18,33 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
     [ExportLanguageService(typeof(IBreakpointResolutionService), LanguageNames.CSharp), Shared]
     internal partial class CSharpBreakpointResolutionService : IBreakpointResolutionService
     {
-        internal static async Task<BreakpointResolutionResult> GetBreakpointAsync(Document document, int position, CancellationToken cancellationToken)
+        /// <summary>
+        /// Returns null if a breakpoint can't be placed at the specified position.
+        /// </summary>
+        public async Task<BreakpointResolutionResult> ResolveBreakpointAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            if (!BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, out var span))
+            try
+            {
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                if (!BreakpointSpans.TryGetBreakpointSpan(tree, textSpan.Start, cancellationToken, out var span))
+                {
+                    return null;
+                }
+
+                if (span.Length == 0)
+                {
+                    return BreakpointResolutionResult.CreateLineResult(document);
+                }
+
+                return BreakpointResolutionResult.CreateSpanResult(document, span);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
                 return null;
             }
-
-            if (span.Length == 0)
-            {
-                return BreakpointResolutionResult.CreateLineResult(document);
-            }
-
-            return BreakpointResolutionResult.CreateSpanResult(document, span);
         }
 
-        public Task<BreakpointResolutionResult> ResolveBreakpointAsync(
-            Document document, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            return GetBreakpointAsync(document, textSpan.Start, cancellationToken);
-        }
-
-        public Task<IEnumerable<BreakpointResolutionResult>> ResolveBreakpointsAsync(Solution solution, string name, CancellationToken cancellationToken)
+        public Task<ImmutableArray<BreakpointResolutionResult>> ResolveBreakpointsAsync(Solution solution, string name, CancellationToken cancellationToken)
         {
             return new BreakpointResolver(solution, name).DoAsync(cancellationToken);
         }

--- a/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Debugging;
@@ -71,13 +73,23 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
             return true;
         }
 
+        /// <summary>
+        /// Returns null indicating a failure.
+        /// </summary>
         public async Task<IList<string>> GetProximityExpressionsAsync(
             Document document,
             int position,
             CancellationToken cancellationToken)
         {
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            return Do(tree, position, cancellationToken);
+            try
+            {
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                return Do(tree, position, cancellationToken);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                return null;
+            }
         }
 
         // Internal for testing purposes

--- a/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -7,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Debugging;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
@@ -16,76 +18,83 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
     {
         internal static async Task<DebugDataTipInfo> GetInfoAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var token = root.FindToken(position);
-
-            var expression = token.Parent as ExpressionSyntax;
-            if (expression == null)
+            try
             {
-                return token.IsKind(SyntaxKind.IdentifierToken)
-                    ? new DebugDataTipInfo(token.Span, text: null)
-                    : default(DebugDataTipInfo);
-            }
+                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var token = root.FindToken(position);
 
-            if (expression.IsAnyLiteralExpression())
-            {
-                // If the user hovers over a literal, give them a DataTip for the type of the
-                // literal they're hovering over.
-                // Partial semantics should always be sufficient because the (unconverted) type
-                // of a literal can always easily be determined.
-                var semanticModel = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
-                return type == null
-                    ? default(DebugDataTipInfo)
-                    : new DebugDataTipInfo(expression.Span, type.ToNameDisplayString());
-            }
-
-            if (expression.IsRightSideOfDotOrArrow())
-            {
-                var curr = expression;
-                while (true)
+                var expression = token.Parent as ExpressionSyntax;
+                if (expression == null)
                 {
-                    var conditionalAccess = curr.GetParentConditionalAccessExpression();
-                    if (conditionalAccess == null)
+                    return token.IsKind(SyntaxKind.IdentifierToken)
+                        ? new DebugDataTipInfo(token.Span, text: null)
+                        : default;
+                }
+
+                if (expression.IsAnyLiteralExpression())
+                {
+                    // If the user hovers over a literal, give them a DataTip for the type of the
+                    // literal they're hovering over.
+                    // Partial semantics should always be sufficient because the (unconverted) type
+                    // of a literal can always easily be determined.
+                    var semanticModel = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                    var type = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
+                    return type == null
+                        ? default
+                        : new DebugDataTipInfo(expression.Span, type.ToNameDisplayString());
+                }
+
+                if (expression.IsRightSideOfDotOrArrow())
+                {
+                    var curr = expression;
+                    while (true)
                     {
-                        break;
+                        var conditionalAccess = curr.GetParentConditionalAccessExpression();
+                        if (conditionalAccess == null)
+                        {
+                            break;
+                        }
+
+                        curr = conditionalAccess;
                     }
 
-                    curr = conditionalAccess;
+                    if (curr == expression)
+                    {
+                        // NB: Parent.Span, not Span as below.
+                        return new DebugDataTipInfo(expression.Parent.Span, text: null);
+                    }
+
+                    // NOTE: There may not be an ExpressionSyntax corresponding to the range we want.
+                    // For example, for input a?.$$B?.C, we want span [|a?.B|]?.C.
+                    return new DebugDataTipInfo(TextSpan.FromBounds(curr.SpanStart, expression.Span.End), text: null);
                 }
 
-                if (curr == expression)
+                // NOTE(cyrusn): This behavior is to mimic what we did in Dev10, I'm not sure if it's
+                // necessary or not.
+                if (expression.IsKind(SyntaxKind.InvocationExpression))
                 {
-                    // NB: Parent.Span, not Span as below.
-                    return new DebugDataTipInfo(expression.Parent.Span, text: null);
+                    expression = ((InvocationExpressionSyntax)expression).Expression;
                 }
 
-                // NOTE: There may not be an ExpressionSyntax corresponding to the range we want.
-                // For example, for input a?.$$B?.C, we want span [|a?.B|]?.C.
-                return new DebugDataTipInfo(TextSpan.FromBounds(curr.SpanStart, expression.Span.End), text: null);
-            }
-
-            // NOTE(cyrusn): This behavior is to mimic what we did in Dev10, I'm not sure if it's
-            // necessary or not.
-            if (expression.IsKind(SyntaxKind.InvocationExpression))
-            {
-                expression = ((InvocationExpressionSyntax)expression).Expression;
-            }
-
-            string textOpt = null;
-            if (expression is TypeSyntax typeSyntax && typeSyntax.IsVar)
-            {
-                // If the user is hovering over 'var', then pass back the full type name that 'var'
-                // binds to.
-                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var type = semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type;
-                if (type != null)
+                string textOpt = null;
+                if (expression is TypeSyntax typeSyntax && typeSyntax.IsVar)
                 {
-                    textOpt = type.ToNameDisplayString();
+                    // If the user is hovering over 'var', then pass back the full type name that 'var'
+                    // binds to.
+                    var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                    var type = semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type;
+                    if (type != null)
+                    {
+                        textOpt = type.ToNameDisplayString();
+                    }
                 }
-            }
 
-            return new DebugDataTipInfo(expression.Span, textOpt);
+                return new DebugDataTipInfo(expression.Span, textOpt);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                return default;
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
@@ -32,7 +33,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _languageService = languageService;
         }
 
-        public virtual int GetDataTipText(TextSpan[] pSpan, out string pbstrText)
+        int IVsTextViewFilter.GetDataTipText(TextSpan[] pSpan, out string pbstrText)
+        {
+            try
+            {
+                return GetDataTipTextImpl(pSpan, out pbstrText);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                pbstrText = null;
+                return VSConstants.E_FAIL;
+            }
+        }
+
+        protected virtual int GetDataTipTextImpl(TextSpan[] pSpan, out string pbstrText)
         {
             pbstrText = null;
 
@@ -45,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return VSConstants.E_FAIL;
                 }
 
-                var vsBuffer = this.EditorAdaptersFactory.GetBufferAdapter(subjectBuffer);
+                var vsBuffer = EditorAdaptersFactory.GetBufferAdapter(subjectBuffer);
 
                 // TODO: broken in REPL
                 if (vsBuffer == null)
@@ -59,15 +73,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return VSConstants.E_FAIL;
         }
 
-        public int GetPairExtents(int iLine, int iIndex, TextSpan[] pSpan)
+        int IVsTextViewFilter.GetPairExtents(int iLine, int iIndex, TextSpan[] pSpan)
         {
-            int result = VSConstants.S_OK;
-            _languageService.Package.ComponentModel.GetService<IWaitIndicator>().Wait(
-                "Intellisense",
-                allowCancel: true,
-                action: c => result = GetPairExtentsWorker(iLine, iIndex, pSpan, c.CancellationToken));
+            try
+            {
+                int result = VSConstants.S_OK;
+                _languageService.Package.ComponentModel.GetService<IWaitIndicator>().Wait(
+                    "Intellisense",
+                    allowCancel: true,
+                    action: c => result = GetPairExtentsWorker(iLine, iIndex, pSpan, c.CancellationToken));
 
-            return result;
+                return result;
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                return VSConstants.E_FAIL;
+            }
         }
 
         private int GetPairExtentsWorker(int iLine, int iIndex, TextSpan[] pSpan, CancellationToken cancellationToken)
@@ -84,10 +105,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 cancellationToken);
         }
 
-        public int GetWordExtent(int iLine, int iIndex, uint dwFlags, TextSpan[] pSpan)
-        {
-            return VSConstants.E_NOTIMPL;
-        }
+        int IVsTextViewFilter.GetWordExtent(int iLine, int iIndex, uint dwFlags, TextSpan[] pSpan)
+            => VSConstants.E_NOTIMPL;
 
         #region Edit and Continue 
 

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
@@ -39,10 +40,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 return GetDataTipTextImpl(pSpan, out pbstrText);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                pbstrText = null;
-                return VSConstants.E_FAIL;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -85,9 +85,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                 return result;
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                return VSConstants.E_FAIL;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
+using Roslyn.Utilities;
 using IVsEnumBSTR = Microsoft.VisualStudio.TextManager.Interop.IVsEnumBSTR;
 using IVsTextBuffer = Microsoft.VisualStudio.TextManager.Interop.IVsTextBuffer;
 using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
@@ -17,10 +18,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                pguidLanguageID = default;
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -30,11 +30,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                pbstrMkDoc = null;
-                pspanLocation = default;
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -44,11 +42,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                pbstrName = null;
-                piLineOffset = 0;
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -58,10 +54,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                ppEnum = default;
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -71,9 +66,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.IsMappedLocation(pBuffer, iLine, iCol);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -83,10 +78,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.ResolveName(pszName, dwFlags, out ppNames);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                ppNames = default;
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 
@@ -96,9 +90,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 return LanguageDebugInfo.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
             }
-            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e) && false)
             {
-                return e.HResult;
+                throw ExceptionUtilities.Unreachable;
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsLanguageDebugInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using IVsEnumBSTR = Microsoft.VisualStudio.TextManager.Interop.IVsEnumBSTR;
 using IVsTextBuffer = Microsoft.VisualStudio.TextManager.Interop.IVsTextBuffer;
@@ -10,39 +11,95 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
     internal partial class AbstractLanguageService<TPackage, TLanguageService> : IVsLanguageDebugInfo
     {
-        public int GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID)
+        int IVsLanguageDebugInfo.GetLanguageID(IVsTextBuffer pBuffer, int iLine, int iCol, out Guid pguidLanguageID)
         {
-            return this.LanguageDebugInfo.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
+            try
+            {
+                return LanguageDebugInfo.GetLanguageID(pBuffer, iLine, iCol, out pguidLanguageID);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                pguidLanguageID = default;
+                return e.HResult;
+            }
         }
 
-        public int GetLocationOfName(string pszName, out string pbstrMkDoc, out TextSpan pspanLocation)
+        int IVsLanguageDebugInfo.GetLocationOfName(string pszName, out string pbstrMkDoc, out TextSpan pspanLocation)
         {
-            return this.LanguageDebugInfo.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
+            try
+            {
+                return LanguageDebugInfo.GetLocationOfName(pszName, out pbstrMkDoc, out pspanLocation);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                pbstrMkDoc = null;
+                pspanLocation = default;
+                return e.HResult;
+            }
         }
 
-        public int GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
+        int IVsLanguageDebugInfo.GetNameOfLocation(IVsTextBuffer pBuffer, int iLine, int iCol, out string pbstrName, out int piLineOffset)
         {
-            return this.LanguageDebugInfo.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
+            try
+            {
+                return LanguageDebugInfo.GetNameOfLocation(pBuffer, iLine, iCol, out pbstrName, out piLineOffset);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                pbstrName = null;
+                piLineOffset = 0;
+                return e.HResult;
+            }
         }
 
-        public int GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
+        int IVsLanguageDebugInfo.GetProximityExpressions(IVsTextBuffer pBuffer, int iLine, int iCol, int cLines, out IVsEnumBSTR ppEnum)
         {
-            return this.LanguageDebugInfo.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
+            try
+            {
+                return LanguageDebugInfo.GetProximityExpressions(pBuffer, iLine, iCol, cLines, out ppEnum);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                ppEnum = default;
+                return e.HResult;
+            }
         }
 
-        public int IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
+        int IVsLanguageDebugInfo.IsMappedLocation(IVsTextBuffer pBuffer, int iLine, int iCol)
         {
-            return this.LanguageDebugInfo.IsMappedLocation(pBuffer, iLine, iCol);
+            try
+            {
+                return LanguageDebugInfo.IsMappedLocation(pBuffer, iLine, iCol);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                return e.HResult;
+            }
         }
 
-        public int ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
+        int IVsLanguageDebugInfo.ResolveName(string pszName, uint dwFlags, out IVsEnumDebugName ppNames)
         {
-            return this.LanguageDebugInfo.ResolveName(pszName, dwFlags, out ppNames);
+            try
+            {
+                return LanguageDebugInfo.ResolveName(pszName, dwFlags, out ppNames);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                ppNames = default;
+                return e.HResult;
+            }
         }
 
-        public int ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan)
+        int IVsLanguageDebugInfo.ValidateBreakpointLocation(IVsTextBuffer pBuffer, int iLine, int iCol, TextSpan[] pCodeSpan)
         {
-            return this.LanguageDebugInfo.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
+            try
+            {
+                return LanguageDebugInfo.ValidateBreakpointLocation(pBuffer, iLine, iCol, pCodeSpan);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+            {
+                return e.HResult;
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
     internal abstract partial class AbstractLanguageService<TPackage, TLanguageService>
     {
-        internal class VsLanguageDebugInfo : IVsLanguageDebugInfo
+        internal sealed class VsLanguageDebugInfo
         {
             private readonly Guid _languageId;
             private readonly TLanguageService _languageService;

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/VisualStudioWaitIndicator.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -48,16 +49,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
                 {
                     return WaitIndicatorResult.Canceled;
                 }
-                catch (AggregateException e)
+                catch (AggregateException aggregate) when (aggregate.InnerExceptions.All(e => e is OperationCanceledException))
                 {
-                    if (e.InnerExceptions[0] is OperationCanceledException operationCanceledException)
-                    {
-                        return WaitIndicatorResult.Canceled;
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    return WaitIndicatorResult.Canceled;
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/VenusCommandFilter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return _subjectBuffer;
         }
 
-        public override int GetDataTipText(TextSpan[] pSpan, out string pbstrText)
+        protected override int GetDataTipTextImpl(TextSpan[] pSpan, out string pbstrText)
         {
             if (pSpan == null || pSpan.Length != 1)
             {
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 // Next, we'll check to see if there is actually a DataTip for this candidate.
                 // If there is, we'll map this span back to the DataBuffer and return it.
                 pSpan[0] = candidateSpan.ToVsTextSpan();
-                int hr = base.GetDataTipText(pSpan, out pbstrText);
+                int hr = base.GetDataTipTextImpl(pSpan, out pbstrText);
                 if (ErrorHandler.Succeeded(hr))
                 {
                     var subjectSpan = _subjectBuffer.CurrentSnapshot.GetSpan(pSpan[0]);

--- a/src/VisualStudio/VisualBasic/Impl/Debugging/VisualBasicBreakpointService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Debugging/VisualBasicBreakpointService.vb
@@ -1,10 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Debugging
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -18,56 +20,62 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
         Implements IBreakpointResolutionService
 
         Friend Shared Async Function GetBreakpointAsync(document As Document, position As Integer, length As Integer, cancellationToken As CancellationToken) As Task(Of BreakpointResolutionResult)
-            Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
+            Try
+                Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
 
-            ' Non-zero length means that the span is passed by the debugger and we may need validate it.
-            ' In a rare VB case, this span may contain multiple methods, e.g., 
-            '
-            '    [Sub Goo() Handles A
-            '
-            '     End Sub
-            '
-            '     Sub Bar() Handles B]
-            '
-            '     End Sub
-            '
-            ' It happens when IDE services (e.g., NavBar or CodeFix) inserts a new method at the beginning of the existing one
-            ' which happens to have a breakpoint on its head. In this situation, we should attempt to validate the span of the existing method,
-            ' not that of a newly-prepended method.
+                ' Non-zero length means that the span is passed by the debugger and we may need validate it.
+                ' In a rare VB case, this span may contain multiple methods, e.g., 
+                '
+                '    [Sub Goo() Handles A
+                '
+                '     End Sub
+                '
+                '     Sub Bar() Handles B]
+                '
+                '     End Sub
+                '
+                ' It happens when IDE services (e.g., NavBar or CodeFix) inserts a new method at the beginning of the existing one
+                ' which happens to have a breakpoint on its head. In this situation, we should attempt to validate the span of the existing method,
+                ' not that of a newly-prepended method.
 
-            Dim descendIntoChildren As Func(Of SyntaxNode, Boolean) =
+                Dim descendIntoChildren As Func(Of SyntaxNode, Boolean) =
                 Function(n)
                     Return (Not n.IsKind(SyntaxKind.ConstructorBlock)) _
                         AndAlso (Not n.IsKind(SyntaxKind.SubBlock))
                 End Function
 
-            If length > 0 Then
-                Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
-                Dim item = root.DescendantNodes(New TextSpan(position, length), descendIntoChildren:=descendIntoChildren).OfType(Of MethodBlockSyntax).Skip(1).LastOrDefault()
-                If item IsNot Nothing Then
-                    position = item.SpanStart
+                If length > 0 Then
+                    Dim root = Await tree.GetRootAsync(cancellationToken).ConfigureAwait(False)
+                    Dim item = root.DescendantNodes(New TextSpan(position, length), descendIntoChildren:=descendIntoChildren).OfType(Of MethodBlockSyntax).Skip(1).LastOrDefault()
+                    If item IsNot Nothing Then
+                        position = item.SpanStart
+                    End If
                 End If
-            End If
 
-            Dim span As TextSpan
-            If Not BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, span) Then
+                Dim span As TextSpan
+                If Not BreakpointSpans.TryGetBreakpointSpan(tree, position, cancellationToken, span) Then
+                    Return Nothing
+                End If
+
+                If span.Length = 0 Then
+                    Return BreakpointResolutionResult.CreateLineResult(document)
+                End If
+
+                Return BreakpointResolutionResult.CreateSpanResult(document, span)
+            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
                 Return Nothing
-            End If
-
-            If span.Length = 0 Then
-                Return BreakpointResolutionResult.CreateLineResult(document)
-            End If
-
-            Return BreakpointResolutionResult.CreateSpanResult(document, span)
+            End Try
         End Function
 
         Public Function ResolveBreakpointAsync(document As Document, textSpan As TextSpan, Optional cancellationToken As CancellationToken = Nothing) As Task(Of BreakpointResolutionResult) Implements IBreakpointResolutionService.ResolveBreakpointAsync
             Return GetBreakpointAsync(document, textSpan.Start, textSpan.Length, cancellationToken)
         End Function
 
-        Public Function ResolveBreakpointsAsync(solution As Solution,
-                                           name As String,
-                                           Optional cancellationToken As CancellationToken = Nothing) As Task(Of IEnumerable(Of BreakpointResolutionResult)) Implements IBreakpointResolutionService.ResolveBreakpointsAsync
+        Public Function ResolveBreakpointsAsync(
+            solution As Solution,
+            name As String,
+            Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of BreakpointResolutionResult)) Implements IBreakpointResolutionService.ResolveBreakpointsAsync
+
             Return New BreakpointResolver(solution, name).DoAsync(cancellationToken)
         End Function
     End Class


### PR DESCRIPTION
Make sure we report NFW for unexpected exceptions thrown from VsLanguageDebugInfo and related methods. Currently the exceptions are converted to HResults on interop boundary and hence full stack is not captured in crash dumps.