### PR TITLE
put both partial method symbols to event queue.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1030,8 +1030,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return semanticModel;
                     });
 
-                    MethodSymbol symbolToProduce = methodSymbol.PartialDefinitionPart ?? methodSymbol;
-                    _compilation.EventQueue.TryEnqueue(new SymbolDeclaredCompilationEvent(_compilation, symbolToProduce, lazySemanticModel));
+                    _compilation.EventQueue.TryEnqueue(new SymbolDeclaredCompilationEvent(_compilation, methodSymbol, lazySemanticModel));
                 }
 
                 // Don't lower if we're not emitting or if there were errors. 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     syntax.Modifiers.Any(SyntaxKind.OverrideKeyword))
                 {
                     diagnostics.Add(
-                        ErrorCode.ERR_OverrideWithConstraints, 
+                        ErrorCode.ERR_OverrideWithConstraints,
                         syntax.ConstraintClauses[0].WhereKeyword.GetLocation());
                 }
             }
@@ -328,8 +328,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if ((object)overriddenMethod != null)
                     {
-                        CustomModifierUtils.CopyMethodCustomModifiers(overriddenMethod, this, out _lazyReturnType, 
-                                                                      out _lazyCustomModifiers, 
+                        CustomModifierUtils.CopyMethodCustomModifiers(overriddenMethod, this, out _lazyReturnType,
+                                                                      out _lazyCustomModifiers,
                                                                       out _lazyParameters, alsoCopyParamsModifier: true);
                     }
                 }
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Debug.Assert(_lazyExplicitInterfaceImplementations.IsDefault);
                     _lazyExplicitInterfaceImplementations = ImmutableArray.Create<MethodSymbol>(implementedMethod);
 
-                    CustomModifierUtils.CopyMethodCustomModifiers(implementedMethod, this, out _lazyReturnType, 
+                    CustomModifierUtils.CopyMethodCustomModifiers(implementedMethod, this, out _lazyReturnType,
                                                                   out _lazyCustomModifiers,
                                                                   out _lazyParameters, alsoCopyParamsModifier: false);
                 }
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     AddDeclarationDiagnostics(diagnosticsOpt);
                 }
