### PR TITLE
IOperation API extensions to expose low-level operations

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -128,6 +128,11 @@ namespace Microsoft.CodeAnalysis
             int index = list.IndexOf(kind);
             return (index >= 0) ? list[index] : default(SyntaxToken);
         }
+
+        internal static CSharpSyntaxNode GetCSharpSyntax(this SyntaxReference syntaxReference, CancellationToken cancellationToken = default)
+        {
+            return (CSharpSyntaxNode)syntaxReference.GetSyntax(cancellationToken);
+        }
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -465,13 +465,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion Helpers for speculative binding
 
-        protected override IOperation GetOperationCore(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken)
+        protected override IOperation GetOperationCore(IMethodSymbol method, CancellationToken cancellationToken)
         {
-            var csbody = (CSharpSyntaxNode)body;
             var csmethod = (MethodSymbol)method;
-            CheckSyntaxNode(csbody);
             CheckSymbol(csmethod);
-            return this.GetOperationWorker(csmethod, csbody, cancellationToken);
+            var csbody = csmethod.GetBodySyntax();
+            CheckSyntaxNode(csbody);
+            return GetOperationWorker(csmethod, csbody, cancellationToken);
         }
 
         internal virtual IOperation GetOperationWorker(MethodSymbol method, CSharpSyntaxNode body, CancellationToken cancellationToken)
@@ -490,7 +490,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var csnode = (CSharpSyntaxNode)node;
             CheckSyntaxNode(csnode);
-            return this.GetOperationWorker(csnode, GetOperationOptions.Lowest, cancellationToken);
+            return GetOperationWorker(csnode, GetOperationOptions.Lowest, cancellationToken);
         }
 
         internal virtual IOperation GetOperationWorker(CSharpSyntaxNode node, GetOperationOptions options, CancellationToken cancellationToken)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -465,11 +465,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion Helpers for speculative binding
 
-        protected override IOperation GetOperationCore(SyntaxNode node, CancellationToken cancellationToken)
+        protected override IOperation GetOperationCore(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken)
         {
-            var csnode = (CSharpSyntaxNode)node;
-            CheckSyntaxNode(csnode);
-            return this.GetOperationWorker(csnode, GetOperationOptions.Lowest, cancellationToken);
+            var csbody = (CSharpSyntaxNode)body;
+            var csmethod = (MethodSymbol)method;
+            CheckSyntaxNode(csbody);
+            CheckSymbol(csmethod);
+            return this.GetOperationWorker(csmethod, csbody, cancellationToken);
+        }
+
+        internal virtual IOperation GetOperationWorker(MethodSymbol method, CSharpSyntaxNode body, CancellationToken cancellationToken)
+        {
+            return null;
         }
 
         internal enum GetOperationOptions
@@ -477,6 +484,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             Highest,
             Lowest,
             Parent
+        }
+
+        protected override IOperation GetOperationCore(SyntaxNode node, CancellationToken cancellationToken)
+        {
+            var csnode = (CSharpSyntaxNode)node;
+            CheckSyntaxNode(csnode);
+            return this.GetOperationWorker(csnode, GetOperationOptions.Lowest, cancellationToken);
         }
 
         internal virtual IOperation GetOperationWorker(CSharpSyntaxNode node, GetOperationOptions options, CancellationToken cancellationToken)
@@ -1244,6 +1258,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected void AssertPositionAdjusted(int position)
         {
             Debug.Assert(position == CheckAndAdjustPosition(position), "Expected adjusted position");
+        }
+
+        protected void CheckSymbol(Symbol symbol)
+        {
+            if (symbol == null)
+            {
+                throw new ArgumentNullException(nameof(symbol));
+            }
         }
 
         protected void CheckSyntaxNode(CSharpSyntaxNode syntax)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -999,15 +999,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override IOperation GetOperationWorker(MethodSymbol method, CSharpSyntaxNode bodySyntax, CancellationToken cancellationToken)
         {
+            IOperation result = null;
             var node = GetBoundNode(bodySyntax, GetOperationOptions.Highest);
-            var body = (BoundStatement)node;
-            var loweredBody = LowerMethodBody(method, body);
 
-            // The CSharp operation factory assumes that UnboundLambda will be bound for error recovery and never be passed to the factory
-            // as the start of a tree to get operations for. This is guaranteed by the builder that populates the node map, as it will call
-            // UnboundLambda.BindForErrorRecovery() when it encounters an UnboundLambda node.
-            Debug.Assert(loweredBody.Kind != BoundKind.UnboundLambda);
-            return _operationFactory.Create(loweredBody);
+            if (!node.HasErrors)
+            {
+                var body = (BoundStatement)node;
+                var loweredBody = LowerMethodBody(method, body);
+
+                // The CSharp operation factory assumes that UnboundLambda will be bound for error recovery and never be passed to the factory
+                // as the start of a tree to get operations for. This is guaranteed by the builder that populates the node map, as it will call
+                // UnboundLambda.BindForErrorRecovery() when it encounters an UnboundLambda node.
+                Debug.Assert(loweredBody.Kind != BoundKind.UnboundLambda);
+                result = _operationFactory.Create(loweredBody);
+            }
+
+            return result;
         }
 
         private BoundStatement LowerMethodBody(MethodSymbol method, BoundStatement body)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1019,16 +1019,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement LowerMethodBody(MethodSymbol method, BoundStatement body)
         {
+            const int methodOrdinal = -1;
             var diagnostics = DiagnosticBag.GetInstance();
             var compilationState = new TypeCompilationState(method.ContainingType, _compilation, null);
-
             var dynamicAnalysisSpans = ImmutableArray<CodeAnalysis.CodeGen.SourceSpan>.Empty;
-            //var synthesizedSubmissionFields = method.ContainingType.IsSubmissionClass ? new SynthesizedSubmissionFields(_compilation, method.ContainingType) : null;
 
             var loweredBody = LocalRewriter.Rewrite(
                     _compilation,
                     method,
-                    -1,
+                    methodOrdinal,
                     method.ContainingType,
                     body,
                     compilationState,

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -166,15 +166,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // in case this is right side of a qualified name or member access (or part of a cref)
             node = SyntaxFactory.GetStandaloneNode(node);
 
-            var model = this.GetMemberModel(node);
-            if (model != null)
-            {
-                return model.GetOperationWorker(method, node, cancellationToken);
-            }
-            else
-            {
-                return null;
-            }
+            var model = GetMemberModel(node);
+            return model?.GetOperationWorker(method, node, cancellationToken);
         }
 
         internal override IOperation GetOperationWorker(CSharpSyntaxNode node, GetOperationOptions options, CancellationToken cancellationToken)
@@ -182,15 +175,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // in case this is right side of a qualified name or member access (or part of a cref)
             node = SyntaxFactory.GetStandaloneNode(node);
 
-            var model = this.GetMemberModel(node);
-            if (model != null)
-            {
-                return model.GetOperationWorker(node, options, cancellationToken);
-            }
-            else
-            {
-                return null;
-            }
+            var model = GetMemberModel(node);
+            return model?.GetOperationWorker(node, options, cancellationToken);
         }
 
         internal override SymbolInfo GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -161,6 +161,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _binderFactory.GetBinder((CSharpSyntaxNode)token.Parent, position).WithAdditionalFlags(GetSemanticModelBinderFlags());
         }
 
