### PR TITLE
Do not specify /doc: when GenerateDocumentation=false

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -472,7 +472,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 commandLine.AppendSwitchIfNotNull("/", this.Verbosity);
             }
 
-            commandLine.AppendSwitchIfNotNull("/doc:", this.DocumentationFile);
+            if ((bool?)this._store[nameof(GenerateDocumentation)] != false)
+            {
+                // Only provide the filename when GenerateDocumentation is not
+                // explicitly disabled.  Otherwise, the /doc switch (which comes
+                // later in the command) overrides and re-enabled generating
+                // documentation.
+                commandLine.AppendSwitchIfNotNull("/doc:", this.DocumentationFile);
+            }
+
             commandLine.AppendSwitchUnquotedIfNotNull("/define:", Vbc.GetDefineConstantsSwitch(this.DefineConstants));
             AddReferencesToCommandLine(commandLine);
             commandLine.AppendSwitchIfNotNull("/win32resource:", this.Win32Resource);

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.BuildTasks;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
@@ -309,6 +310,48 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
             vbc.RefOnly = true;
             Assert.Equal("/optionstrict:custom /out:test.exe /refonly test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(21371, "https://github.com/dotnet/roslyn/issues/21371")]
+        public void GenerateDocumentationFalse()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.GenerateDocumentation = false;
+            vbc.DocumentationFile = "test.xml";
+            Assert.Equal("/doc- /optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(21371, "https://github.com/dotnet/roslyn/issues/21371")]
+        public void GenerateDocumentationTrue()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.GenerateDocumentation = true;
+            vbc.DocumentationFile = "test.xml";
+            Assert.Equal("/doc+ /optionstrict:custom /doc:test.xml /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(21371, "https://github.com/dotnet/roslyn/issues/21371")]
+        public void GenerateDocumentationTrueWithoutFile()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.GenerateDocumentation = true;
+            Assert.Equal("/doc+ /optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        [WorkItem(21371, "https://github.com/dotnet/roslyn/issues/21371")]
+        public void GenerateDocumentationUnspecified()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.DocumentationFile = "test.xml";
+            Assert.Equal("/optionstrict:custom /doc:test.xml /out:test.exe test.vb", vbc.GenerateResponseFileContents());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21371

Note that this is *VB-Only* (documentation is [linked in the issue thread](https://docs.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties), search `GenerateDocumentation`).

Requesting review from the compiler team because that's what the issue is filed under (not sure if compiler or infra or what).