-                if (IsPartialDefinition && (object)PartialImplementationPart == null)
+                if (IsPartialDefinition)
                 {
                     DeclaringCompilation.SymbolDeclaredEvent(this);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/CompilationEventTests.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 "SymbolDeclaredCompilationEvent(F int C<T1>.F @ : (6,8)-(6,14))",
                 "SymbolDeclaredCompilationEvent(C C<T1> @ : (2,2)-(8,3), : (9,2)-(12,3))",
                 "SymbolDeclaredCompilationEvent(M void C<T1>.M(int x1) @ : (4,4)-(4,27))",
+                "SymbolDeclaredCompilationEvent(M void C<T1>.M(int x2) @ : (11,4)-(11,29))",
                 "SymbolDeclaredCompilationEvent(N N @ : (0,0)-(13,1))",
                 "SymbolDeclaredCompilationEvent(<empty>  @ : (0,0)-(13,1))",
                 "SymbolDeclaredCompilationEvent(get_P int C<T1>.P.get @ : (5,21)-(5,25))",

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -273,8 +273,9 @@ namespace N1
                         var added = declaredSymbolNames.Add(symbol.Name);
                         if (!added)
                         {
-                            var isPartialMethod = ((Symbols.SourceMemberMethodSymbol)symbol).PartialDefinitionPart != null ||
-                                                  ((Symbols.SourceMemberMethodSymbol)symbol).PartialImplementationPart != null;
+                            var method = (Symbols.MethodSymbol)symbol;
+                            var isPartialMethod = method.PartialDefinitionPart != null ||
+                                                  method.PartialImplementationPart != null;
                             Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for symbol " + symbol);
                         }
                     }

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -273,7 +273,9 @@ namespace N1
                         var added = declaredSymbolNames.Add(symbol.Name);
                         if (!added)
                         {
-                            var method = (Symbols.MethodSymbol)symbol;
+                            var method = symbol as Symbols.MethodSymbol;
+                            Assert.NotNull(method);
+
                             var isPartialMethod = method.PartialDefinitionPart != null ||
                                                   method.PartialImplementationPart != null;
                             Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for symbol " + symbol);

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -271,9 +271,10 @@ namespace N1
                     {
                         var symbol = symbolDeclaredEvent.Symbol;
                         var added = declaredSymbolNames.Add(symbol.Name);
-                        Assert.True(added, "Unexpected multiple symbol declared events for symbol " + symbol);
-                        var method = symbol as Symbols.MethodSymbol;
-                        Assert.Null(method?.PartialDefinitionPart); // we should never get a partial method's implementation part
+                        if (!added)
+                        {
+                            Assert.True(((Symbols.SourceMemberMethodSymbol)symbol).IsPartial, "Unexpected multiple symbol declared events for symbol " + symbol);
+                        }
                     }
                     else
                     {
@@ -293,7 +294,7 @@ namespace N1
         public void TestEventQueueCompletionForEmptyCompilation()
         {
             var compilation = CreateCompilationWithMscorlib45(SpecializedCollections.EmptyEnumerable<SyntaxTree>()).WithEventQueue(new AsyncQueue<CompilationEvent>());
-            
+
             // Force complete compilation event queue
             var unused = compilation.GetDiagnostics();
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -273,7 +273,9 @@ namespace N1
                         var added = declaredSymbolNames.Add(symbol.Name);
                         if (!added)
                         {
-                            Assert.True(((Symbols.SourceMemberMethodSymbol)symbol).IsPartial, "Unexpected multiple symbol declared events for symbol " + symbol);
+                            var isPartialMethod = ((Symbols.SourceMemberMethodSymbol)symbol).PartialDefinitionPart != null ||
+                                                  ((Symbols.SourceMemberMethodSymbol)symbol).PartialImplementationPart != null;
+                            Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for symbol " + symbol);
                         }
                     }
                     else

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1222,8 +1222,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 End If
                                 Return semanticModel
                             End Function)
-                        Dim symbolToProduce = If(method.PartialDefinitionPart, method)
-                        compilation.EventQueue.TryEnqueue(New SymbolDeclaredCompilationEvent(compilation, symbolToProduce, lazySemanticModel))
+                        compilation.EventQueue.TryEnqueue(New SymbolDeclaredCompilationEvent(compilation, method, lazySemanticModel))
                     End If
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -634,7 +634,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If method.IsPartial() Then
                             Dim impl = method.PartialImplementationPart
                             If impl IsNot method Then
-                                If CType(method, SourceMethodSymbol).SetDiagnostics(ImmutableArray(Of Diagnostic).Empty) AndAlso impl Is Nothing Then
+                                If CType(method, SourceMethodSymbol).SetDiagnostics(ImmutableArray(Of Diagnostic).Empty) Then
                                     method.DeclaringCompilation.SymbolDeclaredEvent(method)
                                 End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/CompilationEventTests.vb
@@ -110,6 +110,7 @@ End Namespace
                 "SymbolDeclaredCompilationEvent(I C(Of T1).I As Integer @ TestQueuedSymbols.vb: (7,15)-(7,16))",
                 "SymbolDeclaredCompilationEvent(C C(Of T1) @ TestQueuedSymbols.vb: (1,4)-(11,13), TestQueuedSymbols.vb: (12,4)-(15,13))",
                 "SymbolDeclaredCompilationEvent(M Sub C(Of T1).M(x1 As Integer) @ TestQueuedSymbols.vb: (2,8)-(2,44))",
+                "SymbolDeclaredCompilationEvent(M Sub C(Of T1).M(x1 As Integer) @ TestQueuedSymbols.vb: (13,8)-(13,36))",
                 "SymbolDeclaredCompilationEvent(M2 Sub Mod1.M2() @ TestQueuedSymbols.vb: (17,8)-(17,24))",
                 "SymbolDeclaredCompilationEvent(get_P Property Get C(Of T1).P() As Integer)",
                 "SymbolDeclaredCompilationEvent(set_P Property Set C(Of T1).P(AutoPropertyValue As Integer))",

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
@@ -424,9 +423,10 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
                     Dim symbolDeclaredEvent = TryCast(compEvent, SymbolDeclaredCompilationEvent)
                     If symbolDeclaredEvent IsNot Nothing Then
                         Dim symbol = symbolDeclaredEvent.Symbol
-                        Assert.True(declaredSymbolNames.Add(symbol.Name), "Unexpected multiple symbol declared events for same symbol")
-                        Dim method = TryCast(symbol, Symbols.MethodSymbol)
-                        Assert.Null(method?.PartialDefinitionPart) ' we should never get a partial method's implementation part
+                        Dim added = declaredSymbolNames.Add(symbol.Name)
+                        If Not added Then
+                            Assert.True(DirectCast(symbol, Symbols.SourceMethodSymbol).IsPartial, "Unexpected multiple symbol declared events for same symbol " + symbol.Name)
+                        End If
                     Else
                         Dim compilationCompeletedEvent = TryCast(compEvent, CompilationUnitCompletedEvent)
                         If compilationCompeletedEvent IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -425,7 +425,9 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
                         Dim symbol = symbolDeclaredEvent.Symbol
                         Dim added = declaredSymbolNames.Add(symbol.Name)
                         If Not added Then
-                            Dim method = DirectCast(symbol, Symbols.MethodSymbol)
+                            Dim method = TryCast(symbol, Symbols.MethodSymbol)
+                            Assert.NotNull(method)
+
                             Dim isPartialMethod = method.PartialDefinitionPart IsNot Nothing OrElse
                                                   method.PartialImplementationPart IsNot Nothing
                             Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for same symbol " + symbol.Name)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -425,8 +425,9 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
                         Dim symbol = symbolDeclaredEvent.Symbol
                         Dim added = declaredSymbolNames.Add(symbol.Name)
                         If Not added Then
-                            Dim isPartialMethod = DirectCast(symbol, Symbols.SourceMethodSymbol).PartialDefinitionPart IsNot Nothing OrElse
-                                                  DirectCast(symbol, Symbols.SourceMethodSymbol).PartialImplementationPart IsNot Nothing
+                            Dim method = DirectCast(symbol, Symbols.MethodSymbol)
+                            Dim isPartialMethod = method.PartialDefinitionPart IsNot Nothing OrElse
+                                                  method.PartialImplementationPart IsNot Nothing
                             Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for same symbol " + symbol.Name)
                         End If
                     Else

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -425,7 +425,9 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
                         Dim symbol = symbolDeclaredEvent.Symbol
                         Dim added = declaredSymbolNames.Add(symbol.Name)
                         If Not added Then
-                            Assert.True(DirectCast(symbol, Symbols.SourceMethodSymbol).IsPartial, "Unexpected multiple symbol declared events for same symbol " + symbol.Name)
+                            Dim isPartialMethod = DirectCast(symbol, Symbols.SourceMethodSymbol).PartialDefinitionPart IsNot Nothing OrElse
+                                                  DirectCast(symbol, Symbols.SourceMethodSymbol).PartialImplementationPart IsNot Nothing
+                            Assert.True(isPartialMethod, "Unexpected multiple symbol declared events for same symbol " + symbol.Name)
                         End If
                     Else
                         Dim compilationCompeletedEvent = TryCast(compEvent, CompilationUnitCompletedEvent)


### PR DESCRIPTION
previously, we have only put partial method definition on event queue and that confused analyzer authors since we do have 2 method symbols for partial methods and people wanted to report diagnostics in the body of partial method implementation but we never gave it to analyzers.

now we report both symbols to analyzers.

address this
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/463586

