### PR TITLE
Add function name terminator to its synthesized method name

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         LambdaMethod = 'b',
         LambdaDisplayClass = 'c',
         StateMachineType = 'd',
-        LocalFunction = 'g',
+        LocalFunction = 'g', // note collision with Deprecated_InitializerLocal, however this one is only used for method names
 
         // Used by EnC:
         AwaiterField = 'u',

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private const string SuffixSeparator = "__";
         private const char IdSeparator = '_';
         private const char GenerationSeparator = '#';
+        private const char LocalFunctionNameTerminator = '|';
 
         internal static bool IsGeneratedMemberName(string memberName)
         {
@@ -149,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(lambdaOrdinal >= 0);
             Debug.Assert(lambdaGeneration >= 0);
 
-            return MakeMethodScopedSynthesizedName(GeneratedNameKind.LocalFunction, methodOrdinal, methodGeneration, methodName, localFunctionName, lambdaOrdinal, lambdaGeneration);
+            return MakeMethodScopedSynthesizedName(GeneratedNameKind.LocalFunction, methodOrdinal, methodGeneration, methodName, localFunctionName, LocalFunctionNameTerminator, lambdaOrdinal, lambdaGeneration);
         }
 
         private static string MakeMethodScopedSynthesizedName(
@@ -158,6 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int methodGeneration,
             string methodNameOpt = null,
             string suffix = null,
+            char suffixTerminator = default,
             int entityOrdinal = -1,
             int entityGeneration = -1)
         {
@@ -195,6 +197,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 builder.Append(SuffixSeparator);
                 builder.Append(suffix);
+
+                if (suffixTerminator != default)
+                {
+                    builder.Append(suffixTerminator);
+                }
 
                 if (methodOrdinal >= 0)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -1555,7 +1555,7 @@ public class C
   IL_0044:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
   IL_0049:  ldloc.1
   IL_004a:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-  IL_004f:  call       ""void C.<Main>g__L10_0(int)""
+  IL_004f:  call       ""void C.<Main>g__L1|0_0(int)""
   IL_0054:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
   IL_0059:  brtrue.s   IL_007f
   IL_005b:  ldc.i4.0
@@ -1572,7 +1572,7 @@ public class C
   IL_008e:  ldloc.1
   IL_008f:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
   IL_0094:  ldloca.s   V_0
-  IL_0096:  call       ""System.Action<int> C.<Main>g__L20_1(int, ref C.<>c__DisplayClass0_0)""
+  IL_0096:  call       ""System.Action<int> C.<Main>g__L2|0_1(int, ref C.<>c__DisplayClass0_0)""
   IL_009b:  stloc.2
   IL_009c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
   IL_00a1:  brtrue.s   IL_00db

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -586,7 +586,7 @@ class C
   IL_0016:  call       ""void System.Console.WriteLine(int)""
   IL_001b:  ldarg.0
   IL_001c:  ldloca.s   V_0
-  IL_001e:  call       ""void C.<M>g__L12_0(ref C.<>c__DisplayClass2_0)""
+  IL_001e:  call       ""void C.<M>g__L1|2_0(ref C.<>c__DisplayClass2_0)""
   IL_0023:  ldarg.0
   IL_0024:  ldfld      ""int C._x""
   IL_0029:  call       ""void System.Console.WriteLine(int)""
@@ -594,39 +594,39 @@ class C
 }");
 
             // L1
