### PR TITLE
fixed performance issues with immutable arrays

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -127,80 +127,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
-        /// Adds the <see cref="ImmutableDictionary{TKey, TValue}"/> of <see cref="ImmutableArray{T}"/> of <see cref="DiagnosticAnalyzer"/> 
-        /// for all languages defined in this assembly reference.
-        /// </summary>
-        internal void AddAnalyzers(ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Builder builder)
-        {
-            _diagnosticAnalyzers.AddExtensions(builder);
-        }
-
-        /// <summary>
         /// Adds the <see cref="ImmutableArray{T}"/> of <see cref="DiagnosticAnalyzer"/> defined in this assembly reference of given <paramref name="language"/>.
         /// </summary>
         internal void AddAnalyzers(ImmutableArray<DiagnosticAnalyzer>.Builder builder, string language)
         {
             _diagnosticAnalyzers.AddExtensions(builder, language);
-        }
-
-        private IEnumerable<DiagnosticAnalyzer> GetLanguageSpecificAnalyzers(Assembly analyzerAssembly, ImmutableDictionary<string, ImmutableHashSet<string>> analyzerTypeNameMap, string language, ref bool reportedError)
-        {
-            var languageSpecificAnalyzerTypeNames = GetLanguageSpecificAnalyzerTypeNames(analyzerTypeNameMap, language);
-            return this.GetAnalyzersForTypeNames(analyzerAssembly, languageSpecificAnalyzerTypeNames, ref reportedError);
-        }
-
-        private static IEnumerable<string> GetLanguageSpecificAnalyzerTypeNames(ImmutableDictionary<string, ImmutableHashSet<string>> analyzerTypeNameMap, string language)
-        {
-            ImmutableHashSet<string> analyzerTypeNames;
-            if (analyzerTypeNameMap.TryGetValue(language, out analyzerTypeNames))
-            {
-                return analyzerTypeNames;
-            }
-            return SpecializedCollections.EmptyEnumerable<string>();
-        }
-
-        private IEnumerable<DiagnosticAnalyzer> GetAnalyzersForTypeNames(Assembly analyzerAssembly, IEnumerable<string> analyzerTypeNames, ref bool reportedError)
-        {
-            var analyzers = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
-
-            // Given the type names, get the actual System.Type and try to create an instance of the type through reflection.
-            foreach (var typeName in analyzerTypeNames)
-            {
-                Type type;
-                try
-                {
-                    // TODO: Once we move to CoreCLR we should just call GetType(typeName, throwOnError: true, ignoreCase: false) directly.
-                    // For now we fall back to reflection shim in order to report good error message (type load exception).
-                    type = analyzerAssembly.GetType(typeName, throwOnError: true, ignoreCase: false);
-                }
-                catch (Exception e)
-                {
-                    AnalyzerLoadFailed?.Invoke(this, CreateAnalyzerFailedArgs(e, typeName));
-                    reportedError = true;
-                    continue;
-                }
-
-                Debug.Assert(type != null);
-
-                DiagnosticAnalyzer analyzer;
-                try
-                {
-                    analyzer = Activator.CreateInstance(type) as DiagnosticAnalyzer;
-                }
-                catch (Exception e)
-                {
-                    AnalyzerLoadFailed?.Invoke(this, CreateAnalyzerFailedArgs(e, typeName));
-                    reportedError = true;
-                    continue;
-                }
-
-                if (analyzer != null)
-                {
-                    analyzers.Add(analyzer);
-                }
-            }
-
-            return analyzers.ToImmutable();
         }
 
         private static AnalyzerLoadFailureEventArgs CreateAnalyzerFailedArgs(Exception e, string typeNameOpt = null)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3632,7 +3632,7 @@ namespace Microsoft.Cci
             return pooled.ToStringAndFree();
         }
 
-        private void SerializePermissionSet(IEnumerable<ICustomAttribute> permissionSet, BlobBuilder writer)
+        private void SerializePermissionSet(ImmutableArray<ICustomAttribute> permissionSet, BlobBuilder writer)
         {
             EmitContext context = this.Context;
             foreach (ICustomAttribute customAttribute in permissionSet)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Threading;
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 return text;
             }
 
-            private static TextBlock GetTextBlock(IEnumerable<TaggedText> parts, ClassificationTypeMap typeMap)
+            private static TextBlock GetTextBlock(ImmutableArray<TaggedText> parts, ClassificationTypeMap typeMap)
             {
                 var result = new TextBlock() { TextWrapping = TextWrapping.Wrap };
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
         }
 
