### PR TITLE
Interactive window to prefer tuple types from mscorlib

### DIFF
--- a/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/CSharp/Interactive/CSharpInteractiveEvaluator.cs
@@ -60,7 +60,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Interactive
                 usings: imports,
                 sourceReferenceResolver: sourceReferenceResolver,
                 metadataReferenceResolver: metadataReferenceResolver,
-                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
+                assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default
+                ).WithTopLevelBinderFlags(BinderFlags.IgnoreCorLibraryDuplicatedTypes);
         }
 
         public override bool CanExecuteCode(string text)


### PR DESCRIPTION
The Interactive window was showing squiggles on tuples on .NET Framework 4.7 (because the ValueTuple type was not properly unified). We're applying the same fix that we used for the processing of interactive submissions, namely to [prefer types from mscorlib](https://github.com/dotnet/roslyn/pull/17192).

Before:
![image](https://user-images.githubusercontent.com/12466233/29936891-961a2520-8e38-11e7-90bd-a3e24e9025cc.png)

After:
![image](https://user-images.githubusercontent.com/12466233/29937588-f584263a-8e3a-11e7-85b8-adf55fd0e422.png)

Fixes https://github.com/dotnet/roslyn/issues/21156
Fixes https://github.com/dotnet/roslyn/issues/20688
@tmat @dotnet/roslyn-interactive for review.