### PR TITLE
Add binding redirects for System.ValueTuple and System.Xml.ReaderWriter

### DIFF
--- a/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -55,5 +55,11 @@
     <SuggestedBindingRedirects Include="System.Security.Principal.Windows, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <MaxVersion>4.0.1.0</MaxVersion>
     </SuggestedBindingRedirects>
+    <SuggestedBindingRedirects Include="System.ValueTuple, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <MaxVersion>4.0.1.0</MaxVersion>
+    </SuggestedBindingRedirects>
+    <SuggestedBindingRedirects Include="System.Xml.ReaderWriter, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <MaxVersion>4.1.0.0</MaxVersion>
+    </SuggestedBindingRedirects>
   </ItemGroup>
 </Project>

--- a/src/Interactive/Host/InteractiveHost.csproj
+++ b/src/Interactive/Host/InteractiveHost.csproj
@@ -2,6 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\build\Targets\Settings.props" />
+  <Import Project="..\..\..\build\Targets\GenerateCompilerExecutableBindingRedirects.targets" />
   <PropertyGroup>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -11,7 +12,6 @@
     <AssemblyName>InteractiveHost</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <RuntimeIdentifiers>win7</RuntimeIdentifiers>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">


### PR DESCRIPTION
This is a mitigation for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/467584

The issue is that when you install 4.7.1 after installing VS, the binaries that depend on "any facade that we have either introduced or that we have changed in 4.7.1" should be ngen'ed again, but they are not. 
The impact is that the compiler (VBCSCompiler.exe, csc.exe, etc) is JIT'ed on every run, resulting is significant performance degradation (50%) which RPS caught.

This PR for 15.3 preview 2 adds binding redirects (without changing the version of the assemblies selected) as a mitigation. We verified those manually.

The binding redirects are shown below. They get added to 5 core binaries (csi, vbi, csc, vbc, VBCSCompiler) and also InteractiveHost.

```xml
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
      </dependentAssembly>
    </assemblyBinding>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
      </dependentAssembly>
    </assemblyBinding>
```