### PR TITLE
VB: handle typeless tuple in array initializer

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -4534,8 +4534,7 @@ lElseClause:
                         allConvertibleToObject = False
                     End If
 
-                    ' this will pick up lambdas which couldn't be inferred, typeless tuples, and array literals which lacked a dominant type,
-                    ' and AddressOf expressions.
+                    ' this will pick up AddressOf expressions.
                 End If
             Next
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -4499,7 +4499,9 @@ lElseClause:
 
                 ElseIf expressionKind = BoundKind.TupleLiteral Then
                     expressionType = DirectCast(expression, BoundTupleLiteral).InferredType
-                    typeList.AddType(expressionType, RequiredConversion.Any, expression)
+                    If expressionType IsNot Nothing Then
+                        typeList.AddType(expressionType, RequiredConversion.Any, expression)
+                    End If
 
                 ElseIf expressionKind = BoundKind.ArrayLiteral Then
                     Dim arrayLiteral = DirectCast(expression, BoundArrayLiteral)
@@ -4532,7 +4534,7 @@ lElseClause:
                         allConvertibleToObject = False
                     End If
 
-                    ' this will pick up lambdas which couldn't be inferred, and array literals which lacked a dominant type,
+                    ' this will pick up lambdas which couldn't be inferred, typeless tuples, and array literals which lacked a dominant type,
                     ' and AddressOf expressions.
                 End If
             Next

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -20833,6 +20833,46 @@ End Module
     'Public Sub M1(Of Integer, (Integer, Integer))(a As ((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, (Integer, Integer)))': Not most specific.").WithLocation(7, 9)
                 )
         End Sub
+
+        <Fact>
+        <WorkItem(21785, "https://github.com/dotnet/roslyn/issues/21785")>
+        Public Sub TypelessTupleInArrayInitializer()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Module Module1
+    Private mTupleArray As (X As Integer, P As System.Func(Of Byte(), Integer))() = {
+            (X:=0, P:=Nothing), (X:=0, P:=AddressOf MyFunction)
+        }
+
+    Sub Main()
+        System.Console.Write(mTupleArray(1).P(Nothing))
+    End Sub
+
+    Public Function MyFunction(ArgBytes As Byte()) As Integer
+        Return 1
+    End Function
+End Module
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs, options:=TestOptions.DebugExe)
+            comp.AssertNoDiagnostics()
+            CompileAndVerify(comp, expectedOutput:="1")
+
+            Dim tree = comp.SyntaxTrees(0)
+
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().ElementAt(1)
+
+            Assert.Equal("(X:=0, P:=AddressOf MyFunction)", node.ToString())
+            Dim tupleSymbol = model.GetTypeInfo(node)
+            Assert.Null(tupleSymbol.Type)
+
+            Assert.Equal("(X As System.Int32, P As System.Func(Of System.Byte(), System.Int32))",
+                         tupleSymbol.ConvertedType.ToTestDisplayString())
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
A typeless tuple in a VB array initializer would crash. For example: `Dim mTupleArray As (X As Integer, P As System.Func(Of Byte(), Integer))() = { (X:=0, P:=AddressOf MyFunction) }`.
The logic for determining the dominant type could handle typeless expressions (like `AddressOf MyFunction`), but not typeless tuples.

Fixes https://github.com/dotnet/roslyn/issues/21785
