### PR TITLE
added test for StreamRpc cancellation issue #21702 for master

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -110,18 +110,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return true;
             }
 
-            if (ex is OperationCanceledException && ((IDisposableObservable)_rpc).IsDisposed)
-            {
-                // JsonRpc will throw its own cancellation token if connection it is attached to
-                // is going away. we can get into this sitatuion when VS is shutting down since we dispose
-                // all connections that are open.
-
-                // return false so that we let cancellation from JsonRpc to propagate. we do this
-                // since it is one of safest way to gracefully shutdown the call. since Host is going
-                // away we are fine as long as there is no crash/NFW/Infobar
-                return false;
-            }
-
             s_debuggingLastDisconnectReason = _debuggingLastDisconnectReason;
             s_debuggingLastDisconnectCallstack = _debuggingLastDisconnectCallstack;
 

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -110,6 +110,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return true;
             }
 
+            if (ex is OperationCanceledException && ((IDisposableObservable)_rpc).IsDisposed)
+            {
+                // JsonRpc will throw its own cancellation token if connection it is attached to
+                // is going away. we can get into this sitatuion when VS is shutting down since we dispose
+                // all connections that are open.
+
+                // return false so that we let cancellation from JsonRpc to propagate. we do this
+                // since it is one of safest way to gracefully shutdown the call. since Host is going
+                // away we are fine as long as there is no crash/NFW/Infobar
+                return false;
+            }
+
             s_debuggingLastDisconnectReason = _debuggingLastDisconnectReason;
             s_debuggingLastDisconnectCallstack = _debuggingLastDisconnectCallstack;
 

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -146,6 +146,53 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public async Task TestSessionClosed()
+        {
+            // enable local remote host service
+            var service = CreateRemoteHostClientService();
+            service.Enable();
+
+            var client = (InProcRemoteHostClient)(await service.GetRemoteHostClientAsync(CancellationToken.None));
+
+            // register local service
+            TestService testService = null;
+            client.RegisterService("Test", (s, p) =>
+            {
+                testService = new TestService(s, p);
+                return testService;
+            });
+
+            // create session that stay alive until client alive (ex, SymbolSearchUpdateEngine)
+            var session = await client.TryCreateServiceSessionAsync("Test", CancellationToken.None);
+            client.ConnectionChanged += (s, connected) =>
+            {
+                if (connected)
+                {
+                    return;
+                }
+
+                // let session go, when client goes away (ex, VS shutdown)
+                session.Dispose();
+            };
+
+            // mimic unfortunate call that happens to be in the middle of communication.
+            var task = Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await session.InvokeAsync("TestMethodAsync");
+            });
+
+            // make client to go away
+            service.Disable();
+
+            // set event so that remote Rpc thread is released. this shouldn't affect
+            // host side's cancellation due to client closed
+            testService.Event.Set();
+
+            // verify session cancelled itself with cancellation token
+            await task;
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public async Task TestRequestNewRemoteHost()
         {
             var service = CreateRemoteHostClientService();
@@ -196,6 +243,26 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var mock = new Mock<IDiagnosticAnalyzerService>(MockBehavior.Strict);
             mock.Setup(a => a.GetHostAnalyzerReferences()).Returns(references);
             return mock.Object;
+        }
+
+        private class TestService : ServiceHubServiceBase
+        {
+            public TestService(Stream stream, IServiceProvider serviceProvider) :
+                base(serviceProvider, stream)
+            {
+                Event = new ManualResetEvent(false);
+
+                Rpc.StartListening();
+            }
+
+            public readonly ManualResetEvent Event;
+
+            public Task TestMethodAsync()
+            {
+                Event.WaitOne();
+
+                return SpecializedTasks.EmptyTask;
+            }
         }
 
         private class Listener : AsynchronousOperationListener { }


### PR DESCRIPTION
KeepAliveSession in master handles the situation properly by letting existing connection to be closed gracefully already. so just added the test.