### PR TITLE
Fixing Incorrect argument value shown in the call stack window

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -152,7 +154,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override MethodSymbol GetMethod(CSharpCompilation compilation, DkmClrInstructionAddress instructionAddress)
         {
-            return compilation.GetSourceMethod(instructionAddress.ModuleInstance.Mvid, instructionAddress.MethodId.Token);
+            var methodHandle = (MethodDefinitionHandle)MetadataTokens.Handle(instructionAddress.MethodId.Token);
+            return compilation.GetSourceMethod(instructionAddress.ModuleInstance.Mvid, methodHandle);
         }
 
         internal override TypeNameDecoder<PEModuleSymbol, TypeSymbol> GetTypeNameDecoder(CSharpCompilation compilation, MethodSymbol method)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1328,15 +1328,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     }
                 }
 
-                var argumentNames = ArrayBuilder<string>.GetInstance();
-                if (sourceMethod != null)
-                {
-                    foreach (var p in sourceMethod.Parameters)
-                    {
-                        argumentNames.Add(p.Name);
-                    }
-                }
-
                 var pooledHoistedParameterNames = PooledHashSet<string>.GetInstance();
                 foreach (var instance in displayClassInstances)
                 {
@@ -1356,9 +1347,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 displayClassVariableNamesInOrder = displayClassVariableNamesInOrderBuilder.ToImmutableAndFree();
                 displayClassVariables = displayClassVariablesBuilder.ToImmutableDictionary();
                 displayClassVariablesBuilder.Free();
-
-                orderedArgumentNames = argumentNames.ToImmutableArray();
-                argumentNames.Free();
             }
             else
             {
@@ -1367,6 +1355,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 displayClassVariables = ImmutableDictionary<string, DisplayClassVariable>.Empty;
                 orderedArgumentNames = ImmutableArray<string>.Empty;
             }
+
+            var argumentNames = ArrayBuilder<string>.GetInstance();
+            if (sourceMethod != null)
+            {
+                foreach (var p in sourceMethod.Parameters)
+                {
+                    argumentNames.Add(p.Name);
+                }
+            }
+
+            orderedArgumentNames = argumentNames.ToImmutableArray();
+            argumentNames.Free();
 
             displayClassTypes.Free();
             displayClassInstances.Free();

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1270,7 +1270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             // For version before .NET 4.5, we cannot find the sourceMethod properly:
             // The source method coincides with the original method in the case.
             // Therefore, for iterators and async state machines, we have to get parameters from the containingType.
-            // This does not guarantees the proper order of parameters.
+            // This does not guarantee the proper order of parameters.
             if (isIteratorOrAsyncMethod && method == sourceMethod)
             {
                 Debug.Assert(IsDisplayClassType(containingType));

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1257,11 +1257,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 isIteratorOrAsyncMethod = GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType;
             }
 
-            var argumentNamesSet = PooledHashSet<string>.GetInstance();
+            var parameterNames = PooledHashSet<string>.GetInstance();
             if (isIteratorOrAsyncMethod)
             {
                 Debug.Assert(IsDisplayClassType(containingType));
-                var argumentNamesArrayBuilder = ArrayBuilder<string>.GetInstance();
+                var parameterNamesInOrder = ArrayBuilder<string>.GetInstance();
                 foreach (var field in containingType.GetMembers().OfType<FieldSymbol>())
                 {
                     // All iterator and async state machine fields (including hoisted locals) have mangled names, except
@@ -1269,18 +1269,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     var fieldName = field.Name;
                     if (GeneratedNames.GetKind(fieldName) == GeneratedNameKind.None)
                     {
-                        argumentNamesArrayBuilder.Add(fieldName);
-                        argumentNamesSet.Add(fieldName);
+                        parameterNamesInOrder.Add(fieldName);
+                        parameterNames.Add(fieldName);
                     }
                 }
-                sourceMethodParametersInOrder = argumentNamesArrayBuilder.ToImmutableArray();
-                argumentNamesArrayBuilder.Free();
+                sourceMethodParametersInOrder = parameterNamesInOrder.ToImmutableArray();
+                parameterNamesInOrder.Free();
             }
             else
             {
                 foreach (var p in method.Parameters)
                 {
-                    argumentNamesSet.Add(p.Name);
+                    parameterNames.Add(p.Name);
                 }
                 sourceMethodParametersInOrder = ImmutableArray<string>.Empty;
             }
@@ -1301,7 +1301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     GetDisplayClassVariables(
                         displayClassVariableNamesInOrderBuilder,
                         displayClassVariablesBuilder,
-                        argumentNamesSet,
+                        parameterNames,
                         inScopeHoistedLocalSlots,
                         instance);
                 }
@@ -1316,7 +1316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 displayClassVariables = ImmutableDictionary<string, DisplayClassVariable>.Empty;
             }
 
-            argumentNamesSet.Free();
+            parameterNames.Free();
             displayClassTypes.Free();
             displayClassInstances.Free();
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -25,9 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return GetType(compilation.GetModule(moduleVersionId), (TypeDefinitionHandle)MetadataTokens.Handle(typeToken));
         }
 