+        internal override IOperation GetOperationWorker(MethodSymbol method, CSharpSyntaxNode node, CancellationToken cancellationToken)
+        {
+            // in case this is right side of a qualified name or member access (or part of a cref)
+            node = SyntaxFactory.GetStandaloneNode(node);
+
+            var model = this.GetMemberModel(node);
+            if (model != null)
+            {
+                return model.GetOperationWorker(method, node, cancellationToken);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         internal override IOperation GetOperationWorker(CSharpSyntaxNode node, GetOperationOptions options, CancellationToken cancellationToken)
         {
             // in case this is right side of a qualified name or member access (or part of a cref)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1389,7 +1389,7 @@ namespace Microsoft.CodeAnalysis.Semantics
             return new LazyConditionalGotoStatement(condition, target, jumpIfTrue, syntax, type, constantValue);
         }
 
-        private IOperation CreateBoundSequenceOperation(BoundSequence boundSequence)
+        private ISequenceExpression CreateBoundSequenceOperation(BoundSequence boundSequence)
         {
             Lazy<ImmutableArray<IOperation>> expressions =
                 new Lazy<ImmutableArray<IOperation>>(() => boundSequence.SideEffects.Select(s => Create(s)).Where(s => s != null && s.Kind != OperationKind.None).ToImmutableArray());

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -315,6 +316,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return (CSharpSyntaxNode)CSharpSyntaxTree.Dummy.GetRoot();
+        }
+
+        internal static CSharpSyntaxNode GetBodySyntax(this MethodSymbol method)
+        {
+            var syntaxReference = method.DeclaringSyntaxReferences.FirstOrDefault();
+            var node = syntaxReference.GetCSharpSyntax();
+            node = node.GetCodeBlockSyntax();
+            return node;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -47,12 +47,107 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.IndexerDeclaration:
                     arrowExpr = ((IndexerDeclarationSyntax)node).ExpressionBody;
                     break;
+                case SyntaxKind.LocalFunctionStatement:
+                    arrowExpr = ((LocalFunctionStatementSyntax)node).ExpressionBody;
+                    break;
                 default:
                     // Don't throw, just use for the assert in case this is used in the semantic model
                     ExceptionUtilities.UnexpectedValue(node.Kind());
                     break;
             }
             return arrowExpr;
+        }
+
+        /// <summary>
+        /// Gets the body syntax from a bodied member. The
+        /// given syntax must be for a member which could contain a body.
+        /// </summary>
+        internal static BlockSyntax GetBodySyntax(this CSharpSyntaxNode node)
+        {
+            BlockSyntax body = null;
+            switch (node.Kind())
+            {
+                case SyntaxKind.Block:
+                    body = (BlockSyntax)node;
+                    break;
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.DestructorDeclaration:
+                    body = ((BaseMethodDeclarationSyntax)node).Body;
+                    break;
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                case SyntaxKind.UnknownAccessorDeclaration:
+                    body = ((AccessorDeclarationSyntax)node).Body;
+                    break;
+                case SyntaxKind.LocalFunctionStatement:
+                    body = ((LocalFunctionStatementSyntax)node).Body;
+                    break;
+                default:
+                    // Don't throw, just use for the assert in case this is used in the semantic model
+                    ExceptionUtilities.UnexpectedValue(node.Kind());
+                    break;
+            }
+            return body;
+        }
+
+        /// <summary>
+        /// Gets the code block syntax from a bodied member. The
+        /// given syntax must be for a member which could contain a code block.
+        /// </summary>
+        internal static CSharpSyntaxNode GetCodeBlockSyntax(this CSharpSyntaxNode node)
+        {
+            CSharpSyntaxNode codeBlock = null;
+            switch (node.Kind())
+            {
+                // The ArrowExpressionClause is the declaring syntax for the
+                // 'get' SourcePropertyAccessorSymbol of properties and indexers.
+                case SyntaxKind.ArrowExpressionClause:
+                    codeBlock = node;
+                    break;
+                case SyntaxKind.Block:
+                    codeBlock = node;
+                    break;
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.DestructorDeclaration:
+                    var methodDeclaration = (BaseMethodDeclarationSyntax)node;
+                    codeBlock = methodDeclaration.ExpressionBody ?? (CSharpSyntaxNode)methodDeclaration.Body;
+                    break;
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                case SyntaxKind.UnknownAccessorDeclaration:
+                    var accessorDeclaration = (BaseMethodDeclarationSyntax)node;
+                    codeBlock = accessorDeclaration.ExpressionBody ?? (CSharpSyntaxNode)accessorDeclaration.Body;
+                    break;
+                case SyntaxKind.PropertyDeclaration:
+                    codeBlock = ((PropertyDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.IndexerDeclaration:
+                    codeBlock = ((IndexerDeclarationSyntax)node).ExpressionBody;
+                    break;
+                case SyntaxKind.SimpleLambdaExpression:
+                case SyntaxKind.ParenthesizedLambdaExpression:
+                    codeBlock = ((AnonymousFunctionExpressionSyntax)node).Body;
+                    break;
+                case SyntaxKind.LocalFunctionStatement:
+                    var localFunctionStatement = (LocalFunctionStatementSyntax)node;
+                    codeBlock = localFunctionStatement.ExpressionBody ?? (CSharpSyntaxNode)localFunctionStatement.Body;
+                    break;
+                default:
+                    // Don't throw, just use for the assert in case this is used in the semantic model
+                    ExceptionUtilities.UnexpectedValue(node.Kind());
+                    break;
+            }
+            return codeBlock;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.cs
@@ -28,7 +28,7 @@ class C
 string expectedOperationTree = @"
 IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }')
   IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'if (p < 0) p = 0;')
-    IConditionalGotoStatement (Target Symbol: <afterif-2>, JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'p < 0')
+    IConditionalGotoStatement (JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'p < 0')
       Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
           Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
           Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
@@ -37,6 +37,46 @@ IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }'
           Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
           Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
     ILabelStatement (OperationKind.LabelStatement) (Syntax: 'if (p < 0) p = 0;')
+      LabeledStatement: null
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+            VerifyOperationTreeAndDiagnosticsForTest<BaseMethodDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, highLevelOperation: false);
+        }
+
+        [Fact]
+        public void IConditionalGotoStatement_FromIfElse()
+        {
+            string source = @"
+class C
+{
+    /*<bind>*/
+    static void Method(int p)
+    {
+        if (p < 0) p = 0;
+        else p = 1;
+    }
+    /*</bind>*/
+}
+";
+            string expectedOperationTree = @"
+IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }')
+  IBlockStatement (6 statements) (OperationKind.BlockStatement) (Syntax: 'if (p < 0)  ... else p = 1;')
+    IConditionalGotoStatement (JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'p < 0')
+      Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 0;')
+      Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IBranchStatement (BranchKind.GoTo) (OperationKind.BranchStatement) (Syntax: 'if (p < 0)  ... else p = 1;')
+    ILabelStatement (OperationKind.LabelStatement) (Syntax: 'if (p < 0)  ... else p = 1;')
+      LabeledStatement: null
+    IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 1;')
+      Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 1')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILabelStatement (OperationKind.LabelStatement) (Syntax: 'if (p < 0)  ... else p = 1;')
       LabeledStatement: null
 ";
             var expectedDiagnostics = DiagnosticDescription.None;

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Semantics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [Fact]
+        public void IConditionalGotoStatement_FromIf()
+        {
+            string source = @"
+class C
+{
+    /*<bind>*/
+    static void Method(int p)
+    {
+        if (p < 0) p = 0;
+    }
+    /*</bind>*/
+}
+";
+string expectedOperationTree = @"
+IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }')
+  IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'if (p < 0) p = 0;')
+    IConditionalGotoStatement (Target Symbol: <afterif-2>, JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'p < 0')
+      Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 0;')
+      Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    ILabelStatement (OperationKind.LabelStatement) (Syntax: 'if (p < 0) p = 0;')
+      LabeledStatement: null
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+            VerifyOperationTreeAndDiagnosticsForTest<BaseMethodDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, highLevelOperation: false);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -64,13 +64,13 @@ namespace Microsoft.CodeAnalysis
         protected abstract SyntaxTree SyntaxTreeCore { get; }
 
         /// <summary>
