### PR TITLE
Add null checks for node and its parent in NewLineUserSettingFormattingRule.IsControlBlock

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -11,12 +11,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         private bool IsControlBlock(SyntaxNode node)
         {
-            if (node.Kind() == SyntaxKind.SwitchStatement)
+            if (node?.Kind() == SyntaxKind.SwitchStatement)
             {
                 return true;
             }
 
-            var parentKind = node?.Parent.Kind();
+            var parentKind = node?.Parent?.Kind();
             switch (parentKind.GetValueOrDefault())
             {
                 case SyntaxKind.IfStatement:


### PR DESCRIPTION
**Customer scenario**

If syntax tree has `NamespaceDeclaration` as a root node instead of `CompilationUnit`, `IsControlBlock` is called for `NamespaceDeclaration` node which has null `Parent`, and this code throws `NullReferenceException` at line 19. This is not a common scenario, as valid trees are supposed to have `CompilationUnit` as a root node, but it's better to have the checks in place.

**Workarounds, if any**

Use `CompilationUnit` as root node of the tree.

**Risk**

Low because these checks were present in the code before.

**Performance impact**

Low perf impact because the only extra work done is two null checks.

**Is this a regression from a previous update?**

Yes, these checks were removed in 146b391d5b622df48da465ded66f2747375ab1b9.

**How was the bug found?**

Customer reported