-        internal static PEMethodSymbol GetSourceMethod(this CSharpCompilation compilation, Guid moduleVersionId, int methodToken)
+        internal static PEMethodSymbol GetSourceMethod(this CSharpCompilation compilation, Guid moduleVersionId, MethodDefinitionHandle methodHandle)
         {
-            var methodHandle = (MethodDefinitionHandle)MetadataTokens.Handle(methodToken);
             var method = GetMethod(compilation, moduleVersionId, methodHandle);
             var metadataDecoder = new MetadataDecoder((PEModuleSymbol)method.ContainingModule);
             var containingType = method.ContainingType;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -40,13 +40,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     {
                         var module = metadataDecoder.Module;
                         methodHandle = candidateMethod.Handle;
-                  //      string stateMachineTypeName;
+                        string stateMachineTypeName;
 
                         if (GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType)
-                        //if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
-                        //module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
+                        if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
+                            module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
                         {
-                        //    if (metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType))
+                            if (metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType))
                             {
                                 return candidateMethod;
                             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -40,11 +40,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     {
                         var module = metadataDecoder.Module;
                         methodHandle = candidateMethod.Handle;
-                        string stateMachineTypeName;
-                        if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
-                            module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
+                  //      string stateMachineTypeName;
+
+                        if (GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType)
+                        //if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
+                        //module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
                         {
-                            if (metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType))
+                        //    if (metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType))
                             {
                                 return candidateMethod;
                             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -41,8 +41,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         var module = metadataDecoder.Module;
                         methodHandle = candidateMethod.Handle;
                         string stateMachineTypeName;
-
-                        if (GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType)
                         if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
                             module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
                         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal readonly CSharpCompilation Compilation;
 
         private readonly MethodSymbol _currentFrame;
+        private readonly MethodSymbol _currentSourceMethod;
         private readonly ImmutableArray<LocalSymbol> _locals;
         private readonly ImmutableSortedSet<int> _inScopeHoistedLocalSlots;
         private readonly MethodDebugInfo<TypeSymbol, LocalSymbol> _methodDebugInfo;
@@ -39,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             MethodContextReuseConstraints? methodContextReuseConstraints,
             CSharpCompilation compilation,
             MethodSymbol currentFrame,
+            MethodSymbol currentSourceMethod,
             ImmutableArray<LocalSymbol> locals,
             ImmutableSortedSet<int> inScopeHoistedLocalSlots,
             MethodDebugInfo<TypeSymbol, LocalSymbol> methodDebugInfo)
@@ -49,6 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             this.MethodContextReuseConstraints = methodContextReuseConstraints;
             this.Compilation = compilation;
             _currentFrame = currentFrame;
+            _currentSourceMethod = currentSourceMethod;
             _locals = locals;
             _inScopeHoistedLocalSlots = inScopeHoistedLocalSlots;
             _methodDebugInfo = methodDebugInfo;
@@ -93,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 null,
                 compilation,
                 currentFrame,
+                null,
                 default(ImmutableArray<LocalSymbol>),
                 ImmutableSortedSet<int>.Empty,
                 MethodDebugInfo<TypeSymbol, LocalSymbol>.None);
@@ -180,6 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             int localSignatureToken)
         {
             var methodHandle = (MethodDefinitionHandle)MetadataTokens.Handle(methodToken);
+            var currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodHandle);
             var localSignatureHandle = (localSignatureToken != 0) ? (StandaloneSignatureHandle)MetadataTokens.Handle(localSignatureToken) : default(StandaloneSignatureHandle);
 
             var currentFrame = compilation.GetMethod(moduleVersionId, methodHandle);
@@ -211,6 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 new MethodContextReuseConstraints(moduleVersionId, methodToken, methodVersion, reuseSpan),
                 compilation,
                 currentFrame,
+                currentSourceMethod,
                 localsBuilder.ToImmutableAndFree(),
                 inScopeHoistedLocals,
                 debugInfo);
@@ -221,6 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return new CompilationContext(
                 this.Compilation,
                 _currentFrame,
+                _currentSourceMethod,
                 _locals,
                 _inScopeHoistedLocalSlots,
                 _methodDebugInfo);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var localSignatureHandle = (localSignatureToken != 0) ? (StandaloneSignatureHandle)MetadataTokens.Handle(localSignatureToken) : default(StandaloneSignatureHandle);
 
             var currentFrame = compilation.GetMethod(moduleVersionId, methodHandle);
-            var currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodToken);
+            var currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodHandle);
             Debug.Assert((object)currentFrame != null);
             var symbolProvider = new CSharpEESymbolProvider(compilation.SourceAssembly, (PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal readonly CSharpCompilation Compilation;
 
         private readonly MethodSymbol _currentFrame;
-        private readonly MethodSymbol _currentSourceMethod;
         private readonly ImmutableArray<LocalSymbol> _locals;
         private readonly ImmutableSortedSet<int> _inScopeHoistedLocalSlots;
         private readonly MethodDebugInfo<TypeSymbol, LocalSymbol> _methodDebugInfo;
@@ -40,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             MethodContextReuseConstraints? methodContextReuseConstraints,
             CSharpCompilation compilation,
             MethodSymbol currentFrame,
-            MethodSymbol currentSourceMethod,
             ImmutableArray<LocalSymbol> locals,
             ImmutableSortedSet<int> inScopeHoistedLocalSlots,
             MethodDebugInfo<TypeSymbol, LocalSymbol> methodDebugInfo)
@@ -51,7 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             this.MethodContextReuseConstraints = methodContextReuseConstraints;
             this.Compilation = compilation;
             _currentFrame = currentFrame;
-            _currentSourceMethod = currentSourceMethod;
             _locals = locals;
             _inScopeHoistedLocalSlots = inScopeHoistedLocalSlots;
             _methodDebugInfo = methodDebugInfo;
@@ -96,7 +93,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 null,
                 compilation,
                 currentFrame,
-                null,
                 default(ImmutableArray<LocalSymbol>),
                 ImmutableSortedSet<int>.Empty,
                 MethodDebugInfo<TypeSymbol, LocalSymbol>.None);