-        /// Gets the operation corresponding to the method body.
+        /// Gets the low-level operation corresponding to the method's body.
         /// </summary>
         /// <param name="method">The method symbol.</param>
         /// <param name="body">The method body syntax node</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns></returns>
-        public IOperation GetOperation(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default(CancellationToken))
+        public IOperation GetOperation(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default)
         {
             if (!this.Compilation.IsIOperationFeatureEnabled())
             {
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis
             return GetOperationInternal(method, body, cancellationToken);
         }
 
-        internal IOperation GetOperationInternal(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default(CancellationToken))
+        internal IOperation GetOperationInternal(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -64,6 +64,40 @@ namespace Microsoft.CodeAnalysis
         protected abstract SyntaxTree SyntaxTreeCore { get; }
 
         /// <summary>
+        /// Gets the operation corresponding to the method body.
+        /// </summary>
+        /// <param name="method">The method symbol.</param>
+        /// <param name="body">The method body syntax node</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        /// <returns></returns>
+        public IOperation GetOperation(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!this.Compilation.IsIOperationFeatureEnabled())
+            {
+                throw new InvalidOperationException(CodeAnalysisResources.IOperationFeatureDisabled);
+            }
+
+            return GetOperationInternal(method, body, cancellationToken);
+        }
+
+        internal IOperation GetOperationInternal(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            try
+            {
+                return GetOperationCore(method, body, cancellationToken);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // Log a Non-fatal-watson and then ignore the crash in the attempt of getting operation
+                Debug.Assert(false);
+            }
+
+            return null;
+        }
+
+        protected abstract IOperation GetOperationCore(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Gets the operation corresponding to the expression or statement syntax node.
         /// </summary>
         /// <param name="node">The expression or statement syntax node.</param>

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -67,24 +67,23 @@ namespace Microsoft.CodeAnalysis
         /// Gets the low-level operation corresponding to the method's body.
         /// </summary>
         /// <param name="method">The method symbol.</param>
-        /// <param name="body">The method body syntax node</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns></returns>
-        public IOperation GetOperation(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default)
+        public IOperation GetOperation(IMethodSymbol method, CancellationToken cancellationToken = default)
         {
             if (!this.Compilation.IsIOperationFeatureEnabled())
             {
                 throw new InvalidOperationException(CodeAnalysisResources.IOperationFeatureDisabled);
             }
 
-            return GetOperationInternal(method, body, cancellationToken);
+            return GetOperationInternal(method, cancellationToken);
         }
 
-        internal IOperation GetOperationInternal(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken = default)
+        internal IOperation GetOperationInternal(IMethodSymbol method, CancellationToken cancellationToken = default)
         {
             try
             {
-                return GetOperationCore(method, body, cancellationToken);
+                return GetOperationCore(method, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
@@ -95,7 +94,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        protected abstract IOperation GetOperationCore(IMethodSymbol method, SyntaxNode body, CancellationToken cancellationToken);
+        protected abstract IOperation GetOperationCore(IMethodSymbol method, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the operation corresponding to the expression or statement syntax node.

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     internal abstract partial class BaseSequenceExpression : Operation, ISequenceExpression
     {
         protected BaseSequenceExpression(ImmutableArray<ILocalSymbol> locals, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
-                    base(OperationKind.BlockStatement, syntax, type, constantValue)
+                    base(OperationKind.SequenceExpression, syntax, type, constantValue)
         {
             Locals = locals;
         }

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -858,6 +858,82 @@ namespace Microsoft.CodeAnalysis.Semantics
     }
 
     /// <summary>
+    /// Represents a conditional goto statement
+    /// </summary>
+    internal abstract partial class BaseConditionalGotoStatement : Operation, IConditionalGotoStatement
+    {
+        public BaseConditionalGotoStatement(ILabelSymbol target, bool jumpIfTrue, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+            base(OperationKind.ConditionalGotoStatement, syntax, type, constantValue)
+        {
+            Target = target;
+            JumpIfTrue = jumpIfTrue;
+        }
+        /// <summary>
+        /// Condition of the branch.
+        /// </summary>
+        public abstract IOperation Condition { get; }
+        /// <summary>
+        /// Label that is the target of the branch.
+        /// </summary>
+        public ILabelSymbol Target { get; }
+        /// <summary>
+        /// Jump if the condition is true.
+        /// </summary>
+        public bool JumpIfTrue { get; }
+
+        public override IEnumerable<IOperation> Children
+        {
+            get
+            {
+                yield return Condition;
+            }
+        }
+
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitConditionalGotoStatement(this);
+        }
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitConditionalGotoStatement(this, argument);
+        }
+    }
+
+    /// <summary>
+    /// Represents a conditional goto statement
+    /// </summary>
+    internal sealed partial class ConditionalGotoStatement : BaseConditionalGotoStatement, IConditionalGotoStatement
+    {
+        public ConditionalGotoStatement(IOperation condition, ILabelSymbol target, bool jumpIfTrue, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+            base(target, jumpIfTrue, syntax, type, constantValue)
+        {
+            Condition = condition;
+        }
+        /// <summary>
+        /// Condition of the branch.
+        /// </summary>
+        public override IOperation Condition { get; }
+    }
+
+    /// <summary>
+    /// Represents a conditional goto statement
+    /// </summary>
+    internal sealed partial class LazyConditionalGotoStatement : BaseConditionalGotoStatement, IConditionalGotoStatement
+    {
+        private readonly Lazy<IOperation> _lazyCondition;
+
+        public LazyConditionalGotoStatement(Lazy<IOperation> condition, ILabelSymbol target, bool jumpIfTrue, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+            base(target, jumpIfTrue, syntax, type, constantValue)
+        {
+            _lazyCondition = condition ?? throw new System.ArgumentNullException(nameof(condition));
+        }
+        /// <summary>
+        /// Condition of the branch.
+        /// </summary>
+        public override IOperation Condition => _lazyCondition.Value;
+    }
+
+    /// <summary>
     /// Represents a C# goto, break, or continue statement, or a VB GoTo, Exit ***, or Continue *** statement
     /// </summary>
     internal sealed partial class BranchStatement : Operation, IBranchStatement

--- a/src/Compilers/Core/Portable/Operations/IConditionalGotoStatement.cs
+++ b/src/Compilers/Core/Portable/Operations/IConditionalGotoStatement.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a conditional goto.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface IConditionalGotoStatement : IOperation
+    {
+        /// <summary>
+        /// Condition of the branch.
+        /// </summary>
+        IOperation Condition { get; }
+        /// <summary>
+        /// Label that is the target of the branch.
+        /// </summary>
+        ILabelSymbol Target { get; }
+        /// <summary>
+        /// Jump if the condition is true.
+        /// </summary>
+        bool JumpIfTrue { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/IConditionalGotoStatement.cs
+++ b/src/Compilers/Core/Portable/Operations/IConditionalGotoStatement.cs
@@ -22,9 +22,9 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         ILabelSymbol Target { get; }
         /// <summary>
-        /// Jump if the condition is true.
+        /// Indicates if the jump will be executed when the condition is true.
+        /// Otherwise, it will be executed when the condition is false.
         /// </summary>
         bool JumpIfTrue { get; }
     }
 }
-

--- a/src/Compilers/Core/Portable/Operations/ISequenceExpression.cs
+++ b/src/Compilers/Core/Portable/Operations/ISequenceExpression.cs
@@ -27,4 +27,3 @@ namespace Microsoft.CodeAnalysis.Semantics
         ImmutableArray<ILocalSymbol> Locals { get; }
     }
 }
-

--- a/src/Compilers/Core/Portable/Operations/ISequenceExpression.cs
+++ b/src/Compilers/Core/Portable/Operations/ISequenceExpression.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a sequence of expressions.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface ISequenceExpression : IOperation
+    {
+        /// <summary>
+        /// Expressions contained within the sequence.
+        /// </summary>
+        ImmutableArray<IOperation> Expressions { get; }
+        /// <summary>
+        /// The value of the whole sequence expression.
+        /// </summary>
+        IOperation Value { get; }
+        /// <summary>
+        /// Local declarations contained within the sequence.
+        /// </summary>
+        ImmutableArray<ILocalSymbol> Locals { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -216,5 +216,10 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>Indicates an <see cref="IDefaultCaseClause"/>.</summary>
         DefaultCaseClause = 0x412,
+
+        // Operations that occur only after lowering phase.
+
+        /// <summary>Indicates an <see cref="IConditionalGotoStatement"/>.</summary>
+        ConditionalGotoStatement = 0x413,
     }
 }

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -221,5 +221,8 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>Indicates an <see cref="IConditionalGotoStatement"/>.</summary>
         ConditionalGotoStatement = 0x413,
+
+        /// <summary>Indicates an <see cref="ISequenceExpression"/>.</summary>
+        SequenceExpression = 0x414
     }
 }

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -469,6 +469,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             DefaultVisit(operation);
         }
+
+        public virtual void VisitSequenceExpression(ISequenceExpression operation)
+        {
+            DefaultVisit(operation);
+        }
     }
 
     /// <summary>
@@ -941,6 +946,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitConditionalGotoStatement(IConditionalGotoStatement operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitSequenceExpression(ISequenceExpression operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -464,6 +464,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             DefaultVisit(operation);
         }
+
+        public virtual void VisitConditionalGotoStatement(IConditionalGotoStatement operation)
+        {
+            DefaultVisit(operation);
+        }
     }
 
     /// <summary>
@@ -931,6 +936,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitTupleExpression(ITupleExpression operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitConditionalGotoStatement(IConditionalGotoStatement operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -790,7 +790,7 @@ Public MustInherit Class BasicTestBaseBase
 
 #Region "IOperation tree validation"
 
-    Friend Shared Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, Optional which As Integer = 0) As (tree As String, syntax As SyntaxNode, operation As IOperation)
+    Friend Shared Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, Optional which As Integer = 0, Optional highLevelOperation As Boolean = True) As (tree As String, syntax As SyntaxNode, operation As IOperation)
         Dim node As SyntaxNode = CompilationUtils.FindBindingText(Of TSyntaxNode)(compilation, fileName, which, prefixMatch:=True)
         If node Is Nothing Then
             Return Nothing
@@ -798,7 +798,20 @@ Public MustInherit Class BasicTestBaseBase
 
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
         Dim semanticModel = compilation.GetSemanticModel(tree)
-        Dim operation = semanticModel.GetOperationInternal(node)
+        Dim operation As IOperation
+
+        If highLevelOperation Then
+            operation = semanticModel.GetOperationInternal(node)
+        Else
+            Dim methodSymbol = DirectCast(semanticModel.GetDeclaredSymbolForNode(node), IMethodSymbol)
+
+            If methodSymbol Is Nothing Then
+                Return (Nothing, Nothing, Nothing)
+            End If
+
+            operation = semanticModel.GetOperationInternal(methodSymbol)
+        End If
+
         If operation IsNot Nothing Then
             Return (OperationTreeVerifier.GetOperationTree(compilation, operation), node, operation)
         Else
@@ -806,47 +819,47 @@ Public MustInherit Class BasicTestBaseBase
         End If
     End Function
 
-    Friend Shared Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0) As (tree As String, syntax As SyntaxNode, operation As IOperation, compilation As Compilation)
+    Friend Shared Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional highLevelOperation As Boolean = True) As (tree As String, syntax As SyntaxNode, operation As IOperation, compilation As Compilation)
         Dim fileName = "a.vb"
         Dim syntaxTree = Parse(testSrc, fileName, parseOptions)
         Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=DefaultVbReferences.Append({ValueTupleRef, SystemRuntimeFacadeRef}), options:=If(compilationOptions, TestOptions.ReleaseDll))
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which, highLevelOperation)
         Return (operationTree.tree, operationTree.syntax, operationTree.operation, compilation)
     End Function
 
