### PR TITLE
Properly collapse the right range when encountering nested #if regions.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/DisabledTextStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/DisabledTextStructureTests.cs
@@ -121,6 +121,77 @@ class P {
                 Region("span", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
+        [WorkItem(459257, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=459257")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task NestedDisabledCodePreProcessorDirectivesWithElseShouldCollapseEntireDisabledRegion()
+        {
+            const string code = @"
+class P {
+#if Goo
+{|span:    void $$M()
+    {
+#if Bar
+       M();
+#else
+
+#endif
+        }|}
+#endif
+    }
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [WorkItem(459257, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=459257")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task NestedDisabledCodePreProcessorDirectivesWithElifShouldCollapseEntireDisabledRegion()
+        {
+            const string code = @"
+class P {
+#if Goo
+{|span:    void $$M()
+    {
+#if Bar
+       M();
+#elif Baz
+
+#endif
+        }|}
+#endif
+    }
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [WorkItem(459257, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=459257")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task NestedDisabledCodePreProcessorDirectivesWithElseAndElifShouldCollapseEntireDisabledRegion()
+        {
+            const string code = @"
+class P {
+#if Goo
+{|span:    void $$M()
+    {
+#if Bar
+       M();
+#else
+
+#elif Baz
+
+#endif
+        }|}
+#endif
+    }
+";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
         [WorkItem(1070677, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070677")]
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task NestedDisabledCodePreProcessorDirectivesShouldCollapseEntireDisabledRegion2()

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -59,18 +59,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var nestedIfDirectiveTrivia = 0;
             for (var i = indexInParent; i < parentTriviaList.Count; i++)
             {
-                if (parentTriviaList[i].IsKind(SyntaxKind.IfDirectiveTrivia))
+                var currentTrivia = parentTriviaList[i];
+                if (currentTrivia.IsKind(SyntaxKind.IfDirectiveTrivia))
                 {
                     nestedIfDirectiveTrivia++;
+                    continue;
                 }
 
-                if (parentTriviaList[i].IsKind(SyntaxKind.EndIfDirectiveTrivia) ||
-                    parentTriviaList[i].IsKind(SyntaxKind.ElifDirectiveTrivia) ||
-                    parentTriviaList[i].IsKind(SyntaxKind.ElseDirectiveTrivia))
+                var isEndIf = currentTrivia.IsKind(SyntaxKind.EndIfDirectiveTrivia);
+                if (isEndIf ||
+                    currentTrivia.IsKind(SyntaxKind.ElifDirectiveTrivia) ||
+                    currentTrivia.IsKind(SyntaxKind.ElseDirectiveTrivia))
                 {
                     if (nestedIfDirectiveTrivia > 0)
                     {
-                        nestedIfDirectiveTrivia--;
+                        if (isEndIf)
+                        {
+                            nestedIfDirectiveTrivia--;
+                        }
                     }
                     else
                     {

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 switch (currentTrivia.Kind())
                 {
                     case SyntaxKind.IfDirectiveTrivia:
-                        // Hit a nested if directive.  Keep track of this so we can ensure
+                        // Hit a nested #if directive.  Keep track of this so we can ensure
                         // that our actual disabled region reached the right end point.
                         nestedIfDirectiveTrivia++;
                         continue;

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Structure;

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -61,8 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
 
             var endPos = GetEndPositionIncludingLastNewLine(trivia, parentTriviaList, indexInParent);
-
-            // Now, exclude the last newline if there is one.
             endPos = GetEndPositionExludingLastNewLine(syntaxTree, endPos, cancellationToken);
 
             var span = TextSpan.FromBounds(startPos, endPos);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=459257

:link: https://developercommunity.visualstudio.com/content/problem/73436/vs2017-c-editor-problem-with-nested-if-else-endif.html