@@ -187,7 +183,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var localSignatureHandle = (localSignatureToken != 0) ? (StandaloneSignatureHandle)MetadataTokens.Handle(localSignatureToken) : default(StandaloneSignatureHandle);
 
             var currentFrame = compilation.GetMethod(moduleVersionId, methodHandle);
-            var currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodHandle);
             Debug.Assert((object)currentFrame != null);
             var symbolProvider = new CSharpEESymbolProvider(compilation.SourceAssembly, (PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
 
@@ -216,7 +211,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 new MethodContextReuseConstraints(moduleVersionId, methodToken, methodVersion, reuseSpan),
                 compilation,
                 currentFrame,
-                currentSourceMethod,
                 localsBuilder.ToImmutableAndFree(),
                 inScopeHoistedLocals,
                 debugInfo);
@@ -227,7 +221,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return new CompilationContext(
                 this.Compilation,
                 _currentFrame,
-                _currentSourceMethod,
                 _locals,
                 _inScopeHoistedLocalSlots,
                 _methodDebugInfo);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal readonly CSharpCompilation Compilation;
 
         private readonly MethodSymbol _currentFrame;
+        private readonly MethodSymbol _currentSourceMethod;
         private readonly ImmutableArray<LocalSymbol> _locals;
         private readonly ImmutableSortedSet<int> _inScopeHoistedLocalSlots;
         private readonly MethodDebugInfo<TypeSymbol, LocalSymbol> _methodDebugInfo;
@@ -39,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             MethodContextReuseConstraints? methodContextReuseConstraints,
             CSharpCompilation compilation,
             MethodSymbol currentFrame,
+            MethodSymbol currentSourceMethod,
             ImmutableArray<LocalSymbol> locals,
             ImmutableSortedSet<int> inScopeHoistedLocalSlots,
             MethodDebugInfo<TypeSymbol, LocalSymbol> methodDebugInfo)
@@ -49,6 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             this.MethodContextReuseConstraints = methodContextReuseConstraints;
             this.Compilation = compilation;
             _currentFrame = currentFrame;
+            _currentSourceMethod = currentSourceMethod;
             _locals = locals;
             _inScopeHoistedLocalSlots = inScopeHoistedLocalSlots;
             _methodDebugInfo = methodDebugInfo;
@@ -93,6 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 null,
                 compilation,
                 currentFrame,
+                null,
                 default(ImmutableArray<LocalSymbol>),
                 ImmutableSortedSet<int>.Empty,
                 MethodDebugInfo<TypeSymbol, LocalSymbol>.None);
@@ -183,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var localSignatureHandle = (localSignatureToken != 0) ? (StandaloneSignatureHandle)MetadataTokens.Handle(localSignatureToken) : default(StandaloneSignatureHandle);
 
             var currentFrame = compilation.GetMethod(moduleVersionId, methodHandle);
+            var currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodToken);
             Debug.Assert((object)currentFrame != null);
             var symbolProvider = new CSharpEESymbolProvider(compilation.SourceAssembly, (PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
 
@@ -211,6 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 new MethodContextReuseConstraints(moduleVersionId, methodToken, methodVersion, reuseSpan),
                 compilation,
                 currentFrame,
+                currentSourceMethod,
                 localsBuilder.ToImmutableAndFree(),
                 inScopeHoistedLocals,
                 debugInfo);
@@ -221,6 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return new CompilationContext(
                 this.Compilation,
                 _currentFrame,
+                _currentSourceMethod,
                 _locals,
                 _inScopeHoistedLocalSlots,
                 _methodDebugInfo);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/InstructionDecoderTests.cs
@@ -453,7 +453,7 @@ class C
             // async/iterator "MoveNext" methods to the original source method.
             MethodSymbol method = compilation.GetSourceMethod(
                 ((PEModuleSymbol)frame.ContainingModule).Module.GetModuleVersionIdOrThrow(),
-                MetadataTokens.GetToken(frame.Handle));
+                frame.Handle);
             if (serializedTypeArgumentNames != null)
             {
                 Assert.NotEmpty(serializedTypeArgumentNames);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1554,7 +1554,8 @@ class C
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                VerifyLocal(testData, typeName, locals[0], "<>m0", "x2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "x1");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "x2", expectedILOpt:
     @"
 {
   // Code size        7 (0x7)
@@ -1566,9 +1567,9 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_0.x2""
   IL_0006:  ret
 }");
-                VerifyLocal(testData, typeName, locals[1], "<>m1", "x3");
-                VerifyLocal(testData, typeName, locals[2], "<>m2", "x4");
-                VerifyLocal(testData, typeName, locals[3], "<>m3", "x1");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "x3");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "x4");
+                
                 Assert.Equal(locals.Count, 4);
 
                 locals.Free();
