### PR TITLE
Added retry on OOP start up

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -37,7 +37,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var remoteHostService = CreateService();
 
             var input = "Test";
-            var output = remoteHostService.Connect(input, serializedSession: null);
+            var output = remoteHostService.Connect(input, serializedSession: null, cancellationToken: CancellationToken.None);
 
             Assert.Equal(input, output);
         }

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
     internal interface IRemoteHostService
     {
-        string Connect(string host, string serializedSession);
+        string Connect(string host, string serializedSession, CancellationToken cancellationToken);
         Task SynchronizePrimaryWorkspaceAsync(Checksum checksum);
         Task SynchronizeGlobalAssetsAsync(Checksum[] checksums);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -41,11 +41,6 @@ namespace Microsoft.CodeAnalysis.Remote
             // we set up logger here
             RoslynLogger.SetLogger(new EtwLogger(GetLoggingChecker()));
 
-            // Set this process's priority BelowNormal.
-            // this should let us to freely try to use all resources possible without worrying about affecting
-            // host's work such as responsiveness or build.
-            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
-
             SetNativeDllSearchDirectories();
         }
 
@@ -56,8 +51,11 @@ namespace Microsoft.CodeAnalysis.Remote
             Rpc.StartListening();
         }
 
-        public string Connect(string host, string serializedSession)
+        public string Connect(string host, string serializedSession, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // this is called only once when Host (VS) started RemoteHost (OOP)
             _primaryInstance = InstanceId;
 
             var existing = Interlocked.CompareExchange(ref _host, host, null);
@@ -71,6 +69,15 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // log telemetry that service hub started
             RoslynLogger.Log(FunctionId.RemoteHost_Connect, KeyValueLogMessage.Create(SetSessionInfo));
+
+            // serializedSession will be null for testing
+            if (serializedSession != null)
+            {
+                // Set this process's priority BelowNormal.
+                // this should let us to freely try to use all resources possible without worrying about affecting
+                // host's work such as responsiveness or build.
+                Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+            }
 
             return _host;
         }


### PR DESCRIPTION
**Customer scenario**

User opened a solution on new VS while its machine is under heavy load. and VS crashed during opening the solution.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/481103

**Workarounds, if any**

kill processes that made the machine to be under heavy load (ex, 100% CPU)

**Risk**

Low. we will retry for 10 mins to connect to OOP.

**Performance impact**

it is retry vs crashing. so hard to compare.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

we try to connect to service hub. and it fails with this message.
"Error : NamedPipeServer.serverTask timed out to finish in 2000 ms."

since we didn't expect this, as usual, we crashed. now we handle this case by retrying.

**How was the bug found?**

Customer feedback, Watson
