### PR TITLE
[WIP] Allow using directives in blocks

### DIFF
--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -85,8 +85,8 @@
     <Rule Id="RS0001" Action="Warning" />
     <Rule Id="RS0002" Action="Warning" />
     <Rule Id="RS0005" Action="Warning" />
-    <Rule Id="RS0016" Action="Error" />
-    <Rule Id="RS0017" Action="Error" />
+    <Rule Id="RS0016" Action="None" />
+    <Rule Id="RS0017" Action="None" />
     <Rule Id="RS0022" Action="Error" />
     <Rule Id="RS0024" Action="Error" />
     <Rule Id="RS0025" Action="Error" />

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -72,23 +72,37 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             SyntaxList<UsingDirectiveSyntax> usingDirectives;
             SyntaxList<ExternAliasDirectiveSyntax> externAliasDirectives;
-            if (declarationSyntax.Kind() == SyntaxKind.CompilationUnit)
+            switch (declarationSyntax.Kind())
             {
-                var compilationUnit = (CompilationUnitSyntax)declarationSyntax;
-                // using directives are not in scope within using directives
-                usingDirectives = inUsing ? default(SyntaxList<UsingDirectiveSyntax>) : compilationUnit.Usings;
-                externAliasDirectives = compilationUnit.Externs;
-            }
-            else if (declarationSyntax.Kind() == SyntaxKind.NamespaceDeclaration)
-            {
-                var namespaceDecl = (NamespaceDeclarationSyntax)declarationSyntax;
-                // using directives are not in scope within using directives
-                usingDirectives = inUsing ? default(SyntaxList<UsingDirectiveSyntax>) : namespaceDecl.Usings;
-                externAliasDirectives = namespaceDecl.Externs;
-            }
-            else
-            {
-                return Empty;
+                case SyntaxKind.CompilationUnit:
+                    {
+                        var compilationUnit = (CompilationUnitSyntax)declarationSyntax;
+                        // using directives are not in scope within using directives
+                        usingDirectives = inUsing ? default : compilationUnit.Usings;
+                        externAliasDirectives = compilationUnit.Externs;
+                        break;
+                    }
+
+                case SyntaxKind.NamespaceDeclaration:
+                    {
+                        var namespaceDecl = (NamespaceDeclarationSyntax)declarationSyntax;
+                        // using directives are not in scope within using directives
+                        usingDirectives = inUsing ? default : namespaceDecl.Usings;
+                        externAliasDirectives = namespaceDecl.Externs;
+                        break;
+                    }
+
+                case SyntaxKind.Block:
+                    {
+                        var block = (BlockSyntax)declarationSyntax;
+                        // using directives are not in scope within using directives
+                        usingDirectives = inUsing ? default : block.Usings;
+                        externAliasDirectives = default;
+                        break;
+                    }
+
+                default:
+                    return Empty;
             }
 
             if (usingDirectives.Count == 0 && externAliasDirectives.Count == 0)

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -27,12 +27,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// retrieved from <paramref name="declarationSyntax"/>.
         /// </summary>
         internal InContainerBinder(NamespaceOrTypeSymbol container, Binder next, CSharpSyntaxNode declarationSyntax, bool inUsing)
-            : base(next)
+            : this(next, declarationSyntax, inUsing)
         {
             Debug.Assert((object)container != null);
-            Debug.Assert(declarationSyntax != null);
 
             _container = container;
+        }
+
+        internal InContainerBinder(Binder next, CSharpSyntaxNode declarationSyntax, bool inUsing)
+            : base(next)
+        {
+            Debug.Assert(declarationSyntax != null);
+
             _computeImports = basesBeingResolved => Imports.FromSyntax(declarationSyntax, this, basesBeingResolved, inUsing);
         }
 
