### PR TITLE
Add support for the CLI invoking Roslyn without CscToolPath

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -16,19 +16,5 @@
   <PropertyGroup>
     <!-- Compiler server is not currently supported on CoreCLR -->
     <UseSharedCompilation>false</UseSharedCompilation>
-    <CscToolPath>$(MSBuildThisFileDirectory)..\tools\bincore</CscToolPath>
-    <CscToolExe Condition="'$(OS)' == 'Windows_NT'">RunCsc.cmd</CscToolExe>
-    <CscToolExe Condition="'$(OS)' != 'Windows_NT'">RunCsc</CscToolExe>
-    <VbcToolPath>$(MSBuildThisFileDirectory)..\tools\bincore</VbcToolPath>
-    <VbcToolExe Condition="'$(OS)' == 'Windows_NT'">RunVbc.cmd</VbcToolExe>
-    <VbcToolExe Condition="'$(OS)' != 'Windows_NT'">RunVbc</VbcToolExe>
   </PropertyGroup>
-
-  <!-- If packaged on Windows, the RunCsc and RunVbc scripts may not be marked
-       executable. If we're not running on Windows, mark them as such, just in case -->
-  <Target Name="MakeCompilerScriptsExecutable"
-          Condition="'$(BuildingProject)' == 'true' AND '$(OS)' != 'Windows_NT'"
-          BeforeTargets="CoreCompile">
-    <Exec Command="chmod +x &quot;$(CscToolPath)/$(CscToolExe)&quot; &quot;$(VbcToolPath)/$(VbcToolExe)&quot;" />
-  </Target>
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -165,11 +165,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Return the name of the tool to execute.
         /// </summary>
-        override protected string ToolName
+        override protected string ToolNameWithoutExtension
         {
             get
             {
-                return "csc.exe";
+                return "csc";
             }
         }
 

--- a/src/Compilers/Core/MSBuildTask/Csi.cs
+++ b/src/Compilers/Core/MSBuildTask/Csi.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         /// Return the name of the tool to execute.
         /// </summary>