-        private ImmutableArray<CodeActionOperation> GetNewFixAllOperations(IEnumerable<CodeActionOperation> operations, Solution newSolution, CancellationToken cancellationToken)
+        private static ImmutableArray<CodeActionOperation> GetNewFixAllOperations(ImmutableArray<CodeActionOperation> operations, Solution newSolution, CancellationToken cancellationToken)
         {
             var result = ArrayBuilder<CodeActionOperation>.GetInstance();
             var foundApplyChanges = false;

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// always show up last after all other fixes (and refactorings) for the selected line of code.
             /// </remarks>
             private static ImmutableArray<SuggestedActionSet> PrioritizeFixGroups(
-                IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, IList<CodeFixGroupKey> order)
+                ImmutableDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, ImmutableArray<CodeFixGroupKey> order)
             {
                 var sets = ArrayBuilder<SuggestedActionSet>.GetInstance();
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private IEnumerable<CompletionItem> CreateCompletionItems(
-            Workspace workspace, SemanticModel semanticModel, IEnumerable<ISymbol> symbols, SyntaxToken token, TextSpan itemSpan, int position, ImmutableDictionary<string, string> options)
+            Workspace workspace, SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, TextSpan itemSpan, int position, ImmutableDictionary<string, string> options)
         {
             var builder = SharedPools.Default<StringBuilder>().Allocate();
             try

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
         protected override ImmutableArray<ParameterName> GenerateParameterNames(
             SemanticModel semanticModel, IEnumerable<AttributeArgumentSyntax> arguments, IList<string> reservedNames, CancellationToken cancellationToken)
-            => semanticModel.GenerateParameterNames(arguments, reservedNames, cancellationToken).ToImmutableArray();
+            => semanticModel.GenerateParameterNames(arguments, reservedNames, cancellationToken);
 
         protected override string GenerateNameForArgument(SemanticModel semanticModel, ArgumentSyntax argument, CancellationToken cancellationToken)
             => semanticModel.GenerateNameForArgument(argument, cancellationToken);

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -40,9 +40,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             }
         }
 
