### PR TITLE
Don't crash in QuickInfo if the search for linked tokens goes out of bounds

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -109,6 +109,7 @@
     <Compile Include="FindUsages\IFindUsagesService.cs" />
     <Compile Include="FindUsages\SimpleFindUsagesContext.cs" />
     <Compile Include="Implementation\InlineRename\Dashboard\DashboardAutomationPeer.cs" />
+    <Compile Include="Implementation\Intellisense\QuickInfo\Providers\LinkedFileDiscrepancyException.cs" />
     <Compile Include="Implementation\Structure\BlockTagState.cs" />
     <Compile Include="Tags\ExportImageMonikerServiceAttribute.cs" />
     <Compile Include="Implementation\NavigateTo\AbstractNavigateToItemDisplay.cs" />

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -143,9 +143,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 // Capturing more information for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
                 var originalText = await originalDocument.GetTextAsync().ConfigureAwait(false);
                 var linkedText = await linkedDocument.GetTextAsync().ConfigureAwait(false);
-
                 var linkedFileException = new LinkedFileDiscrepancyException(thrownException, originalText.ToString(), linkedText.ToString());
-                FatalError.Report(linkedFileException);
+
+                // This problem itself does not cause any corrupted state, it just changes the set
+                // of symbols included in QuickInfo, so we report and continue running.
+                FatalError.ReportWithoutCrash(linkedFileException);
             }
 
             return default(SyntaxToken);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -137,13 +137,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                     return linkedToken;
                 }
             }
-            catch (Exception e)
+            catch (Exception thrownException)
             {
                 // We are seeing linked files with different spans cause FindToken to crash.
                 // Capturing more information for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
                 var originalText = await originalDocument.GetTextAsync().ConfigureAwait(false);
                 var linkedText = await linkedDocument.GetTextAsync().ConfigureAwait(false);
-                FatalError.Report(e);
+
+                var linkedFileException = new LinkedFileDiscrepancyException(thrownException, originalText.ToString(), linkedText.ToString());
+                FatalError.Report(linkedFileException);
             }
 
             return default(SyntaxToken);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/LinkedFileDiscrepancyException.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/LinkedFileDiscrepancyException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
+{
+    // Used to aid the investigation of https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
+    internal class LinkedFileDiscrepancyException : Exception
+    {
+        private readonly string _originalText;
+        private readonly string _linkedText;
+
+        public LinkedFileDiscrepancyException(Exception innerException, string originalText, string linkedText)
+            : base("The contents of linked files do not match.", innerException)
+        {
+            _originalText = originalText;
+            _linkedText = linkedText;
+        }
+    }
+}


### PR DESCRIPTION
Port #17884 and #21567 to dev15.0.x

15.0.x Tracking Bug: [484304](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/484304)