@@ -1581,7 +1582,8 @@ class C
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                VerifyLocal(testData, typeName, locals[0], "<>m0", "y2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "y1");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "y2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1592,8 +1594,7 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_1.y2""
   IL_0006:  ret
 }");
-                VerifyLocal(testData, typeName, locals[1], "<>m1", "y3");
-                VerifyLocal(testData, typeName, locals[2], "<>m2", "y1");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "y3");
                 VerifyLocal(testData, typeName, locals[3], "<>m3", "x2");
                 VerifyLocal(testData, typeName, locals[4], "<>m4", "x3", expectedILOpt:
 @"{
@@ -1618,7 +1619,8 @@ class C
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                VerifyLocal(testData, typeName, locals[0], "<>m0", "z2", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "z1");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "z2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1629,7 +1631,6 @@ class C
   IL_0001:  ldfld      ""object C.<>c__DisplayClass0_2.z2""
   IL_0006:  ret
 }");
-                VerifyLocal(testData, typeName, locals[1], "<>m1", "z1");
                 VerifyLocal(testData, typeName, locals[2], "<>m2", "y2");
                 VerifyLocal(testData, typeName, locals[3], "<>m3", "y3");
                 VerifyLocal(testData, typeName, locals[4], "<>m4", "x2");

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3838,6 +3838,7 @@ class C
                 var names = locals.Select(l => l.LocalName).ToArray();
                 // The order must confirm the order of the arguments in the method signature.
                 Assert.Equal(names, new[] { "y", "x" });
+                locals.Free();
             });
 
             comp = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
@@ -3851,6 +3852,7 @@ class C
                 var names = locals.Select(l => l.LocalName).ToArray();
                 // The problem is not fixed in versions before 4.5: the order of arguments can be wrong.
                 Assert.Equal(names, new[] { "x", "y" });
+                locals.Free();
             });
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3827,7 +3827,7 @@ class C
     {
     }
 }";
-            var comp = CreateStandardCompilation(source, options: TestOptions.DebugDll);
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 EvaluationContext context;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3827,7 +3827,7 @@ class C
     {
     }
 }";
-            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(comp, runtime =>
             {
                 EvaluationContext context;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -2840,8 +2840,8 @@ class C
         yield return local;
     }
 }";
-            // Iterator requires .Net4.5 compilation to use AttributeDescription.IteratorStateMachineAttribute.
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll);
+
+            var compilation = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation, runtime =>
             {
                 string displayClassName;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3839,6 +3839,19 @@ class C
                 // The order must confirm the order of the arguments in the method signature.
                 Assert.Equal(names, new[] { "y", "x" });
             });
+
+            comp = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                EvaluationContext context;
+                context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext", atLineNumber: 500);
+                string unused;
+                var locals = new ArrayBuilder<LocalAndMethod>();
+                context.CompileGetLocals(locals, argumentsOnly: true, typeName: out unused, testData: null);
+                var names = locals.Select(l => l.LocalName).ToArray();
+                // The problem is not fixed in versions before 4.5: the order of arguments can be wrong.
+                Assert.Equal(names, new[] { "x", "y" });
+            });
         }
 
         private static void GetLocals(RuntimeInstance runtime, string methodName, bool argumentsOnly, ArrayBuilder<LocalAndMethod> locals, int count, out string typeName, out CompilationTestData testData)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -1066,7 +1066,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             ' For version before .NET 4.5, we cannot find the sourceMethod properly:
             ' The source method coincides with the original method in the case.
             ' Here, we have to get parameters from the containingType.
-            ' This does Not guarantees the proper order of parameters.
+            ' This does not guarantee the proper order of parameters.
             If isIteratorOrAsyncMethod AndAlso method = sourceMethod Then
                 Debug.Assert(containingType.IsClosureOrStateMachineType())
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private ReadOnly _currentFrame As MethodSymbol
         Private ReadOnly _locals As ImmutableArray(Of LocalSymbol)
         Private ReadOnly _displayClassVariables As ImmutableDictionary(Of String, DisplayClassVariable)
