### PR TITLE
Fix documentation comment watson

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5015,5 +5015,23 @@ class Test
 ",
             MainDescription("T Test.F<T>()"));
         }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [WorkItem(403665, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=403665&_a=edit")]
+        public async Task TestExceptionWithCrefToConstructorDoesNotCrash()
+        {
+            await TestAsync(
+@"
+class Test
+{
+    /// <summary>
+    /// </summary>
+    /// <exception cref=""Test.Test""/>
+    public Test$$() {}
+}
+",
+            MainDescription("Test.Test()"));
+        }
     }
 }

--- a/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
@@ -213,6 +213,7 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
                 var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId(crefValue, semanticModel.Compilation);
                 if (symbol != null)
                 {
+                    format = format ?? SymbolDisplayFormat.MinimallyQualifiedFormat;
                     if (symbol.IsConstructor())
                     {
                         format = format.WithMemberOptions(SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeExplicitInterface);


### PR DESCRIPTION
QuickInfo could crash when showing a documentation comment whose exceptions section included a cref to a constructor.
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=403665&_a=edit