-    Friend Shared Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, expectedOperationTree As String, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing)
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
+    Friend Shared Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, expectedOperationTree As String, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing, Optional highLevelOperation As Boolean = True)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which, highLevelOperation)
         OperationTreeVerifier.Verify(expectedOperationTree, operationTree.tree)
         If additionalOperationTreeVerifier IsNot Nothing Then
             additionalOperationTreeVerifier(operationTree.operation, compilation, operationTree.syntax)
         End If
     End Sub
 
-    Friend Shared Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, expectedOperationTree As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing)
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which)
+    Friend Shared Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, expectedOperationTree As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing, Optional highLevelOperation As Boolean = True)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which, highLevelOperation)
         OperationTreeVerifier.Verify(expectedOperationTree, operationTree.tree)
         If additionalOperationTreeVerifier IsNot Nothing Then
             additionalOperationTreeVerifier(operationTree.operation, operationTree.compilation, operationTree.syntax)
         End If
     End Sub
 
-    Friend Shared Sub VerifyNoOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0)
-        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which)
+    Friend Shared Sub VerifyNoOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional highLevelOperation As Boolean = True)
+        Dim operationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, compilationOptions, parseOptions, which, highLevelOperation)
         Assert.Null(operationTree.tree)
     End Sub
 
-    Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, expectedOperationTree As String, expectedDiagnostics As String, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing)
+    Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, expectedOperationTree As String, expectedDiagnostics As String, Optional which As Integer = 0, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing, Optional highLevelOperation As Boolean = True)
         compilation.AssertTheseDiagnostics(FilterString(expectedDiagnostics))