-            verifier.VerifyIL("C.<M>g__L12_0(ref C.<>c__DisplayClass2_0)", @"
+            verifier.VerifyIL("C.<M>g__L1|2_0(ref C.<>c__DisplayClass2_0)", @"
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
-  IL_0002:  call       ""void C.<M>g__L22_1(ref C.<>c__DisplayClass2_0)""
+  IL_0002:  call       ""void C.<M>g__L2|2_1(ref C.<>c__DisplayClass2_0)""
   IL_0007:  ret
 }");
             // L2
-            verifier.VerifyIL("C.<M>g__L22_1(ref C.<>c__DisplayClass2_0)", @"
+            verifier.VerifyIL("C.<M>g__L2|2_1(ref C.<>c__DisplayClass2_0)", @"
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
-  IL_0002:  call       ""void C.<M>g__L32_3(ref C.<>c__DisplayClass2_0)""
+  IL_0002:  call       ""void C.<M>g__L3|2_3(ref C.<>c__DisplayClass2_0)""
   IL_0007:  ret
 }");
             // Skip some... L5
-            verifier.VerifyIL("C.<M>g__L52_5(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
+            verifier.VerifyIL("C.<M>g__L5|2_5(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
 {
   // Code size       10 (0xa)
   .maxstack  3
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
   IL_0002:  ldarg.2
-  IL_0003:  call       ""int C.<M>g__L62_6(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)""
+  IL_0003:  call       ""int C.<M>g__L6|2_6(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)""
   IL_0008:  pop
   IL_0009:  ret
 }");
             // L6
-            verifier.VerifyIL("C.<M>g__L62_6(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
+            verifier.VerifyIL("C.<M>g__L6|2_6(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
 {
   // Code size       25 (0x19)
   .maxstack  4
@@ -4865,7 +4865,7 @@ class Program
   IL_0033:  ldloca.s   V_0
   IL_0035:  ldloca.s   V_1
   IL_0037:  ldloca.s   V_2
-  IL_0039:  call       ""void Program.<Main>g__Print0_0(ref Program.<>c__DisplayClass0_0, ref Program.<>c__DisplayClass0_1, ref Program.<>c__DisplayClass0_2)""
+  IL_0039:  call       ""void Program.<Main>g__Print|0_0(ref Program.<>c__DisplayClass0_0, ref Program.<>c__DisplayClass0_1, ref Program.<>c__DisplayClass0_2)""
   IL_003e:  ret
 }
 ");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -1557,9 +1557,9 @@ class Program
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  call       ""ref int Program.<M>g__N0_0()""
+  IL_0000:  call       ""ref int Program.<M>g__N|0_0()""
   IL_0005:  ret
-}").VerifyIL("Program.<M>g__N0_0", @"
+}").VerifyIL("Program.<M>g__N|0_0", @"
 {
   // Code size       13 (0xd)
   .maxstack  2
@@ -1615,9 +1615,9 @@ class Program
   IL_000c:  stelem.i4
   IL_000d:  stfld      ""int[] Program.<>c__DisplayClass0_0.arr""
   IL_0012:  ldloca.s   V_0
-  IL_0014:  call       ""ref int Program.<M>g__N0_0(ref Program.<>c__DisplayClass0_0)""
+  IL_0014:  call       ""ref int Program.<M>g__N|0_0(ref Program.<>c__DisplayClass0_0)""
   IL_0019:  ret
-}").VerifyIL("Program.<M>g__N0_0", @"
+}").VerifyIL("Program.<M>g__N|0_0", @"
 {
   // Code size       24 (0x18)
   .maxstack  4
@@ -1625,7 +1625,7 @@ class Program
   IL_0001:  ldfld      ""int[] Program.<>c__DisplayClass0_0.arr""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelema    ""int""
-  IL_000c:  call       ""ref int Program.<M>g__NN0_1(ref int)""
+  IL_000c:  call       ""ref int Program.<M>g__NN|0_1(ref int)""
   IL_0011:  dup
   IL_0012:  dup
   IL_0013:  ldind.i4
@@ -1633,7 +1633,7 @@ class Program
   IL_0015:  add
   IL_0016:  stind.i4
   IL_0017:  ret
-}").VerifyIL("Program.<M>g__NN0_1", @"
+}").VerifyIL("Program.<M>g__NN|0_1", @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -1690,10 +1690,10 @@ class Program
   IL_0011:  stelem.i4
   IL_0012:  stfld      ""int[] Program.<>c__DisplayClass1_0.arr""
   IL_0017:  ldloc.0
-  IL_0018:  ldftn      ""ref int Program.<>c__DisplayClass1_0.<M>g__N0()""
+  IL_0018:  ldftn      ""ref int Program.<>c__DisplayClass1_0.<M>g__N|0()""
   IL_001e:  newobj     ""Program.D..ctor(object, System.IntPtr)""
   IL_0023:  ret
-}").VerifyIL("Program.<>c__DisplayClass1_0.<M>g__N0()", @"
+}").VerifyIL("Program.<>c__DisplayClass1_0.<M>g__N|0()", @"
 {
   // Code size       24 (0x18)
   .maxstack  4
@@ -1701,7 +1701,7 @@ class Program
   IL_0001:  ldfld      ""int[] Program.<>c__DisplayClass1_0.arr""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelema    ""int""
-  IL_000c:  call       ""ref int Program.<M>g__NN1_1(ref int)""
+  IL_000c:  call       ""ref int Program.<M>g__NN|1_1(ref int)""
   IL_0011:  dup
   IL_0012:  dup
   IL_0013:  ldind.i4
@@ -1709,7 +1709,7 @@ class Program
   IL_0015:  add
   IL_0016:  stind.i4
   IL_0017:  ret
-}").VerifyIL("Program.<M>g__NN1_1(ref int)", @"
+}").VerifyIL("Program.<M>g__NN|1_1(ref int)", @"
 {
   // Code size        2 (0x2)
   .maxstack  1

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -2401,11 +2401,11 @@ class C
             var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
 
             AssertNotInstrumented(verifier, "C.M1");
-            AssertNotInstrumented(verifier, "C.<M1>g__L10_0");
+            AssertNotInstrumented(verifier, "C.<M1>g__L1|0_0");
             AssertNotInstrumented(verifier, "C.<>c.<M1>b__0_1");
 
             AssertInstrumented(verifier, "C.M2");
-            AssertInstrumented(verifier, "C.<>c__DisplayClass1_0.<M2>g__L20"); // M2:L2
+            AssertInstrumented(verifier, "C.<>c__DisplayClass1_0.<M2>g__L2|0"); // M2:L2
             AssertInstrumented(verifier, "C.<>c__DisplayClass1_0.<M2>b__1"); // M2:L2 lambda
         }
 
