### PR TITLE
Fixed variable name for Extract Local refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4333,5 +4333,84 @@ struct TextSpan
     }
 }");
         }
+
+        [WorkItem(21665, "https://github.com/dotnet/roslyn/issues/21665")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestPickNameBasedOnValueTupleFieldName1()
+        {
+            await TestAsync(
+@"using System;
+
+class C
+{
+    public C(string a, string b)
+    {
+        var tuple = (id: 1, date: [|DateTime.Now.ToString()|]);
+    }
+}",
+@"using System;
+
+class C
+{
+    public C(string a, string b)
+    {
+        string {|Rename:date|} = DateTime.Now.ToString();
+        var tuple = (id: 1, date: date);
+    }
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+        }
+
+        [WorkItem(21665, "https://github.com/dotnet/roslyn/issues/21665")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestPickNameBasedOnValueTupleFieldName2()
+        {
+            await TestAsync(
+@"using System;
+
+class C
+{
+    public C()
+    {
+        var tuple = (key: 1, value: [|1 + 1|]);
+    }
+}",
+@"using System;
+
+class C
+{
+    private const int {|Rename:Value|} = 1 + 1;
+
+    public C()
+    {
+        var tuple = (key: 1, value: Value);
+    }
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), index: 0);
+        }
+
+        [WorkItem(21665, "https://github.com/dotnet/roslyn/issues/21665")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestPickNameBasedOnValueTupleFieldName3()
+        {
+            await TestAsync(
+@"using System;
+
+class C
+{
+    public C()
+    {
+        var tuple = (key: 1, value: [|1 + 1|]);
+    }
+}",
+@"using System;
+
+class C
+{
+    public C()
+    {
+        const int {|Rename:Value|} = 1 + 1;
+        var tuple = (key: 1, value: Value);
+    }
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), index: 2);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             // relate to the type the user is casting to, and it should not collisde with anything
             // in scope.
             var reservedNames = semanticModel.LookupSymbols(isExpression.SpanStart)
-                                             .Concat(GetExistingSymbols(semanticModel, container, cancellationToken))
+                                             .Concat(semanticModel.GetExistingSymbols(container, cancellationToken))
                                              .Select(s => s.Name)
                                              .ToSet();
 
@@ -151,15 +151,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             }
 
             return (matches, localName);
-        }
-
-        private static IEnumerable<ISymbol> GetExistingSymbols(
-            SemanticModel semanticModel, SyntaxNode container, CancellationToken cancellationToken)
-        {
-            // Ignore an annonymous type property or tuple field.  It's ok if they have a name that 
-            // matches the name of the local we're introducing.
-            return semanticModel.GetAllDeclaredSymbols(container, cancellationToken)
-                                .Where(s => !s.IsAnonymousTypeProperty() && !s.IsTupleField());
         }
 
         private bool ReplacementCausesError(

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             var semanticFacts = document.Document.GetLanguageService<ISemanticFactsService>();
 
             var semanticModel = document.SemanticModel;
-            var existingSymbols = GetExistingSymbols(semanticModel, container, cancellationToken);
+            var existingSymbols = semanticModel.GetExistingSymbols(container, cancellationToken);
 
             var baseName = semanticFacts.GenerateNameForExpression(
                 semanticModel, expression, capitalize: isConstant, cancellationToken: cancellationToken);
@@ -235,15 +235,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
 
             return syntaxFacts.ToIdentifierToken(
                 NameGenerator.EnsureUniqueness(baseName, reservedNames, syntaxFacts.IsCaseSensitive));
-        }
-
-        private static IEnumerable<ISymbol> GetExistingSymbols(
-            SemanticModel semanticModel, SyntaxNode container, CancellationToken cancellationToken)
-        {
-            // Ignore an annonymous type property and value tuple type field. It's ok if they have a name that 
-            // matches the name of the local we're introducing.
-            return semanticModel.GetAllDeclaredSymbols(container, cancellationToken)
-                                .Where(s => !(s.IsAnonymousTypeProperty() || s.IsTupleField()));
         }
 
         protected ISet<TExpressionSyntax> FindMatches(

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -240,10 +240,10 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
         private static IEnumerable<ISymbol> GetExistingSymbols(
             SemanticModel semanticModel, SyntaxNode container, CancellationToken cancellationToken)
         {
-            // Ignore an annonymous type property.  It's ok if they have a name that 
+            // Ignore an annonymous type property and value tuple type field. It's ok if they have a name that 
             // matches the name of the local we're introducing.
             return semanticModel.GetAllDeclaredSymbols(container, cancellationToken)
-                                .Where(s => !s.IsAnonymousTypeProperty());
+                                .Where(s => !(s.IsAnonymousTypeProperty() || s.IsTupleField()));
         }
 
         protected ISet<TExpressionSyntax> FindMatches(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -239,6 +239,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return symbols;
         }
 
+        public static IEnumerable<ISymbol> GetExistingSymbols(
+            this SemanticModel semanticModel, SyntaxNode container, CancellationToken cancellationToken)
+        {
+            // Ignore an annonymous type property or tuple field.  It's ok if they have a name that 
+            // matches the name of the local we're introducing.
+            return semanticModel.GetAllDeclaredSymbols(container, cancellationToken)
+                                .Where(s => !s.IsAnonymousTypeProperty() && !s.IsTupleField());
+        }
+
         private static void GetAllDeclaredSymbols(
             SemanticModel semanticModel, SyntaxNode node,
             HashSet<ISymbol> symbols, CancellationToken cancellationToken)


### PR DESCRIPTION
**Customer scenario**

Extract Local refactoring: variable name should be equal to value tuple field name

**Bugs this fixes:**

Fixes #21665

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**

```GetExistingSymbols``` doesn't exclude tuple field names.

**How was the bug found?**

customer reported