-        VerifyOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, which, additionalOperationTreeVerifier)
+        VerifyOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, which, additionalOperationTreeVerifier, highLevelOperation)
     End Sub
 
-    Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, expectedOperationTree As String, expectedDiagnostics As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional additionalReferences As IEnumerable(Of MetadataReference) = Nothing, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing)
+    Friend Shared Sub VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, expectedOperationTree As String, expectedDiagnostics As String, Optional compilationOptions As VisualBasicCompilationOptions = Nothing, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0, Optional additionalReferences As IEnumerable(Of MetadataReference) = Nothing, Optional additionalOperationTreeVerifier As Action(Of IOperation, Compilation, SyntaxNode) = Nothing, Optional highLevelOperation As Boolean = True)
         Dim fileName = "a.vb"
         Dim syntaxTree = Parse(testSrc, fileName, parseOptions)
         Dim references = DefaultVbReferences.Concat({ValueTupleRef, SystemRuntimeFacadeRef})
         references = If(additionalReferences IsNot Nothing, references.Concat(additionalReferences), references)
         Dim compilation = CreateCompilationWithMscorlib45AndVBRuntime({syntaxTree}, references:=references, options:=If(compilationOptions, TestOptions.ReleaseDll))
-        VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, expectedDiagnostics, which, additionalOperationTreeVerifier)
+        VerifyOperationTreeAndDiagnosticsForTest(Of TSyntaxNode)(compilation, fileName, expectedOperationTree, expectedDiagnostics, which, additionalOperationTreeVerifier, highLevelOperation)
     End Sub
 
     Public Shared Function GetAssertTheseDiagnosticsString(allDiagnostics As ImmutableArray(Of Diagnostic), suppressInfos As Boolean) As String

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -830,25 +830,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function LowerMethodBody(method As MethodSymbol, body As BoundBlock) As BoundBlock
+            Dim sawLambdas As Boolean
             Dim diagnostics = DiagnosticBag.GetInstance()
             Dim compilationState = New TypeCompilationState(Compilation, Nothing, Nothing)