-        Private ReadOnly _hoistedParameterNames As ImmutableHashSet(Of String)
+        Private ReadOnly _sourceMethodParametersInOrder As ImmutableArray(Of String)
         Private ReadOnly _localsForBinding As ImmutableArray(Of LocalSymbol)
         Private ReadOnly _methodNotType As Boolean
         Private ReadOnly _voidType As NamedTypeSymbol
@@ -44,6 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Sub New(
             compilation As VisualBasicCompilation,
             currentFrame As MethodSymbol,
+            currentSourceMethod As MethodSymbol,
             locals As ImmutableArray(Of LocalSymbol),
             inScopeHoistedLocalSlots As ImmutableSortedSet(Of Integer),
             methodDebugInfo As MethodDebugInfo(Of TypeSymbol, LocalSymbol),
@@ -96,7 +97,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             If _methodNotType Then
                 _locals = locals
                 Dim displayClassVariableNamesInOrder As ImmutableArray(Of String) = Nothing
-                GetDisplayClassVariables(currentFrame, locals, inScopeHoistedLocalSlots, displayClassVariableNamesInOrder, _displayClassVariables, _hoistedParameterNames)
+                GetDisplayClassVariables(
+                    currentFrame,
+                    currentSourceMethod,
+                    locals,
+                    inScopeHoistedLocalSlots,
+                    displayClassVariableNamesInOrder,
+                    _displayClassVariables,
+                    _sourceMethodParametersInOrder)
                 Debug.Assert(displayClassVariableNamesInOrder.Length = _displayClassVariables.Count)
                 _localsForBinding = GetLocalsForBinding(locals, displayClassVariableNamesInOrder, _displayClassVariables)
             Else
@@ -257,38 +265,48 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         End If
                     End If
 
-                    ' Hoisted method parameters (represented as locals in the EE).
-                    If Not _hoistedParameterNames.IsEmpty Then
-                        Dim localIndex As Integer = 0
+                    Dim itemsAdded = PooledHashSet(Of String).GetInstance()
 
-                        For Each local In _localsForBinding
-                            ' Since we are showing hoisted method parameters first, the parameters may appear out of order
-                            ' in the Locals window if only some of the parameters are hoisted.  This is consistent with the
-                            ' behavior of the old EE.
-                            If _hoistedParameterNames.Contains(local.Name) Then
-                                AppendLocalAndMethod(localBuilder, methodBuilder, local, container, localIndex, GetLocalResultFlags(local))
-                            End If
-
-                            localIndex += 1
-                        Next
-                    End If
-
-                    ' Method parameters (except those that have been hoisted).
+                    ' Method parameters
                     Dim parameterIndex = If(m.IsShared, 0, 1)
                     For Each parameter In m.Parameters
                         Dim parameterName As String = parameter.Name
-                        If Not _hoistedParameterNames.Contains(parameterName) AndAlso GeneratedNames.GetKind(parameterName) = GeneratedNameKind.None Then
+                        If GeneratedNames.GetKind(parameterName) = GeneratedNameKind.None Then
                             AppendParameterAndMethod(localBuilder, methodBuilder, parameter, container, parameterIndex)
+                            itemsAdded.Add(parameterName)
                         End If
 
                         parameterIndex += 1
                     Next
 
+                    ' In case of iterator Or async state machine, the 'm' method has no parameters
+                    ' but the source method can have parameters to iterate over.
+                    If itemsAdded.Count = 0 AndAlso _sourceMethodParametersInOrder.Length <> 0 Then
+                        Dim localsDictionary = PooledDictionary(Of String, (LocalSymbol, Integer)).GetInstance()
+                        Dim localIndex = 0
+                        For Each local In _localsForBinding
+                            localsDictionary.Add(local.Name, (local, localIndex))
+                            localIndex += 1
+                        Next
+
+                        For Each argumentName In _sourceMethodParametersInOrder
+
+                            Dim localSymbolAndIndex As (LocalSymbol, Integer) = Nothing
+                            If localsDictionary.TryGetValue(argumentName, localSymbolAndIndex) Then
+                                itemsAdded.Add(argumentName)
+                                Dim local = localSymbolAndIndex.Item1
+                                AppendLocalAndMethod(localBuilder, methodBuilder, local, container, localSymbolAndIndex.Item2, GetLocalResultFlags(local))
+                            End If
+                        Next
+
+                        localsDictionary.Free()
+                    End If
+
                     If Not argumentsOnly Then
                         ' Locals.
                         Dim localIndex As Integer = 0
                         For Each local In _localsForBinding
-                            If Not _hoistedParameterNames.Contains(local.Name) Then
+                            If Not itemsAdded.Contains(local.Name) Then
                                 AppendLocalAndMethod(localBuilder, methodBuilder, local, container, localIndex, GetLocalResultFlags(local))
                             End If
 
@@ -309,6 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         End If
                     End If
 
+                    itemsAdded.Free()
                     Return methodBuilder.ToImmutableAndFree()
                 End Function)
 