-        protected override string ToolName => "csi.exe";
+        protected override string ToolNameWithoutExtension => "csi";
         #endregion
 
         #region Interactive Compiler Members

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -4,44 +4,48 @@ using System;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
 {
-    internal class DotnetHost
+    internal sealed class DotnetHost
     {
-        public string ToolName { get; }
+        public string ToolNameOpt { get; }
 
         public string PathToToolOpt { get; }
 
         public string CommandLineArgs { get; }
 
-        public DotnetHost(string toolName, string pathToTool, string commandLineArgs)
+        private DotnetHost(string toolNameOpt, string pathToToolOpt, string commandLineArgs)
         {
-            ToolName = toolName;
-            PathToToolOpt = pathToTool;
+            ToolNameOpt = toolNameOpt;
+            PathToToolOpt = pathToToolOpt;
             CommandLineArgs = commandLineArgs;
         }
 
-        public DotnetHost(string toolNameWithoutExtension, string commandLineArgs)
+        public static DotnetHost CreateUnmanagedToolInvocation(string pathToTool, string commandLineArgs)
         {
-            string pathToTool;
+            return new DotnetHost(null, pathToTool, commandLineArgs);
+        }
+
+        public static DotnetHost CreateManagedToolInvocation(string toolNameWithoutExtension, string commandLineArgs)
+        {
+            string pathToToolOpt;
             string toolName;
             if (IsCliHost(out string pathToDotnet))
             {
                 toolName = $"{toolNameWithoutExtension}.dll";
-                pathToTool = Utilities.GenerateFullPathToTool(toolName);
-                if (pathToTool != null)
+                pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
+                if (pathToToolOpt != null)
                 {
-                    commandLineArgs = $"\"{pathToTool}\" {commandLineArgs}";
-                    pathToTool = pathToDotnet;
+                    commandLineArgs = $"\"{pathToToolOpt}\" {commandLineArgs}";
+                    pathToToolOpt = pathToDotnet;
                 }
             }
             else
             {
                 // Desktop executes tool directly
                 toolName = $"{toolNameWithoutExtension}.exe";
-                pathToTool = Utilities.GenerateFullPathToTool(toolName);
+                pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
             }
 
-            PathToToolOpt = pathToTool;
-            CommandLineArgs = commandLineArgs;
+            return new DotnetHost(toolName, pathToToolOpt, commandLineArgs);
         }
 
         private static bool IsCliHost(out string pathToDotnet)

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    class DotnetHost
+    {
+        public string ToolName { get; }
+
+        public string PathToTool { get; }
+
+        public string CommandLineArgs { get; }
+
+        public DotnetHost(string toolName, string pathToTool, string commandLineArgs)
+        {
+            ToolName = toolName;
+            PathToTool = pathToTool;
+            CommandLineArgs = commandLineArgs;
+        }
+
+        public DotnetHost(string toolNameWithoutExtension, string commandLineArgs)
+        {
+            string pathToTool;
+            string toolName;
+            if (IsCliHost(out string pathToDotnet))
+            {
+                toolName = $"{toolNameWithoutExtension}.dll";
+                pathToTool = Utilities.GenerateFullPathToTool(toolName);
+                if (pathToTool != null)
+                {
+                    RewriteToCliInvocation(ref pathToTool, ref commandLineArgs, pathToDotnet);
+                }
+            }
+            else
+            {
+                // Desktop executes tool directly
+                toolName = $"{toolNameWithoutExtension}.exe";
+                pathToTool = Utilities.GenerateFullPathToTool(toolName);
+            }
+            PathToTool = pathToTool;
+            CommandLineArgs = commandLineArgs;
+        }
+
+        private static void RewriteToCliInvocation(ref string pathToTool, ref string commandLineArgs, string pathToDotnet)
+        {
+            commandLineArgs = $"\"{pathToTool}\" {commandLineArgs}";
+            pathToTool = pathToDotnet;
+        }
+
+        private static bool IsCliHost(out string pathToDotnet)
+        {
+            pathToDotnet = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+            return !string.IsNullOrEmpty(pathToDotnet);
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
                 if (pathToToolOpt != null)
                 {
-                    commandLineArgs = $"\"{pathToToolOpt}\" {commandLineArgs}";
+                    commandLineArgs = PrependFileToArgs(pathToToolOpt, commandLineArgs);
                     pathToToolOpt = pathToDotnet;
                 }
             }
@@ -60,6 +60,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 pathToDotnet = null;
                 return false;
             }
+        }
+
+        private static string PrependFileToArgs(string pathToTool, string commandLineArgs)
+        {
+            var builder = new CommandLineBuilderExtension();
+            builder.AppendFileNameIfNotNull(pathToTool);
+            builder.AppendTextUnquoted(commandLineArgs);
+            return builder.ToString();
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -186,23 +186,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 if (_dotnetHostInfo is null)
                 {
-                    var commandLineBuilder = new CommandLineBuilderExtension();
+                    CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension();
                     AddCommandLineCommands(commandLineBuilder);
+                    var commandLine = commandLineBuilder.ToString();
 
                     if (string.IsNullOrEmpty(ToolPath))
                     {
-                        _dotnetHostInfo = new DotnetHost(ToolNameWithoutExtension, commandLineBuilder.ToString());
+                        _dotnetHostInfo = DotnetHost.CreateManagedToolInvocation(ToolNameWithoutExtension, commandLine);
 
                         // See comment in ManagedCompiler.cs on why this if statement is here.
-                        if (ToolExe != _dotnetHostInfo.ToolName)
+                        if (ToolExe != _dotnetHostInfo.ToolNameOpt)
                         {
-                            _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
                         }
                     }
                     else
                     {
                         // Explicitly provided ToolPath, don't try to figure anything out
-                        _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
                     }
                 }
                 return _dotnetHostInfo;
@@ -213,7 +214,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected abstract string ToolNameWithoutExtension { get; }
 
-        protected sealed override string ToolName => DotnetHostInfo.ToolName;
+        protected sealed override string ToolName => DotnetHostInfo.ToolNameOpt;
 
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            var pathToTool = DotnetHostInfo.PathToTool;
+            var pathToTool = DotnetHostInfo.PathToToolOpt;
 
             if (null == pathToTool)
             {

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -189,8 +189,21 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     var commandLineBuilder = new CommandLineBuilderExtension();
                     AddCommandLineCommands(commandLineBuilder);
 
-                    var dotnetHost = new DotnetHost(ToolNameWithoutExtension, commandLineBuilder.ToString());
-                    _dotnetHostInfo = dotnetHost;
+                    if (string.IsNullOrEmpty(ToolPath))
+                    {
+                        _dotnetHostInfo = new DotnetHost(ToolNameWithoutExtension, commandLineBuilder.ToString());
+
+                        // See comment in ManagedCompiler.cs on why this if statement is here.
+                        if (ToolExe != _dotnetHostInfo.ToolName)
+                        {
+                            _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                        }
+                    }
+                    else
+                    {
+                        // Explicitly provided ToolPath, don't try to figure anything out
+                        _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                    }
                 }
                 return _dotnetHostInfo;
             }

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -179,7 +179,29 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
         #endregion
 
+        private DotnetHost _dotnetHostInfo;
+        private DotnetHost DotnetHostInfo
+        {
+            get
+            {
+                if (_dotnetHostInfo is null)
+                {
+                    var commandLineBuilder = new CommandLineBuilderExtension();
+                    AddCommandLineCommands(commandLineBuilder);
+
+                    var dotnetHost = new DotnetHost(ToolNameWithoutExtension, commandLineBuilder.ToString());
+                    _dotnetHostInfo = dotnetHost;
+                }
+                return _dotnetHostInfo;
+            }
+        }
+
         #region Tool Members
+
+        protected abstract string ToolNameWithoutExtension { get; }
+
+        protected sealed override string ToolName => DotnetHostInfo.ToolName;
+
         protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
         {
             if (ProvideCommandLineArgs)
@@ -194,9 +216,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected override string GenerateCommandLineCommands()
         {
-            var commandLineBuilder = new CommandLineBuilderExtension();
-            AddCommandLineCommands(commandLineBuilder);
-            return commandLineBuilder.ToString();
+            return DotnetHostInfo.CommandLineArgs;
         }
 
         /// <summary>
@@ -204,7 +224,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            var pathToTool = Utilities.GenerateFullPathToTool(ToolName);
+            var pathToTool = DotnetHostInfo.PathToTool;
 
             if (null == pathToTool)
             {

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -27,6 +27,9 @@
     <Compile Include="..\..\Shared\BuildServerConnection.cs">
       <Link>BuildServerConnection.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\CoreClrShim.cs">
+      <Link>CoreClrShim.cs</Link>
+    </Compile>
     <Compile Include="..\Portable\CorLightup.cs">
       <Link>CorLightup.cs</Link>
     </Compile>

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -412,10 +412,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 {
                     CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension();
                     AddCommandLineCommands(commandLineBuilder);
+                    var commandLine = commandLineBuilder.ToString();
 
                     // ToolExe delegates back to ToolName if the override is not
                     // set.
-                    // So, we can't check if it's unset, as that will recurse
+                    // So, we can't check if it's unset, as that will recur
                     // and stackoverflow.
                     // However, checking only ToolPath is inadequate, as some
                     // callers only set ToolExe, and not ToolPath (e.g. CLI).
@@ -429,17 +430,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // arguments).
                     if (string.IsNullOrEmpty(ToolPath))
                     {
-                        _dotnetHostInfo = new DotnetHost(ToolNameWithoutExtension, commandLineBuilder.ToString());
+                        _dotnetHostInfo = DotnetHost.CreateManagedToolInvocation(ToolNameWithoutExtension, commandLine);
 
-                        if (ToolExe != _dotnetHostInfo.ToolName)
+                        if (ToolExe != _dotnetHostInfo.ToolNameOpt)
                         {
-                            _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
                         }
                     }
                     else
                     {
                         // Explicitly provided ToolPath, don't try to figure anything out
-                        _dotnetHostInfo = new DotnetHost(null, ToolPath, commandLineBuilder.ToString());
+                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
                     }
                 }
                 return _dotnetHostInfo;
@@ -448,7 +449,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         protected abstract string ToolNameWithoutExtension { get; }
 
-        protected sealed override string ToolName => DotnetHostInfo.ToolName;
+        protected sealed override string ToolName => DotnetHostInfo.ToolNameOpt;
 
         /// <summary>
         /// Return the path to the tool to execute.

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            var pathToTool = DotnetHostInfo.PathToTool;
+            var pathToTool = DotnetHostInfo.PathToToolOpt;
 
             if (null == pathToTool)
             {

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -200,11 +200,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     if(assemblyPath != null)
                     {
                         var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
-                        var toolLocalLocation = Path.Combine(assemblyDirectory, toolName);
+                        var desktopToolLocalLocation = Path.Combine(assemblyDirectory, toolName);
+                        var cliToolLocalLocation = Path.Combine(assemblyDirectory, "bincore", toolName);
 
-                        if (File.Exists(toolLocalLocation))
+                        if (File.Exists(desktopToolLocalLocation))
                         {
-                            toolLocation = toolLocalLocation;
+                            toolLocation = desktopToolLocalLocation;
+                        }
+                        else if (File.Exists(cliToolLocalLocation))
+                        {
+                            toolLocation = cliToolLocalLocation;
                         }
                     }
                 }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -246,11 +246,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// <summary>
         ///  Return the name of the tool to execute.
         /// </summary>
-        override protected string ToolName
+        override protected string ToolNameWithoutExtension
         {
             get
             {
-                return "vbc.exe";
+                return "vbc";
             }
         }
 


### PR DESCRIPTION
The new `DotnetHost` class is the core of the logic here. It handles the following:

* If we're running under desktop, search for `csc.exe`, and don't touch the command line.
* If we're running under dotnet, search for `csc.dll`, and rewrite the command line to use `dotnet` as the process, and `csc.dll` as the first command line argument.

Additionally, add `<task dll path>/bincore/<search name>` to the list of paths searched. This corresponds to the way the `Microsoft.NETCore.Compilers` package is laid out.

The logic to detect which case we're in could be refined. Currently in this PR, this is the logic:

* If the environment variable `DOTNET_HOST_PATH` is set, assume we're running under `dotnet`, and use that as the path to the `dotnet` process (the presence/meaning of that environment variable was discussed in other PRs/issues)
* Otherwise, assume we're running under desktop.

We could multitarget the build task: the above logic would fail if we're actually running under desktop, and `DOTNET_HOST_PATH` is set to something silly. However, I feel like this is a good first revision.

I have left the `RunCsc` scripts in this repo, as they should still function (and, before being updated, CLI still needs them).

The above is identical for VB - swap out csc for vbc where appropriate.

---

These changes were manually tested in the CLI, using this build of Roslyn as a local package source. I wish there was a better way to test :(

Additionally, I have changes in the CLI that removes all setting of `CscHostPath`, and will submit that once these changes are in a Roslyn nuget.

---

This change is part of a larger process to reduce coupling of Roslyn and the CLI. Once this is in, we can begin to modify the msbuild task to use a new cross-plat compiler server, etc.

Ping @jaredpar as an FYI (and also reviewer).