### PR TITLE
Do not inline variables into the left side of a deconstruction

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4210,18 +4210,16 @@ class C
         var t = ((i, (i, _)) = (1, (i, 3)));
     }
 }";
-
             var expected = @"
 class C
 {
     static int y = 1;
     void M()
     {
-        var t = (((int)C.y, ((int)C.y, _)) = (1, (C.y, 3)));
+        int i = C.y;
+        var t = (({|Conflict:(int)C.y|}, ({|Conflict:(int)C.y|}, _)) = (1, (C.y, 3)));
     }
 }";
-            // This refactoring should be blocked with an annotation, as the result of a cast is an L-value
-            // Follow-up issue: https://github.com/dotnet/roslyn/issues/19047
             await TestInRegularAndScriptAsync(code, expected);
         }
 
@@ -4239,18 +4237,16 @@ class C
         var t = ((i, _) = (1, 2));
     }
 }";
-
             var expected = @"
 class C
 {
     static int y = 1;
     void M()
     {
-        var t = (((int)C.y, _) = (1, 2));
+        int i = C.y;
+        var t = (({|Conflict:(int)C.y|}, _) = (1, 2));
     }
 }";
-            // This refactoring should be blocked with an annotation, as the result of a cast is an L-value
-            // Follow-up issue: https://github.com/dotnet/roslyn/issues/19047
             await TestInRegularAndScriptAsync(code, expected);
         }
 

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -580,14 +580,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                 parent = parent.Parent;
             }
 
-            while (parent?.Kind() == SyntaxKind.Argument)
+            while (parent.IsKind(SyntaxKind.Argument))
             {
                 parent = parent.Parent;
-                if (parent?.Kind() != SyntaxKind.TupleExpression)
+                if (!parent.IsKind(SyntaxKind.TupleExpression))
                 {
                     return false;
                 }
-                else if (parent?.IsParentKind(SyntaxKind.SimpleAssignmentExpression) == true)
+                else if (parent.IsParentKind(SyntaxKind.SimpleAssignmentExpression))
                 {
                     return ((AssignmentExpressionSyntax)parent.Parent).Left == parent;
                 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                             newInitializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(inlinedNode, cancellationToken);
                             if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInitializerSymbolInfo, performEquivalenceCheck: true))
                             {
-                                initReplacementNodesWithChangedSemantics();
+                                replacementNodesWithChangedSemantics = replacementNodesWithChangedSemantics ?? new Dictionary<SyntaxNode, SyntaxNode>();
                                 replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
                             }
                         }
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                         // Verification: Do not inline a variable into the left side of a deconstruction-assignment
                         if (IsInDeconstructionAssignmentLeft(innerInitializerInInlineNode))
                         {
-                            initReplacementNodesWithChangedSemantics();
+                            replacementNodesWithChangedSemantics = replacementNodesWithChangedSemantics ?? new Dictionary<SyntaxNode, SyntaxNode>();
                             replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
                         }
                     }
@@ -562,14 +562,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                     newNode.WithAdditionalAnnotations(ConflictAnnotation.Create(CSharpFeaturesResources.Conflict_s_detected));
 
             return await inlinedDocument.ReplaceNodesAsync(replacementNodesWithChangedSemantics.Keys, conflictAnnotationAdder, cancellationToken).ConfigureAwait(false);
-
-            void initReplacementNodesWithChangedSemantics()
-            {
-                if (replacementNodesWithChangedSemantics == null)
-                {
-                    replacementNodesWithChangedSemantics = new Dictionary<SyntaxNode, SyntaxNode>();
-                }
-            }
         }
 
         private static bool IsInDeconstructionAssignmentLeft(ExpressionSyntax node)

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -536,13 +536,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                             newInitializerSymbolInfo = newSemanticModelForInlinedDocument.GetSymbolInfo(inlinedNode, cancellationToken);
                             if (!SpeculationAnalyzer.SymbolInfosAreCompatible(originalInitializerSymbolInfo, newInitializerSymbolInfo, performEquivalenceCheck: true))
                             {
-                                if (replacementNodesWithChangedSemantics == null)
-                                {
-                                    replacementNodesWithChangedSemantics = new Dictionary<SyntaxNode, SyntaxNode>();
-                                }
-
+                                initReplacementNodesWithChangedSemantics();
                                 replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
                             }
+                        }
+
+                        // Verification: Do not inline a variable into the left side of a deconstruction-assignment
+                        if (IsInDeconstructionAssignmentLeft(innerInitializerInInlineNode))
+                        {
+                            initReplacementNodesWithChangedSemantics();
+                            replacementNodesWithChangedSemantics.Add(inlinedNode, originalNode);
                         }
                     }
                 }
@@ -559,6 +562,40 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                     newNode.WithAdditionalAnnotations(ConflictAnnotation.Create(CSharpFeaturesResources.Conflict_s_detected));
 
             return await inlinedDocument.ReplaceNodesAsync(replacementNodesWithChangedSemantics.Keys, conflictAnnotationAdder, cancellationToken).ConfigureAwait(false);
+
+            void initReplacementNodesWithChangedSemantics()
+            {
+                if (replacementNodesWithChangedSemantics == null)
+                {
+                    replacementNodesWithChangedSemantics = new Dictionary<SyntaxNode, SyntaxNode>();
+                }
+            }
+        }
+
+        private static bool IsInDeconstructionAssignmentLeft(ExpressionSyntax node)
+        {
+            var parent = node.Parent;
+            while (parent.IsKind(SyntaxKind.ParenthesizedExpression, SyntaxKind.CastExpression))
+            {
+                parent = parent.Parent;
+            }
+
+            while (parent?.Kind() == SyntaxKind.Argument)
+            {
+                parent = parent.Parent;
+                if (parent?.Kind() != SyntaxKind.TupleExpression)
+                {
+                    return false;
+                }
+                else if (parent?.IsParentKind(SyntaxKind.SimpleAssignmentExpression) == true)
+                {
+                    return ((AssignmentExpressionSyntax)parent.Parent).Left == parent;
+                }
+
+                parent = parent.Parent;
+            }
+
+            return false;
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Workspaces/CSharp/Portable/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19047

![image](https://user-images.githubusercontent.com/12466233/29992450-2c1e8fd0-8f50-11e7-8ff2-dba4b5da7429.png)