@@ -998,11 +1017,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' </summary>
         Private Shared Sub GetDisplayClassVariables(
             method As MethodSymbol,
+            sourceMethod As MethodSymbol,
             locals As ImmutableArray(Of LocalSymbol),
             inScopeHoistedLocalSlots As ImmutableSortedSet(Of Integer),
             <Out> ByRef displayClassVariableNamesInOrder As ImmutableArray(Of String),
             <Out> ByRef displayClassVariables As ImmutableDictionary(Of String, DisplayClassVariable),
-            <Out> ByRef hoistedParameterNames As ImmutableHashSet(Of String))
+            <Out> ByRef sourceMethodParametersInOrder As ImmutableArray(Of String))
 
             ' Calculated the shortest paths from locals to instances of display classes.
             ' There should not be two instances of the same display class immediately
@@ -1041,6 +1061,44 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 isIteratorOrAsyncMethod = containingType.IsStateMachineType()
             End If
 
+            Dim parameterNamesInOrder = ArrayBuilder(Of String).GetInstance()
+
+            ' For version before .NET 4.5, we cannot find the sourceMethod properly:
+            ' The source method coincides with the original method in the case.
+            ' Here, we have to get parameters from the containingType.
+            ' This does Not guarantees the proper order of parameters.
+            If isIteratorOrAsyncMethod AndAlso method = sourceMethod Then
+                Debug.Assert(containingType.IsClosureOrStateMachineType())
+
+                For Each member In containingType.GetMembers
+                    ' All iterator and async state machine fields in VB have mangled names.
+                    ' The ones beginning with "$VB$Local_" are the hoisted parameters.
+                    If member.Kind <> SymbolKind.Field Then
+                        Continue For
+                    End If
+
+                    Dim field = DirectCast(member, FieldSymbol)
+                    Dim fieldName = field.Name
+                    Dim parameterName As String = Nothing
+                    If GeneratedNames.TryParseHoistedUserVariableName(fieldName, parameterName) Then
+                        parameterNamesInOrder.Add(parameterName)
+                    End If
+                Next
+            Else
+                If sourceMethod <> Nothing Then
+                    For Each parameter In sourceMethod.Parameters
+                        parameterNamesInOrder.Add(parameter.Name)
+                    Next
+                End If
+            End If
+
+            Dim parameterNames = PooledHashSet(Of String).GetInstance()
+            For Each p In parameterNamesInOrder
+                parameterNames.Add(p)
+            Next
+
+            sourceMethodParametersInOrder = parameterNamesInOrder.ToImmutableAndFree()
+
             If displayClassInstances.Any() Then
                 ' Find any additional display class instances breadth first.
                 Dim depth = 0
@@ -1052,49 +1110,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Dim displayClassVariableNamesInOrderBuilder = ArrayBuilder(Of String).GetInstance()
                 Dim displayClassVariablesBuilder = PooledDictionary(Of String, DisplayClassVariable).GetInstance()
 
-                Dim parameterNames = PooledHashSet(Of String).GetInstance()
-                If isIteratorOrAsyncMethod Then
-                    Debug.Assert(containingType.IsClosureOrStateMachineType())
-
-                    For Each field In containingType.GetMembers.OfType(Of FieldSymbol)()
-                        ' All iterator and async state machine fields in VB have mangled names.
-                        ' The ones beginning with "$VB$Local_" are the hoisted parameters.
-                        Dim fieldName = field.Name
-                        Dim parameterName As String = Nothing
-                        If GeneratedNames.TryParseHoistedUserVariableName(fieldName, parameterName) Then
-                            parameterNames.Add(parameterName)
-                        End If
-                    Next
-                Else
-                    For Each parameter In method.Parameters
-                        parameterNames.Add(parameter.Name)
-                    Next
-                End If
-
-                Dim pooledHoistedParameterNames = PooledHashSet(Of String).GetInstance()
                 For Each instance In displayClassInstances
                     GetDisplayClassVariables(
                         displayClassVariableNamesInOrderBuilder,
                         displayClassVariablesBuilder,
                         parameterNames,
                         inScopeHoistedLocalSlots,
-                        instance,
-                        pooledHoistedParameterNames)
+                        instance)
                 Next
-
-                hoistedParameterNames = pooledHoistedParameterNames.ToImmutableHashSet()
-                pooledHoistedParameterNames.Free()
-                parameterNames.Free()
 
                 displayClassVariableNamesInOrder = displayClassVariableNamesInOrderBuilder.ToImmutableAndFree()
                 displayClassVariables = displayClassVariablesBuilder.ToImmutableDictionary()
                 displayClassVariablesBuilder.Free()
             Else
-                hoistedParameterNames = ImmutableHashSet(Of String).Empty
                 displayClassVariableNamesInOrder = ImmutableArray(Of String).Empty
                 displayClassVariables = ImmutableDictionary(Of String, DisplayClassVariable).Empty
             End If
 
+            parameterNames.Free()
             displayClassTypes.Free()
             displayClassInstances.Free()
         End Sub
@@ -1211,8 +1244,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             displayClassVariablesBuilder As Dictionary(Of String, DisplayClassVariable),
             parameterNames As HashSet(Of String),
             inScopeHoistedLocalSlots As ImmutableSortedSet(Of Integer),
