### PR TITLE
Fix a crash that  could occur in override completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
@@ -2626,6 +2628,71 @@ class Program : C
 }";
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "goo()", expectedCodeAfterCommit);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task FilterOutMethodsWithNonRoundTrippableSymbolKeys()
+        {
+            var text = XElement.Parse(@"<Workspace>
+    <Project Name=""P1"" Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj1"">
+        <Document FilePath=""CurrentDocument.cs""><![CDATA[
+class C : ClassLibrary7.Class1
+{
+    override $$
+}
+]]>
+        </Document>
+    </Project>
+    <Project Name=""P2"" Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj2"">
+        <Document>
+namespace ClassLibrary2
+{
+    public class Missing {}
+}
+        </Document>
+    </Project>
+    <Project Name=""P3"" Language=""C#"" CommonReferences=""true"" AssemblyName=""Proj3.dll"">
+        <ProjectReference>P2</ProjectReference>
+        <Document>
+namespace ClassLibrary7
+{
+    public class Class1
+    {
+        public virtual void Goo(ClassLibrary2.Missing m) {}
+        public virtual void Bar() {}
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+
+            // P3 has a P2P ref to Project P2 and uses the type "Missing" from P2
+            // as the return type of a virtual method.
+            // P1 has a metadata reference to P3 and therefore doesn't get the transitive
+            // reference to P2. If we try to override Goo, the missing "Missing" type will
+            // prevent round tripping the symbolkey.
+            using (var workspace = TestWorkspace.Create(text))
+            {
+                var compilation = await workspace.CurrentSolution.Projects.First(p => p.Name == "P3").GetCompilationAsync();
+                
+                // CompilationExtensions is in the MS.CA.Test.Utilities namespace which has a "Traits" type that conflicts with the one in 
+                // Roslyn.Test.Utilities
+                var reference = MetadataReference.CreateFromImage(Test.Utilities.CompilationExtensions.EmitToArray(compilation));
+
+                var p1 = workspace.CurrentSolution.Projects.First(p => p.Name == "P1");
+                var updatedP1 = p1.AddMetadataReference(reference);
+                workspace.ChangeSolution(updatedP1.Solution);
+
+                var provider = new OverrideCompletionProvider();
+                var testDocument = workspace.Documents.First(d => d.Name == "CurrentDocument.cs");
+                var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+
+                var service = GetCompletionService(workspace);
+                var completionList = await GetCompletionListAsync(service, document, testDocument.CursorPosition.Value, CompletionTrigger.Invoke);
+
+                Assert.True(completionList.Items.Any(c => c.DisplayText == "Bar()"));
+                Assert.False(completionList.Items.Any(c => c.DisplayText == "Goo()"));
+            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2666,7 +2666,7 @@ namespace ClassLibrary7
     </Project>
 </Workspace>");
 
-            // P3 has a P2P ref to Project P2 and uses the type "Missing" from P2
+            // P3 has a project ref to Project P2 and uses the type "Missing" from P2
             // as the return type of a virtual method.
             // P1 has a metadata reference to P3 and therefore doesn't get the transitive
             // reference to P2. If we try to override Goo, the missing "Missing" type will
@@ -2674,11 +2674,10 @@ namespace ClassLibrary7
             using (var workspace = TestWorkspace.Create(text))
             {
                 var compilation = await workspace.CurrentSolution.Projects.First(p => p.Name == "P3").GetCompilationAsync();
-                
-                // CompilationExtensions is in the MS.CA.Test.Utilities namespace which has a "Traits" type that conflicts with the one in 
-                // Roslyn.Test.Utilities
-                var reference = MetadataReference.CreateFromImage(Test.Utilities.CompilationExtensions.EmitToArray(compilation));
 
+                // CompilationExtensions is in the Microsoft.CodeAnalysis.Test.Utilities namespace 
+                // which has a "Traits" type that conflicts with the one in Roslyn.Test.Utilities
+                var reference = MetadataReference.CreateFromImage(Test.Utilities.CompilationExtensions.EmitToArray(compilation));
                 var p1 = workspace.CurrentSolution.Projects.First(p => p.Name == "P1");
                 var updatedP1 = p1.AddMetadataReference(reference);
                 workspace.ChangeSolution(updatedP1.Solution);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -104,7 +104,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var memberContainingDocument = await GenerateMemberAndUsingsAsync(document, completionItem, line, cancellationToken).ConfigureAwait(false);
             if (memberContainingDocument == null)
             {
-                // Generating the new document failed, return no changes.
+                // Generating the new document failed because we somehow couldn't resolve
+                // the underlying symbol's SymbolKey. At this point, we won't be able to 
+                // make any changes, so just return the document we started with.
                 return document;
             }
 
@@ -141,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             if (overriddenMember == null)
             {
-                // Unfortunately, SymbolKey resolution failed. We have to bail.
+                // Unfortunately, SymbolKey resolution failed. Bail.
                 return null;
             }
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -90,8 +91,19 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 overridableMembers = _provider.FilterOverrides(overridableMembers, returnType);
                 var symbolDisplayService = _document.GetLanguageService<ISymbolDisplayService>();
 
+                var resolvableMembers = overridableMembers.Where(m => CanSerializeSymbolKey(m, semanticModel.Compilation));
+
                 return overridableMembers.Select(m => CreateItem(
                     m, symbolDisplayService, semanticModel, startToken, modifiers)).ToList();
+            }
+
+            private bool CanSerializeSymbolKey(ISymbol m, Compilation compilation)
+            {
+                // SymbolKey doesn't guarantee roundtrip-ability, which we need in order to generate overrides.
+                // Preemptively filter out those methods whose SymbolKeys we won't be able to round trip.
+                var key = SymbolKey.Create(m, _cancellationToken);
+                var result = key.Resolve(compilation, cancellationToken: _cancellationToken);
+                return result.Symbol != null;
             }
 
             private CompletionItem CreateItem(

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
@@ -91,13 +91,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 overridableMembers = _provider.FilterOverrides(overridableMembers, returnType);
                 var symbolDisplayService = _document.GetLanguageService<ISymbolDisplayService>();
 
-                var resolvableMembers = overridableMembers.Where(m => CanSerializeSymbolKey(m, semanticModel.Compilation));
+                var resolvableMembers = overridableMembers.Where(m => CanResolveSymbolKey(m, semanticModel.Compilation));
 
                 return overridableMembers.Select(m => CreateItem(
                     m, symbolDisplayService, semanticModel, startToken, modifiers)).ToList();
             }
 
-            private bool CanSerializeSymbolKey(ISymbol m, Compilation compilation)
+            private bool CanResolveSymbolKey(ISymbol m, Compilation compilation)
             {
                 // SymbolKey doesn't guarantee roundtrip-ability, which we need in order to generate overrides.
                 // Preemptively filter out those methods whose SymbolKeys we won't be able to round trip.


### PR DESCRIPTION
In order to insert code, override completion has to serialize/restore a
SymbolKey multiple times: once to actually create the completion item,
and additionally during the process of transforming the document.

Some symbolkeys cannot actually be restored. Specifically, a method
whose return type or parameters have use a type from an assembly not
referenced by the project the user is typing in cannot be restored. This
caused crashes/error dialogs when attempting override such members in a
way that is not predicable to the user.

To mitigate this we will:
* Not suggest members that can't be restored from their symbolkeys
* Stop the insertion process if we fail to restore a symbolkey

Fixes
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=419771&_a=edit

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)

**Test documentation updated?**

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.