-
-            Dim sawLambdas As Boolean
-            Dim symbolsCapturedWithoutCopyCtor As ISet(Of Symbol) = Nothing
-            Dim rewrittenNodes As HashSet(Of BoundNode) = Nothing
-            Dim flags = LocalRewriter.RewritingFlags.Default
 
             Dim loweredBody = LocalRewriter.Rewrite(
                     body,
                     method,
                     compilationState,
-                    Nothing,
-                    diagnostics,
-                    rewrittenNodes,
-                    sawLambdas,
-                    symbolsCapturedWithoutCopyCtor,
-                    flags,
-                    DebugInfoInjector.Singleton,
+                    previousSubmissionFields:=Nothing,
+                    diagnostics:=diagnostics,
+                    rewrittenNodes:=Nothing,
+                    hasLambdas:=sawLambdas,
+                    symbolsCapturedWithoutCopyCtor:=Nothing,
+                    flags:=LocalRewriter.RewritingFlags.Default,
+                    instrumenterOpt:=DebugInfoInjector.Singleton,
                     currentMethod:=Nothing)
 
             Return loweredBody

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -794,8 +794,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function GetOperationWorker(node As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
+            Dim result = GetBoundNode(node, options)
+
+            Return _operationFactory.Create(result)
+        End Function
+
+        Private Function GetBoundNode(node As VisualBasicSyntaxNode, options As GetOperationOptions) As BoundNode
             Dim summary = GetBoundNodeSummary(node)
             Dim result As BoundNode
+
             Select Case options
                 Case GetOperationOptions.Highest
                     result = summary.HighestBoundNode
@@ -805,7 +812,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     result = summary.LowestBoundNode
             End Select
 
-            Return _operationFactory.Create(result)
+            Return result
+        End Function
+
+        Friend Overrides Function GetOperationWorker(method As MethodSymbol, bodySyntax As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
+            Dim node = GetBoundNode(bodySyntax, GetOperationOptions.Highest)
+            Dim body = DirectCast(node, BoundStatement)
+            Dim loweredBody = LowerMethodBody(method, body)
+
+            Return _operationFactory.Create(loweredBody)
+        End Function
+
+        Private Function LowerMethodBody(method As MethodSymbol, body As BoundStatement) As BoundStatement
+            Throw New NotImplementedException()
         End Function
 
         Friend Overrides Function GetExpressionTypeInfo(node As ExpressionSyntax, Optional cancellationToken As CancellationToken = Nothing) As VisualBasicTypeInfo

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -815,7 +815,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Friend Overrides Function GetOperationWorker(method As MethodSymbol, bodySyntax As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
+        Friend Overrides Function GetOperationWorker(method As MethodSymbol, bodySyntax As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
             Dim node = GetBoundNode(bodySyntax, GetOperationOptions.Highest)
             Dim body = DirectCast(node, BoundStatement)
             Dim loweredBody = LowerMethodBody(method, body)

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -132,6 +132,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                  TypeOf (node) Is OrderingSyntax)
         End Function
 
+        Protected Overrides Function GetOperationCore(method As IMethodSymbol, body As SyntaxNode, cancellationToken As CancellationToken) As IOperation
+            Dim vbbody = DirectCast(body, VisualBasicSyntaxNode)
+            Dim vbmethod = DirectCast(method, MethodSymbol)
+            CheckSyntaxNode(vbbody)
+            CheckSymbol(vbmethod)
+            Return GetOperationWorker(vbmethod, vbbody, GetOperationOptions.Highest, cancellationToken)
+        End Function
+
+        Friend Overridable Function GetOperationWorker(method As MethodSymbol, node As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
+            Return Nothing
+        End Function
+
         Friend Enum GetOperationOptions
             Lowest
             Highest
@@ -576,6 +588,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Throw New ArgumentException(VBResources.PositionIsNotWithinSyntax)
+        End Sub
+
+        Friend Sub CheckSymbol(symbol As Symbol)
+            If symbol Is Nothing Then
+                Throw New ArgumentNullException(NameOf(symbol))
+            End If
         End Sub
 
         Friend Sub CheckSyntaxNode(node As VisualBasicSyntaxNode)

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -137,10 +137,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim vbmethod = DirectCast(method, MethodSymbol)
             CheckSyntaxNode(vbbody)
             CheckSymbol(vbmethod)
-            Return GetOperationWorker(vbmethod, vbbody, GetOperationOptions.Highest, cancellationToken)
+            Return GetOperationWorker(vbmethod, vbbody, cancellationToken)
         End Function
 
-        Friend Overridable Function GetOperationWorker(method As MethodSymbol, node As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
+        Friend Overridable Function GetOperationWorker(method As MethodSymbol, node As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -132,11 +132,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                  TypeOf (node) Is OrderingSyntax)
         End Function
 
-        Protected Overrides Function GetOperationCore(method As IMethodSymbol, body As SyntaxNode, cancellationToken As CancellationToken) As IOperation
-            Dim vbbody = DirectCast(body, VisualBasicSyntaxNode)
+        Protected Overrides Function GetOperationCore(method As IMethodSymbol, cancellationToken As CancellationToken) As IOperation
             Dim vbmethod = DirectCast(method, MethodSymbol)
-            CheckSyntaxNode(vbbody)
             CheckSymbol(vbmethod)
+            Dim vbbody = vbmethod.GetBodySyntax()
+            CheckSyntaxNode(vbbody)
             Return GetOperationWorker(vbmethod, vbbody, cancellationToken)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -363,14 +363,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' This will cause it to try to get the interior MemberSemanticModel.
                 model = GetMemberSemanticModel(methodBlock.BlockStatement.EndPosition)
             Else
-                model = Me.GetMemberSemanticModel(node)
+                model = GetMemberSemanticModel(node)
             End If
 
-            If model IsNot Nothing Then
-                Return model.GetOperationWorker(method, node, cancellationToken)
-            Else
-                Return Nothing
-            End If
+            Return model?.GetOperationWorker(method, node, cancellationToken)
         End Function
 
         Friend Overrides Function GetOperationWorker(node As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
@@ -385,14 +381,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' This will cause it to try to get the interior MemberSemanticModel.
                 model = GetMemberSemanticModel(methodBlock.BlockStatement.EndPosition)
             Else
-                model = Me.GetMemberSemanticModel(node)
+                model = GetMemberSemanticModel(node)
             End If
 
-            If model IsNot Nothing Then
-                Return model.GetOperationWorker(node, options, cancellationToken)
-            Else
-                Return Nothing
-            End If
+            Return model?.GetOperationWorker(node, options, cancellationToken)
         End Function
 
         Friend Overrides Function GetAttributeSymbolInfo(attribute As AttributeSyntax, Optional cancellationToken As CancellationToken = Nothing) As SymbolInfo

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -351,6 +351,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
+        Friend Overrides Function GetOperationWorker(method As MethodSymbol, node As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
+            Dim model As MemberSemanticModel
+
+            Dim methodBlock = TryCast(node, MethodBlockBaseSyntax)
+            If methodBlock IsNot Nothing Then
+                ' Trying to get the MemberSemanticModel for a MethodBlock will end up returning
+                ' nothing.  That's because trying to get Binder for the MethodBlock will actually
+                ' return the binder for the containing type.  To avoid this we ask for the model
+                ' passing in a position at the end of the method's starting block-statement.
+                ' This will cause it to try to get the interior MemberSemanticModel.
+                model = GetMemberSemanticModel(methodBlock.BlockStatement.EndPosition)
+            Else
+                model = Me.GetMemberSemanticModel(node)
+            End If
+
+            If model IsNot Nothing Then
+                Return model.GetOperationWorker(method, node, cancellationToken)
+            Else
+                Return Nothing
+            End If
+        End Function
+
         Friend Overrides Function GetOperationWorker(node As VisualBasicSyntaxNode, options As GetOperationOptions, cancellationToken As CancellationToken) As IOperation
             Dim model As MemberSemanticModel
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -852,7 +852,7 @@ Namespace Microsoft.CodeAnalysis.Semantics
         Private Function CreateBoundBlockOperation(boundBlock As BoundBlock) As IBlockStatement
             Dim statements As Lazy(Of ImmutableArray(Of IOperation)) = New Lazy(Of ImmutableArray(Of IOperation))(
                 Function()
-                    Return boundBlock.Statements.Select(Function(n) Create(n)).Where(Function(s) s.Kind <> OperationKind.None).ToImmutableArray()
+                    Return boundBlock.Statements.Select(Function(n) Create(n)).Where(Function(s) s IsNot Nothing AndAlso s.Kind <> OperationKind.None).ToImmutableArray()
                 End Function)
             Dim locals As ImmutableArray(Of ILocalSymbol) = boundBlock.Locals.As(Of ILocalSymbol)()
             Dim syntax As SyntaxNode = boundBlock.Syntax
@@ -1125,7 +1125,7 @@ Namespace Microsoft.CodeAnalysis.Semantics
         Private Function CreateBoundStatementListOperation(boundStatementList As BoundStatementList) As IOperation
             Dim statements As Lazy(Of ImmutableArray(Of IOperation)) = New Lazy(Of ImmutableArray(Of IOperation))(
                 Function()
-                    Return boundStatementList.Statements.Select(Function(n) Create(n)).Where(Function(s) s.Kind <> OperationKind.None).ToImmutableArray()
+                    Return boundStatementList.Statements.Select(Function(n) Create(n)).Where(Function(s) s IsNot Nothing AndAlso s.Kind <> OperationKind.None).ToImmutableArray()
                 End Function)
 
             Dim locals As ImmutableArray(Of ILocalSymbol) = ImmutableArray(Of ILocalSymbol).Empty
@@ -1148,7 +1148,7 @@ Namespace Microsoft.CodeAnalysis.Semantics
         Private Function CreateBoundSequenceOperation(boundSequence As BoundSequence) As IOperation
             Dim expressions As Lazy(Of ImmutableArray(Of IOperation)) = New Lazy(Of ImmutableArray(Of IOperation))(
                 Function()
-                    Return boundSequence.SideEffects.Select(Function(n) Create(n)).Where(Function(s) s.Kind <> OperationKind.None).ToImmutableArray()
+                    Return boundSequence.SideEffects.Select(Function(n) Create(n)).Where(Function(s) s IsNot Nothing AndAlso s.Kind <> OperationKind.None).ToImmutableArray()
                 End Function)
 
             Dim value As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundSequence.ValueOpt))

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1122,7 +1122,7 @@ Namespace Microsoft.CodeAnalysis.Semantics
             Return Create(boundSequencePointExpression.Expression)
         End Function
 
-        Private Function CreateBoundStatementListOperation(boundStatementList As BoundStatementList) As IOperation
+        Private Function CreateBoundStatementListOperation(boundStatementList As BoundStatementList) As IBlockStatement
             Dim statements As Lazy(Of ImmutableArray(Of IOperation)) = New Lazy(Of ImmutableArray(Of IOperation))(
                 Function()
                     Return boundStatementList.Statements.Select(Function(n) Create(n)).Where(Function(s) s IsNot Nothing AndAlso s.Kind <> OperationKind.None).ToImmutableArray()
@@ -1135,17 +1135,17 @@ Namespace Microsoft.CodeAnalysis.Semantics
             Return New LazyBlockStatement(statements, locals, syntax, type, constantValue)
         End Function
 
-        Private Function CreateBoundConditionalGotoOperation(boundConditionalGoto As BoundConditionalGoto) As IOperation
+        Private Function CreateBoundConditionalGotoOperation(boundConditionalGoto As BoundConditionalGoto) As IConditionalGotoStatement
             Dim condition As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundConditionalGoto.Condition))
             Dim target As ILabelSymbol = boundConditionalGoto.Label
             Dim jumpIfTrue As Boolean = boundConditionalGoto.JumpIfTrue
             Dim Syntax As SyntaxNode = boundConditionalGoto.Syntax
             Dim Type As ITypeSymbol = Nothing
             Dim constantValue As [Optional](Of Object) = Nothing
-            Return New LazyConditionalGotoStatement(condition, target, jumpIfTrue, Syntax, Type, ConstantValue)
+            Return New LazyConditionalGotoStatement(condition, target, jumpIfTrue, Syntax, Type, constantValue)
         End Function
 
-        Private Function CreateBoundSequenceOperation(boundSequence As BoundSequence) As IOperation
+        Private Function CreateBoundSequenceOperation(boundSequence As BoundSequence) As ISequenceExpression
             Dim expressions As Lazy(Of ImmutableArray(Of IOperation)) = New Lazy(Of ImmutableArray(Of IOperation))(
                 Function()
                     Return boundSequence.SideEffects.Select(Function(n) Create(n)).Where(Function(s) s IsNot Nothing AndAlso s.Kind <> OperationKind.None).ToImmutableArray()
@@ -1156,7 +1156,7 @@ Namespace Microsoft.CodeAnalysis.Semantics
             Dim Syntax As SyntaxNode = boundSequence.Syntax
             Dim type As ITypeSymbol = Nothing
             Dim constantValue As [Optional](Of Object) = Nothing
-            return new LazySequenceExpression(expressions, value, locals, syntax, type, constantValue)
+            Return New LazySequenceExpression(expressions, value, locals, Syntax, type, constantValue)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbolExtensions.vb
@@ -97,5 +97,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return If(method.IsGenericMethod(), method.Construct(typeArguments), method)
         End Function
 
+        <Extension()>
+        Friend Function GetBodySyntax(method As MethodSymbol) As VisualBasicSyntaxNode
+            Dim syntaxReference = method.DeclaringSyntaxReferences.FirstOrDefault()
+            Dim node = syntaxReference.GetVisualBasicSyntax()
+            node = node.GetCodeBlockSyntax()
+            Return node
+        End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxExtensions.vb
@@ -123,5 +123,58 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim nameToken As SyntaxToken = expr.ExtractAnonymousTypeMemberName(ignore)
             Return If(nameToken.Kind() = SyntaxKind.IdentifierToken, nameToken.ValueText, Nothing)
         End Function
+
+        ''' <summary>
+        ''' Gets the code block syntax from a bodied member. The
+        ''' given syntax must be for a member which could contain a code block.
+        ''' </summary>
+        <Extension>
+        Friend Function GetCodeBlockSyntax(node As VisualBasicSyntaxNode) As VisualBasicSyntaxNode
+            Dim codeBlock As VisualBasicSyntaxNode = Nothing
+            Select Case node.Kind()
+                ' The ArrowExpressionClause is the declaring syntax for the
+                ' 'get' SourcePropertyAccessorSymbol of properties and indexers.
+                Case SyntaxKind.AddHandlerAccessorBlock,
+                    SyntaxKind.CaseBlock,
+                    SyntaxKind.CaseElseBlock,
+                    SyntaxKind.CatchBlock,
+                    SyntaxKind.ConstructorBlock,
+                    SyntaxKind.DoLoopUntilBlock,
+                    SyntaxKind.DoLoopWhileBlock,
+                    SyntaxKind.DoUntilLoopBlock,
+                    SyntaxKind.DoWhileLoopBlock,
+                    SyntaxKind.ElseBlock,
+                    SyntaxKind.ElseIfBlock,
+                    SyntaxKind.FinallyBlock,
+                    SyntaxKind.ForBlock,
+                    SyntaxKind.ForEachBlock,
+                    SyntaxKind.FunctionBlock,
+                    SyntaxKind.GetAccessorBlock,
+                    SyntaxKind.MultiLineIfBlock,
+                    SyntaxKind.OperatorBlock,
+                    SyntaxKind.RaiseEventAccessorBlock,
+                    SyntaxKind.RemoveHandlerAccessorBlock,
+                    SyntaxKind.SelectBlock,
+                    SyntaxKind.SetAccessorBlock,
+                    SyntaxKind.SimpleDoLoopBlock,
+                    SyntaxKind.SubBlock,
+                    SyntaxKind.SyncLockBlock,
+                    SyntaxKind.TryBlock,
+                    SyntaxKind.UsingBlock,
+                    SyntaxKind.WhileBlock,
+                    SyntaxKind.WithBlock
+                    codeBlock = node
+                Case SyntaxKind.SubStatement,
+                    SyntaxKind.FunctionStatement,
+                    SyntaxKind.GetAccessorStatement,
+                    SyntaxKind.SetAccessorStatement
+                    codeBlock = node.Parent
+                Case Else
+                    ' Don't throw, just use for the assert in case this is used in the semantic model
+                    ExceptionUtilities.UnexpectedValue(node.Kind())
+            End Select
+
+            Return codeBlock
+        End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.vb
@@ -1,0 +1,48 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
+
+    Partial Public Class IOperationTests
+        Inherits SemanticModelTestBase
+
+        <Fact>
+        Public Sub IConditionalGotoStatement_FromIf()
+            Dim source = <![CDATA[
+Class C
+    Sub Method(p As Integer)'BIND:"Sub Method(p As Integer)"
+        If p < 0 Then
+            p = 0
+        End If
+    End Sub
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'Sub Method( ... End Sub')
+  IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'If p < 0 Th ... End If')
+    IConditionalGotoStatement (Target Symbol: afterif, JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'If p < 0 Th ... End If')
+      Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: 'If p < 0 Th ... End If')
+      IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 0')
+        Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 0')
+            Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+            Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    ILabelStatement (Label: afterif) (OperationKind.LabelStatement) (Syntax: 'If p < 0 Th ... End If')
+      LabeledStatement: null
+  ILabelStatement (Label: exit) (OperationKind.LabelStatement) (Syntax: 'End Sub')
+    LabeledStatement: null
+  IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'End Sub')
+    ReturnedValue: null
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of MethodStatementSyntax)(source, expectedOperationTree, expectedDiagnostics, highLevelOperation:=False)
+        End Sub
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConditionalGotoStatement.vb
@@ -23,7 +23,7 @@ End Class
             Dim expectedOperationTree = <![CDATA[
 IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'Sub Method( ... End Sub')
   IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'If p < 0 Th ... End If')
-    IConditionalGotoStatement (Target Symbol: afterif, JumpIfTrue: False) (OperationKind.ConditionalGotoStatement) (Syntax: 'If p < 0 Th ... End If')
+    IConditionalGotoStatement (JumpIfTrue: False, Target: afterif) (OperationKind.ConditionalGotoStatement) (Syntax: 'If p < 0 Th ... End If')
       Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
           Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
           Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
@@ -32,6 +32,54 @@ IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'Sub Meth
         Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 0')
             Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
             Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    ILabelStatement (Label: afterif) (OperationKind.LabelStatement) (Syntax: 'If p < 0 Th ... End If')
+      LabeledStatement: null
+  ILabelStatement (Label: exit) (OperationKind.LabelStatement) (Syntax: 'End Sub')
+    LabeledStatement: null
+  IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'End Sub')
+    ReturnedValue: null
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of MethodStatementSyntax)(source, expectedOperationTree, expectedDiagnostics, highLevelOperation:=False)
+        End Sub
+
+        <Fact>
+        Public Sub IConditionalGotoStatement_FromIfElse()
+            Dim source = <![CDATA[
+Class C
+    Sub Method(p As Integer)'BIND:"Sub Method(p As Integer)"
+        If p < 0 Then
+            p = 0
+        Else
+            p = 1
+        End If
+    End Sub
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IBlockStatement (3 statements) (OperationKind.BlockStatement) (Syntax: 'Sub Method( ... End Sub')
+  IBlockStatement (6 statements) (OperationKind.BlockStatement) (Syntax: 'If p < 0 Th ... End If')
+    IConditionalGotoStatement (JumpIfTrue: False, Target: alternative) (OperationKind.ConditionalGotoStatement) (Syntax: 'If p < 0 Th ... End If')
+      Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean) (Syntax: 'p < 0')
+          Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: 'If p < 0 Th ... End If')
+      IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 0')
+        Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 0')
+            Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+            Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IBranchStatement (BranchKind.GoTo, Label: afterif) (OperationKind.BranchStatement) (Syntax: 'If p < 0 Th ... End If')
+    ILabelStatement (Label: alternative) (OperationKind.LabelStatement) (Syntax: 'If p < 0 Th ... End If')
+      LabeledStatement: null
+    IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: 'Else ... p = 1')
+      IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: 'Else ... p = 1')
+        IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'p = 1')
+          Expression: ISimpleAssignmentExpression (OperationKind.SimpleAssignmentExpression, Type: System.Int32) (Syntax: 'p = 1')
+              Left: IParameterReferenceExpression: p (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'p')
+              Right: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
     ILabelStatement (Label: afterif) (OperationKind.LabelStatement) (Syntax: 'If p < 0 Th ... End If')
       LabeledStatement: null
   ILabelStatement (Label: exit) (OperationKind.LabelStatement) (Syntax: 'End Sub')

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1267,8 +1267,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitConditionalGotoStatement(IConditionalGotoStatement operation)
         {
             LogString(nameof(IConditionalGotoStatement));
-            LogSymbol(operation.Target, " (Target Symbol");
-            LogString($", JumpIfTrue: {operation.JumpIfTrue})");
+            LogString($" (JumpIfTrue: {operation.JumpIfTrue}");
+
+            // TODO: Put a better workaround to skip compiler generated labels.
+            if (!operation.Target.IsImplicitlyDeclared)
+            {
+                LogString($", Target: {operation.Target.Name}");
+            }
+
+            LogString(")");
             LogCommonPropertiesAndNewLine(operation);
 
             Visit(operation.Condition, "Condition");

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1264,6 +1264,26 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.GuardExpression, "Guard Expression");
         }
 
+        public override void VisitConditionalGotoStatement(IConditionalGotoStatement operation)
+        {
+            LogString(nameof(IConditionalGotoStatement));
+            LogSymbol(operation.Target, " (Target Symbol");
+            LogString($", JumpIfTrue: {operation.JumpIfTrue})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Condition, "Condition");
+        }
+
+        public override void VisitSequenceExpression(ISequenceExpression operation)
+        {
+            LogString(nameof(ISequenceExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            LogLocals(operation.Locals, header: "Locals");
+            VisitArray(operation.Expressions, "Expressions", logElementCount: true);
+            Visit(operation.Value, "Value");
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Since there are several requested changes I have decided to create a new PR #21810 with those changes. 
Please take a look to the new PR #21810 instead.

These changes add a new overload to the `SemanticModel.GetOperation` method to generate an IOperation tree from the compiler's internal BoundTree after performing the local rewriting transformation phase. The new low-level IOperation tree reuses most of the original IOperation interfaces and extend them by adding a few newly created ones that can only appear after the local rewriting phase. This has been done to support both C# and VB.

**Remarks**
These changes are experimental so we still need to keep them behind the IOperation feature flag even after releasing the API in Dev 15.5.

More detailed information of the changes can be found in this issue #21507.