-            instance As DisplayClassInstanceAndFields,
-            hoistedParameterNames As HashSet(Of String))
+            instance As DisplayClassInstanceAndFields)
 
             ' Display class instance.  The display class fields are variables.
             For Each member In instance.Type.GetMembers()
@@ -1258,7 +1290,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     variableName = fieldName ' As in C#, we retain the mangled name.  It shouldn't be used, other than as a dictionary key.
                 ElseIf fieldName.StartsWith(StringConstants.LambdaCacheFieldPrefix, StringComparison.Ordinal) Then
                     Continue For
-                ElseIf GeneratedNames.GetKind(fieldName) = GeneratedNameKind.TransparentIdentifier
+                ElseIf GeneratedNames.GetKind(fieldName) = GeneratedNameKind.TransparentIdentifier Then
                     ' A transparent identifier (field) in an anonymous type synthesized for a transparent identifier.
                     Debug.Assert(Not field.IsShared)
                     Continue For
@@ -1273,7 +1305,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
                 If variableKind = DisplayClassVariableKind.Local AndAlso parameterNames.Contains(variableName) Then
                     variableKind = DisplayClassVariableKind.Parameter
-                    hoistedParameterNames.Add(variableName)
                 End If
 
                 If displayClassVariablesBuilder.ContainsKey(variableName) Then

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -24,8 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         <Extension>
-        Friend Function GetSourceMethod(compilation As VisualBasicCompilation, moduleVersionId As Guid, methodToken As Integer) As PEMethodSymbol
-            Dim methodHandle = CType(MetadataTokens.Handle(methodToken), MethodDefinitionHandle)
+        Friend Function GetSourceMethod(compilation As VisualBasicCompilation, moduleVersionId As Guid, methodHandle As MethodDefinitionHandle) As PEMethodSymbol
             Dim method = GetMethod(compilation, moduleVersionId, methodHandle)
             Dim metadataDecoder = New MetadataDecoder(DirectCast(method.ContainingModule, PEModuleSymbol))
             Dim containingType = method.ContainingType

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -36,6 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend ReadOnly Compilation As VisualBasicCompilation
 
         Private ReadOnly _currentFrame As MethodSymbol
+        Private ReadOnly _currentSourceMethod As MethodSymbol
         Private ReadOnly _locals As ImmutableArray(Of LocalSymbol)
         Private ReadOnly _inScopeHoistedLocalSlots As ImmutableSortedSet(Of Integer)
         Private ReadOnly _methodDebugInfo As MethodDebugInfo(Of TypeSymbol, LocalSymbol)
@@ -44,6 +45,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             methodContextReuseConstraints As MethodContextReuseConstraints?,
             compilation As VisualBasicCompilation,
             currentFrame As MethodSymbol,
+            currentSourceMethod As MethodSymbol,
             locals As ImmutableArray(Of LocalSymbol),
             inScopeHoistedLocalSlots As ImmutableSortedSet(Of Integer),
             methodDebugInfo As MethodDebugInfo(Of TypeSymbol, LocalSymbol))
@@ -51,6 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Me.MethodContextReuseConstraints = methodContextReuseConstraints
             Me.Compilation = compilation
             _currentFrame = currentFrame
+            _currentSourceMethod = currentSourceMethod
             _locals = locals
             _inScopeHoistedLocalSlots = inScopeHoistedLocalSlots
             _methodDebugInfo = methodDebugInfo
@@ -96,6 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Nothing,
                 compilation,
                 currentFrame,
+                Nothing,
                 locals:=Nothing,
                 inScopeHoistedLocalSlots:=Nothing,
                 methodDebugInfo:=MethodDebugInfo(Of TypeSymbol, LocalSymbol).None)
@@ -184,6 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             localSignatureToken As Integer) As EvaluationContext
 
             Dim methodHandle = CType(MetadataTokens.Handle(methodToken), MethodDefinitionHandle)
+            Dim currentSourceMethod = compilation.GetSourceMethod(moduleVersionId, methodHandle)
             Dim localSignatureHandle = If(localSignatureToken <> 0, CType(MetadataTokens.Handle(localSignatureToken), StandaloneSignatureHandle), Nothing)
 
             Dim currentFrame = compilation.GetMethod(moduleVersionId, methodHandle)
@@ -224,6 +229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 New MethodContextReuseConstraints(moduleVersionId, methodToken, methodVersion, reuseSpan),
                 compilation,
                 currentFrame,
+                currentSourceMethod,
                 localsBuilder.ToImmutableAndFree(),
                 inScopeHoistedLocalSlots,
                 debugInfo)
