### PR TITLE
Fix lightbulb issues

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -902,9 +902,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                             var errorTask = Task.Run(
                                 () => GetFixLevelAsync(provider, document, range, linkedToken), linkedToken);
 
-                            var refactoringTask = Task.Run(
-                                () => TryGetRefactoringSuggestedActionCategoryAsync(provider, document, selection, linkedToken),
-                                linkedToken);
+                            var refactoringTask = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring)
+                                ? Task.Run(
+                                    () => TryGetRefactoringSuggestedActionCategoryAsync(provider, document, selection, linkedToken),
+                                    linkedToken)
+                                : Task.FromResult((string)null);
 
                             // If we happen to get the result of the error task before the refactoring task,
                             // and that result is non-null, we can just cancel the refactoring task.

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -891,35 +891,32 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var provider = _owner;
                 using (var asyncToken = _owner.OperationListener.BeginAsyncOperation(nameof(GetSuggestedActionCategoriesAsync)))
                 {
-                    var selection = await GetSpanAsync(range).ConfigureAwait(false);
-                    if (selection != null)
+                    var document = range.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                    using (var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
                     {
-                        var document = range.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                        using (var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                        var linkedToken = linkedTokenSource.Token;
+
+                        var errorTask = Task.Run(
+                            () => GetFixLevelAsync(provider, document, range, linkedToken), linkedToken);
+
+                        var selection = await GetSpanAsync(range).ConfigureAwait(false);
+                        Task<string> refactoringTask = Task.FromResult((string)null);
+                        if (selection != null && requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
                         {
-                            var linkedToken = linkedTokenSource.Token;
-
-                            var errorTask = Task.Run(
-                                () => GetFixLevelAsync(provider, document, range, linkedToken), linkedToken);
-
-                            var refactoringTask = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring)
-                                ? Task.Run(
+                            refactoringTask = Task.Run(
                                     () => TryGetRefactoringSuggestedActionCategoryAsync(provider, document, selection, linkedToken),
-                                    linkedToken)
-                                : Task.FromResult((string)null);
-
-                            // If we happen to get the result of the error task before the refactoring task,
-                            // and that result is non-null, we can just cancel the refactoring task.
-                            var result = await errorTask.ConfigureAwait(false) ?? await refactoringTask.ConfigureAwait(false);
-                            linkedTokenSource.Cancel();
-                            return result == null
-                                ? null
-                                : _suggestedActionCategoryRegistry.CreateSuggestedActionCategorySet(result);
+                                    linkedToken);
                         }
+                        
+                        // If we happen to get the result of the error task before the refactoring task,
+                        // and that result is non-null, we can just cancel the refactoring task.
+                        var result = await errorTask.ConfigureAwait(false) ?? await refactoringTask.ConfigureAwait(false);
+                        linkedTokenSource.Cancel();
+                        return result == null
+                            ? null
+                            : _suggestedActionCategoryRegistry.CreateSuggestedActionCategorySet(result);
                     }
                 }
-
-                return null;
             }
         }
     }


### PR DESCRIPTION
The move to SuggestedActionsSource2 introduced 2 issues tracked by https://github.com/dotnet/roslyn/issues/19772. This change fixes both:
1. The "refactoring" lightbulb would sometimes be available but disappear if clicked on
2. QuickInfo for error squiggles would not show a lightbulb for available fixes unless the caret was within the squiggle's span.

Tag @dotnet/roslyn-ide for review