### PR TITLE
Simplification should remove parentheses around the expression of an expression-bodied member

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -1242,6 +1242,32 @@ class C
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(12600, "https://github.com/dotnet/roslyn/issues/12600")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_RemoveParensInLambdaExpression() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    Func&lt;object&gt; Value => () => {|Simplify:(new object())|};
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    Func&lt;object&gt; Value => () => new object();
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
 #Region "C# Binary Expressions"

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -1190,6 +1190,58 @@ class Program
             Await TestAsync(input, expected)
         End Function
 
+        <WorkItem(12600, "https://github.com/dotnet/roslyn/issues/12600")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_RemoveParensInExpressionBodiedProperty() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    object Value => {|Simplify:(new object())|};
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    object Value => new object();
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(12600, "https://github.com/dotnet/roslyn/issues/12600")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_RemoveParensInExpressionBodiedMethod() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    object GetValue() => {|Simplify:(new object())|};
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    object GetValue() => new object();
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
 #Region "C# Binary Expressions"

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -29,6 +29,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
+            // int Prop => (x); -> int Prop => x;
+            if (node.Parent is ArrowExpressionClauseSyntax arrowExpressionClause && arrowExpressionClause.Expression == node)
+            {
+                return true;
+            }
+
             // Don't change (x?.Count).GetValueOrDefault() to x?.Count.GetValueOrDefault()
             if (expression.IsKind(SyntaxKind.ConditionalAccessExpression) && parentExpression is MemberAccessExpressionSyntax)
             {


### PR DESCRIPTION
Fixes #12600

Tagging @dotnet/roslyn-ide 