### PR TITLE
Load DSRN from an alternate path if set

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9480,6 +9480,39 @@ class C
                 result.Output.Trim());
         }
 
+        [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=484417")]
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void MicrosoftDiaSymReaderNativeAltLoadPath()
+        {
+            var dir = Temp.CreateDirectory();
+            var cscDir = Path.GetDirectoryName(s_CSharpCompilerExecutable);
+            
+            // copy csc and dependencies except for DSRN:
+            foreach (var filePath in Directory.EnumerateFiles(cscDir))
+            {
+                var fileName = Path.GetFileName(filePath);
+
+                if (fileName.StartsWith("csc") ||
+                    fileName.StartsWith("System.") ||
+                    fileName.StartsWith("Microsoft.") && !fileName.StartsWith("Microsoft.DiaSymReader.Native"))
+                {
+                    dir.CopyFile(filePath);
+                }
+            }
+
+            dir.CreateFile("Source.cs").WriteAllText("class C { void F() { } }");
+
+            var cscCopy = Path.Combine(dir.Path, "csc.exe");
+
+            var result = ProcessUtilities.Run(
+                cscCopy, 
+                arguments: "/nologo /t:library /debug:full /deterministic Source.cs",
+                workingDirectory: dir.Path, 
+                additionalEnvironmentVars: new[] { KeyValuePair.Create("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", cscDir) });
+
+            Assert.Equal("", result.Output.Trim());
+        }
+
         public class QuotedArgumentTests
         {
             private void VerifyQuotedValid<T>(string name, string value, T expected, Func<CSharpCommandLineArguments, T> getValue)

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -790,9 +790,13 @@ namespace Microsoft.Cci
                             CreateSymWriter64(ref guid, out symWriter);
                         }
                     }
-                    catch (DllNotFoundException)
+                    catch (DllNotFoundException e)
                     {
                         symWriter = TryLoadFromAlternativePath();
+                        if (symWriter == null)
+                        {
+                            s_MicrosoftDiaSymReaderNativeLoadFailure = e.Message;
+                        }
                     }
                 }
                 catch (Exception e)

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -752,7 +752,7 @@ namespace Microsoft.Cci
         [DllImport(DiaSymReaderModuleName64, EntryPoint = "CreateSymWriter")]
         private extern static void CreateSymWriter64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
 
-        private static string DiaSymReaderModuleName 
+        private static string DiaSymReaderModuleName
             => (IntPtr.Size == 4) ? DiaSymReaderModuleName32 : DiaSymReaderModuleName64;
 
         private static string LoadedDiaSymReaderModuleName
@@ -778,14 +778,21 @@ namespace Microsoft.Cci
             {
                 try
                 {
-                    var guid = new Guid(SymWriterClsid);
-                    if (IntPtr.Size == 4)
+                    try
                     {
-                        CreateSymWriter32(ref guid, out symWriter);
+                        var guid = new Guid(SymWriterClsid);
+                        if (IntPtr.Size == 4)
+                        {
+                            CreateSymWriter32(ref guid, out symWriter);
+                        }
+                        else
+                        {
+                            CreateSymWriter64(ref guid, out symWriter);
+                        }
                     }
-                    else
+                    catch (DllNotFoundException)
                     {
-                        CreateSymWriter64(ref guid, out symWriter);
+                        symWriter = TryLoadFromAlternativePath();
                     }
                 }
                 catch (Exception e)
@@ -799,6 +806,56 @@ namespace Microsoft.Cci
             {
                 // Try to find a registered CLR implementation
                 symWriter = Activator.CreateInstance(GetCorSymWriterSxSType());
+            }
+
+            return symWriter;
+        }
+
+        [DllImport("kernel32")]
+        private static extern IntPtr LoadLibrary(string path);
+
+        [DllImport("kernel32")]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
+        [DllImport("kernel32")]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+
+        private delegate void CreateSymWriterDelegate(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
+
+        private static object TryLoadFromAlternativePath()
+        {
+            var dir = Environment.GetEnvironmentVariable("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH");
+            if (string.IsNullOrEmpty(dir))
+            {
+                return null;
+            }
+
+            var moduleHandle = LoadLibrary(Path.Combine(dir, DiaSymReaderModuleName));
+            if (moduleHandle == IntPtr.Zero)
+            {
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+
+            object symWriter = null;
+            try
+            {
+                var createAddress = GetProcAddress(moduleHandle, "CreateSymWriter");
+                if (createAddress == IntPtr.Zero)
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+
+                var creator = Marshal.GetDelegateForFunctionPointer<CreateSymWriterDelegate>(createAddress);
+
+                var guid = new Guid(SymWriterClsid);
+                creator(ref guid, out symWriter);
+            }
+            finally
+            {
+                if (symWriter == null && !FreeLibrary(moduleHandle))
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
             }
 
             return symWriter;

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -232,10 +232,19 @@ namespace Microsoft.CodeAnalysis.Remote
                 //   "appBasePath": "%VSAPPIDDIR%"
                 //
 
-                var cookie = AddDllDirectory(AppDomain.CurrentDomain.BaseDirectory);
-                if (cookie == IntPtr.Zero)
+                var loadDir = AppDomain.CurrentDomain.BaseDirectory;
+
+                try
                 {
-                    throw new Win32Exception();
+                    if (AddDllDirectory(loadDir) == IntPtr.Zero)
+                    {
+                        throw new Win32Exception();
+                    }
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    // AddDllDirectory API might not be available on Windows 7.
+                    Environment.SetEnvironmentVariable("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", loadDir);
                 }
             }
         }


### PR DESCRIPTION
**Customer scenario**

Visual Studio Update 15.3 sometimes fails to install on Windows 7. 

For some reason, which could be a bug in Windows Update, OS corruption, restrictive update policies, etc. VS setup is not able to install an update KB2533623 that is now required by Roslyn. We added this prerequisite so that we can use Win32 function ```AddDllDirectory``` that is not available on Windows 7 without this update. This function is called in our OOP process to set the paths where P/Invoke LoadLibrary searches for Microsoft.DiaSymReader.Native to the directory in VS that contains it. 

This change implements a work around that allows us to remove dependency on KB2533623. If the CLR library loading logic fails to find Microsoft.DiaSymReader.Native we try to load it from a path specified by a special environment variable ```MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH```. This variable is set by the OOP process if ```AddDllDirectory``` is not available.

Corresponding PR in d15rel: [82773](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/82773) 

**Bugs this fixes:**

[VSO 484417](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=484417)

**Workarounds, if any**

Install updates manually if possible, or none depending on situation.

**Risk**

Low.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

KB2533623 update is unreliable.

**How was the bug found?**

Customer reported.

**Test documentation updated?**

N/A. 