### PR TITLE
Harden against null in GetInfoAsync

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
@@ -21,6 +21,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
             try
             {
                 var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                if (root == null)
+                {
+                    return default;
+                }
+
                 var token = root.FindToken(position);
 
                 var expression = token.Parent as ExpressionSyntax;


### PR DESCRIPTION
GetSyntaxRootAsync might return null if the document doesn't support syntax tree (JavaScript)

Fixes VSO bug 404601