-        private void RegisterSuppressionFixes(CodeFixContext context, IEnumerable<CodeFix> suppressionFixes)
+        private static void RegisterSuppressionFixes(CodeFixContext context, ImmutableArray<CodeFix> suppressionFixes)
         {
-            if (suppressionFixes != null)
+            if (!suppressionFixes.IsDefault)
             {
                 foreach (var suppressionFix in suppressionFixes)
                 {

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -400,9 +400,9 @@ namespace Microsoft.CodeAnalysis.Completion
             return item;
         }
 
-        private Dictionary<CompletionProvider, int> GetCompletionProviderToIndex(IEnumerable<CompletionProvider> completionProviders)
+        private static Dictionary<CompletionProvider, int> GetCompletionProviderToIndex(ImmutableArray<CompletionProvider> completionProviders)
         {
-            var result = new Dictionary<CompletionProvider, int>();
+            var result = new Dictionary<CompletionProvider, int>(completionProviders.Length);
 
             int i = 0;
             foreach (var completionProvider in completionProviders)

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -202,9 +202,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SpecializedCollections.EmptyEnumerable<DiagnosticData>();
         }
 
-        private static IEnumerable<DiagnosticData> FilterSuppressedDiagnostics(IEnumerable<DiagnosticData> diagnostics)
+        private static IEnumerable<DiagnosticData> FilterSuppressedDiagnostics(ImmutableArray<DiagnosticData> diagnostics)
         {
-            if (diagnostics != null)
+            if (!diagnostics.IsDefault)
             {
                 foreach (var diagnostic in diagnostics)
                 {

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         }
 
         private static IEnumerable<SymbolResult> GetContainers(
-            IEnumerable<SymbolResult> symbols, Compilation compilation)
+            ImmutableArray<SymbolResult> symbols, Compilation compilation)
         {
             foreach (var symbolResult in symbols)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         RemoveDocument(this.Analyzers, documentId);
                     }
 
-                    private static void RemoveDocument(IEnumerable<IIncrementalAnalyzer> analyzers, DocumentId documentId)
+                    private static void RemoveDocument(ImmutableArray<IIncrementalAnalyzer> analyzers, DocumentId documentId)
                     {
                         foreach (var analyzer in analyzers)
                         {

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -348,14 +348,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             _console.Out.WriteLine();
         }
 
-        private void DisplayDiagnostics(IEnumerable<Diagnostic> diagnostics)
+        private void DisplayDiagnostics(ImmutableArray<Diagnostic> diagnostics)
         {
             const int MaxDisplayCount = 5;
 
-            var errorsAndWarnings = diagnostics.ToArray();
-
             // by severity, then by location
-            var ordered = errorsAndWarnings.OrderBy((d1, d2) =>
+            var ordered = diagnostics.OrderBy((d1, d2) =>
             {
                 int delta = (int)d2.Severity - (int)d1.Severity;
                 return (delta != 0) ? delta : d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start;
@@ -369,9 +367,9 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                     _console.Error.WriteLine(diagnostic.ToString());
                 }
 
-                if (errorsAndWarnings.Length > MaxDisplayCount)
+                if (diagnostics.Length > MaxDisplayCount)
                 {
-                    int notShown = errorsAndWarnings.Length - MaxDisplayCount;
+                    int notShown = diagnostics.Length - MaxDisplayCount;
                     _console.ForegroundColor = ConsoleColor.DarkRed;
                     _console.Error.WriteLine(string.Format(ScriptingResources.PlusAdditionalError, notShown));
                 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -101,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 : SyntaxFactory.ConstructorInitializer(kind).WithArgumentList(GenerateArgumentList(arguments));
         }
 
-        private static ArgumentListSyntax GenerateArgumentList(IList<SyntaxNode> arguments)
+        private static ArgumentListSyntax GenerateArgumentList(ImmutableArray<SyntaxNode> arguments)
         {
             return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(ArgumentGenerator.GenerateArgument)));
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 argumentList.Arguments, reservedNames: null, cancellationToken: cancellationToken);
         }
 
-        public static IList<ParameterName> GenerateParameterNames(
+        public static ImmutableArray<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             AttributeArgumentListSyntax argumentList,
             CancellationToken cancellationToken)
@@ -328,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                                 .Skip(reservedNames.Count).ToImmutableArray();
         }
 
-        public static IList<ParameterName> GenerateParameterNames(
+        public static ImmutableArray<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             IEnumerable<AttributeArgumentSyntax> arguments,
             IList<string> reservedNames,

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -100,12 +100,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var typeInferenceInfo = new TypeInferenceInfo(typeInfo.Type);
 
                         // If it bound to a method, try to get the Action/Func form of that method.
-                        if (typeInferenceInfo.InferredType == null &&
-                            symbolInfo.GetAllSymbols().Count() == 1 &&
-                            symbolInfo.GetAllSymbols().First().Kind == SymbolKind.Method)
+                        if (typeInferenceInfo.InferredType == null)
                         {
-                            var method = symbolInfo.GetAllSymbols().First();
-                            typeInferenceInfo = new TypeInferenceInfo(method.ConvertToType(this.Compilation));
+                            var allSymbols = symbolInfo.GetAllSymbols();
+                            if (allSymbols.Length == 1 &&
+                                allSymbols[0].Kind == SymbolKind.Method)
+                            {
+                                var method = allSymbols[0];
+                                typeInferenceInfo = new TypeInferenceInfo(method.ConvertToType(this.Compilation));
+                            }
                         }
 
                         if (IsUsableTypeFunc(typeInferenceInfo))

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -352,9 +352,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                         ? newToken.ValueText.Substring(0, newToken.ValueText.IndexOf('_') + 1)
                         : null;
 
-                    if (symbols.Count() == 1)
+                    if (symbols.Length == 1)
                     {
-                        var symbol = symbols.Single();
+                        var symbol = symbols[0];
 
                         if (symbol.IsConstructor())
                         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
         }
 
-        private void CheckDocuments(IEnumerable<DocumentFileInfo> docs, string projectFilePath, ProjectId projectId)
+        private void CheckDocuments(ImmutableArray<DocumentFileInfo> docs, string projectFilePath, ProjectId projectId)
         {
             var paths = new HashSet<string>();
             foreach (var doc in docs)

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         /// <summary>
         /// Make sure annotations are positioned outside of any spans. If not, merge two adjacent spans to one.
         /// </summary>
-        private ImmutableArray<TextSpan> GetNonOverlappingSpans(ISyntaxFactsService syntaxFactsService, SyntaxNode root, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
+        private ImmutableArray<TextSpan> GetNonOverlappingSpans(ISyntaxFactsService syntaxFactsService, SyntaxNode root, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
         {
             // Create interval tree for spans
             var intervalTree = SimpleIntervalTree.Create(TextSpanIntervalIntrospector.Instance, spans);
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 #endif
 
                 var current = 0;
-                var count = codeCleaners.Count();
+                var count = codeCleaners.Length;
 
                 foreach (var codeCleaner in codeCleaners)
                 {
@@ -547,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
                 var spans = ImmutableArray<TextSpan>.Empty;
 
                 var current = 0;
-                var count = codeCleaners.Count();
+                var count = codeCleaners.Length;
 
                 foreach (var codeCleaner in codeCleaners)
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
@@ -158,10 +158,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private void AddSymbolTasks(
             ConcurrentSet<SymbolAndProjectId> result,
-            IEnumerable<SymbolAndProjectId> symbols,
+            ImmutableArray<SymbolAndProjectId> symbols,
             List<Task> symbolTasks)
         {
-            if (symbols != null)
+            if (!symbols.IsDefault)
             {
                 foreach (var child in symbols)
                 {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                         int symbolIndex = 0;
                         foreach (var symbol in newReferencedSymbols)
                         {
-                            if (conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].SymbolLocationsCount != symbol.Locations.Count())
+                            if (conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].SymbolLocationsCount != symbol.Locations.Length)
                             {
                                 hasConflict = true;
                                 break;
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
             private IEnumerable<ISymbol> GetSymbolsInNewSolution(Document newDocument, SemanticModel newDocumentSemanticModel, RenameActionAnnotation conflictAnnotation, SyntaxNodeOrToken tokenOrNode)
             {
-                var newReferencedSymbols = RenameUtilities.GetSymbolsTouchingPosition(tokenOrNode.Span.Start, newDocumentSemanticModel, newDocument.Project.Solution.Workspace, _cancellationToken);
+                IEnumerable<ISymbol> newReferencedSymbols = RenameUtilities.GetSymbolsTouchingPosition(tokenOrNode.Span.Start, newDocumentSemanticModel, newDocument.Project.Solution.Workspace, _cancellationToken);
 
                 if (conflictAnnotation.IsInvocationExpression)
                 {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/DeclarationConflictHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 {
     internal static class DeclarationConflictHelpers
     {
-        public static IEnumerable<Location> GetMembersWithConflictingSignatures(IMethodSymbol renamedMethod, bool trimOptionalParameters)
+        public static ImmutableArray<Location> GetMembersWithConflictingSignatures(IMethodSymbol renamedMethod, bool trimOptionalParameters)
         {
             var potentiallyConfictingMethods =
                 renamedMethod.ContainingType.GetMembers(renamedMethod.Name)

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Rename
             return token;
         }
 
-        internal static IEnumerable<ISymbol> GetSymbolsTouchingPosition(
+        internal static ImmutableArray<ISymbol> GetSymbolsTouchingPosition(
             int position, SemanticModel semanticModel, Workspace workspace, CancellationToken cancellationToken)
         {
             var bindableToken = semanticModel.SyntaxTree.GetRoot(cancellationToken).FindToken(position, findInsideTrivia: true);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/SyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/SyntaxContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
         public bool IsPossibleTupleContext { get; }
         public bool IsPatternContext { get; }
 
-        public IEnumerable<ITypeSymbol> InferredTypes { get; }
+        public ImmutableArray<ITypeSymbol> InferredTypes { get; }
 
         private ISet<INamedTypeSymbol> ComputeOuterTypes(CancellationToken cancellationToken)
         {
@@ -104,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             return SpecializedCollections.EmptySet<INamedTypeSymbol>();
         }
 
-        protected IEnumerable<ITypeSymbol> ComputeInferredTypes(Workspace workspace,
+        protected ImmutableArray<ITypeSymbol> ComputeInferredTypes(Workspace workspace,
             SemanticModel semanticModel,
             int position,
             CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         private static ImmutableArray<ITypeParameterSymbol> RenameTypeParameters(
-            IList<ITypeParameterSymbol> typeParameters,
+            ImmutableArray<ITypeParameterSymbol> typeParameters,
             IList<string> newNames,
             ITypeGenerator typeGenerator)
         {
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // parameter.  The second updates the constraints to point at this new type parameter.
             var newTypeParameters = new List<CodeGenerationTypeParameterSymbol>();
             var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>();
-            for (int i = 0; i < typeParameters.Count; i++)
+            for (int i = 0; i < typeParameters.Length; i++)
             {
                 var typeParameter = typeParameters[i];
 

--- a/src/Workspaces/Core/Portable/Simplification/SymbolAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SymbolAnnotation.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Simplification
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             return GetSymbols(annotation, compilation).FirstOrDefault();
         }
 
-        public static IEnumerable<ISymbol> GetSymbols(SyntaxAnnotation annotation, Compilation compilation)
+        public static ImmutableArray<ISymbol> GetSymbols(SyntaxAnnotation annotation, Compilation compilation)
         {
             return DocumentationCommentId.GetSymbolsForReferenceId(annotation.Data, compilation);
         }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis
         private static IEnumerable<INamedTypeSymbol> InstantiateTypes(
             Compilation compilation,
             bool ignoreAssemblyKey,
-            IEnumerable<INamedTypeSymbol> types,
+            ImmutableArray<INamedTypeSymbol> types,
             int arity,
             ImmutableArray<SymbolKeyResolution> typeArgumentKeys)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectDependencyGraph.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IEnumerable<ProjectId> GetTopologicallySortedProjects(CancellationToken cancellationToken = default)
         {
-            if (_lazyTopologicallySortedProjects == null)
+            if (_lazyTopologicallySortedProjects.IsDefault)
             {
                 using (_dataLock.DisposableWait(cancellationToken))
                 {
@@ -252,9 +252,9 @@ namespace Microsoft.CodeAnalysis
             return _lazyTopologicallySortedProjects;
         }
 
-        private IEnumerable<ProjectId> GetTopologicallySortedProjects_NoLock(CancellationToken cancellationToken)
+        private void GetTopologicallySortedProjects_NoLock(CancellationToken cancellationToken)
         {
-            if (_lazyTopologicallySortedProjects == null)
+            if (_lazyTopologicallySortedProjects.IsDefault)
             {
                 using (var seenProjects = SharedPools.Default<HashSet<ProjectId>>().GetPooledObject())
                 using (var resultList = SharedPools.Default<List<ProjectId>>().GetPooledObject())
@@ -263,8 +263,6 @@ namespace Microsoft.CodeAnalysis
                     _lazyTopologicallySortedProjects = resultList.Object.ToImmutableArray();
                 }
             }
-
-            return _lazyTopologicallySortedProjects;
         }
 
         private void TopologicalSort(
@@ -308,7 +306,7 @@ namespace Microsoft.CodeAnalysis
             return _lazyDependencySets;
         }
 
-        private IEnumerable<IEnumerable<ProjectId>> GetDependencySets_NoLock(CancellationToken cancellationToken)
+        private ImmutableArray<IEnumerable<ProjectId>> GetDependencySets_NoLock(CancellationToken cancellationToken)
         {
             if (_lazyDependencySets == null)
             {

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -278,8 +278,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 Dim prefix = If(isRenameLocation AndAlso Me._renameLocations(token.Span).IsRenamableAccessor, newToken.ValueText.Substring(0, newToken.ValueText.IndexOf("_"c) + 1), String.Empty)
                 Dim suffix As String = Nothing
 
-                If symbols.Count() = 1 Then
-                    Dim symbol = symbols.Single()
+                If symbols.Length = 1 Then
+                    Dim symbol = symbols(0)
 
                     If symbol.IsConstructor() Then
                         symbol = symbol.ContainingSymbol


### PR DESCRIPTION
Passing an `ImmutableArray<T>` as an `IEnumerable<T>` creates several issues:

- the value is boxed
- the efficient `foreach` implementation is not used
- the optimized extension methods are not used
- the `Length` property cannot be accessed as easily

This PR fixes several of those issues.

In addition:

- Some affected but unused code was removed.
- Some of the affected methods were made `static`, where possible.
- A collection was initialized using the length of the immutable array as the initial capacity.
- A redundant `.ToArray()` call was removed, as well as a redundant `.ToImmutableArray()` call.

**Risk**

All methods are private or internal methods. Risk should be low.

**Performance impact**

The changes are meant to improve the performance of the affected methods, without changing the functionality.

This is a follow-up for #20610 