@@ -2468,13 +2468,13 @@ class C
 
             AssertNotInstrumented(verifier, "C.P1.get");
             AssertNotInstrumented(verifier, "C.P1.set");
-            AssertNotInstrumented(verifier, "C.<get_P1>g__L11_0");
-            AssertNotInstrumented(verifier, "C.<set_P1>g__L22_0");
+            AssertNotInstrumented(verifier, "C.<get_P1>g__L1|1_0");
+            AssertNotInstrumented(verifier, "C.<set_P1>g__L2|2_0");
 
             AssertInstrumented(verifier, "C.P2.get");
             AssertInstrumented(verifier, "C.P2.set");
-            AssertInstrumented(verifier, "C.<get_P2>g__L34_0");
-            AssertInstrumented(verifier, "C.<set_P2>g__L45_0");
+            AssertInstrumented(verifier, "C.<get_P2>g__L3|4_0");
+            AssertInstrumented(verifier, "C.<set_P2>g__L4|5_0");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -7401,7 +7401,7 @@ partial class C
         <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
       </sequencePoints>
     </method>
-    <method containingType=""Program"" name=""&lt;Main&gt;g__Local10_0"" parameterNames=""a"">
+    <method containingType=""Program"" name=""&lt;Main&gt;g__Local1|0_0"" parameterNames=""a"">
       <customDebugInfo>
         <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
@@ -7409,7 +7409,7 @@ partial class C
         <entry offset=""0x0"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""21"" />
       </sequencePoints>
     </method>
-    <method containingType=""Program"" name=""&lt;Main&gt;g__Local20_1"" parameterNames=""a"">
+    <method containingType=""Program"" name=""&lt;Main&gt;g__Local2|0_1"" parameterNames=""a"">
       <customDebugInfo>
         <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
         <encLocalSlotMap>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
@@ -413,11 +413,11 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
             var verifier = CompileAndVerify(compilation);
             verifier.VerifyDiagnostics();
             var testData = verifier.TestData;
-            var method = (MethodSymbol)testData.GetMethodData("C.<M>g__F0_0()").Method;
+            var method = (MethodSymbol)testData.GetMethodData("C.<M>g__F|0_0()").Method;
             Assert.True(method.IsAsync);
             Assert.True(method.IsTaskReturningAsync(compilation));
             Assert.Equal("MyTask", method.ReturnType.ToDisplayString());
-            method = (MethodSymbol)testData.GetMethodData("C.<M>g__G0_1<T>(T)").Method;
+            method = (MethodSymbol)testData.GetMethodData("C.<M>g__G|0_1<T>(T)").Method;
             Assert.True(method.IsAsync);
             Assert.True(method.IsGenericTaskReturningAsync(compilation));
             Assert.Equal("MyTask<T>", method.ReturnType.ToDisplayString());

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F>g__G0_0");
+                var context = CreateMethodContext(runtime, "C.<F>g__G|0_0");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F>g__G0_0");
+                var context = CreateMethodContext(runtime, "C.<F>g__G|0_0");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F>g__G1_0");
+                var context = CreateMethodContext(runtime, "C.<F>g__G|1_0");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F1>g__F30_1");
+                var context = CreateMethodContext(runtime, "C.<F1>g__F3|0_1");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F>g__G0_0");
+                var context = CreateMethodContext(runtime, "C.<F>g__G|0_0");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<F>g__G0_0");
+                var context = CreateMethodContext(runtime, "C.<F>g__G|0_0");
                 var testData = new CompilationTestData();
                 string error;
                 context.CompileExpression("value", out error, testData);


### PR DESCRIPTION
Enables extracting local function name from the name of the synthesized method unambiguously.

Fixes https://github.com/dotnet/roslyn/issues/21822