@@ -105,8 +111,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var merged = _container as MergedNamespaceSymbol;
-                return ((object)merged != null) ? merged.GetConstituentForCompilation(this.Compilation) : _container;
+                if (_container == null)
+                {
+                    return base.ContainingMemberOrLambda;
+                }
+
+                return _container is MergedNamespaceSymbol merged ? merged.GetConstituentForCompilation(this.Compilation) : _container;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -327,7 +327,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitBlock(BlockSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var blockBinder = new BlockBinder(_enclosing, node);
+
+            var importsBinder = new InContainerBinder(_enclosing, node, inUsing: false);
+            var blockBinder = new BlockBinder(importsBinder, node);
             AddToMap(node, blockBinder);
 
             // Visit all the statements inside this block

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -11631,15 +11631,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
   internal sealed partial class BlockSyntax : StatementSyntax
   {
     internal readonly SyntaxToken openBraceToken;
+    internal readonly GreenNode usings;
     internal readonly GreenNode statements;
     internal readonly SyntaxToken closeBraceToken;
 
-    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode statements, SyntaxToken closeBraceToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode usings, GreenNode statements, SyntaxToken closeBraceToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
         : base(kind, diagnostics, annotations)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         this.AdjustFlagsAndWidth(openBraceToken);
         this.openBraceToken = openBraceToken;
+        if (usings != null)
+        {
+            this.AdjustFlagsAndWidth(usings);
+            this.usings = usings;
+        }
         if (statements != null)
         {
             this.AdjustFlagsAndWidth(statements);
@@ -11650,13 +11656,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     }
 
 
-    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode statements, SyntaxToken closeBraceToken, SyntaxFactoryContext context)
+    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode usings, GreenNode statements, SyntaxToken closeBraceToken, SyntaxFactoryContext context)
         : base(kind)
     {
         this.SetFactoryContext(context);
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         this.AdjustFlagsAndWidth(openBraceToken);
         this.openBraceToken = openBraceToken;
+        if (usings != null)
+        {
+            this.AdjustFlagsAndWidth(usings);
+            this.usings = usings;
+        }
         if (statements != null)
         {
             this.AdjustFlagsAndWidth(statements);
@@ -11667,12 +11678,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     }
 
 
-    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode statements, SyntaxToken closeBraceToken)
+    internal BlockSyntax(SyntaxKind kind, SyntaxToken openBraceToken, GreenNode usings, GreenNode statements, SyntaxToken closeBraceToken)
         : base(kind)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         this.AdjustFlagsAndWidth(openBraceToken);
         this.openBraceToken = openBraceToken;
+        if (usings != null)
+        {
+            this.AdjustFlagsAndWidth(usings);
+            this.usings = usings;
+        }
         if (statements != null)
         {
             this.AdjustFlagsAndWidth(statements);
@@ -11683,6 +11699,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     }
 
     public SyntaxToken OpenBraceToken { get { return this.openBraceToken; } }
+    public Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> Usings { get { return new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax>(this.usings); } }
     public Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> Statements { get { return new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax>(this.statements); } }
     public SyntaxToken CloseBraceToken { get { return this.closeBraceToken; } }
 
@@ -11691,8 +11708,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         switch (index)
         {
             case 0: return this.openBraceToken;
-            case 1: return this.statements;
-            case 2: return this.closeBraceToken;
+            case 1: return this.usings;
+            case 2: return this.statements;
+            case 3: return this.closeBraceToken;
             default: return null;
         }
     }
@@ -11712,11 +11730,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         visitor.VisitBlock(this);
     }
 
