### PR TITLE
in escape analysis receivers of readonly structs should be considered as `in` parameters.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1115,7 +1115,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             uint escapeTo = scopeOfTheContainingExpression;
 
             // collect all writeable ref-like arguments, including receiver
-            if (receiverOpt?.Type?.IsByRefLikeType == true)
+            var receiverType = receiverOpt?.Type;
+            if (receiverType?.IsByRefLikeType == true && receiverType?.IsReadOnly == false)
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2069,7 +2069,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         {
                             isByRefLike = ThreeState.True;
                         }
-                        else
+                        else if (this.TypeKind == TypeKind.Struct)
                         {
                             var moduleSymbol = this.ContainingPEModule;
                             var module = moduleSymbol.Module;
@@ -2098,7 +2098,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     var isReadOnly = ThreeState.False;
 
-                    if (this.TypeKind == TypeKind.Struct)
+                    //PROTOTYPE(span): Span and ReadOnlySpan should have IsReadOnly attribute, eventually.
+                    //                 For now assume that any "System.Span" and "System.ReadOnlySpan" structs 
+                    //                 are ReadOnly
+                    if (this.IsSpanType())
+                    {
+                        isReadOnly = ThreeState.True;
+                    }
+                    else if (this.TypeKind == TypeKind.Struct)
                     {
                         var moduleSymbol = this.ContainingPEModule;
                         var module = moduleSymbol.Module;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -1299,5 +1299,48 @@ class Program
                 Diagnostic(ErrorCode.ERR_RefReturnStructThis, "x").WithArguments("this").WithLocation(31, 28)
                 );
         }
+
+        [WorkItem(21880, "https://github.com/dotnet/roslyn/issues/21880")]
+        [Fact()]
+        public void MemberOfReadonlyRefLikeEscape()
+        {
+            var text = @"
+    public static class Program
+    {
+        public static void Main()
+        {
+            // OK, SR is readonly
+            new SR().TryGet(out int value1);
+
+            // not OK, TryGet can write into the instance
+            new SW().TryGet(out int value2);
+        }
+    }
+
+    public readonly ref struct SR
+    {
+        public void TryGet(out int result)
+        {
+            result = 1;
+        }
+    }
+
+    public ref struct SW
+    {
+        public void TryGet(out int result)
+        {
+            result = 1;
+        }
+    }
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (10,33): error CS8168: Cannot return local 'value2' by reference because it is not a ref local
+                //             new SW().TryGet(out int value2);
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "int value2").WithArguments("value2").WithLocation(10, 33),
+                // (10,13): error CS8524: This combination of arguments to 'SW.TryGet(out int)' is disallowed because it may expose variables referenced by parameter 'result' outside of their declaration scope
+                //             new SW().TryGet(out int value2);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "new SW().TryGet(out int value2)").WithArguments("SW.TryGet(out int)", "result").WithLocation(10, 13)
+                );
+        }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1112,12 +1112,16 @@ namespace System
         {
             this.Length = length;
         }
+
+        public void CopyTo(Span<T> other){}
     }
 
     public ref struct ReadOnlySpan<T>
     {
         public ref readonly T this[int i] => throw null;
         public override int GetHashCode() => 2;
+
+        public void CopyTo(Span<T> other){}
     }
 
     public ref struct SpanLike<T>


### PR DESCRIPTION
in escape analysis receivers of readonly structs should be considered as `in` parameters.

Fixes:#21880
