### PR TITLE
Complete goto default; without extra colon

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLabelSymbol.cs
@@ -44,6 +44,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var node = _identifierNodeOrToken.AsNode();
             if (node != null)
             {
+                if (node.Kind() == SyntaxKind.DefaultSwitchLabel)
+                {
+                    return ((DefaultSwitchLabelSyntax)node).Keyword.ToString();
+                }
+
                 return node.ToString();
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -1493,7 +1493,7 @@ label1:
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
             var symbols = model.LookupLabels(source.ToString().IndexOf("HERE", StringComparison.Ordinal));
-            Assert.Equal(new[] { "default", "case int i:", "label1" }, symbols.Select(s => s.ToTestDisplayString()));
+            AssertEx.SetEqual(new[] { "default", "case int i:", "label1" }, symbols.Select(s => s.ToTestDisplayString()));
         }
 
         [WorkItem(586815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586815")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -1468,6 +1468,34 @@ label1:
             Assert.True(symbols.IsEmpty);
         }
 
+        [Fact]
+        public void GotoLabelShouldNotHaveColon()
+        {
+            var source = @"
+class Program
+{
+    static void M(object o)
+    {
+        switch (o)
+        {
+            case int i:
+                goto HERE;
+            default:
+@default:
+label1:
+                break;
+        }
+    }
+}
+";
+
+            var compilation = CreateStandardCompilation(source);
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+            var symbols = model.LookupLabels(source.ToString().IndexOf("HERE", StringComparison.Ordinal));
+            Assert.Equal(new[] { "default", "case int i:", "label1" }, symbols.Select(s => s.ToTestDisplayString()));
+        }
+
         [WorkItem(586815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586815")]
         [WorkItem(598371, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/598371")]
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -5608,9 +5608,9 @@ namespace System
 ";
             var compilation = CreateCompilationWithMscorlib45(source);
             compilation.VerifyDiagnostics(
-                // (9,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
+                // (9,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
                 //             default:
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(9, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(9, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -377,19 +377,48 @@ public class TestClass
     }
 }";
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
-                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
                 //             default:            //CS0152
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(15, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(15, 13)
                 );
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
-                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
                 //             default:            //CS0152
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(15, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(15, 13)
                 );
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
                 //             default:            //CS0152
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(15, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(15, 13)
+                );
+        }
+
+        [Fact]
+        public void CS0152_DuplicateDefaultLabel2()
+        {
+            var text = @"
+public class TestClass
+{
+    public static void Main()
+    {
+        int i = 10;
+        switch (i)
+        {
+            default:
+                break;
+            case (default):
+                break;
+            case 1:
+                break;
+            default:            //CS0152
+                break;
+        }
+    }
+}";
+            CreateStandardCompilation(text, parseOptions: TestOptions.Regular7_1).VerifyDiagnostics(
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
+                //             default:            //CS0152
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(15, 13)
                 );
         }
 
@@ -2483,17 +2512,17 @@ class Test
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (14,13): error CS8070: Control cannot fall out of switch from final case label ('default')
                 //             default:                        // CS8070
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(14, 13)
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default").WithLocation(14, 13)
                 );
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
-                // (14,13): error CS8070: Control cannot fall out of switch from final case label ('default')
+                // (14,13): error CS8070: Control cannot fall out of switch from final case label ('default:')
                 //             default:                        // CS8070
                 Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(14, 13)
                 );
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (14,13): error CS8070: Control cannot fall out of switch from final case label ('default')
                 //             default:                        // CS8070
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(14, 13)
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default").WithLocation(14, 13)
                 );
         }
 
@@ -2589,9 +2618,10 @@ namespace Test
                 // (24,17): error CS8070: Control cannot fall out of switch from final case label ('case 5:')
                 //                 case 5:
                 Diagnostic(ErrorCode.ERR_SwitchFallOut, "case 5:").WithArguments("case 5:").WithLocation(24, 17),
-                // (32,17): error CS8070: Control cannot fall out of switch from final case label ('default:')
+                // (32,17): error CS8070: Control cannot fall out of switch from final case label ('default')
                 //                 default:
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(32, 17));
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default").WithLocation(32, 17)
+                );
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (15,17): error CS8070: Control cannot fall out of switch from final case label ('case 11:')
                 //                 case 11:
@@ -2601,7 +2631,8 @@ namespace Test
                 Diagnostic(ErrorCode.ERR_SwitchFallOut, "case 5:").WithArguments("case 5:").WithLocation(24, 17),
                 // (32,17): error CS8070: Control cannot fall out of switch from final case label ('default:')
                 //                 default:
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(32, 17));
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(32, 17) // BUG
+                );
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (15,17): error CS8070: Control cannot fall out of switch from final case label ('case 11:')
                 //                 case 11:
@@ -2609,9 +2640,10 @@ namespace Test
                 // (24,17): error CS8070: Control cannot fall out of switch from final case label ('case 5:')
                 //                 case 5:
                 Diagnostic(ErrorCode.ERR_SwitchFallOut, "case 5:").WithArguments("case 5:").WithLocation(24, 17),
-                // (32,17): error CS8070: Control cannot fall out of switch from final case label ('default:')
+                // (32,17): error CS8070: Control cannot fall out of switch from final case label ('default')
                 //                 default:
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(32, 17));
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default").WithLocation(32, 17)
+                );
         }
 
         [Fact]
@@ -2627,9 +2659,9 @@ switch (1)
         Console.WriteLine(2);
 }";
             CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script).VerifyDiagnostics(
-                // (4,5): error CS0163: Control cannot fall through from one case label ('default:') to another
+                // (4,5): error CS0163: Control cannot fall through from one case label ('default') to another
                 //     default:
-                Diagnostic(ErrorCode.ERR_SwitchFallThrough, "default:").WithArguments("default:").WithLocation(4, 5),
+                Diagnostic(ErrorCode.ERR_SwitchFallThrough, "default:").WithArguments("default").WithLocation(4, 5),
                 // (6,5): error CS8070: Control cannot fall out of switch from final case label ('case 2:')
                 //     case 2:
                 Diagnostic(ErrorCode.ERR_SwitchFallOut, "case 2:").WithArguments("case 2:").WithLocation(6, 5)
@@ -2656,9 +2688,9 @@ switch (1)
                 // (4,5): error CS0163: Control cannot fall through from one case label ('case 1:') to another
                 //     case 1:
                 Diagnostic(ErrorCode.ERR_SwitchFallThrough, "case 1:").WithArguments("case 1:").WithLocation(4, 5),
-                // (6,5): error CS8070: Control cannot fall out of switch from final case label ('default:')
+                // (6,5): error CS8070: Control cannot fall out of switch from final case label ('default')
                 //     default:
-                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(6, 5)
+                Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default").WithLocation(6, 5)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -705,7 +705,7 @@ class C
             var labelSymbol = (SourceLabelSymbol)symbol1;
             Assert.Null(labelSymbol.SwitchCaseLabelConstant);
             Assert.Equal(switchLabel, labelSymbol.IdentifierNodeOrToken.AsNode());
-            Assert.Equal("default:", labelSymbol.Name);
+            Assert.Equal("default", labelSymbol.Name);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
@@ -638,7 +638,7 @@ class C1
             CheckDeclaringSyntax<LabeledStatementSyntax>(comp, tree, "lab3", SymbolKind.Label);
             CheckDeclaringSyntax<SwitchLabelSyntax>(comp, tree, "case 4:", SymbolKind.Label);
             CheckDeclaringSyntax<SwitchLabelSyntax>(comp, tree, "case 3:", SymbolKind.Label);
-            CheckDeclaringSyntax<SwitchLabelSyntax>(comp, tree, "default:", SymbolKind.Label);
+            CheckDeclaringSyntax<SwitchLabelSyntax>(comp, tree, "default", SymbolKind.Label);
         }
 
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -2261,7 +2261,7 @@ class Program
             default:
                 goto $$";
 
-            await VerifyItemExistsAsync(markup, "default:");
+            await VerifyItemExistsAsync(markup, "default");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -575,6 +575,97 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestDefaultSwitchLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+        switch (o)
+        {
+            default:
+                goto $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestGotoOrdinaryLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+label1:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("l")
+                Await state.AssertSelectedCompletionItem(displayText:="label1", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto label1;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabel() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+@default:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="@default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto @default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabel2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+        switch (o)
+        {
+            default:
+@default:
+                goto $$
+        }
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -666,6 +666,27 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(4677, "https://github.com/dotnet/roslyn/issues/4677")>
+        Public Async Function TestEscapedDefaultLabelWithoutSwitch() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(object o)
+    {
+@default:
+        goto $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("d")
+                Await state.AssertSelectedCompletionItem(displayText:="@default", isHardSelected:=True)
+                state.SendTypeChars(";")
+                Assert.Contains("goto @default;", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -107,6 +107,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
             }
 
+            if (symbol.Kind == SymbolKind.Label &&
+                symbol.DeclaringSyntaxReferences[0].GetSyntax().Kind() == SyntaxKind.DefaultSwitchLabel)
+            {
+                return symbol.Name;
+            }
+
             return symbol.Name.EscapeIdentifier(isQueryContext: context.IsInQuery);
         }
     }


### PR DESCRIPTION
Type "goto default;" and use completion for "default". You end up with "goto default:;".
The reason is that the name for that label symbol included the colon, which this PR fixes.
But doing so results in "default" getting escaped to `@default` during completion, which this PR mitigates.

Fixes https://github.com/dotnet/roslyn/issues/4677