@@ -363,6 +369,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return New CompilationContext(
                 Compilation,
                 _currentFrame,
+                _currentSourceMethod,
                 _locals,
                 _inScopeHoistedLocalSlots,
                 _methodDebugInfo,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -1,6 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Reflection.Metadata
+Imports System.Reflection.Metadata.Ecma335
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
@@ -97,7 +99,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Friend Overrides Function GetMethod(compilation As VisualBasicCompilation, instructionAddress As DkmClrInstructionAddress) As MethodSymbol
-            Return compilation.GetSourceMethod(instructionAddress.ModuleInstance.Mvid, instructionAddress.MethodId.Token)
+            Dim methodHandle = CType(MetadataTokens.Handle(instructionAddress.MethodId.Token), MethodDefinitionHandle)
+            Return compilation.GetSourceMethod(instructionAddress.ModuleInstance.Mvid, methodHandle)
         End Function
 
         Friend Overrides Function GetTypeNameDecoder(compilation As VisualBasicCompilation, method As MethodSymbol) As TypeNameDecoder(Of PEModuleSymbol, TypeSymbol)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/InstructionDecoderTests.vb
@@ -515,7 +515,7 @@ End Class"
             ' async/ iterator "MoveNext" methods to the original source method.
             Dim method As MethodSymbol = compilation.GetSourceMethod(
                 DirectCast(frame.ContainingModule, PEModuleSymbol).Module.GetModuleVersionIdOrThrow(),
-                MetadataTokens.GetToken(frame.Handle))
+                frame.Handle)
             If serializedTypeArgumentNames IsNot Nothing Then
                 Assert.NotEmpty(serializedTypeArgumentNames)
                 Dim typeParameters = instructionDecoder.GetAllTypeParameters(method)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -910,7 +910,8 @@ End Class
 
                     Assert.Equal(locals.Count, 4)
 
-                    VerifyLocal(testData, typeName, locals(0), "<>m0", "x2", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(0), "<>m0", "x1")
+                    VerifyLocal(testData, typeName, locals(1), "<>m1", "x2", expectedILOpt:=
 "{
   // Code size        7 (0x7)
   .maxstack  1
@@ -921,9 +922,8 @@ End Class
   IL_0001:  ldfld      ""C._Closure$__1-0.$VB$Local_x2 As Object""
   IL_0006:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(1), "<>m1", "x3")
-                    VerifyLocal(testData, typeName, locals(2), "<>m2", "x4")
-                    VerifyLocal(testData, typeName, locals(3), "<>m3", "x1")
+                    VerifyLocal(testData, typeName, locals(2), "<>m2", "x3")
+                    VerifyLocal(testData, typeName, locals(3), "<>m3", "x4")
 
                     context = CreateMethodContext(runtime, methodName:="C._Closure$__1-0._Lambda$__1")
                     testData = New CompilationTestData()
@@ -933,7 +933,8 @@ End Class
 
                     Assert.Equal(locals.Count, 6)
 
-                    VerifyLocal(testData, typeName, locals(0), "<>m0", "y2", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(0), "<>m0", "y1")
+                    VerifyLocal(testData, typeName, locals(1), "<>m1", "y2", expectedILOpt:=
 "{
   // Code size        7 (0x7)
   .maxstack  1
@@ -944,8 +945,7 @@ End Class
   IL_0001:  ldfld      ""C._Closure$__1-1.$VB$Local_y2 As Object""
   IL_0006:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(1), "<>m1", "y3")
-                    VerifyLocal(testData, typeName, locals(2), "<>m2", "y1")
+                    VerifyLocal(testData, typeName, locals(2), "<>m2", "y3")
                     VerifyLocal(testData, typeName, locals(3), "<>m3", "x2")
                     VerifyLocal(testData, typeName, locals(4), "<>m4", "x3", expectedILOpt:=
 "{
@@ -968,7 +968,8 @@ End Class
 
                     Assert.Equal(locals.Count, 7)
 
-                    VerifyLocal(testData, typeName, locals(0), "<>m0", "z2", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(0), "<>m0", "z1")
+                    VerifyLocal(testData, typeName, locals(1), "<>m1", "z2", expectedILOpt:=
 "{
   // Code size        7 (0x7)
   .maxstack  1
@@ -979,7 +980,6 @@ End Class
   IL_0001:  ldfld      ""C._Closure$__1-2.$VB$Local_z2 As Object""
   IL_0006:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(1), "<>m1", "z1")
                     VerifyLocal(testData, typeName, locals(2), "<>m2", "y2")
                     VerifyLocal(testData, typeName, locals(3), "<>m3", "y3")
                     VerifyLocal(testData, typeName, locals(4), "<>m4", "x2")
@@ -3275,6 +3275,7 @@ End Class"
                     Dim testData As CompilationTestData = Nothing
                     Assert.Equal("y", locals(0).LocalName)
                     Assert.Equal("x", locals(1).LocalName)
+                    locals.Free()
                 End Sub)
         End Sub
 


### PR DESCRIPTION
Fixes [Incorrect argument value shown in the call stack window](https://devdiv.visualstudio.com/DevDiv/_workitems?id=298297 )

Customer scenario: using Call Stack window with Show Value options can sometimes provide an incorrect order of arguments, e.g. 

**Expected**
`f(string a = "a", string b = "b")`

**Actual**
`f(string a = "b", string b = "a")`

That is, the binding of parameters is incorrect. The change fixes the issue starting .NET 4.5.