### PR TITLE
fixed one of InvokeAsync crash case due to cancellation token

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Remoting;
@@ -58,6 +59,11 @@ namespace Roslyn.Test.Utilities.Remote
         }
 
         public AssetStorage AssetStorage => _inprocServices.AssetStorage;
+
+        public void RegisterService(string name, Func<Stream, IServiceProvider, ServiceHubServiceBase> serviceCreator)
+        {
+            _inprocServices.RegisterService(name, serviceCreator);
+        }
 
         protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
         {
@@ -122,38 +128,33 @@ namespace Roslyn.Test.Utilities.Remote
         private class InProcRemoteServices
         {
             private readonly ServiceProvider _serviceProvider;
+            private readonly Dictionary<string, Func<Stream, IServiceProvider, ServiceHubServiceBase>> _creatorMap;
 
             public InProcRemoteServices(bool runCacheCleanup)
             {
                 _serviceProvider = new ServiceProvider(runCacheCleanup);
+                _creatorMap = new Dictionary<string, Func<Stream, IServiceProvider, ServiceHubServiceBase>>();
+
+                RegisterService(WellKnownRemoteHostServices.RemoteHostService, (s, p) => new RemoteHostService(s, p));
+                RegisterService(WellKnownServiceHubServices.CodeAnalysisService, (s, p) => new CodeAnalysisService(s, p));
+                RegisterService(WellKnownServiceHubServices.SnapshotService, (s, p) => new SnapshotService(s, p));
+                RegisterService(WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine, (s, p) => new RemoteSymbolSearchUpdateEngine(s, p));
             }
 
             public AssetStorage AssetStorage => _serviceProvider.AssetStorage;
 
+            public void RegisterService(string name, Func<Stream, IServiceProvider, ServiceHubServiceBase> serviceCreator)
+            {
+                _creatorMap.Add(name, serviceCreator);
+            }
+
             public Task<Stream> RequestServiceAsync(string serviceName, CancellationToken cancellationToken)
             {
-                switch (serviceName)
+                Func<Stream, IServiceProvider, ServiceHubServiceBase> creator;
+                if (_creatorMap.TryGetValue(serviceName, out creator))
                 {
-                    case WellKnownRemoteHostServices.RemoteHostService:
-                        {
-                            var tuple = FullDuplexStream.CreateStreams();
-                            return Task.FromResult<Stream>(new WrappedStream(new RemoteHostService(tuple.Item1, _serviceProvider), tuple.Item2));
-                        }
-                    case WellKnownServiceHubServices.CodeAnalysisService:
-                        {
-                            var tuple = FullDuplexStream.CreateStreams();
-                            return Task.FromResult<Stream>(new WrappedStream(new CodeAnalysisService(tuple.Item1, _serviceProvider), tuple.Item2));
-                        }
-                    case WellKnownServiceHubServices.SnapshotService:
-                        {
-                            var tuple = FullDuplexStream.CreateStreams();
-                            return Task.FromResult<Stream>(new WrappedStream(new SnapshotService(tuple.Item1, _serviceProvider), tuple.Item2));
-                        }
-                    case WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine:
-                        {
-                            var tuple = FullDuplexStream.CreateStreams();
-                            return Task.FromResult<Stream>(new WrappedStream(new RemoteSymbolSearchUpdateEngine(tuple.Item1, _serviceProvider), tuple.Item2));
-                        }
+                    var tuple = FullDuplexStream.CreateStreams();
+                    return Task.FromResult<Stream>(new WrappedStream(creator(tuple.Item1, _serviceProvider), tuple.Item2));
                 }
 
                 throw ExceptionUtilities.UnexpectedValue(serviceName);

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -127,6 +127,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return true;
             }
 
+            if (ex is OperationCanceledException && ((IDisposableObservable)_rpc).IsDisposed)
+            {
+                // JsonRpc will throw its own cancellation token if connection it is attached to
+                // is going away. we can get into this sitatuion when VS is shutting down since we dispose
+                // all connections that are open.
+
+                // return false so that we let cancellation from JsonRpc to propagate. we do this
+                // since it is one of safetest way to gracefully shutdown the call. since Host is going
+                // away we are fine as long as there is no crash/NFW/Infobar
+                return false;
+            }
+
             s_debuggingLastDisconnectReason = _debuggingLastDisconnectReason;
             s_debuggingLastDisconnectCallstack = _debuggingLastDisconnectCallstack;
 


### PR DESCRIPTION
**Customer scenario**

sometimes, VS sends NFW when VS is closed.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/457151

not all of these case, but just one of case which cause this.

**Workarounds, if any**

this doesn't happen 100% time, but if VS is closed at a point when VS happen to be in the middle of communicating with OOP.

**Risk**

I dont see any risk on this fix.

**Performance impact**

code change shouldn't affect performance.

**Is this a regression from a previous update?**

Yes. change to move explicit crash to where it happens cause this cancellation exception to be caught as well.

**Root cause analysis:**

didn't handle one of cancellation case properly.

**How was the bug found?**

Dogfooding.

Test added.