### PR TITLE
Val-escape for a struct field should defer to _val_ escape of the receiver

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1903,7 +1903,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(!fieldSymbol.IsStatic && fieldSymbol.ContainingType.IsByRefLikeType);
 
                     // for ref-like fields defer to the receiver.
-                    return GetRefEscape(fieldAccess.ReceiverOpt, scopeOfTheContainingExpression);
+                    return GetValEscape(fieldAccess.ReceiverOpt, scopeOfTheContainingExpression);
 
                 case BoundKind.Call:
                     var call = (BoundCall)expr;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -84,21 +84,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _scopeBinder.ScopeDesignator; }
         }
 
-        internal override uint RefEscapeScope
-        {
-            get
-            {
-                return _refEscapeScope;
-            }
-        }
+        internal override uint RefEscapeScope => _refEscapeScope;
 
-        internal override uint ValEscapeScope
-        {
-            get
-            {
-                return _valEscapeScope;
-            }
-        }
+        internal override uint ValEscapeScope => _valEscapeScope;
 
         /// <summary>
         /// Binder that should be used to bind type syntax for the local.


### PR DESCRIPTION
Val-escape for a struct field should defer to _val_ escape of the receiver

Fixes:#21858