### PR TITLE
Be resilient to getting busy messages back from sqlite while retrieving data.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -277,6 +277,8 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
             => Throw(_handle, result);
 
         public static void Throw(sqlite3 handle, Result result)
-            => throw new SqlException(result, raw.sqlite3_errmsg(handle));
+            => throw new SqlException(result,
+                raw.sqlite3_errmsg(handle) + "\r\n" +
+                raw.sqlite3_errstr(raw.sqlite3_extended_errcode(handle)));
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -270,12 +270,16 @@ $@"create table if not exists ""{DocumentDataTableName}"" (
     ""{DataColumnName}"" blob)");
 
                 // Also get the known set of string-to-id mappings we already have in the DB.
-                FetchStringTable(connection);
+                // Do this in one batch if possible.
+                var fetched = TryFetchStringTable(connection);
+
+                // If we weren't able to retrieve the entire string table in one batch,
+                // attempt to retrieve it for each 
+                var fetchStringTable = !fetched;
 
                 // Try to bulk populate all the IDs we'll need for strings/projects/documents.
                 // Bulk population is much faster than trying to do everything individually.
-                // Note: we don't need to fetch the string table as we did it right above this.
-                BulkPopulateIds(connection, solution, fetchStringTable: false);
+                BulkPopulateIds(connection, solution, fetchStringTable);
             }
         }
     }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
@@ -53,7 +53,12 @@ namespace Microsoft.CodeAnalysis.SQLite
                 // the current string table, it will keep having problems trying to bulk populate.
                 if (fetchStringTable)
                 {
-                    FetchStringTable(connection);
+                    if (!TryFetchStringTable(connection))
+                    {
+                        // Weren't able to fetch the string table.  Have to try this again
+                        // later once the DB frees up.
+                        return;
+                    }
                 }
 
                 if (!BulkPopulateProjectIdsWorker(connection, project))

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
@@ -12,23 +12,34 @@ namespace Microsoft.CodeAnalysis.SQLite
     {
         private readonly ConcurrentDictionary<string, int> _stringToIdMap = new ConcurrentDictionary<string, int>();
 
-        private void FetchStringTable(SqlConnection connection)
+        private bool TryFetchStringTable(SqlConnection connection)
         {
-            using (var resettableStatement = connection.GetResettableStatement(
-                $@"select * from ""{StringInfoTableName}"""))
+            try
             {
-                var statement = resettableStatement.Statement;
-                while (statement.Step() == Result.ROW)
+                using (var resettableStatement = connection.GetResettableStatement(
+                    $@"select * from ""{StringInfoTableName}"""))
                 {
-                    var id = statement.GetInt32At(columnIndex: 0);
-                    var value = statement.GetStringAt(columnIndex: 1);
+                    var statement = resettableStatement.Statement;
+                    while (statement.Step() == Result.ROW)
+                    {
+                        var id = statement.GetInt32At(columnIndex: 0);
+                        var value = statement.GetStringAt(columnIndex: 1);
 
-                    // Note that TryAdd won't overwrite an existing string->id pair.  That's what
-                    // we want.  we don't want the strings we've allocated from the DB to be what
-                    // we hold onto.  We'd rather hold onto the strings we get from sources like
-                    // the workspaces.  This helps avoid unnecessary string instance duplication.
-                    _stringToIdMap.TryAdd(value, id);
+                        // Note that TryAdd won't overwrite an existing string->id pair.  That's what
+                        // we want.  we don't want the strings we've allocated from the DB to be what
+                        // we hold onto.  We'd rather hold onto the strings we get from sources like
+                        // the workspaces.  This helps avoid unnecessary string instance duplication.
+                        _stringToIdMap.TryAdd(value, id);
+                    }
                 }
+
+                return true;
+            }
+            catch (SqlException e) when (e.Result == Result.BUSY)
+            {
+                // Couldn't get access to sql database to fetch the string table.  
+                // Try again later.
+                return false;
             }
         }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=452360&fullScreen=true&_a=edit

Note: this issue should happen a lot less in 15.5 as heejae made a change in https://github.com/dotnet/roslyn/pull/21532 to have separate DBs for VS and for the OOP process.  Without having two processes hitting the same DB, there should be a lot less contention on the DB and busy exceptions should be much rarer.

Also, because we enabled WAL (write ahead logging) busy errors happen far less: https://sqlite.org/wal.html

"The second advantage of WAL-mode is that writers do not block readers and readers to do not block writers. "