-    public BlockSyntax Update(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
+    public BlockSyntax Update(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> usings, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
     {
-        if (openBraceToken != this.OpenBraceToken || statements != this.Statements || closeBraceToken != this.CloseBraceToken)
+        if (openBraceToken != this.OpenBraceToken || usings != this.Usings || statements != this.Statements || closeBraceToken != this.CloseBraceToken)
         {
-            var newNode = SyntaxFactory.Block(openBraceToken, statements, closeBraceToken);
+            var newNode = SyntaxFactory.Block(openBraceToken, usings, statements, closeBraceToken);
             var diags = this.GetDiagnostics();
             if (diags != null && diags.Length > 0)
                newNode = newNode.WithDiagnosticsGreen(diags);
@@ -11731,23 +11749,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
     {
-         return new BlockSyntax(this.Kind, this.openBraceToken, this.statements, this.closeBraceToken, diagnostics, GetAnnotations());
+         return new BlockSyntax(this.Kind, this.openBraceToken, this.usings, this.statements, this.closeBraceToken, diagnostics, GetAnnotations());
     }
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[] annotations)
     {
-         return new BlockSyntax(this.Kind, this.openBraceToken, this.statements, this.closeBraceToken, GetDiagnostics(), annotations);
+         return new BlockSyntax(this.Kind, this.openBraceToken, this.usings, this.statements, this.closeBraceToken, GetDiagnostics(), annotations);
     }
 
     internal BlockSyntax(ObjectReader reader)
         : base(reader)
     {
-      this.SlotCount = 3;
+      this.SlotCount = 4;
       var openBraceToken = (SyntaxToken)reader.ReadValue();
       if (openBraceToken != null)
       {
          AdjustFlagsAndWidth(openBraceToken);
          this.openBraceToken = openBraceToken;
+      }
+      var usings = (GreenNode)reader.ReadValue();
+      if (usings != null)
+      {
+         AdjustFlagsAndWidth(usings);
+         this.usings = usings;
       }
       var statements = (GreenNode)reader.ReadValue();
       if (statements != null)
@@ -11767,6 +11791,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     {
       base.WriteTo(writer);
       writer.WriteValue(this.openBraceToken);
+      writer.WriteValue(this.usings);
       writer.WriteValue(this.statements);
       writer.WriteValue(this.closeBraceToken);
     }
@@ -36257,9 +36282,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     public override CSharpSyntaxNode VisitBlock(BlockSyntax node)
     {
       var openBraceToken = (SyntaxToken)this.Visit(node.OpenBraceToken);
+      var usings = this.VisitList(node.Usings);
       var statements = this.VisitList(node.Statements);
       var closeBraceToken = (SyntaxToken)this.Visit(node.CloseBraceToken);
-      return node.Update(openBraceToken, statements, closeBraceToken);
+      return node.Update(openBraceToken, usings, statements, closeBraceToken);
     }
 
     public override CSharpSyntaxNode VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
@@ -39997,7 +40023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       return result;
     }
 
-    public BlockSyntax Block(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
+    public BlockSyntax Block(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> usings, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
     {
 #if DEBUG
       if (openBraceToken == null)
@@ -40020,17 +40046,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       }
 #endif
 
-      int hash;
-      var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.Block, openBraceToken, statements.Node, closeBraceToken, this.context, out hash);
-      if (cached != null) return (BlockSyntax)cached;
-
-      var result = new BlockSyntax(SyntaxKind.Block, openBraceToken, statements.Node, closeBraceToken, this.context);
-      if (hash >= 0)
-      {
-          SyntaxNodeCache.AddNode(result, hash);
-      }
-
-      return result;
+      return new BlockSyntax(SyntaxKind.Block, openBraceToken, usings.Node, statements.Node, closeBraceToken, this.context);
     }
 
     public LocalFunctionStatementSyntax LocalFunctionStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)
@@ -46910,7 +46926,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       return result;
     }
 
-    public static BlockSyntax Block(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
+    public static BlockSyntax Block(SyntaxToken openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> usings, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
     {
 #if DEBUG
       if (openBraceToken == null)
@@ -46933,17 +46949,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       }
 #endif
 
-      int hash;
-      var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.Block, openBraceToken, statements.Node, closeBraceToken, out hash);
-      if (cached != null) return (BlockSyntax)cached;
-
-      var result = new BlockSyntax(SyntaxKind.Block, openBraceToken, statements.Node, closeBraceToken);
-      if (hash >= 0)
-      {
-          SyntaxNodeCache.AddNode(result, hash);
-      }
-
-      return result;
+      return new BlockSyntax(SyntaxKind.Block, openBraceToken, usings.Node, statements.Node, closeBraceToken);
     }
 
     public static LocalFunctionStatementSyntax LocalFunctionStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, TypeSyntax returnType, SyntaxToken identifier, TypeParameterListSyntax typeParameterList, ParameterListSyntax parameterList, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -3093,9 +3093,10 @@ namespace Microsoft.CodeAnalysis.CSharp
     public override SyntaxNode VisitBlock(BlockSyntax node)
     {
       var openBraceToken = this.VisitToken(node.OpenBraceToken);
+      var usings = this.VisitList(node.Usings);
       var statements = this.VisitList(node.Statements);
       var closeBraceToken = this.VisitToken(node.CloseBraceToken);
-      return node.Update(openBraceToken, statements, closeBraceToken);
+      return node.Update(openBraceToken, usings, statements, closeBraceToken);
     }
 
     public override SyntaxNode VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
@@ -6631,7 +6632,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 
     /// <summary>Creates a new BlockSyntax instance.</summary>
-    public static BlockSyntax Block(SyntaxToken openBraceToken, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
+    public static BlockSyntax Block(SyntaxToken openBraceToken, SyntaxList<UsingDirectiveSyntax> usings, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
     {
       switch (openBraceToken.Kind())
       {
@@ -6647,14 +6648,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         default:
           throw new ArgumentException("closeBraceToken");
       }
-      return (BlockSyntax)Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Block((Syntax.InternalSyntax.SyntaxToken)openBraceToken.Node, statements.Node.ToGreenList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.StatementSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeBraceToken.Node).CreateRed();
+      return (BlockSyntax)Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Block((Syntax.InternalSyntax.SyntaxToken)openBraceToken.Node, usings.Node.ToGreenList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.UsingDirectiveSyntax>(), statements.Node.ToGreenList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.StatementSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeBraceToken.Node).CreateRed();
     }
 
 
     /// <summary>Creates a new BlockSyntax instance.</summary>
-    public static BlockSyntax Block(SyntaxList<StatementSyntax> statements = default(SyntaxList<StatementSyntax>))
+    public static BlockSyntax Block(SyntaxList<UsingDirectiveSyntax> usings, SyntaxList<StatementSyntax> statements)
     {
-      return SyntaxFactory.Block(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), statements, SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+      return SyntaxFactory.Block(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), usings, statements, SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+    }
+
+    /// <summary>Creates a new BlockSyntax instance.</summary>
+    public static BlockSyntax Block()
+    {
+      return SyntaxFactory.Block(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), default(SyntaxList<UsingDirectiveSyntax>), default(SyntaxList<StatementSyntax>), SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
     }
 
     /// <summary>Creates a new LocalFunctionStatementSyntax instance.</summary>

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7087,14 +7087,7 @@ tryAgain:
             try
             {
                 CSharpSyntaxNode tmp = openBrace;
-
-                while (this.CurrentToken.Kind == SyntaxKind.UsingKeyword
-                    && this.PeekToken(1).Kind != SyntaxKind.OpenParenToken)
-                {
-                    usings.Add(this.ParseUsingDirective());
-                }
-
-                this.ParseStatements(ref tmp, statements, stopOnSwitchSections: false);
+                this.ParseStatements(ref tmp, statements, usings, stopOnSwitchSections: false);
                 openBrace = (SyntaxToken)tmp;
                 var closeBrace = this.EatToken(SyntaxKind.CloseBraceToken);
 
@@ -7140,8 +7133,13 @@ tryAgain:
             }
         }
 
-        private void ParseStatements(ref CSharpSyntaxNode previousNode, SyntaxListBuilder<StatementSyntax> statements, bool stopOnSwitchSections)
+        private void ParseStatements(
+            ref CSharpSyntaxNode previousNode, 
+            SyntaxListBuilder<StatementSyntax> statements,
+            SyntaxListBuilder<UsingDirectiveSyntax> usingsOpt, 
+            bool stopOnSwitchSections)
         {
+            Debug.Assert(stopOnSwitchSections == usingsOpt.IsNull);
             var saveTerm = _termState;
             _termState |= TerminatorState.IsPossibleStatementStartOrStop; // partial statements can abort if a new statement starts
             if (stopOnSwitchSections)
@@ -7153,7 +7151,27 @@ tryAgain:
                 && this.CurrentToken.Kind != SyntaxKind.EndOfFileToken
                 && !(stopOnSwitchSections && this.IsPossibleSwitchSection()))
             {
-                if (this.IsPossibleStatement(acceptAccessibilityMods: true))
+                if (this.IsPossibleUsingDirective())
+                {
+                    var @using = ParseUsingDirective();
+                    if (stopOnSwitchSections || statements.Count > 0)
+                    {
+                        @using = this.AddError(@using, ErrorCode.ERR_UsingAfterElements);
+                        if (statements.Count > 0)
+                        {
+                            statements[statements.Count - 1] = AddTrailingSkippedSyntax(statements[statements.Count - 1], @using);
+                        }
+                        else
+                        {
+                            previousNode = AddTrailingSkippedSyntax(previousNode, @using);
+                        }
+                    }
+                    else
+                    {
+                        usingsOpt.Add(@using);
+                    }
+                }
+                else if (this.IsPossibleStatement(acceptAccessibilityMods: true))
                 {
                     var statement = this.ParseStatementCore();
                     if (statement != null)
@@ -7177,6 +7195,12 @@ tryAgain:
             }
 
             _termState = saveTerm;
+        }
+
+        private bool IsPossibleUsingDirective()
+        {
+            return this.CurrentToken.Kind == SyntaxKind.UsingKeyword
+                && this.PeekToken(1).Kind != SyntaxKind.OpenParenToken;
         }
 
         private bool IsPossibleStatementStartOrStop()
@@ -7976,7 +8000,7 @@ tryAgain:
 
                 // Next, parse statement list stopping for new sections
                 CSharpSyntaxNode tmp = labels[labels.Count - 1];
-                this.ParseStatements(ref tmp, statements, true);
+                this.ParseStatements(ref tmp, statements, usingsOpt: default, stopOnSwitchSections: true);
                 labels[labels.Count - 1] = (SwitchLabelSyntax)tmp;
 
                 return _syntaxFactory.SwitchSection(labels, statements);

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1779,6 +1779,7 @@
     <Field Name="OpenBraceToken" Type="SyntaxToken">
       <Kind Name="OpenBraceToken"/>
     </Field>
+    <Field Name="Usings" Type="SyntaxList&lt;UsingDirectiveSyntax&gt;"/>
     <Field Name="Statements" Type="SyntaxList&lt;StatementSyntax&gt;"/>
     <Field Name="CloseBraceToken" Type="SyntaxToken">
       <Kind Name="CloseBraceToken"/>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalImportsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalImportsTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class LocalImportsTests : CSharpTestBase
+    {
+        [Fact]
+        public void TestLocalImport()
+        {
+            var source = @"
+class Program
+{   
+    public static void Main()
+    {
+        using System;
+        Console.Write(2);
+    }
+}
+";
+
+            CompileAndVerify(source, expectedOutput: "2");
+        }
+
+        [Fact]
+        public void TestLocalStaticImport_1()
+        {
+            var source = @"
+class Program
+{   
+    public static void Main()
+    {
+        using static System.Console;
+        Write(2);
+    }
+}
+";
+
+            CompileAndVerify(source, expectedOutput: "2");
+        }
+        [Fact]
+        public void TestLocalStaticImport_2()
+        {
+            var source = @"
+using System;
+class Program
+{   
+    public static void Main()
+    {
+        using static Console;
+        Write(2);
+    }
+}
+";
+
+            CompileAndVerify(source, expectedOutput: "2");
+        }
+
+        [Fact]
+        public void TestLocalStaticImport_3()
+        {
+            var source =
+@"using static C1; // global
+namespace Namespace
+{
+    using static C2; // namespace
+    class Class
+    {
+        public static void Main()
+        {
+            using static C3; // method
+            void Local()
+            {
+                using static C4; // local function
+                {
+                    using static C5; // block
+                    System.Action action = () =>
+                    {
+                        using static C6; // lambda
+                        {
+                            using static C7; 
+                            M();
+                        }
+                    };
+                    action();
+                }
+            }
+            Local();
+        }
+    }
+}";
+            var member = @"
+public static void M()
+{
+    System.Console.Write(1);
+}";
+
+            var classes = Enumerable.Range(1, 7).Reverse()
+                .Aggregate(member, (body, i) => $"public static class C{i} {{{body}}}");
+
+            CompileAndVerify(source + classes, expectedOutput: "1");
+        }
+
+        [Fact]
+        public void TestExtensionMethod()
+        {
+            var source = @"
+class Program
+{   
+    public static void Main()
+    {
+        using System;
+        using System.Linq;
+        foreach (var item in new [] {1}.Select(x => x * 2))
+        {
+            Console.Write(item);
+        }
+    }
+}
+";
+
+            CompileAndVerify(source, expectedOutput: "2", additionalRefs: new[] { LinqAssemblyRef });
+        }
+
+        [Fact]
+        public void TestAfterStatement()
+        {
+            var source = @"
+class Program
+{   
+    public static void Main()
+    {
+        using (null) {}
+        using System;
+    }
+}
+";
+            // TODO(local-imports): needs better diagnostic
+
+            CreateStandardCompilation(source)
+                .VerifyDiagnostics(
+                // (7,15): error CS1003: Syntax error, '(' expected
+                //         using System;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "System").WithArguments("(", "").WithLocation(7, 15),
+                // (7,21): error CS1026: ) expected
+                //         using System;
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(7, 21),
+                // (7,15): error CS0118: 'System' is a namespace but is used like a variable
+                //         using System;
+                Diagnostic(ErrorCode.ERR_BadSKknown, "System").WithArguments("System", "namespace", "variable").WithLocation(7, 15),
+                // (7,21): warning CS0642: Possible mistaken empty statement
+                //         using System;
+                Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";").WithLocation(7, 21)
+                );
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalImportsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalImportsTests.cs
@@ -105,7 +105,7 @@ public static void M()
         }
 
         [Fact]
-        public void TestExtensionMethod()
+        public void TestLocalImport_ExtensionMethod()
         {
             var source = @"
 class Program
@@ -126,7 +126,7 @@ class Program
         }
 
         [Fact]
-        public void TestAfterStatement()
+        public void TestLocalImport_AfterStatement()
         {
             var source = @"
 class Program
@@ -140,20 +140,50 @@ class Program
 ";
             // TODO(local-imports): needs better diagnostic
 
-            CreateStandardCompilation(source)
-                .VerifyDiagnostics(
-                // (7,15): error CS1003: Syntax error, '(' expected
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,9): error CS1529: A using clause must precede all other elements defined in the namespace except extern alias declarations
                 //         using System;
-                Diagnostic(ErrorCode.ERR_SyntaxError, "System").WithArguments("(", "").WithLocation(7, 15),
-                // (7,21): error CS1026: ) expected
-                //         using System;
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(7, 21),
-                // (7,15): error CS0118: 'System' is a namespace but is used like a variable
-                //         using System;
-                Diagnostic(ErrorCode.ERR_BadSKknown, "System").WithArguments("System", "namespace", "variable").WithLocation(7, 15),
-                // (7,21): warning CS0642: Possible mistaken empty statement
-                //         using System;
-                Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";").WithLocation(7, 21)
+                Diagnostic(ErrorCode.ERR_UsingAfterElements, "using System;").WithLocation(7, 9)
+                );
+        }
+
+        [Fact]
+        public void TestLocalImport_SwitchSection()
+        {
+            var source = @"
+class Program
+{   
+    public static void Main()
+    {
+        int i = 0;
+        switch (i)
+        {
+            case 1:
+                using System;
+                break;
+        }
+
+        switch (i)
+        {
+            case 1:
+                System.Console.WriteLine();
+                using System;
+                break;
+        }
+    }
+}
+";
+            // TODO(local-imports): needs better diagnostic
+
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,17): error CS1529: A using clause must precede all other elements defined in the namespace except extern alias declarations
+                //                 using System;
+                Diagnostic(ErrorCode.ERR_UsingAfterElements, "using System;").WithLocation(10, 17),
+                // (18,17): error CS1529: A using clause must precede all other elements defined in the namespace except extern alias declarations
+                //                 using System;
+                Diagnostic(ErrorCode.ERR_UsingAfterElements, "using System;").WithLocation(18, 17)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.BlockSyntax GenerateBlock()
         {
-            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Block(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.OpenBraceToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.StatementSyntax>(), Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Block(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.OpenBraceToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.UsingDirectiveSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.StatementSyntax>(), Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
         }
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.LocalFunctionStatementSyntax GenerateLocalFunctionStatement()
@@ -1977,6 +1977,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
+            Assert.NotNull(node.Usings);
             Assert.NotNull(node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
@@ -9329,7 +9330,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static BlockSyntax GenerateBlock()
         {
-            return SyntaxFactory.Block(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), new SyntaxList<StatementSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+            return SyntaxFactory.Block(SyntaxFactory.Token(SyntaxKind.OpenBraceToken), new SyntaxList<UsingDirectiveSyntax>(), new SyntaxList<StatementSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
         }
         
         private static LocalFunctionStatementSyntax GenerateLocalFunctionStatement()
@@ -10895,9 +10896,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
+            Assert.NotNull(node.Usings);
             Assert.NotNull(node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
-            var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithStatements(node.Statements).WithCloseBraceToken(node.CloseBraceToken);
+            var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithUsings(node.Usings).WithStatements(node.Statements).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
         }
         


### PR DESCRIPTION
Proposal: https://github.com/dotnet/csharplang/issues/218

Lets you write code like this:
```cs
void M()
{
  using static System.Console;
  WriteLine();
}
``` 
This PR does not cover type-level usings yet.

Note: Public API analyzer is disabled for now.