### PR TITLE
Document name

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -37,7 +37,7 @@
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.2.0-beta1-62008-01</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62016-01</MicrosoftDiaSymReaderConverterXmlVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.7.0-private-25621</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.7.0-beta-25631</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.4.0-beta1-62016-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetIBCMerge>4.7.2-alpha-00001</MicrosoftDotNetIBCMerge>
     <MicrosoftDotNetVersionToolsVersion>1.0.27-prerelease-01811-02</MicrosoftDotNetVersionToolsVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -36,7 +36,7 @@
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.2.0-beta1-62008-01</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62016-01</MicrosoftDiaSymReaderConverterXmlVersion>
+    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62106-02</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0-beta-25631</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.4.0-beta1-62016-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetIBCMerge>4.7.2-alpha-00001</MicrosoftDotNetIBCMerge>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -955,6 +955,9 @@ class Test
 
             v.VerifyPdb("Test.G", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""Test"" methodName=""Main"" />
   <methods>
     <method containingType=""Test"" name=""G"">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -334,6 +334,9 @@ class C
 
             vd.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""disposable"">
       <customDebugInfo>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -9566,6 +9566,9 @@ public class Program
             );
             compVerifier.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""Program"" methodName=""Main"" />
   <methods>
     <method containingType=""Program"" name=""Main"">
@@ -9575,8 +9578,8 @@ public class Program
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -9597,30 +9600,30 @@ public class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" />
-        <entry offset=""0x4"" hidden=""true"" />
-        <entry offset=""0xa4"" hidden=""true"" />
-        <entry offset=""0xa6"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0xb2"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" />
-        <entry offset=""0xb4"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" />
-        <entry offset=""0xc0"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" />
-        <entry offset=""0xc2"" hidden=""true"" />
-        <entry offset=""0xc4"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" />
-        <entry offset=""0xcd"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" />
-        <entry offset=""0xcf"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" />
-        <entry offset=""0xdb"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" />
-        <entry offset=""0xdd"" hidden=""true"" />
-        <entry offset=""0xe0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" />
-        <entry offset=""0xe9"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" />
-        <entry offset=""0xeb"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" />
-        <entry offset=""0xf4"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" />
-        <entry offset=""0xf6"" hidden=""true"" />
-        <entry offset=""0xf9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" />
-        <entry offset=""0x102"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" />
-        <entry offset=""0x104"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" />
-        <entry offset=""0x10d"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" />
-        <entry offset=""0x10f"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x4"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa4"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa6"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xb2"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xb4"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xc2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc4"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xcd"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xcf"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xdb"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xdd"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xe9"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xeb"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xf4"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xf6"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x102"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x104"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x10d"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x10f"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x110"">
         <scope startOffset=""0xa4"" endOffset=""0xb4"">
@@ -9642,7 +9645,7 @@ public class Program
         <forward declaringType=""Program"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""27"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -1043,7 +1043,11 @@ class C
 }
 ", sequencePoints: "C+<F>d__0.MoveNext");
 
-                    v0.VerifyPdb("C+<F>d__0.MoveNext", @"<symbols>
+                    v0.VerifyPdb("C+<F>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1059,15 +1063,15 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" />
-        <entry offset=""0x1b"" hidden=""true"" />
-        <entry offset=""0x6c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
-        <entry offset=""0x70"" hidden=""true"" />
-        <entry offset=""0x8a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x92"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x70"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x92"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa0"">
         <namespace name=""System.Threading.Tasks"" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -3451,6 +3451,9 @@ class B : A<B>
 }");
             diff1.VerifyPdb(new[] { 0x06000001, 0x06000002, 0x06000003, 0x06000004 }, @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method token=""0x6000003"">
       <customDebugInfo>
@@ -3459,13 +3462,13 @@ class B : A<B>
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" />
-        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""22"" />
-        <entry offset=""0xd"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x14"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""14"" />
-        <entry offset=""0x1c"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""14"" />
-        <entry offset=""0x23"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xd"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x14"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x23"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x24"">
         <local name=""z"" il_index=""3"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
@@ -3505,6 +3508,9 @@ class B : A<B>
 
             diff2.VerifyPdb(new[] { 0x06000001, 0x06000002, 0x06000003, 0x06000004 }, @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method token=""0x6000003"">
       <customDebugInfo>
@@ -3513,12 +3519,12 @@ class B : A<B>
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x8"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""19"" />
-        <entry offset=""0xe"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""14"" />
-        <entry offset=""0x16"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""14"" />
-        <entry offset=""0x1d"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x8"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xe"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x16"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1e"">
         <local name=""x"" il_index=""5"" il_start=""0x0"" il_end=""0x1e"" attributes=""0"" />
@@ -3559,6 +3565,9 @@ class B : A<B>
 }");
             diff3.VerifyPdb(new[] { 0x06000001, 0x06000002, 0x06000003, 0x06000004 }, @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method token=""0x6000004"">
       <customDebugInfo>
@@ -3567,12 +3576,12 @@ class B : A<B>
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""24"" />
-        <entry offset=""0x7"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""24"" />
-        <entry offset=""0xd"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""14"" />
-        <entry offset=""0x14"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" />
-        <entry offset=""0x1b"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x7"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xd"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x14"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <local name=""c"" il_index=""2"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
@@ -3645,6 +3654,9 @@ class B : A<B>
 }");
             diff2.VerifyPdb(new[] { 0x06000002 }, @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method token=""0x6000002"">
       <customDebugInfo>
@@ -3653,10 +3665,10 @@ class B : A<B>
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" />
-        <entry offset=""0x3"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""30"" />
-        <entry offset=""0x9"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x9"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <local name=""a"" il_index=""2"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -181,7 +181,11 @@ public class C
   IL_004a:  ret
 }
 ");
-            v0.VerifyPdb("C.M", @"<symbols>
+            v0.VerifyPdb("C.M", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -198,26 +202,26 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""14"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x3"" hidden=""true"" />
-        <entry offset=""0x5"" startLine=""8"" startColumn=""37"" endLine=""8"" endColumn=""58"" />
-        <entry offset=""0xc"" startLine=""8"" startColumn=""32"" endLine=""8"" endColumn=""35"" />
-        <entry offset=""0x10"" startLine=""8"" startColumn=""25"" endLine=""8"" endColumn=""30"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x18"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x1a"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""9"" startColumn=""37"" endLine=""9"" endColumn=""58"" />
-        <entry offset=""0x23"" startLine=""9"" startColumn=""32"" endLine=""9"" endColumn=""35"" />
-        <entry offset=""0x27"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""30"" />
-        <entry offset=""0x2d"" hidden=""true"" />
-        <entry offset=""0x31"" startLine=""12"" startColumn=""14"" endLine=""12"" endColumn=""19"" />
-        <entry offset=""0x33"" hidden=""true"" />
-        <entry offset=""0x35"" startLine=""12"" startColumn=""33"" endLine=""12"" endColumn=""54"" />
-        <entry offset=""0x3c"" startLine=""12"" startColumn=""28"" endLine=""12"" endColumn=""31"" />
-        <entry offset=""0x40"" startLine=""12"" startColumn=""21"" endLine=""12"" endColumn=""26"" />
-        <entry offset=""0x46"" hidden=""true"" />
-        <entry offset=""0x4a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""14"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5"" startLine=""8"" startColumn=""37"" endLine=""8"" endColumn=""58"" document=""1"" />
+        <entry offset=""0xc"" startLine=""8"" startColumn=""32"" endLine=""8"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x10"" startLine=""8"" startColumn=""25"" endLine=""8"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x18"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""9"" startColumn=""37"" endLine=""9"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x23"" startLine=""9"" startColumn=""32"" endLine=""9"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x27"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x2d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x31"" startLine=""12"" startColumn=""14"" endLine=""12"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x33"" hidden=""true"" document=""1"" />
+        <entry offset=""0x35"" startLine=""12"" startColumn=""33"" endLine=""12"" endColumn=""54"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""12"" startColumn=""28"" endLine=""12"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x40"" startLine=""12"" startColumn=""21"" endLine=""12"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x46"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4b"">
         <namespace name=""System"" />
@@ -334,6 +338,9 @@ public class C
 
             CompileAndVerify(debug).VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -345,18 +352,18 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" />
-        <entry offset=""0x12"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x13"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x16"" hidden=""true"" />
-        <entry offset=""0x20"" hidden=""true"" />
-        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" />
-        <entry offset=""0x27"" startLine=""10"" startColumn=""21"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0x28"" startLine=""10"" startColumn=""23"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x2b"" hidden=""true"" />
-        <entry offset=""0x35"" hidden=""true"" />
-        <entry offset=""0x36"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x12"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x13"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x16"" hidden=""true"" document=""1"" />
+        <entry offset=""0x20"" hidden=""true"" document=""1"" />
+        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x27"" startLine=""10"" startColumn=""21"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x28"" startLine=""10"" startColumn=""23"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x2b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x35"" hidden=""true"" document=""1"" />
+        <entry offset=""0x36"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -364,21 +371,24 @@ public class C
 ");
             CompileAndVerify(release).VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" />
-        <entry offset=""0x10"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x12"" hidden=""true"" />
-        <entry offset=""0x1b"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" />
-        <entry offset=""0x22"" startLine=""10"" startColumn=""23"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x24"" hidden=""true"" />
-        <entry offset=""0x2d"" hidden=""true"" />
-        <entry offset=""0x2e"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x10"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x12"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x22"" startLine=""10"" startColumn=""23"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x24"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2e"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -2292,6 +2302,9 @@ class C
             // Validate that we emit a hidden sequence point @IL_0007.
             v0.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2301,14 +2314,14 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x13"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""49"" />
-        <entry offset=""0x1a"" startLine=""9"" startColumn=""50"" endLine=""9"" endColumn=""56"" />
-        <entry offset=""0x1c"" startLine=""10"" startColumn=""21"" endLine=""10"" endColumn=""49"" />
-        <entry offset=""0x23"" startLine=""10"" startColumn=""50"" endLine=""10"" endColumn=""56"" />
-        <entry offset=""0x25"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x13"" startLine=""9"" startColumn=""21"" endLine=""9"" endColumn=""49"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""9"" startColumn=""50"" endLine=""9"" endColumn=""56"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""10"" startColumn=""21"" endLine=""10"" endColumn=""49"" document=""1"" />
+        <entry offset=""0x23"" startLine=""10"" startColumn=""50"" endLine=""10"" endColumn=""56"" document=""1"" />
+        <entry offset=""0x25"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -2381,6 +2394,9 @@ class C
 
             v0.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2712,6 +2728,9 @@ class C
             // Validate presence of a hidden sequence point @IL_0007 that is required for proper function remapping.
             v0.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2721,13 +2740,13 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""17"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xa"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0xb"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" />
-        <entry offset=""0x12"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x13"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xb"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x12"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x13"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -2817,6 +2836,9 @@ class C
             // Validate presence of a hidden sequence point @IL_0012 that is required for proper function remapping.
             v0.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2826,14 +2848,14 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" hidden=""true"" />
-        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x4"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" />
-        <entry offset=""0xb"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0xc"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""20"" />
-        <entry offset=""0x12"" hidden=""true"" />
-        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" document=""1"" />
+        <entry offset=""0xb"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x12"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -2924,6 +2946,9 @@ class C
             // Validate presence of a hidden sequence point @IL_0010 that is required for proper function remapping.
             v0.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2933,13 +2958,13 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" />
-        <entry offset=""0x9"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0xa"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""21"" />
-        <entry offset=""0x10"" hidden=""true"" />
-        <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x9"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x10"" hidden=""true"" document=""1"" />
+        <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -185,16 +185,20 @@ class Driver
 }",
 sequencePoints: "TestCase+<Run>d__1.MoveNext");
 
-            v.VerifyPdb(@"<symbols>
+            v.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""DynamicMembers"" name=""get_Prop"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""39"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""DynamicMembers"" name=""set_Prop"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""40"" endLine=""8"" endColumn=""44"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""40"" endLine=""8"" endColumn=""44"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""TestCase"" name=""Run"">
@@ -218,7 +222,7 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""33"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""33"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
@@ -235,12 +239,12 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""32"" />
-        <entry offset=""0x7"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""17"" />
-        <entry offset=""0xe"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""35"" />
-        <entry offset=""0x19"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""30"" />
-        <entry offset=""0x21"" startLine=""36"" startColumn=""5"" endLine=""36"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""30"" startColumn=""5"" endLine=""30"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""32"" document=""1"" />
+        <entry offset=""0x7"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""17"" document=""1"" />
+        <entry offset=""0xe"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x19"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x21"" startLine=""36"" startColumn=""5"" endLine=""36"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
@@ -251,8 +255,8 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <forward declaringType=""TestCase"" methodName="".cctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""35"" />
-        <entry offset=""0x6"" startLine=""28"" startColumn=""5"" endLine=""28"" endColumn=""78"" />
+        <entry offset=""0x0"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x6"" startLine=""28"" startColumn=""5"" endLine=""28"" endColumn=""78"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""TestCase+&lt;&gt;c"" name=""&lt;Run&gt;b__1_0"">
@@ -276,21 +280,21 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0xf"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" />
-        <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" />
-        <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" />
-        <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" />
-        <entry offset=""0xca"" hidden=""true"" />
-        <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" />
-        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" />
-        <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" />
-        <entry offset=""0xf2"" hidden=""true"" />
-        <entry offset=""0x10c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
-        <entry offset=""0x114"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" document=""1"" />
+        <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xca"" hidden=""true"" document=""1"" />
+        <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
+        <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xf2"" hidden=""true"" document=""1"" />
+        <entry offset=""0x10c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x114"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0xf2"" />
@@ -310,15 +314,15 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" />
-        <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" />
-        <entry offset=""0x74"" hidden=""true"" />
-        <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" />
-        <entry offset=""0x96"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" document=""1"" />
+        <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" document=""1"" />
+        <entry offset=""0x74"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" document=""1"" />
+        <entry offset=""0x96"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
@@ -368,7 +372,11 @@ namespace ConsoleApplication1
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(text, options: TestOptions.DebugDll).VerifyDiagnostics();
-            compilation.VerifyPdb(@"<symbols>
+            compilation.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""ConsoleApplication1.Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -378,9 +386,9 @@ namespace ConsoleApplication1
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""34"" />
-        <entry offset=""0xc"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""34"" document=""1"" />
+        <entry offset=""0xc"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xd"">
         <namespace name=""System"" />
@@ -414,9 +422,9 @@ namespace ConsoleApplication1
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""31"" startColumn=""13"" endLine=""31"" endColumn=""51"" />
-        <entry offset=""0xf"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""31"" startColumn=""13"" endLine=""31"" endColumn=""51"" document=""1"" />
+        <entry offset=""0xf"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""ConsoleApplication1.Program"" name="".cctor"">
@@ -424,7 +432,7 @@ namespace ConsoleApplication1
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""53"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""53"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""ConsoleApplication1.Program+&lt;QBar&gt;d__2"" name=""MoveNext"">
@@ -438,14 +446,14 @@ namespace ConsoleApplication1
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0xf"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" />
-        <entry offset=""0x20"" hidden=""true"" />
-        <entry offset=""0x73"" hidden=""true"" />
-        <entry offset=""0x8b"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
-        <entry offset=""0x93"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xf"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x20"" hidden=""true"" document=""1"" />
+        <entry offset=""0x73"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8b"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x93"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0x73"" />
@@ -472,25 +480,25 @@ namespace ConsoleApplication1
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x11"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" />
-        <entry offset=""0x12"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""45"" />
-        <entry offset=""0x1d"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""20"" />
-        <entry offset=""0x1e"" startLine=""22"" startColumn=""31"" endLine=""22"" endColumn=""46"" />
-        <entry offset=""0x3c"" hidden=""true"" />
-        <entry offset=""0x41"" startLine=""22"" startColumn=""22"" endLine=""22"" endColumn=""27"" />
-        <entry offset=""0x54"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" />
-        <entry offset=""0x55"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" />
-        <entry offset=""0x6b"" hidden=""true"" />
-        <entry offset=""0xd0"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" />
-        <entry offset=""0xe2"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" />
-        <entry offset=""0xe3"" hidden=""true"" />
-        <entry offset=""0xf1"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" />
-        <entry offset=""0x10b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" />
-        <entry offset=""0x114"" hidden=""true"" />
-        <entry offset=""0x12e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0x136"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x12"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""22"" startColumn=""31"" endLine=""22"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x3c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x41"" startLine=""22"" startColumn=""22"" endLine=""22"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x54"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x55"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x6b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd0"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" document=""1"" />
+        <entry offset=""0xe2"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""1"" />
+        <entry offset=""0xe3"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf1"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x10b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x114"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x136"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""ZBar"" />
@@ -520,7 +528,11 @@ class TestCase
                     references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef })
                 .VerifyDiagnostics();
 
-            compilation.VerifyPdb(@"<symbols>
+            compilation.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""TestCase"" name=""Await"" parameterNames=""d"">
       <customDebugInfo>
@@ -551,14 +563,14 @@ class TestCase
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x11"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x12"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""27"" />
-        <entry offset=""0xae"" hidden=""true"" />
-        <entry offset=""0x22e"" hidden=""true"" />
-        <entry offset=""0x248"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x250"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xae"" hidden=""true"" document=""1"" />
+        <entry offset=""0x22e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x248"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x250"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0x22e"" />
@@ -737,25 +749,29 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x17"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x25"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x36"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" />
-        <entry offset=""0x55"" hidden=""true"" />
-        <entry offset=""0xa3"" hidden=""true"" />
-        <entry offset=""0xba"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
-        <entry offset=""0xc2"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x17"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x25"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x36"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x55"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa3"" hidden=""true"" document=""1"" />
+        <entry offset=""0xba"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xc2"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xce"">
         <scope startOffset=""0xa"" endOffset=""0xa3"">
@@ -772,6 +788,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""b"">
       <customDebugInfo>
@@ -820,7 +839,11 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -836,19 +859,19 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" />
-        <entry offset=""0x86"" hidden=""true"" />
-        <entry offset=""0xd9"" hidden=""true"" />
-        <entry offset=""0xf1"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0xf9"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x86"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf1"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf9"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -860,6 +883,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""b"">
       <customDebugInfo>
@@ -914,7 +940,11 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -924,19 +954,19 @@ class C
         </hoistedLocalScopes>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0x15"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x2d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x39"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x4f"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" />
-        <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0xa7"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0xb9"" hidden=""true"" />
-        <entry offset=""0xd0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
-        <entry offset=""0xd8"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x39"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
+        <entry offset=""0xb9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xd8"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -948,6 +978,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""b"">
       <customDebugInfo>
@@ -995,7 +1028,11 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1011,20 +1048,20 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" />
-        <entry offset=""0x64"" hidden=""true"" />
-        <entry offset=""0xb5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0xc8"" hidden=""true"" />
-        <entry offset=""0xe0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
-        <entry offset=""0xe8"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x35"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
+        <entry offset=""0xc8"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe8"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -1036,6 +1073,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""b"">
       <customDebugInfo>
@@ -1085,7 +1125,11 @@ class C
 
             // CHANGE: Dev12 emits a <dynamiclocal> entry for "d", but gives it slot "-1", preventing it from matching
             // any locals when consumed by the EE (i.e. it has no effect).  See FUNCBRECEE::IsLocalDynamic.
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1103,16 +1147,16 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" />
-        <entry offset=""0x27"" hidden=""true"" />
-        <entry offset=""0x7b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0xd5"" hidden=""true"" />
-        <entry offset=""0xed"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0xf5"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xed"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
@@ -1127,6 +1171,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1170,7 +1217,11 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1182,15 +1233,15 @@ class C
         </dynamicLocals>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x14"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" />
-        <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" />
-        <entry offset=""0x70"" hidden=""true"" />
-        <entry offset=""0xbe"" hidden=""true"" />
-        <entry offset=""0xd5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0xdd"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x14"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x70"" hidden=""true"" document=""1"" />
+        <entry offset=""0xbe"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xdd"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xe9"">
         <namespace name=""System.Threading.Tasks"" />
@@ -1208,6 +1259,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1250,7 +1304,11 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1268,16 +1326,16 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0x11"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x12"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" />
-        <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" />
-        <entry offset=""0x82"" hidden=""true"" />
-        <entry offset=""0xd5"" hidden=""true"" />
-        <entry offset=""0xed"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0xf5"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xed"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
@@ -1292,6 +1350,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1389,6 +1450,9 @@ class C
 
             v.VerifyPdb("C.G", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""G"">
       <customDebugInfo>
@@ -1542,7 +1606,11 @@ class C
   IL_0111:  ret
 }", sequencePoints: "C+<G>d__0.MoveNext");
 
-            v.VerifyPdb("C+<G>d__0.MoveNext", @"<symbols>
+            v.VerifyPdb("C+<G>d__0.MoveNext", @"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;G&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1563,24 +1631,24 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" hidden=""true"" />
-        <entry offset=""0xe"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
-        <entry offset=""0x17"" hidden=""true"" />
-        <entry offset=""0x25"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x26"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x27"" hidden=""true"" />
-        <entry offset=""0x29"" hidden=""true"" />
-        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x34"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" />
-        <entry offset=""0x3f"" hidden=""true"" />
-        <entry offset=""0xa5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0xa6"" hidden=""true"" />
-        <entry offset=""0xd9"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" />
-        <entry offset=""0xe2"" hidden=""true"" />
-        <entry offset=""0xfc"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
-        <entry offset=""0x104"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x17"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x26"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" hidden=""true"" document=""1"" />
+        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x34"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x3f"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa6"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xfc"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x104"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x112"">
         <namespace name=""System"" />
@@ -1643,6 +1711,9 @@ class C
 
             v.VerifyPdb("C.G", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""G"">
       <customDebugInfo>
@@ -1682,6 +1753,9 @@ public partial class C
             var v = CompileAndVerify(compilation);
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -34,6 +34,9 @@ public class T
             //        unpaired surrogates.
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""T"" name=""Main"">
       <customDebugInfo>
@@ -42,8 +45,8 @@ public class T
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -57,11 +60,14 @@ public class T
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""T"" name=""Main"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""HighSurrogateCharacter"" value=""\uD800"" type=""String"" />
@@ -93,6 +99,9 @@ public class T
             //        unpaired surrogates.
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""T"" name=""Main"">
       <customDebugInfo>
@@ -101,8 +110,8 @@ public class T
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -114,11 +123,14 @@ public class T
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""T"" name=""Main"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""invalidUnicodeString"" value=""\uD800\u0000\uDC00"" type=""String"" />
@@ -193,6 +205,9 @@ public class C<S>
 
             c.VerifyPdb("C`1.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C`1"" name=""F"">
       <customDebugInfo>
@@ -205,8 +220,8 @@ public class C<S>
         </dynamicLocals>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""56"" startColumn=""5"" endLine=""56"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""56"" startColumn=""5"" endLine=""56"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -266,6 +281,9 @@ class C
 ";
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -274,10 +292,10 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <constant name=""x"" value=""1"" type=""Int32"" />
@@ -314,6 +332,9 @@ class C
             var c = CompileAndVerify(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""a"">
       <customDebugInfo>
@@ -326,9 +347,9 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""15"" endColumn=""12"" />
-        <entry offset=""0x27"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""15"" endColumn=""12"" document=""1"" />
+        <entry offset=""0x27"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <namespace name=""System"" />
@@ -340,10 +361,10 @@ class C
         <forward declaringType=""C"" methodName=""M"" parameterNames=""a"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""14"" />
-        <entry offset=""0x2"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" />
-        <entry offset=""0x3"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x2"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x3"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <constant name=""y"" value=""2"" type=""Int32"" />
@@ -394,6 +415,9 @@ class C
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -410,18 +434,18 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x20"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x27"" hidden=""true"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x2a"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" />
-        <entry offset=""0x41"" hidden=""true"" />
-        <entry offset=""0x48"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x49"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" />
-        <entry offset=""0x59"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" />
-        <entry offset=""0x64"" hidden=""true"" />
-        <entry offset=""0x67"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x41"" hidden=""true"" document=""1"" />
+        <entry offset=""0x48"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x49"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x59"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
+        <entry offset=""0x67"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x69"">
         <namespace name=""System.Collections.Generic"" />
@@ -456,6 +480,9 @@ class C
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -464,8 +491,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""o"" value=""null"" type=""Object"" />
@@ -578,6 +605,9 @@ this is a string constant that is too long to fit into the PDB"";
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -586,8 +616,8 @@ this is a string constant that is too long to fit into the PDB"";
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""43"" startColumn=""5"" endLine=""43"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""43"" startColumn=""5"" endLine=""43"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -595,11 +625,14 @@ this is a string constant that is too long to fit into the PDB"";
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""43"" startColumn=""5"" endLine=""43"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""43"" startColumn=""5"" endLine=""43"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""text"" value=""\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB\u000D\u000Athis is a string constant that is too long to fit into the PDB"" type=""String"" />
@@ -628,6 +661,9 @@ class C
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -636,8 +672,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""x"" value=""" + str.Replace("\0", @"\u0000") + @""" type=""String"" />
@@ -648,11 +684,14 @@ class C
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""x"" value=""" + str.Replace("\0", @"\u0000") + @""" type=""String"" />
@@ -681,6 +720,9 @@ class C
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -689,8 +731,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -698,11 +740,14 @@ class C
 
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""x"" value=""" + str.Replace("\0", @"\u0000") + @""" type=""String"" />
@@ -728,6 +773,9 @@ class C
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -736,8 +784,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""d"" value=""1.5"" type=""Decimal"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBDynamicLocalsTests.cs
@@ -40,6 +40,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, references: new[] { CSharpRef }, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Helper"" name=""goo"" parameterNames=""y"">
       <customDebugInfo>
@@ -48,8 +51,8 @@ class Test
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Helper"" name="".ctor"">
@@ -57,9 +60,9 @@ class Test
         <forward declaringType=""Helper"" methodName=""goo"" parameterNames=""y"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""17"" />
-        <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" />
-        <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Helper"" name="".ctor"" parameterNames=""x"">
@@ -67,9 +70,9 @@ class Test
         <forward declaringType=""Helper"" methodName=""goo"" parameterNames=""y"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""22"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
@@ -88,12 +91,12 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""3"" endLine=""18"" endColumn=""4"" />
-        <entry offset=""0x1"" startLine=""19"" startColumn=""3"" endLine=""19"" endColumn=""29"" />
-        <entry offset=""0x7"" startLine=""20"" startColumn=""3"" endLine=""20"" endColumn=""28"" />
-        <entry offset=""0x17"" startLine=""21"" startColumn=""3"" endLine=""21"" endColumn=""24"" />
-        <entry offset=""0xb1"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""30"" />
-        <entry offset=""0x10f"" startLine=""24"" startColumn=""3"" endLine=""24"" endColumn=""4"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""3"" endLine=""18"" endColumn=""4"" document=""1"" />
+        <entry offset=""0x1"" startLine=""19"" startColumn=""3"" endLine=""19"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x7"" startLine=""20"" startColumn=""3"" endLine=""20"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x17"" startLine=""21"" startColumn=""3"" endLine=""21"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xb1"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x10f"" startLine=""24"" startColumn=""3"" endLine=""24"" endColumn=""4"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x110"">
         <local name=""d1"" il_index=""0"" il_start=""0x0"" il_end=""0x110"" attributes=""0"" />
@@ -125,6 +128,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -143,17 +149,17 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""46"" />
-        <entry offset=""0x10"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" />
-        <entry offset=""0x11"" startLine=""8"" startColumn=""31"" endLine=""8"" endColumn=""41"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""27"" />
-        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x1c"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x1d"" hidden=""true"" />
-        <entry offset=""0x21"" startLine=""8"" startColumn=""28"" endLine=""8"" endColumn=""30"" />
-        <entry offset=""0x27"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x10"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x11"" startLine=""8"" startColumn=""31"" endLine=""8"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x21"" startLine=""8"" startColumn=""28"" endLine=""8"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x27"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <namespace name=""System"" />
@@ -188,6 +194,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -201,12 +210,12 @@ class Test
         </dynamicLocals>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x4"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x5"" startLine=""14"" startColumn=""2"" endLine=""14"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x5"" startLine=""14"" startColumn=""2"" endLine=""14"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <scope startOffset=""0x1"" endOffset=""0x3"">
@@ -244,6 +253,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -263,16 +275,16 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""30"" />
-        <entry offset=""0x4"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""29"" />
-        <entry offset=""0x6"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x7"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x8"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""32"" />
-        <entry offset=""0xa"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0xc"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0xd"" startLine=""14"" startColumn=""2"" endLine=""14"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x4"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x6"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""32"" document=""1"" />
+        <entry offset=""0xa"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xc"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xd"" startLine=""14"" startColumn=""2"" endLine=""14"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xe"">
         <scope startOffset=""0x1"" endOffset=""0x7"">
@@ -306,6 +318,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -322,10 +337,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""89"" />
-        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""88"" />
-        <entry offset=""0x5"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""89"" document=""1"" />
+        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""88"" document=""1"" />
+        <entry offset=""0x5"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <local name=""c123456789012345678901234567890123456789012345678901234567890123"" il_index=""0"" il_start=""0x0"" il_end=""0x6"" attributes=""0"" />
@@ -359,6 +374,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -377,11 +395,11 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""3"" endLine=""9"" endColumn=""4"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""3"" endLine=""10"" endColumn=""35"" />
-        <entry offset=""0x9"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""39"" />
-        <entry offset=""0x11"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""39"" />
-        <entry offset=""0x18"" startLine=""13"" startColumn=""3"" endLine=""13"" endColumn=""4"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""3"" endLine=""9"" endColumn=""4"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""3"" endLine=""10"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x9"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x11"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x18"" startLine=""13"" startColumn=""3"" endLine=""13"" endColumn=""4"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <local name=""arr"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
@@ -412,6 +430,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -434,13 +455,13 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""3"" endLine=""6"" endColumn=""4"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""32"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""3"" endLine=""8"" endColumn=""42"" />
-        <entry offset=""0xd"" startLine=""9"" startColumn=""3"" endLine=""9"" endColumn=""36"" />
-        <entry offset=""0x13"" startLine=""10"" startColumn=""3"" endLine=""10"" endColumn=""70"" />
-        <entry offset=""0x19"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""42"" />
-        <entry offset=""0x20"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""4"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""3"" endLine=""6"" endColumn=""4"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""32"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""3"" endLine=""8"" endColumn=""42"" document=""1"" />
+        <entry offset=""0xd"" startLine=""9"" startColumn=""3"" endLine=""9"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x13"" startLine=""10"" startColumn=""3"" endLine=""10"" endColumn=""70"" document=""1"" />
+        <entry offset=""0x19"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x20"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""4"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <namespace name=""System.Collections.Generic"" />
@@ -485,6 +506,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Helper"" name=""goo"" parameterNames=""y"">
       <customDebugInfo>
@@ -493,8 +517,8 @@ class Test
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""24"" endLine=""5"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""25"" endLine=""5"" endColumn=""26"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Helper"" name="".ctor"">
@@ -502,9 +526,9 @@ class Test
         <forward declaringType=""Helper"" methodName=""goo"" parameterNames=""y"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""17"" />
-        <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" />
-        <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""17"" endLine=""6"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x8"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""19"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Helper"" name="".ctor"" parameterNames=""x"">
@@ -512,9 +536,9 @@ class Test
         <forward declaringType=""Helper"" methodName=""goo"" parameterNames=""y"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""22"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""23"" endLine=""7"" endColumn=""24"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
@@ -531,11 +555,11 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""3"" endLine=""18"" endColumn=""4"" />
-        <entry offset=""0x1"" startLine=""19"" startColumn=""3"" endLine=""19"" endColumn=""35"" />
-        <entry offset=""0x7"" startLine=""20"" startColumn=""3"" endLine=""20"" endColumn=""29"" />
-        <entry offset=""0xd"" startLine=""21"" startColumn=""3"" endLine=""21"" endColumn=""37"" />
-        <entry offset=""0x1a"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""4"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""3"" endLine=""18"" endColumn=""4"" document=""1"" />
+        <entry offset=""0x1"" startLine=""19"" startColumn=""3"" endLine=""19"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x7"" startLine=""20"" startColumn=""3"" endLine=""20"" endColumn=""29"" document=""1"" />
+        <entry offset=""0xd"" startLine=""21"" startColumn=""3"" endLine=""21"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""22"" startColumn=""3"" endLine=""22"" endColumn=""4"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1b"">
         <local name=""staticObj"" il_index=""0"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
@@ -564,6 +588,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name="".ctor"">
       <customDebugInfo>
@@ -578,9 +605,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""2"" endLine=""4"" endColumn=""15"" />
-        <entry offset=""0x7"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""2"" endLine=""4"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x7"" startLine=""5"" startColumn=""2"" endLine=""5"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""2"" endLine=""7"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <scope startOffset=""0x7"" endOffset=""0x9"">
@@ -593,8 +620,8 @@ class Test
         <forward declaringType=""Test"" methodName="".ctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -628,6 +655,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""get_Field"">
       <customDebugInfo>
@@ -643,10 +673,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""39"" />
-        <entry offset=""0x13"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x13"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x19"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x19"" attributes=""0"" />
@@ -663,9 +693,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" />
-        <entry offset=""0x3"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x3"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
@@ -676,8 +706,8 @@ class Test
         <forward declaringType=""Test"" methodName=""get_Field"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -713,6 +743,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Complex"" name="".ctor"" parameterNames=""real, imaginary"">
       <customDebugInfo>
@@ -721,11 +754,11 @@ class Test
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""44"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""36"" />
-        <entry offset=""0x16"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xf"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x16"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Complex"" name=""op_Addition"" parameterNames=""c1, c2"">
@@ -740,10 +773,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""81"" />
-        <entry offset=""0x21"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""18"" />
-        <entry offset=""0x25"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""81"" document=""1"" />
+        <entry offset=""0x21"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x25"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
@@ -754,8 +787,8 @@ class Test
         <forward declaringType=""Complex"" methodName="".ctor"" parameterNames=""real, imaginary"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -790,6 +823,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""get_Item"" parameterNames=""i"">
       <customDebugInfo>
@@ -805,10 +841,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""32"" />
-        <entry offset=""0xa"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0xe"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""32"" document=""1"" />
+        <entry offset=""0xa"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xe"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x10"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x10"" attributes=""0"" />
@@ -825,10 +861,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""41"" />
-        <entry offset=""0x3"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0xc"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x3"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xc"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xd"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
@@ -839,8 +875,8 @@ class Test
         <forward declaringType=""Test"" methodName=""get_Item"" parameterNames=""i"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -869,6 +905,9 @@ class Sample
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Sample"" name=""Main"">
       <customDebugInfo>
@@ -880,10 +919,10 @@ class Sample
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" />
-        <entry offset=""0x7"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""76"" />
-        <entry offset=""0x19"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x7"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""76"" document=""1"" />
+        <entry offset=""0x19"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1a"">
         <namespace name=""System"" />
@@ -901,8 +940,8 @@ class Sample
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""d"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
@@ -952,6 +991,9 @@ struct Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name="".ctor"" parameterNames=""d"">
       <customDebugInfo>
@@ -966,9 +1008,9 @@ struct Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
-        <entry offset=""0x8"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x8"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
@@ -987,9 +1029,9 @@ struct Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""22"" />
-        <entry offset=""0xa"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xa"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xc"">
         <local name=""d2"" il_index=""0"" il_start=""0x0"" il_end=""0xc"" attributes=""0"" />
@@ -1006,9 +1048,9 @@ struct Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""23"" />
-        <entry offset=""0x8"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x8"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""d3"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
@@ -1026,9 +1068,9 @@ struct Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""38"" />
-        <entry offset=""0x16"" startLine=""29"" startColumn=""5"" endLine=""29"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x16"" startLine=""29"" startColumn=""5"" endLine=""29"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x18"">
         <local name=""d4"" il_index=""0"" il_start=""0x0"" il_end=""0x18"" attributes=""0"" />
@@ -1045,8 +1087,8 @@ struct Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
@@ -1075,6 +1117,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1094,11 +1139,11 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" />
-        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""58"" />
-        <entry offset=""0x41"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""50"" />
-        <entry offset=""0x61"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x41"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""50"" document=""1"" />
+        <entry offset=""0x61"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x62"">
         <namespace name=""System"" />
@@ -1112,7 +1157,7 @@ class Test
         <forward declaringType=""Test"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""27"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__2_1"" parameterNames=""d4"">
@@ -1126,9 +1171,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""32"" endLine=""10"" endColumn=""33"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""46"" endLine=""10"" endColumn=""54"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""55"" endLine=""10"" endColumn=""56"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""32"" endLine=""10"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""46"" endLine=""10"" endColumn=""54"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""55"" endLine=""10"" endColumn=""56"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""d5"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
@@ -1142,9 +1187,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""35"" endLine=""11"" endColumn=""36"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""37"" endLine=""11"" endColumn=""47"" />
-        <entry offset=""0x5"" startLine=""11"" startColumn=""48"" endLine=""11"" endColumn=""49"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""35"" endLine=""11"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""37"" endLine=""11"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x5"" startLine=""11"" startColumn=""48"" endLine=""11"" endColumn=""49"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1219,6 +1264,9 @@ class Test
 }";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1275,61 +1323,61 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""46"" />
-        <entry offset=""0x15"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""69"" />
-        <entry offset=""0x3c"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""64"" />
-        <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0x5d"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x5e"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""18"" />
-        <entry offset=""0x62"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x63"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""23"" />
-        <entry offset=""0x69"" hidden=""true"" />
-        <entry offset=""0x6d"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x6e"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""18"" />
-        <entry offset=""0x72"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
-        <entry offset=""0x73"" startLine=""22"" startColumn=""11"" endLine=""22"" endColumn=""26"" />
-        <entry offset=""0x79"" hidden=""true"" />
-        <entry offset=""0x7d"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""16"" />
-        <entry offset=""0x7e"" startLine=""23"" startColumn=""27"" endLine=""23"" endColumn=""33"" />
-        <entry offset=""0x84"" hidden=""true"" />
-        <entry offset=""0x86"" startLine=""23"" startColumn=""18"" endLine=""23"" endColumn=""23"" />
-        <entry offset=""0x8d"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""10"" />
-        <entry offset=""0x8e"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" />
-        <entry offset=""0x8f"" hidden=""true"" />
-        <entry offset=""0x95"" startLine=""23"" startColumn=""24"" endLine=""23"" endColumn=""26"" />
-        <entry offset=""0x9d"" startLine=""27"" startColumn=""14"" endLine=""27"" endColumn=""23"" />
-        <entry offset=""0xa0"" hidden=""true"" />
-        <entry offset=""0xa2"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0xa3"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" />
-        <entry offset=""0xa4"" startLine=""27"" startColumn=""32"" endLine=""27"" endColumn=""35"" />
-        <entry offset=""0xaa"" startLine=""27"" startColumn=""25"" endLine=""27"" endColumn=""30"" />
-        <entry offset=""0xb1"" hidden=""true"" />
-        <entry offset=""0xb5"" startLine=""31"" startColumn=""14"" endLine=""31"" endColumn=""29"" />
-        <entry offset=""0xbc"" hidden=""true"" />
-        <entry offset=""0xbe"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" />
-        <entry offset=""0xbf"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" />
-        <entry offset=""0xc0"" startLine=""31"" startColumn=""31"" endLine=""31"" endColumn=""37"" />
-        <entry offset=""0xc6"" hidden=""true"" />
-        <entry offset=""0xca"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""21"" />
-        <entry offset=""0xd0"" hidden=""true"" />
-        <entry offset=""0xd4"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" />
-        <entry offset=""0xd5"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" />
-        <entry offset=""0xd8"" startLine=""40"" startColumn=""9"" endLine=""40"" endColumn=""10"" />
-        <entry offset=""0xd9"" startLine=""42"" startColumn=""9"" endLine=""42"" endColumn=""10"" />
-        <entry offset=""0xda"" hidden=""true"" />
-        <entry offset=""0xdb"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""10"" />
-        <entry offset=""0xdc"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""35"" />
-        <entry offset=""0xe2"" startLine=""48"" startColumn=""9"" endLine=""48"" endColumn=""14"" />
-        <entry offset=""0xe3"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" />
-        <entry offset=""0xe4"" startLine=""51"" startColumn=""9"" endLine=""51"" endColumn=""10"" />
-        <entry offset=""0xe7"" hidden=""true"" />
-        <entry offset=""0xe9"" startLine=""53"" startColumn=""9"" endLine=""53"" endColumn=""10"" />
-        <entry offset=""0xea"" startLine=""55"" startColumn=""9"" endLine=""55"" endColumn=""10"" />
-        <entry offset=""0xec"" startLine=""56"" startColumn=""9"" endLine=""58"" endColumn=""26"" />
-        <entry offset=""0x113"" startLine=""59"" startColumn=""9"" endLine=""61"" endColumn=""26"" />
-        <entry offset=""0x13a"" startLine=""62"" startColumn=""5"" endLine=""62"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x15"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""69"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""64"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5d"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x5e"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x62"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x63"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x69"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6d"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6e"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x72"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x73"" startLine=""22"" startColumn=""11"" endLine=""22"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x79"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7d"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x7e"" startLine=""23"" startColumn=""27"" endLine=""23"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x84"" hidden=""true"" document=""1"" />
+        <entry offset=""0x86"" startLine=""23"" startColumn=""18"" endLine=""23"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x8d"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8e"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x95"" startLine=""23"" startColumn=""24"" endLine=""23"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x9d"" startLine=""27"" startColumn=""14"" endLine=""27"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xa0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa2"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa3"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa4"" startLine=""27"" startColumn=""32"" endLine=""27"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xaa"" startLine=""27"" startColumn=""25"" endLine=""27"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xb1"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""31"" startColumn=""14"" endLine=""31"" endColumn=""29"" document=""1"" />
+        <entry offset=""0xbc"" hidden=""true"" document=""1"" />
+        <entry offset=""0xbe"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xbf"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""31"" startColumn=""31"" endLine=""31"" endColumn=""37"" document=""1"" />
+        <entry offset=""0xc6"" hidden=""true"" document=""1"" />
+        <entry offset=""0xca"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""21"" document=""1"" />
+        <entry offset=""0xd0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd4"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xd5"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xd8"" startLine=""40"" startColumn=""9"" endLine=""40"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""42"" startColumn=""9"" endLine=""42"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xda"" hidden=""true"" document=""1"" />
+        <entry offset=""0xdb"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xdc"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xe2"" startLine=""48"" startColumn=""9"" endLine=""48"" endColumn=""14"" document=""1"" />
+        <entry offset=""0xe3"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe4"" startLine=""51"" startColumn=""9"" endLine=""51"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe9"" startLine=""53"" startColumn=""9"" endLine=""53"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xea"" startLine=""55"" startColumn=""9"" endLine=""55"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xec"" startLine=""56"" startColumn=""9"" endLine=""58"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x113"" startLine=""59"" startColumn=""9"" endLine=""61"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x13a"" startLine=""62"" startColumn=""5"" endLine=""62"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x13b"">
         <namespace name=""System"" />
@@ -1384,7 +1432,7 @@ class Test
         <forward declaringType=""Test"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""58"" startColumn=""20"" endLine=""58"" endColumn=""25"" />
+        <entry offset=""0x0"" startLine=""58"" startColumn=""20"" endLine=""58"" endColumn=""25"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test+&lt;&gt;c"" name=""&lt;Main&gt;b__0_1"" parameterNames=""score"">
@@ -1392,7 +1440,7 @@ class Test
         <forward declaringType=""Test"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""61"" startColumn=""20"" endLine=""61"" endColumn=""25"" />
+        <entry offset=""0x0"" startLine=""61"" startColumn=""20"" endLine=""61"" endColumn=""25"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1465,6 +1513,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1503,57 +1554,57 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""46"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x18"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""18"" />
-        <entry offset=""0x1c"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""23"" />
-        <entry offset=""0x22"" hidden=""true"" />
-        <entry offset=""0x25"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x26"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""18"" />
-        <entry offset=""0x2a"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
-        <entry offset=""0x2b"" startLine=""22"" startColumn=""11"" endLine=""22"" endColumn=""26"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x33"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""16"" />
-        <entry offset=""0x34"" startLine=""23"" startColumn=""27"" endLine=""23"" endColumn=""33"" />
-        <entry offset=""0x3a"" hidden=""true"" />
-        <entry offset=""0x3c"" startLine=""23"" startColumn=""18"" endLine=""23"" endColumn=""23"" />
-        <entry offset=""0x43"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""10"" />
-        <entry offset=""0x44"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" />
-        <entry offset=""0x45"" hidden=""true"" />
-        <entry offset=""0x4b"" startLine=""23"" startColumn=""24"" endLine=""23"" endColumn=""26"" />
-        <entry offset=""0x53"" startLine=""27"" startColumn=""14"" endLine=""27"" endColumn=""23"" />
-        <entry offset=""0x56"" hidden=""true"" />
-        <entry offset=""0x58"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0x59"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" />
-        <entry offset=""0x5a"" startLine=""27"" startColumn=""32"" endLine=""27"" endColumn=""35"" />
-        <entry offset=""0x60"" startLine=""27"" startColumn=""25"" endLine=""27"" endColumn=""30"" />
-        <entry offset=""0x67"" hidden=""true"" />
-        <entry offset=""0x6b"" startLine=""31"" startColumn=""14"" endLine=""31"" endColumn=""29"" />
-        <entry offset=""0x72"" hidden=""true"" />
-        <entry offset=""0x74"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" />
-        <entry offset=""0x75"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" />
-        <entry offset=""0x76"" startLine=""31"" startColumn=""31"" endLine=""31"" endColumn=""37"" />
-        <entry offset=""0x7c"" hidden=""true"" />
-        <entry offset=""0x80"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""21"" />
-        <entry offset=""0x86"" hidden=""true"" />
-        <entry offset=""0x8a"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" />
-        <entry offset=""0x8b"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" />
-        <entry offset=""0x8e"" startLine=""40"" startColumn=""9"" endLine=""40"" endColumn=""10"" />
-        <entry offset=""0x8f"" startLine=""42"" startColumn=""9"" endLine=""42"" endColumn=""10"" />
-        <entry offset=""0x90"" hidden=""true"" />
-        <entry offset=""0x91"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""10"" />
-        <entry offset=""0x92"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""35"" />
-        <entry offset=""0x98"" startLine=""48"" startColumn=""9"" endLine=""48"" endColumn=""14"" />
-        <entry offset=""0x99"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" />
-        <entry offset=""0x9a"" startLine=""51"" startColumn=""9"" endLine=""51"" endColumn=""10"" />
-        <entry offset=""0x9d"" hidden=""true"" />
-        <entry offset=""0x9f"" startLine=""53"" startColumn=""9"" endLine=""53"" endColumn=""10"" />
-        <entry offset=""0xa0"" startLine=""55"" startColumn=""9"" endLine=""55"" endColumn=""10"" />
-        <entry offset=""0xa2"" startLine=""58"" startColumn=""5"" endLine=""58"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x18"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x22"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x26"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""22"" startColumn=""11"" endLine=""22"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x33"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x34"" startLine=""23"" startColumn=""27"" endLine=""23"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""23"" startColumn=""18"" endLine=""23"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x43"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x44"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x45"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4b"" startLine=""23"" startColumn=""24"" endLine=""23"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x53"" startLine=""27"" startColumn=""14"" endLine=""27"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x56"" hidden=""true"" document=""1"" />
+        <entry offset=""0x58"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x59"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x5a"" startLine=""27"" startColumn=""32"" endLine=""27"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x60"" startLine=""27"" startColumn=""25"" endLine=""27"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x67"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6b"" startLine=""31"" startColumn=""14"" endLine=""31"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x72"" hidden=""true"" document=""1"" />
+        <entry offset=""0x74"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x75"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x76"" startLine=""31"" startColumn=""31"" endLine=""31"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x7c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x80"" startLine=""35"" startColumn=""9"" endLine=""35"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x86"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8a"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8b"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8e"" startLine=""40"" startColumn=""9"" endLine=""40"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8f"" startLine=""42"" startColumn=""9"" endLine=""42"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x90"" hidden=""true"" document=""1"" />
+        <entry offset=""0x91"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x92"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x98"" startLine=""48"" startColumn=""9"" endLine=""48"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x99"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x9a"" startLine=""51"" startColumn=""9"" endLine=""51"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x9d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x9f"" startLine=""53"" startColumn=""9"" endLine=""53"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa0"" startLine=""55"" startColumn=""9"" endLine=""55"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa2"" startLine=""58"" startColumn=""5"" endLine=""58"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa3"">
         <namespace name=""System"" />
@@ -1649,6 +1700,9 @@ class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -1668,9 +1722,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" />
-        <entry offset=""0x8"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x8"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <local name=""v1"" il_index=""0"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
@@ -1700,6 +1754,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1716,10 +1773,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""3"" endLine=""8"" endColumn=""13"" />
-        <entry offset=""0x9"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""2"" endLine=""6"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""3"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""3"" endLine=""8"" endColumn=""13"" document=""1"" />
+        <entry offset=""0x9"" startLine=""9"" startColumn=""2"" endLine=""9"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <namespace name=""System"" />
@@ -1751,6 +1808,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1765,10 +1825,10 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""49"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""19"" />
-        <entry offset=""0x12"" startLine=""13"" startColumn=""2"" endLine=""13"" endColumn=""3"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""2"" endLine=""10"" endColumn=""3"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""3"" endLine=""11"" endColumn=""49"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""3"" endLine=""12"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x12"" startLine=""13"" startColumn=""2"" endLine=""13"" endColumn=""3"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x13"">
         <namespace name=""System"" />
@@ -1798,6 +1858,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1814,8 +1877,8 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -1853,6 +1916,9 @@ class Goo<T>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1869,8 +1935,8 @@ class Goo<T>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -1908,6 +1974,9 @@ class Goo<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1924,8 +1993,8 @@ class Goo<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -1964,6 +2033,9 @@ class Goo<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -1981,9 +2053,9 @@ class Goo<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x3"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x3"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <namespace name=""System"" />
@@ -2021,6 +2093,9 @@ class F<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2035,8 +2110,8 @@ class F<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -2072,6 +2147,9 @@ class F<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2083,8 +2161,8 @@ class F<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -2124,6 +2202,9 @@ class F<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2139,10 +2220,10 @@ class F<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" />
-        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x6"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x6"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
@@ -2185,6 +2266,9 @@ class F<T,V>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2203,8 +2287,8 @@ class F<T,V>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -2244,6 +2328,9 @@ class F<T>
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2261,8 +2348,8 @@ class F<T>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -2300,6 +2387,9 @@ class Program
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2318,15 +2408,15 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x3"" hidden=""true"" />
-        <entry offset=""0x5"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x6"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x7"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" />
-        <entry offset=""0xb"" startLine=""9"" startColumn=""24"" endLine=""9"" endColumn=""30"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x14"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x7"" startLine=""9"" startColumn=""33"" endLine=""9"" endColumn=""36"" document=""1"" />
+        <entry offset=""0xb"" startLine=""9"" startColumn=""24"" endLine=""9"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x15"">
         <namespace name=""System"" />
@@ -2351,8 +2441,8 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <local name=""localInner"" il_index=""0"" il_start=""0x0"" il_end=""0x2"" attributes=""0"" />
@@ -2383,6 +2473,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.ReleaseDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -2391,8 +2484,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""34"" />
-        <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""GetDynamic"">
@@ -2400,7 +2493,7 @@ class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""20"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""20"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -31,6 +31,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Goo"">
       <customDebugInfo>
@@ -47,9 +50,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -73,6 +76,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Goo"">
       <customDebugInfo>
@@ -89,9 +95,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -115,6 +121,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Goo"">
       <customDebugInfo>
@@ -131,11 +140,11 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x20"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x37"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x37"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -165,6 +174,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.ReleaseDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""IEI"" parameterNames=""i0, i1"">
       <customDebugInfo>
@@ -182,18 +194,18 @@ class Program
         </hoistedLocalScopes>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" />
-        <entry offset=""0x36"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" />
-        <entry offset=""0x4b"" hidden=""true"" />
-        <entry offset=""0x52"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" />
-        <entry offset=""0x67"" hidden=""true"" />
-        <entry offset=""0x6e"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x7a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" />
-        <entry offset=""0x8f"" hidden=""true"" />
-        <entry offset=""0x96"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" />
-        <entry offset=""0xab"" hidden=""true"" />
-        <entry offset=""0xb2"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x36"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x4b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x52"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x67"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6e"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x7a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x96"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xab"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb2"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -223,6 +235,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""IEI"" parameterNames=""i0, i1"">
       <customDebugInfo>
@@ -247,21 +262,21 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x39"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x3a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" />
-        <entry offset=""0x46"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" />
-        <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0x62"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" />
-        <entry offset=""0x77"" hidden=""true"" />
-        <entry offset=""0x7e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x7f"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x8b"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" />
-        <entry offset=""0xa0"" hidden=""true"" />
-        <entry offset=""0xa7"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" />
-        <entry offset=""0xbc"" hidden=""true"" />
-        <entry offset=""0xc3"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0xc4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x39"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x46"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x5b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x62"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x77"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7f"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x8b"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xa0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xbc"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc3"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -293,6 +308,9 @@ class Test<T>
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test`1"" name=""M"" parameterNames=""items"">
       <customDebugInfo>
@@ -320,23 +338,23 @@ class Test<T>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x32"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x33"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" />
-        <entry offset=""0x3f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" />
-        <entry offset=""0x40"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""33"" />
-        <entry offset=""0x59"" hidden=""true"" />
-        <entry offset=""0x5b"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" />
-        <entry offset=""0x6c"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x6d"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" />
-        <entry offset=""0x79"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" />
-        <entry offset=""0x90"" hidden=""true"" />
-        <entry offset=""0x98"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0xa5"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" />
-        <entry offset=""0xc0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""26"" />
-        <entry offset=""0xd7"" hidden=""true"" />
-        <entry offset=""0xde"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
-        <entry offset=""0xe2"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x33"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x40"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x59"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5b"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x6c"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6d"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x79"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x90"" hidden=""true"" document=""1"" />
+        <entry offset=""0x98"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xa5"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xd7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xde"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xec"">
         <namespace name=""System"" />
@@ -383,6 +401,9 @@ class C
                 var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.ReleaseExe);
                 c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""M"">
@@ -397,14 +418,14 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""21"" startColumn=""27"" endLine=""21"" endColumn=""38"" />
-        <entry offset=""0x10"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""21"" startColumn=""18"" endLine=""21"" endColumn=""23"" />
-        <entry offset=""0x18"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""41"" />
-        <entry offset=""0x1d"" startLine=""21"" startColumn=""24"" endLine=""21"" endColumn=""26"" />
-        <entry offset=""0x27"" hidden=""true"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x31"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""21"" startColumn=""27"" endLine=""21"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x10"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""21"" startColumn=""18"" endLine=""21"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x18"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""21"" startColumn=""24"" endLine=""21"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x27"" hidden=""true"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x31"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x32"">
         <namespace name=""System.Collections.Generic"" />
@@ -415,14 +436,14 @@ class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x26"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" />
-        <entry offset=""0x3f"" hidden=""true"" />
-        <entry offset=""0x46"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""25"" />
-        <entry offset=""0x60"" hidden=""true"" />
-        <entry offset=""0x67"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""29"" />
-        <entry offset=""0x80"" hidden=""true"" />
-        <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x26"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x3f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x46"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x60"" hidden=""true"" document=""1"" />
+        <entry offset=""0x67"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x80"" hidden=""true"" document=""1"" />
+        <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x89"">
         <scope startOffset=""0x26"" endOffset=""0x89"">
@@ -495,6 +516,9 @@ public class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugExe);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""Test"" methodName=""Main"" />
   <methods>
     <method containingType=""Test`1"" name=""System.Collections.IEnumerable.GetEnumerator"">
@@ -507,9 +531,9 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""32"" />
-        <entry offset=""0xa"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""32"" document=""1"" />
+        <entry offset=""0xa"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xc"">
         <namespace name=""System"" />
@@ -547,17 +571,17 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""45"" startColumn=""5"" endLine=""45"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""46"" startColumn=""9"" endLine=""46"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""46"" startColumn=""27"" endLine=""46"" endColumn=""45"" />
-        <entry offset=""0xd"" hidden=""true"" />
-        <entry offset=""0xf"" startLine=""46"" startColumn=""18"" endLine=""46"" endColumn=""23"" />
-        <entry offset=""0x16"" startLine=""46"" startColumn=""47"" endLine=""46"" endColumn=""48"" />
-        <entry offset=""0x17"" startLine=""46"" startColumn=""49"" endLine=""46"" endColumn=""50"" />
-        <entry offset=""0x18"" startLine=""46"" startColumn=""24"" endLine=""46"" endColumn=""26"" />
-        <entry offset=""0x22"" hidden=""true"" />
-        <entry offset=""0x2c"" hidden=""true"" />
-        <entry offset=""0x2d"" startLine=""47"" startColumn=""5"" endLine=""47"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""45"" startColumn=""5"" endLine=""45"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""46"" startColumn=""9"" endLine=""46"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""46"" startColumn=""27"" endLine=""46"" endColumn=""45"" document=""1"" />
+        <entry offset=""0xd"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf"" startLine=""46"" startColumn=""18"" endLine=""46"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x16"" startLine=""46"" startColumn=""47"" endLine=""46"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x17"" startLine=""46"" startColumn=""49"" endLine=""46"" endColumn=""50"" document=""1"" />
+        <entry offset=""0x18"" startLine=""46"" startColumn=""24"" endLine=""46"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x22"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""47"" startColumn=""5"" endLine=""47"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2e"">
         <scope startOffset=""0xf"" endOffset=""0x18"">
@@ -580,28 +604,28 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x32"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""16"" />
-        <entry offset=""0x34"" startLine=""15"" startColumn=""27"" endLine=""15"" endColumn=""40"" />
-        <entry offset=""0x52"" hidden=""true"" />
-        <entry offset=""0x54"" startLine=""15"" startColumn=""18"" endLine=""15"" endColumn=""23"" />
-        <entry offset=""0x65"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x66"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" />
-        <entry offset=""0x80"" hidden=""true"" />
-        <entry offset=""0x88"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
-        <entry offset=""0x95"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""26"" />
-        <entry offset=""0xb0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" />
-        <entry offset=""0xb1"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""39"" />
-        <entry offset=""0xcf"" hidden=""true"" />
-        <entry offset=""0xd1"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" />
-        <entry offset=""0xe2"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" />
-        <entry offset=""0xe3"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""28"" />
-        <entry offset=""0xfa"" hidden=""true"" />
-        <entry offset=""0x102"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
-        <entry offset=""0x10f"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" />
-        <entry offset=""0x12a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
-        <entry offset=""0x12e"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x32"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x34"" startLine=""15"" startColumn=""27"" endLine=""15"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x52"" hidden=""true"" document=""1"" />
+        <entry offset=""0x54"" startLine=""15"" startColumn=""18"" endLine=""15"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x65"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x66"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x80"" hidden=""true"" document=""1"" />
+        <entry offset=""0x88"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x95"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xb0"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" document=""1"" />
+        <entry offset=""0xb1"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""39"" document=""1"" />
+        <entry offset=""0xcf"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd1"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xe2"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe3"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xfa"" hidden=""true"" document=""1"" />
+        <entry offset=""0x102"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x10f"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x12a"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12e"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test`1+&lt;get_IterProp&gt;d__3"" name=""MoveNext"">
@@ -612,13 +636,13 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" />
-        <entry offset=""0x40"" hidden=""true"" />
-        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" />
-        <entry offset=""0x5c"" hidden=""true"" />
-        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x40"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Test`1+&lt;IterMethod&gt;d__4"" name=""MoveNext"">
@@ -629,13 +653,13 @@ public class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" />
-        <entry offset=""0x2b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" />
-        <entry offset=""0x40"" hidden=""true"" />
-        <entry offset=""0x47"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" />
-        <entry offset=""0x5c"" hidden=""true"" />
-        <entry offset=""0x63"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x40"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x63"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -674,6 +698,9 @@ class C
 
             v.VerifyPdb("C+<F>d__0`1.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__0`1"" name=""MoveNext"">
       <customDebugInfo>
@@ -689,15 +716,15 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x2b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0x32"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0x3e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" />
-        <entry offset=""0x53"" hidden=""true"" />
-        <entry offset=""0x5a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x7a"" hidden=""true"" />
-        <entry offset=""0x81"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x32"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x3e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x53"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5a"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x7a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x81"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x83"">
         <namespace name=""System.Collections.Generic"" />
@@ -785,6 +812,9 @@ class C
 
             v.VerifyPdb("C+<F>d__1.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__1"" name=""MoveNext"">
       <customDebugInfo>
@@ -795,15 +825,15 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" />
-        <entry offset=""0x26"" hidden=""true"" />
-        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x2a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" />
-        <entry offset=""0x3a"" hidden=""true"" />
-        <entry offset=""0x41"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x42"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x26"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x41"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x42"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -880,6 +910,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"" parameterNames=""disposable"">
       <customDebugInfo>
@@ -946,6 +979,9 @@ class C
             // One iterator local entry for the lambda local.
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -958,18 +994,18 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x3b"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x3c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x48"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x54"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x60"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x77"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" />
-        <entry offset=""0xa9"" hidden=""true"" />
-        <entry offset=""0xb0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" />
-        <entry offset=""0xe2"" hidden=""true"" />
-        <entry offset=""0xe9"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3b"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x48"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x54"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x60"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x77"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xa9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb0"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xe2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe9"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1062,21 +1098,24 @@ class C
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x17"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x23"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x2a"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x31"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x41"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x51"" hidden=""true"" />
-        <entry offset=""0x58"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x23"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x31"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x41"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x51"" hidden=""true"" document=""1"" />
+        <entry offset=""0x58"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1084,6 +1123,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1194,6 +1236,9 @@ class C
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1206,16 +1251,16 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x2b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" />
-        <entry offset=""0x37"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x43"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" />
-        <entry offset=""0x4f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
-        <entry offset=""0x66"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x76"" hidden=""true"" />
-        <entry offset=""0x7d"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x37"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x43"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x66"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x76"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7d"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1223,6 +1268,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1274,6 +1322,9 @@ class C
             // any locals when consumed by the EE (i.e. it has no effect).  See FUNCBRECEE::IsLocalDynamic.
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1288,13 +1339,13 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" />
-        <entry offset=""0x82"" hidden=""true"" />
-        <entry offset=""0x89"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0xe1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0x89"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xe1"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xe3"">
         <namespace name=""System.Collections.Generic"" />
@@ -1305,6 +1356,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1349,6 +1403,9 @@ class C
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1360,11 +1417,11 @@ class C
         </dynamicLocals>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" />
-        <entry offset=""0x6d"" hidden=""true"" />
-        <entry offset=""0x74"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x6d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x74"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x76"">
         <namespace name=""System.Collections.Generic"" />
@@ -1409,6 +1466,9 @@ class C
 
             v.VerifyPdb("C+<M>d__0.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1423,12 +1483,12 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" />
-        <entry offset=""0x82"" hidden=""true"" />
-        <entry offset=""0x89"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x20"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0x89"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8b"">
         <namespace name=""System.Collections.Generic"" />
@@ -1463,6 +1523,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.DebugDll);
             c.VerifyPdb("C+<F>d__1.MoveNext", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__1"" name=""MoveNext"">
       <customDebugInfo>
@@ -1472,9 +1535,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
-        <entry offset=""0x18"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x18"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -29,6 +29,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -44,10 +47,10 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""38"" />
-        <entry offset=""0x21"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""13"" />
-        <entry offset=""0x28"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x21"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""13"" document=""1"" />
+        <entry offset=""0x28"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x29"">
         <namespace name=""System"" />
@@ -59,7 +62,7 @@ class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""21"" endLine=""8"" endColumn=""37"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""21"" endLine=""8"" endColumn=""37"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -98,6 +101,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugExe);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""Test"" methodName=""Main"" />
   <methods>
     <method containingType=""Test"" name=""Main"">
@@ -111,12 +117,12 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""10"" endLine=""7"" endColumn=""25"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""22"" />
-        <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
-        <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""10"" endLine=""7"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <namespace name=""System"" />
@@ -139,11 +145,11 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""22"" endColumn=""11"" />
-        <entry offset=""0x1b"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""22"" />
-        <entry offset=""0x25"" startLine=""24"" startColumn=""5"" endLine=""24"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""22"" endColumn=""11"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x25"" startLine=""24"" startColumn=""5"" endLine=""24"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
@@ -160,12 +166,12 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" />
-        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""20"" endColumn=""15"" />
-        <entry offset=""0x29"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""26"" />
-        <entry offset=""0x33"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""20"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x29"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x33"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -180,9 +186,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""14"" />
-        <entry offset=""0x1"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""38"" />
-        <entry offset=""0x1f"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""14"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""14"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -206,6 +212,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Goo"" parameterNames=""p"">
       <customDebugInfo>
@@ -223,11 +232,11 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0xe"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""39"" />
-        <entry offset=""0x1b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""14"" />
-        <entry offset=""0x22"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x22"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x23"" attributes=""0"" />
@@ -239,7 +248,7 @@ class Test
         <forward declaringType=""Test"" methodName=""Goo"" parameterNames=""p"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""38"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""38"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -276,6 +285,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -288,12 +300,12 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""22"" />
-        <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
-        <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x16"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <namespace name=""System"" />
@@ -316,11 +328,11 @@ class Test
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""19"" endColumn=""11"" />
-        <entry offset=""0x1b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""22"" />
-        <entry offset=""0x25"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""19"" endColumn=""11"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x25"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x27"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x27"" attributes=""0"" />
@@ -337,12 +349,12 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" />
-        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""66"" />
-        <entry offset=""0x29"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""26"" />
-        <entry offset=""0x33"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x15"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""66"" document=""1"" />
+        <entry offset=""0x29"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x33"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -357,9 +369,9 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""40"" endLine=""17"" endColumn=""41"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""42"" endLine=""17"" endColumn=""63"" />
-        <entry offset=""0x1f"" startLine=""17"" startColumn=""64"" endLine=""17"" endColumn=""65"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""40"" endLine=""17"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""42"" endLine=""17"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""17"" startColumn=""64"" endLine=""17"" endColumn=""65"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -391,6 +403,9 @@ class C : B
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""B"" name="".ctor"" parameterNames=""f"">
       <customDebugInfo>
@@ -399,9 +414,9 @@ class C : B
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" />
-        <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" />
-        <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
@@ -409,7 +424,7 @@ class C : B
     </method>
     <method containingType=""C"" name=""get_P"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""23"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name="".ctor"">
@@ -423,11 +438,11 @@ class C : B
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""28"" />
-        <entry offset=""0x25"" startLine=""13"" startColumn=""28"" endLine=""13"" endColumn=""38"" />
-        <entry offset=""0x4a"" startLine=""14"" startColumn=""18"" endLine=""14"" endColumn=""31"" />
-        <entry offset=""0x70"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""33"" />
-        <entry offset=""0x71"" startLine=""14"" startColumn=""33"" endLine=""14"" endColumn=""34"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x25"" startLine=""13"" startColumn=""28"" endLine=""13"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x4a"" startLine=""14"" startColumn=""18"" endLine=""14"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x70"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x71"" startLine=""14"" startColumn=""33"" endLine=""14"" endColumn=""34"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name="".cctor"">
@@ -439,7 +454,7 @@ class C : B
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""35"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""35"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_0"">
@@ -447,7 +462,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""14"" startColumn=""29"" endLine=""14"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""14"" startColumn=""29"" endLine=""14"" endColumn=""30"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_1"">
@@ -455,7 +470,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""26"" endLine=""11"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""26"" endLine=""11"" endColumn=""27"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__5_2"">
@@ -463,7 +478,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""34"" endLine=""13"" endColumn=""38"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""34"" endLine=""13"" endColumn=""38"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__6_0"">
@@ -471,7 +486,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""33"" endLine=""12"" endColumn=""34"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""33"" endLine=""12"" endColumn=""34"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -508,6 +523,9 @@ class C : B
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""B"" name="".ctor"" parameterNames=""f"">
       <customDebugInfo>
@@ -516,9 +534,9 @@ class C : B
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" />
-        <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" />
-        <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x8"" startLine=""6"" startColumn=""29"" endLine=""6"" endColumn=""30"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
@@ -542,15 +560,15 @@ class C : B
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x14"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""43"" />
-        <entry offset=""0x2e"" hidden=""true"" />
-        <entry offset=""0x34"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0x35"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" />
-        <entry offset=""0x3c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" />
-        <entry offset=""0x4e"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""23"" />
-        <entry offset=""0x60"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""21"" />
-        <entry offset=""0x72"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""43"" document=""1"" />
+        <entry offset=""0x2e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x34"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x35"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x4e"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x60"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x72"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x73"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
@@ -564,7 +582,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""41"" endLine=""13"" endColumn=""42"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""41"" endLine=""13"" endColumn=""42"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_0"" name=""&lt;.ctor&gt;b__1"">
@@ -572,7 +590,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""19"" endLine=""16"" endColumn=""20"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""19"" endLine=""16"" endColumn=""20"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_0"" name=""&lt;.ctor&gt;b__2"">
@@ -580,7 +598,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""22"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""22"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c__DisplayClass3_1"" name=""&lt;.ctor&gt;b__3"">
@@ -588,7 +606,7 @@ class C : B
         <forward declaringType=""B"" methodName="".ctor"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""19"" endLine=""18"" endColumn=""20"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""19"" endLine=""18"" endColumn=""20"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -619,6 +637,9 @@ class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -638,11 +659,11 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" />
-        <entry offset=""0xe"" startLine=""9"" startColumn=""9"" endLine=""12"" endColumn=""31"" />
-        <entry offset=""0x79"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xe"" startLine=""9"" startColumn=""9"" endLine=""12"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x79"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7a"">
         <namespace name=""System.Linq"" />
@@ -655,7 +676,7 @@ class C
         <forward declaringType=""C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""30"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_1"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
@@ -663,7 +684,7 @@ class C
         <forward declaringType=""C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""23"" endLine=""11"" endColumn=""29"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""23"" endLine=""11"" endColumn=""29"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_2"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
@@ -671,7 +692,7 @@ class C
         <forward declaringType=""C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -701,6 +722,9 @@ class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -721,9 +745,9 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""11"" endColumn=""40"" />
-        <entry offset=""0xe6"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""11"" endColumn=""40"" document=""1"" />
+        <entry offset=""0xe6"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xe7"">
         <namespace name=""System.Linq"" />
@@ -735,7 +759,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""52"" endLine=""9"" endColumn=""57"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""52"" endLine=""9"" endColumn=""57"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_1"" parameterNames=""b"">
@@ -743,7 +767,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""65"" endLine=""9"" endColumn=""70"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""65"" endLine=""9"" endColumn=""70"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_2"" parameterNames=""a, b"">
@@ -751,7 +775,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""70"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""22"" endLine=""9"" endColumn=""70"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_3"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
@@ -759,7 +783,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""57"" endLine=""10"" endColumn=""74"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""57"" endLine=""10"" endColumn=""74"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_4"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
@@ -767,7 +791,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""33"" endLine=""10"" endColumn=""53"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""33"" endLine=""10"" endColumn=""53"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;F&gt;b__0_5"" parameterNames=""d"">
@@ -775,7 +799,7 @@ class C
         <forward declaringType=""C"" methodName=""F"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""34"" endLine=""11"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""34"" endLine=""11"" endColumn=""39"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -809,6 +833,9 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -828,21 +855,21 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""39"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x20"" hidden=""true"" />
-        <entry offset=""0x26"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x27"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x2e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" />
-        <entry offset=""0x41"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x54"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x55"" hidden=""true"" />
-        <entry offset=""0x59"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x5f"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""39"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x20"" hidden=""true"" document=""1"" />
+        <entry offset=""0x26"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x27"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x2e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x41"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x54"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x55"" hidden=""true"" document=""1"" />
+        <entry offset=""0x59"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x5f"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x60"">
         <scope startOffset=""0x11"" endOffset=""0x55"">
@@ -885,6 +912,9 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -907,24 +937,24 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""44"" />
-        <entry offset=""0x2b"" hidden=""true"" />
-        <entry offset=""0x36"" hidden=""true"" />
-        <entry offset=""0x38"" hidden=""true"" />
-        <entry offset=""0x3f"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x4f"" hidden=""true"" />
-        <entry offset=""0x56"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x57"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x5f"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" />
-        <entry offset=""0x73"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x88"" hidden=""true"" />
-        <entry offset=""0x8e"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x93"" hidden=""true"" />
-        <entry offset=""0x97"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x9b"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x2b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x36"" hidden=""true"" document=""1"" />
+        <entry offset=""0x38"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x4f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x56"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x57"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x5f"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x73"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x87"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x88"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8e"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x93"" hidden=""true"" document=""1"" />
+        <entry offset=""0x97"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x9b"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9c"">
         <scope startOffset=""0x38"" endOffset=""0x88"">
@@ -967,6 +997,9 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -986,21 +1019,21 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""31"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0xc"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x25"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x26"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x2d"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" />
-        <entry offset=""0x40"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x53"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x54"" hidden=""true"" />
-        <entry offset=""0x58"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" />
-        <entry offset=""0x61"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""28"" endLine=""10"" endColumn=""31"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""10"" startColumn=""18"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x26"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x40"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x53"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x54"" hidden=""true"" document=""1"" />
+        <entry offset=""0x58"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x61"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x62"">
         <scope startOffset=""0xc"" endOffset=""0x54"">
@@ -1044,6 +1077,9 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -1062,21 +1098,21 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""43"" />
-        <entry offset=""0xd"" hidden=""true"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x15"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" />
-        <entry offset=""0x22"" hidden=""true"" />
-        <entry offset=""0x28"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x29"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" />
-        <entry offset=""0x30"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" />
-        <entry offset=""0x43"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""24"" />
-        <entry offset=""0x56"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x57"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" />
-        <entry offset=""0x62"" hidden=""true"" />
-        <entry offset=""0x71"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""11"" startColumn=""28"" endLine=""11"" endColumn=""43"" document=""1"" />
+        <entry offset=""0xd"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" startLine=""11"" startColumn=""18"" endLine=""11"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x22"" hidden=""true"" document=""1"" />
+        <entry offset=""0x28"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x29"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x30"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x43"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x56"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x57"" startLine=""11"" startColumn=""25"" endLine=""11"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x62"" hidden=""true"" document=""1"" />
+        <entry offset=""0x71"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x72"">
         <scope startOffset=""0xf"" endOffset=""0x57"">
@@ -1117,6 +1153,9 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -1136,19 +1175,19 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""10"" startColumn=""14"" endLine=""10"" endColumn=""24"" />
-        <entry offset=""0xe"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""32"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x17"" hidden=""true"" />
-        <entry offset=""0x1d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x1e"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x25"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" />
-        <entry offset=""0x38"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x39"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""58"" />
-        <entry offset=""0x63"" hidden=""true"" />
-        <entry offset=""0x66"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""10"" startColumn=""14"" endLine=""10"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xe"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""32"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x17"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x25"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x38"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x39"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x63"" hidden=""true"" document=""1"" />
+        <entry offset=""0x66"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x67"">
         <scope startOffset=""0x1"" endOffset=""0x66"">
@@ -1201,6 +1240,9 @@ class C
 
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -1220,19 +1262,19 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x6"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""20"" />
-        <entry offset=""0xe"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""21"" />
-        <entry offset=""0x21"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" />
-        <entry offset=""0x2e"" hidden=""true"" />
-        <entry offset=""0x3a"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""28"" />
-        <entry offset=""0x41"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""29"" />
-        <entry offset=""0x54"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""23"" />
-        <entry offset=""0x56"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""28"" />
-        <entry offset=""0x5d"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""29"" />
-        <entry offset=""0x70"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" />
-        <entry offset=""0x72"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""20"" document=""1"" />
+        <entry offset=""0xe"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x21"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x2e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x41"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x54"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x56"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x5d"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x70"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x72"" startLine=""27"" startColumn=""5"" endLine=""27"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x73"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x73"" attributes=""0"" />
@@ -1276,13 +1318,16 @@ class C
             // note that the two closures have a different syntax offset
             c.VerifyPdb("C.F", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"" parameterNames=""a, b"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""G"" parameterNames=""f"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""41"" endLine=""7"" endColumn=""42"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""41"" endLine=""7"" endColumn=""42"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""F"">
@@ -1302,23 +1347,23 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0x1"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""36"" />
-        <entry offset=""0x12"" startLine=""12"" startColumn=""38"" endLine=""12"" endColumn=""46"" />
-        <entry offset=""0x1d"" hidden=""true"" />
-        <entry offset=""0x23"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x24"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" />
-        <entry offset=""0x2b"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""25"" />
-        <entry offset=""0x3d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""25"" />
-        <entry offset=""0x4f"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" />
-        <entry offset=""0x61"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x64"" hidden=""true"" />
-        <entry offset=""0x78"" hidden=""true"" />
-        <entry offset=""0x79"" hidden=""true"" />
-        <entry offset=""0x7b"" hidden=""true"" />
-        <entry offset=""0x8f"" hidden=""true"" />
-        <entry offset=""0x90"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x12"" startLine=""12"" startColumn=""38"" endLine=""12"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x23"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x24"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x3d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x61"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x64"" hidden=""true"" document=""1"" />
+        <entry offset=""0x78"" hidden=""true"" document=""1"" />
+        <entry offset=""0x79"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x90"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x91"">
         <scope startOffset=""0x1"" endOffset=""0x90"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -73,8 +73,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
 <symbols>
   <files>
     <file id=""1"" name=""Foo.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""" + checksum1 + @""" />
-    <file id=""2"" name=""Bar.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""" + checksum3 + @""" />
-    <file id=""3"" name=""Baz.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""" + checksum4 + @""" />
+    <file id=""2"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    <file id=""3"" name=""Bar.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""" + checksum3 + @""" />
+    <file id=""4"" name=""Baz.cs"" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" checkSumAlgorithmId=""ff1816ec-aa5e-4d10-87f7-6f4963833460"" checkSum=""" + checksum4 + @""" />
   </files>
 </symbols>", options: PdbToXmlOptions.ExcludeMethods);
         }
@@ -249,6 +250,9 @@ public class C
             var debug = CreateStandardCompilation(source, new[] { CSharpRef, SystemCoreRef }, options: TestOptions.DebugWinMD);
             debug.VerifyPdb(@"
 <symbols>
+    <files>
+      <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    </files>
     <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -257,19 +261,19 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0xa"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" />
-        <entry offset=""0xb"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""42"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x24"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x29"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2a"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""45"" />
-        <entry offset=""0xe6"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0xe7"" hidden=""true"" />
-        <entry offset=""0xeb"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0xf4"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xa"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
+        <entry offset=""0xb"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x24"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x29"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""45"" document=""1"" />
+        <entry offset=""0xe6"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe7"" hidden=""true"" document=""1"" />
+        <entry offset=""0xeb"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xf4"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xf5"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xf5"" attributes=""0"" />
@@ -285,6 +289,9 @@ public class C
             var release = CreateStandardCompilation(source, new[] { CSharpRef, SystemCoreRef }, options: TestOptions.ReleaseWinMD);
             release.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -293,15 +300,15 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0x9"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""42"" />
-        <entry offset=""0x1d"" hidden=""true"" />
-        <entry offset=""0x22"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x26"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""45"" />
-        <entry offset=""0xdd"" hidden=""true"" />
-        <entry offset=""0xe1"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0xea"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x9"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x1d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x22"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x26"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""45"" document=""1"" />
+        <entry offset=""0xdd"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe1"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xea"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xeb"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xeb"" attributes=""0"" />
@@ -327,6 +334,9 @@ public class C
             var debug = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugWinMD);
             debug.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -335,9 +345,9 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""35"" />
-        <entry offset=""0x9"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x9"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xa"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0xa"" attributes=""0"" />
@@ -349,6 +359,9 @@ public class C
             var release = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseWinMD);
             release.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -357,7 +370,7 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -415,6 +428,9 @@ public class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""F"" />
   <methods/>
 </symbols>", debugEntryPoint: f, options: PdbToXmlOptions.ExcludeScopes | PdbToXmlOptions.ExcludeSequencePoints | PdbToXmlOptions.ExcludeCustomDebugInformation);
@@ -435,6 +451,9 @@ public class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""F"" />
   <methods/>
 </symbols>", debugEntryPoint: f, options: PdbToXmlOptions.ExcludeScopes | PdbToXmlOptions.ExcludeSequencePoints | PdbToXmlOptions.ExcludeCustomDebugInformation);
@@ -514,6 +533,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("Program.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -523,9 +545,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""35"" />
-        <entry offset=""0x7"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x7"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <local name=""p"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
@@ -565,6 +587,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.Method", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Method"">
       <customDebugInfo>
@@ -578,21 +603,21 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""28"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""58"" />
-        <entry offset=""0x14"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x15"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""14"" />
-        <entry offset=""0x16"" startLine=""12"" startColumn=""17"" endLine=""12"" endColumn=""33"" />
-        <entry offset=""0x1d"" startLine=""13"" startColumn=""17"" endLine=""13"" endColumn=""60"" />
-        <entry offset=""0x29"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" />
-        <entry offset=""0x2a"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""14"" />
-        <entry offset=""0x2b"" startLine=""17"" startColumn=""17"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0x2d"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""62"" />
-        <entry offset=""0x3e"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""14"" />
-        <entry offset=""0x3f"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""45"" />
-        <entry offset=""0x4a"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" />
-        <entry offset=""0x4b"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""58"" document=""1"" />
+        <entry offset=""0x14"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x15"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x16"" startLine=""12"" startColumn=""17"" endLine=""12"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""17"" endLine=""13"" endColumn=""60"" document=""1"" />
+        <entry offset=""0x29"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""17"" startColumn=""17"" endLine=""17"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""62"" document=""1"" />
+        <entry offset=""0x3e"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x4a"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4b"" startLine=""22"" startColumn=""5"" endLine=""22"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4c"">
         <local name=""version"" il_index=""0"" il_start=""0x0"" il_end=""0x4c"" attributes=""0"" />
@@ -627,6 +652,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -638,9 +666,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""3"" startColumn=""5"" endLine=""3"" endColumn=""8"" />
-        <entry offset=""0x7"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""3"" startColumn=""5"" endLine=""3"" endColumn=""8"" document=""1"" />
+        <entry offset=""0x7"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <scope startOffset=""0x7"" endOffset=""0x9"">
@@ -656,10 +684,10 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""16"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" />
-        <entry offset=""0xa"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xa"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <scope startOffset=""0x7"" endOffset=""0xb"">
@@ -692,6 +720,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C..ctor",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -703,10 +734,10 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""18"" />
-        <entry offset=""0xb"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""8"" />
-        <entry offset=""0x12"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x13"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""18"" document=""1"" />
+        <entry offset=""0xb"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""8"" document=""1"" />
+        <entry offset=""0x12"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x13"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <scope startOffset=""0x12"" endOffset=""0x14"">
@@ -722,11 +753,11 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""18"" />
-        <entry offset=""0xb"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""16"" />
-        <entry offset=""0x12"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x13"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""22"" />
-        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""18"" document=""1"" />
+        <entry offset=""0xb"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x12"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x13"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x16"">
         <scope startOffset=""0x12"" endOffset=""0x16"">
@@ -782,6 +813,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Hidden"">
       <customDebugInfo>
@@ -793,10 +827,10 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" />
-        <entry offset=""0x3"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""30"" />
-        <entry offset=""0xa"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xa"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <namespace name=""System"" />
@@ -812,10 +846,10 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""19"" />
-        <entry offset=""0x3"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""30"" />
-        <entry offset=""0xa"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xa"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <local name=""y"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
@@ -829,10 +863,10 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""19"" />
-        <entry offset=""0x3"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""30"" />
-        <entry offset=""0xa"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xa"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
@@ -866,6 +900,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".cctor"">
       <customDebugInfo>
@@ -882,7 +919,7 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""9"" endColumn=""7"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""9"" endColumn=""7"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x16"">
         <namespace name=""System"" />
@@ -893,7 +930,7 @@ class C
         <forward declaringType=""C"" methodName="".cctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""66"" endLine=""7"" endColumn=""70"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""66"" endLine=""7"" endColumn=""70"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__2_0"" parameterNames=""x"">
@@ -906,11 +943,11 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""38"" />
-        <entry offset=""0x21"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""71"" />
-        <entry offset=""0x41"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""27"" />
-        <entry offset=""0x51"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x21"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""71"" document=""1"" />
+        <entry offset=""0x41"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x51"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x53"">
         <local name=""f"" il_index=""0"" il_start=""0x0"" il_end=""0x53"" attributes=""0"" />
@@ -922,7 +959,7 @@ class C
         <forward declaringType=""C"" methodName="".cctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""36"" endLine=""6"" endColumn=""37"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""36"" endLine=""6"" endColumn=""37"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__2_2"" parameterNames=""h"">
@@ -933,8 +970,8 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""7"" startColumn=""61"" endLine=""7"" endColumn=""70"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1a"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1a"" attributes=""0"" />
@@ -961,6 +998,9 @@ class C
             // verify that both syntax offsets are the same
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main1"">
       <customDebugInfo>
@@ -972,9 +1012,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""44"" endLine=""4"" endColumn=""45"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""57"" endLine=""4"" endColumn=""67"" />
-        <entry offset=""0x3"" startLine=""4"" startColumn=""79"" endLine=""4"" endColumn=""80"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""44"" endLine=""4"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""57"" endLine=""4"" endColumn=""67"" document=""1"" />
+        <entry offset=""0x3"" startLine=""4"" startColumn=""79"" endLine=""4"" endColumn=""80"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
@@ -988,9 +1028,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""32"" endLine=""5"" endColumn=""33"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""45"" endLine=""5"" endColumn=""55"" />
-        <entry offset=""0x3"" startLine=""5"" startColumn=""67"" endLine=""5"" endColumn=""68"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""32"" endLine=""5"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""45"" endLine=""5"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x3"" startLine=""5"" startColumn=""67"" endLine=""5"" endColumn=""68"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x4"" attributes=""0"" />
@@ -1026,6 +1066,9 @@ class C2
             // verify that syntax offsets of both .cctor's are the same
             c.VerifyPdb("C1..cctor", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C1"" name="".cctor"">
       <customDebugInfo>
@@ -1040,9 +1083,9 @@ class C2
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""39"" />
-        <entry offset=""0x15"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""63"" />
-        <entry offset=""0x2a"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x15"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""39"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
@@ -1053,6 +1096,9 @@ class C2
 
             c.VerifyPdb("C2..cctor", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C2"" name="".cctor"">
       <customDebugInfo>
@@ -1065,9 +1111,9 @@ class C2
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""39"" />
-        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""51"" />
-        <entry offset=""0x2a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x15"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""39"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1110,6 +1156,9 @@ class Program
 
             v.VerifyPdb("Program.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"">
       <customDebugInfo>
@@ -1121,9 +1170,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""18"" />
-        <entry offset=""0x5"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x5"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1162,6 +1211,9 @@ class C
 
             v.VerifyPdb("C.get_P", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_P"">
       <customDebugInfo>
@@ -1173,9 +1225,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""14"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""15"" endLine=""6"" endColumn=""24"" />
-        <entry offset=""0x5"" startLine=""6"" startColumn=""25"" endLine=""6"" endColumn=""26"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""15"" endLine=""6"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x5"" startLine=""6"" startColumn=""25"" endLine=""6"" endColumn=""26"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1281,6 +1333,9 @@ class Program
 
             v.VerifyPdb("Program.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"">
       <customDebugInfo>
@@ -1292,14 +1347,14 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""33"" />
-        <entry offset=""0x8"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""22"" />
-        <entry offset=""0xc"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""26"" />
-        <entry offset=""0xd"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0xe"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""22"" />
-        <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x8"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xc"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xd"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <namespace name=""System"" />
@@ -1347,6 +1402,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.Method", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Method"">
       <customDebugInfo>
@@ -1365,29 +1423,29 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x3"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""15"" />
-        <entry offset=""0x5"" hidden=""true"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x9"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""31"" />
-        <entry offset=""0xf"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" />
-        <entry offset=""0x16"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x19"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x1a"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""32"" />
-        <entry offset=""0x20"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""23"" />
-        <entry offset=""0x23"" hidden=""true"" />
-        <entry offset=""0x25"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""14"" />
-        <entry offset=""0x26"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""26"" />
-        <entry offset=""0x2a"" startLine=""19"" startColumn=""28"" endLine=""19"" endColumn=""33"" />
-        <entry offset=""0x2d"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""45"" />
-        <entry offset=""0x35"" startLine=""21"" startColumn=""17"" endLine=""21"" endColumn=""27"" />
-        <entry offset=""0x3c"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""14"" />
-        <entry offset=""0x3d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" />
-        <entry offset=""0x45"" hidden=""true"" />
-        <entry offset=""0x49"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""23"" />
-        <entry offset=""0x4f"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" />
-        <entry offset=""0x50"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x3"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x5"" hidden=""true"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x9"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""31"" document=""1"" />
+        <entry offset=""0xf"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x16"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x19"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""32"" document=""1"" />
+        <entry offset=""0x20"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x23"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x26"" startLine=""19"" startColumn=""17"" endLine=""19"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""19"" startColumn=""28"" endLine=""19"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x35"" startLine=""21"" startColumn=""17"" endLine=""21"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x3d"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x45"" hidden=""true"" document=""1"" />
+        <entry offset=""0x49"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x50"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x51"">
         <local name=""b"" il_index=""0"" il_start=""0x0"" il_end=""0x51"" attributes=""0"" />
@@ -1457,13 +1515,16 @@ public class SeqPointForWhile
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.ReleaseExe);
 
             // Offset 0x01 should be:
-            //  <entry offset=""0x1"" hidden=""true"" />
+            //  <entry offset=""0x1"" hidden=""true"" document=""1"" />
             // Move original offset 0x01 to 0x33
-            //  <entry offset=""0x33"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""22"" />
+            //  <entry offset=""0x33"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""22"" document=""1"" />
             // 
             // Note: 16707566 == 0x00FEEFEE
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""SeqPointForWhile"" methodName=""Main"" />
   <methods>
     <method containingType=""SeqPointForWhile"" name=""Main"">
@@ -1473,9 +1534,9 @@ public class SeqPointForWhile
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""55"" />
-        <entry offset=""0x5"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" />
-        <entry offset=""0xf"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x5"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
+        <entry offset=""0xf"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x10"">
         <namespace name=""System"" />
@@ -1486,19 +1547,19 @@ public class SeqPointForWhile
         <forward declaringType=""SeqPointForWhile"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""30"" />
-        <entry offset=""0x7"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" />
-        <entry offset=""0xc"" startLine=""22"" startColumn=""18"" endLine=""22"" endColumn=""29"" />
-        <entry offset=""0x11"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" />
-        <entry offset=""0x13"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""27"" />
-        <entry offset=""0x1a"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" />
-        <entry offset=""0x1c"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""27"" />
-        <entry offset=""0x1d"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""38"" />
-        <entry offset=""0x22"" startLine=""31"" startColumn=""17"" endLine=""31"" endColumn=""23"" />
-        <entry offset=""0x24"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""22"" />
-        <entry offset=""0x28"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""20"" />
-        <entry offset=""0x2f"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x7"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xc"" startLine=""22"" startColumn=""18"" endLine=""22"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x11"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x13"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x22"" startLine=""31"" startColumn=""17"" endLine=""31"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x24"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x28"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x2f"" startLine=""35"" startColumn=""5"" endLine=""35"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x30"">
         <scope startOffset=""0x11"" endOffset=""0x1a"">
@@ -1534,6 +1595,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1544,16 +1608,16 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" />
-        <entry offset=""0x3"" hidden=""true"" />
-        <entry offset=""0x5"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x6"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""41"" />
-        <entry offset=""0xd"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0xe"" startLine=""9"" startColumn=""31"" endLine=""9"" endColumn=""35"" />
-        <entry offset=""0x15"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""29"" />
-        <entry offset=""0x1c"" hidden=""true"" />
-        <entry offset=""0x1f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""14"" endLine=""9"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""41"" document=""1"" />
+        <entry offset=""0xd"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe"" startLine=""9"" startColumn=""31"" endLine=""9"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x15"" startLine=""9"" startColumn=""25"" endLine=""9"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x20"">
         <scope startOffset=""0x1"" endOffset=""0x1f"">
@@ -1582,6 +1646,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1590,12 +1657,12 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" hidden=""true"" />
-        <entry offset=""0x3"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x4"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" />
-        <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0xc"" hidden=""true"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" document=""1"" />
+        <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1620,6 +1687,9 @@ class C
 }";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.M", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -1631,14 +1701,14 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""19"" />
-        <entry offset=""0x3"" hidden=""true"" />
-        <entry offset=""0x5"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x6"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""41"" />
-        <entry offset=""0xd"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0xe"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0x12"" hidden=""true"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""41"" document=""1"" />
+        <entry offset=""0xd"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x12"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x14"" attributes=""0"" />
@@ -1684,6 +1754,9 @@ public class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -1693,13 +1766,13 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""34"" />
-        <entry offset=""0x8"" hidden=""true"" />
-        <entry offset=""0xa"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x11"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" />
-        <entry offset=""0x16"" hidden=""true"" />
-        <entry offset=""0x1a"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" />
-        <entry offset=""0x23"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x8"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x11"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x16"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x23"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1739,6 +1812,9 @@ public class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -1752,17 +1828,17 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""37"" />
-        <entry offset=""0xb"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x11"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" />
-        <entry offset=""0x19"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x1a"" hidden=""true"" />
-        <entry offset=""0x1e"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" />
-        <entry offset=""0x24"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""6"" startColumn=""27"" endLine=""6"" endColumn=""37"" document=""1"" />
+        <entry offset=""0xb"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""6"" startColumn=""18"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x11"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x12"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x19"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""6"" startColumn=""24"" endLine=""6"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x24"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x25"">
         <scope startOffset=""0xd"" endOffset=""0x1a"">
@@ -1950,6 +2026,9 @@ class Program
 ", sequencePoints: "Program+<Test>d__0.MoveNext", source: source);
 
             v.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Test"">
       <customDebugInfo>
@@ -1974,16 +2053,16 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" />
-        <entry offset=""0xf"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" />
-        <entry offset=""0x19"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""11"" startColumn=""13"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0x22"" hidden=""true"" />
-        <entry offset=""0x24"" hidden=""true"" />
-        <entry offset=""0x3c"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
-        <entry offset=""0x44"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xf"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x19"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""11"" startColumn=""13"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x22"" hidden=""true"" document=""1"" />
+        <entry offset=""0x24"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x44"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x51"">
         <namespace name=""System"" />
@@ -2220,6 +2299,9 @@ class Program
 ", sequencePoints: "Program+<Test>d__0.MoveNext", source: source);
 
             v.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Test"">
       <customDebugInfo>
@@ -2244,17 +2326,17 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" />
-        <entry offset=""0xf"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" />
-        <entry offset=""0x19"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""38"" />
-        <entry offset=""0x29"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""40"" />
-        <entry offset=""0x34"" hidden=""true"" />
-        <entry offset=""0x36"" hidden=""true"" />
-        <entry offset=""0x4e"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0x56"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xf"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x19"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x29"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x34"" hidden=""true"" document=""1"" />
+        <entry offset=""0x36"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4e"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x56"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x63"">
         <namespace name=""System"" />
@@ -2338,6 +2420,9 @@ class Program
 ", sequencePoints: "Program.Test", source: source);
 
             v.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Test"">
       <customDebugInfo>
@@ -2350,17 +2435,17 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""23"" />
-        <entry offset=""0x4"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x9"" hidden=""true"" />
-        <entry offset=""0xc"" startLine=""13"" startColumn=""17"" endLine=""13"" endColumn=""37"" />
-        <entry offset=""0x12"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x15"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""14"" />
-        <entry offset=""0x16"" startLine=""15"" startColumn=""15"" endLine=""15"" endColumn=""16"" />
-        <entry offset=""0x17"" startLine=""15"" startColumn=""17"" endLine=""15"" endColumn=""18"" />
-        <entry offset=""0x1a"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x4"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc"" startLine=""13"" startColumn=""17"" endLine=""13"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x12"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x15"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x16"" startLine=""15"" startColumn=""15"" endLine=""15"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x17"" startLine=""15"" startColumn=""17"" endLine=""15"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1b"">
         <namespace name=""System"" />
@@ -2618,6 +2703,9 @@ class Program
             // we just want this to compile without crashing/asserting
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("Program.Main", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -2632,25 +2720,25 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""20"" />
-        <entry offset=""0x2"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""47"" />
-        <entry offset=""0x12"" hidden=""true"" />
-        <entry offset=""0x14"" startLine=""12"" startColumn=""22"" endLine=""12"" endColumn=""27"" />
-        <entry offset=""0x1b"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""14"" />
-        <entry offset=""0x1c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""33"" />
-        <entry offset=""0x23"" hidden=""true"" />
-        <entry offset=""0x29"" startLine=""17"" startColumn=""25"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0x2b"" startLine=""20"" startColumn=""25"" endLine=""20"" endColumn=""42"" />
-        <entry offset=""0x35"" hidden=""true"" />
-        <entry offset=""0x38"" startLine=""21"" startColumn=""25"" endLine=""21"" endColumn=""26"" />
-        <entry offset=""0x39"" startLine=""22"" startColumn=""25"" endLine=""22"" endColumn=""26"" />
-        <entry offset=""0x3a"" startLine=""24"" startColumn=""25"" endLine=""24"" endColumn=""31"" />
-        <entry offset=""0x3c"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" />
-        <entry offset=""0x3d"" startLine=""12"" startColumn=""28"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0x47"" hidden=""true"" />
-        <entry offset=""0x51"" hidden=""true"" />
-        <entry offset=""0x52"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x2"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x12"" hidden=""true"" document=""1"" />
+        <entry offset=""0x14"" startLine=""12"" startColumn=""22"" endLine=""12"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x23"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""17"" startColumn=""25"" endLine=""17"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""20"" startColumn=""25"" endLine=""20"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x35"" hidden=""true"" document=""1"" />
+        <entry offset=""0x38"" startLine=""21"" startColumn=""25"" endLine=""21"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x39"" startLine=""22"" startColumn=""25"" endLine=""22"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""24"" startColumn=""25"" endLine=""24"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x3d"" startLine=""12"" startColumn=""28"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x47"" hidden=""true"" document=""1"" />
+        <entry offset=""0x51"" hidden=""true"" document=""1"" />
+        <entry offset=""0x52"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x53"">
         <namespace name=""System"" />
@@ -2748,6 +2836,9 @@ public class C
 
             v.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -2756,7 +2847,7 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""50"" endLine=""4"" endColumn=""76"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""50"" endLine=""4"" endColumn=""76"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""Main"">
@@ -2772,17 +2863,17 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""8"" startColumn=""37"" endLine=""8"" endColumn=""40"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0xc"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""33"" />
-        <entry offset=""0x32"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x33"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" />
-        <entry offset=""0x3a"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x3b"" hidden=""true"" />
-        <entry offset=""0x3f"" startLine=""8"" startColumn=""34"" endLine=""8"" endColumn=""36"" />
-        <entry offset=""0x45"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""8"" startColumn=""37"" endLine=""8"" endColumn=""40"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x32"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x33"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""8"" startColumn=""34"" endLine=""8"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x45"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x46"">
         <scope startOffset=""0xc"" endOffset=""0x3b"">
@@ -2844,6 +2935,9 @@ class Student : Person { public double GPA; }
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("Program.Operate",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Operate"" parameterNames=""p"">
       <customDebugInfo>
@@ -2860,18 +2954,18 @@ class Student : Person { public double GPA; }
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" />
-        <entry offset=""0x4"" hidden=""true"" />
-        <entry offset=""0x28"" hidden=""true"" />
-        <entry offset=""0x2a"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" />
-        <entry offset=""0x3d"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" />
-        <entry offset=""0x5c"" hidden=""true"" />
-        <entry offset=""0x61"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" />
-        <entry offset=""0x82"" hidden=""true"" />
-        <entry offset=""0x87"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" />
-        <entry offset=""0xa3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" />
-        <entry offset=""0xb7"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x4"" hidden=""true"" document=""1"" />
+        <entry offset=""0x28"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x3d"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x61"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x82"" hidden=""true"" document=""1"" />
+        <entry offset=""0x87"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" document=""1"" />
+        <entry offset=""0xa3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" document=""1"" />
+        <entry offset=""0xb7"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xba"">
         <scope startOffset=""0x28"" endOffset=""0x5c"">
@@ -2933,6 +3027,9 @@ class Student : Person { public double GPA; }
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("Program.Operate",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Operate"" parameterNames=""p"">
       <customDebugInfo>
@@ -2957,19 +3054,19 @@ class Student : Person { public double GPA; }
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0xe"" hidden=""true"" />
-        <entry offset=""0x1c"" hidden=""true"" />
-        <entry offset=""0x41"" hidden=""true"" />
-        <entry offset=""0x48"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" />
-        <entry offset=""0x60"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""63"" />
-        <entry offset=""0x70"" hidden=""true"" />
-        <entry offset=""0x79"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""63"" />
-        <entry offset=""0x89"" hidden=""true"" />
-        <entry offset=""0x93"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""65"" />
-        <entry offset=""0xa3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""49"" />
-        <entry offset=""0xb3"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xe"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x41"" hidden=""true"" document=""1"" />
+        <entry offset=""0x48"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x60"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x70"" hidden=""true"" document=""1"" />
+        <entry offset=""0x79"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""63"" document=""1"" />
+        <entry offset=""0x89"" hidden=""true"" document=""1"" />
+        <entry offset=""0x93"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""65"" document=""1"" />
+        <entry offset=""0xa3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""49"" document=""1"" />
+        <entry offset=""0xb3"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb6"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0xb6"" attributes=""0"" />
@@ -3459,6 +3556,9 @@ public class SeqPointForWhile
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""SeqPointForWhile"" name=""Main"">
       <customDebugInfo>
@@ -3470,10 +3570,10 @@ public class SeqPointForWhile
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""55"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" />
-        <entry offset=""0x13"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x13"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x14"">
         <namespace name=""System"" />
@@ -3490,25 +3590,25 @@ public class SeqPointForWhile
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""30"" />
-        <entry offset=""0x7"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" />
-        <entry offset=""0xd"" hidden=""true"" />
-        <entry offset=""0x10"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""14"" />
-        <entry offset=""0x11"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""26"" />
-        <entry offset=""0x13"" startLine=""22"" startColumn=""18"" endLine=""22"" endColumn=""29"" />
-        <entry offset=""0x19"" hidden=""true"" />
-        <entry offset=""0x1c"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" />
-        <entry offset=""0x1d"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" />
-        <entry offset=""0x24"" startLine=""25"" startColumn=""13"" endLine=""25"" endColumn=""14"" />
-        <entry offset=""0x27"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""14"" />
-        <entry offset=""0x28"" startLine=""28"" startColumn=""17"" endLine=""28"" endColumn=""23"" />
-        <entry offset=""0x2a"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" />
-        <entry offset=""0x2b"" startLine=""30"" startColumn=""11"" endLine=""30"" endColumn=""25"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x33"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""20"" />
-        <entry offset=""0x3a"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x7"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xd"" hidden=""true"" document=""1"" />
+        <entry offset=""0x10"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x11"" startLine=""20"" startColumn=""17"" endLine=""20"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x13"" startLine=""22"" startColumn=""18"" endLine=""22"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x19"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x24"" startLine=""25"" startColumn=""13"" endLine=""25"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x27"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x28"" startLine=""28"" startColumn=""17"" endLine=""28"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""30"" startColumn=""11"" endLine=""30"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x33"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""33"" startColumn=""5"" endLine=""33"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -3579,6 +3679,9 @@ public class SeqPointForWhile
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""NS.MyClass"" name="".ctor"">
       <customDebugInfo>
@@ -3588,10 +3691,10 @@ public class SeqPointForWhile
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""25"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""27"" />
-        <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x10"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""NS.MyClass"" name="".ctor"" parameterNames=""values"">
@@ -3599,10 +3702,10 @@ public class SeqPointForWhile
         <forward declaringType=""NS.MyClass"" methodName="".ctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""44"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x8"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""57"" />
-        <entry offset=""0x19"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""57"" document=""1"" />
+        <entry offset=""0x19"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""NS.MyClass"" name=""Main"">
@@ -3617,14 +3720,14 @@ public class SeqPointForWhile
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" />
-        <entry offset=""0x3"" startLine=""18"" startColumn=""27"" endLine=""18"" endColumn=""35"" />
-        <entry offset=""0x5"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""26"" />
-        <entry offset=""0x7"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""40"" />
-        <entry offset=""0xd"" startLine=""25"" startColumn=""13"" endLine=""25"" endColumn=""48"" />
-        <entry offset=""0x25"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""36"" />
-        <entry offset=""0x32"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x3"" startLine=""18"" startColumn=""27"" endLine=""18"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x5"" startLine=""19"" startColumn=""13"" endLine=""19"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x7"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""40"" document=""1"" />
+        <entry offset=""0xd"" startLine=""25"" startColumn=""13"" endLine=""25"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x25"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x32"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""intI"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -3726,6 +3829,9 @@ public class Derived : Base
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Base"" name=""Finalize"">
       <customDebugInfo>
@@ -3734,11 +3840,11 @@ public class Derived : Base
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x2"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""29"" />
-        <entry offset=""0xa"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x12"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""29"" document=""1"" />
+        <entry offset=""0xa"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x13"">
         <namespace name=""System"" />
@@ -3749,11 +3855,11 @@ public class Derived : Base
         <forward declaringType=""Base"" methodName=""Finalize"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" />
-        <entry offset=""0x2"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0xa"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
-        <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""15"" startColumn=""5"" endLine=""15"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x2"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0xa"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x12"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -3925,6 +4031,9 @@ class C
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -3937,7 +4046,7 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""50"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""50"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__1_0"" parameterNames=""z"">
@@ -3945,7 +4054,7 @@ class C
         <forward declaringType=""C"" methodName="".ctor"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""43"" endLine=""4"" endColumn=""44"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""43"" endLine=""4"" endColumn=""44"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -3964,6 +4073,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -3972,8 +4084,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""14"" />
-        <entry offset=""0x7"" startLine=""4"" startColumn=""16"" endLine=""4"" endColumn=""21"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x7"" startLine=""4"" startColumn=""16"" endLine=""4"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4000,35 +4112,38 @@ public class C
 
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_AutoProp1"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""35"" endLine=""4"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""35"" endLine=""4"" endColumn=""39"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_AutoProp1"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""40"" endLine=""4"" endColumn=""52"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""40"" endLine=""4"" endColumn=""52"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""get_AutoProp2"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""33"" endLine=""5"" endColumn=""37"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""33"" endLine=""5"" endColumn=""37"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_AutoProp2"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""38"" endLine=""5"" endColumn=""42"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""38"" endLine=""5"" endColumn=""42"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""get_AutoProp3"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""38"" endLine=""6"" endColumn=""51"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""38"" endLine=""6"" endColumn=""51"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_AutoProp3"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""52"" endLine=""6"" endColumn=""56"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""52"" endLine=""6"" endColumn=""56"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4089,6 +4204,9 @@ public class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -4097,8 +4215,8 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4120,6 +4238,9 @@ public class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -4128,9 +4249,9 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" />
-        <entry offset=""0x3"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x3"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4199,12 +4320,15 @@ public class SeqPointAfterReturn
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
 
             // Expected are current actual output plus Two extra expected SeqPt:
-            //  <entry offset=""0x73"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" />
-            //  <entry offset=""0x22"" startLine=""52"" startColumn=""5"" endLine=""52"" endColumn=""6"" />
+            //  <entry offset=""0x73"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""1"" />
+            //  <entry offset=""0x22"" startLine=""52"" startColumn=""5"" endLine=""52"" endColumn=""6"" document=""1"" />
             // 
             // Note: NOT include other differences between Roslyn and Dev10, as they are filed in separated bugs
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""SeqPointAfterReturn"" name=""Main"">
       <customDebugInfo>
@@ -4222,26 +4346,26 @@ public class SeqPointAfterReturn
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" />
-        <entry offset=""0x3"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" />
-        <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" />
-        <entry offset=""0x1b"" hidden=""true"" />
-        <entry offset=""0x1e"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""21"" />
-        <entry offset=""0x20"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" />
-        <entry offset=""0x28"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""28"" />
-        <entry offset=""0x38"" hidden=""true"" />
-        <entry offset=""0x3b"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""27"" />
-        <entry offset=""0x3f"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""40"" />
-        <entry offset=""0x47"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""27"" />
-        <entry offset=""0x54"" hidden=""true"" />
-        <entry offset=""0x58"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""27"" />
-        <entry offset=""0x5c"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""33"" />
-        <entry offset=""0x64"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""28"" />
-        <entry offset=""0x71"" hidden=""true"" />
-        <entry offset=""0x75"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""27"" />
-        <entry offset=""0x79"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""20"" />
-        <entry offset=""0x7e"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x3"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xb"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x20"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x28"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x38"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3b"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x47"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x54"" hidden=""true"" document=""1"" />
+        <entry offset=""0x58"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x5c"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x64"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x71"" hidden=""true"" document=""1"" />
+        <entry offset=""0x75"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x79"" startLine=""24"" startColumn=""9"" endLine=""24"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x7e"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x81"">
         <namespace name=""System"" />
@@ -4258,17 +4382,17 @@ public class SeqPointAfterReturn
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""29"" startColumn=""5"" endLine=""29"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""30"" />
-        <entry offset=""0x5"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""20"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" />
-        <entry offset=""0xe"" startLine=""33"" startColumn=""13"" endLine=""33"" endColumn=""28"" />
-        <entry offset=""0x18"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" />
-        <entry offset=""0x1b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" />
-        <entry offset=""0x1c"" startLine=""37"" startColumn=""13"" endLine=""37"" endColumn=""27"" />
-        <entry offset=""0x26"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" />
-        <entry offset=""0x27"" startLine=""39"" startColumn=""5"" endLine=""39"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""29"" startColumn=""5"" endLine=""29"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""30"" startColumn=""9"" endLine=""30"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x5"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""20"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""32"" startColumn=""9"" endLine=""32"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe"" startLine=""33"" startColumn=""13"" endLine=""33"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x18"" startLine=""34"" startColumn=""9"" endLine=""34"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""36"" startColumn=""9"" endLine=""36"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""37"" startColumn=""13"" endLine=""37"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x26"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x27"" startLine=""39"" startColumn=""5"" endLine=""39"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x28"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x28"" attributes=""0"" />
@@ -4284,15 +4408,15 @@ public class SeqPointAfterReturn
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""42"" startColumn=""5"" endLine=""42"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""43"" startColumn=""9"" endLine=""43"" endColumn=""30"" />
-        <entry offset=""0x5"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""20"" />
-        <entry offset=""0xa"" hidden=""true"" />
-        <entry offset=""0xd"" startLine=""45"" startColumn=""9"" endLine=""45"" endColumn=""10"" />
-        <entry offset=""0xe"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""27"" />
-        <entry offset=""0x16"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" />
-        <entry offset=""0x17"" startLine=""50"" startColumn=""13"" endLine=""50"" endColumn=""26"" />
-        <entry offset=""0x1f"" startLine=""52"" startColumn=""5"" endLine=""52"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""42"" startColumn=""5"" endLine=""42"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""43"" startColumn=""9"" endLine=""43"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x5"" startLine=""44"" startColumn=""9"" endLine=""44"" endColumn=""20"" document=""1"" />
+        <entry offset=""0xa"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd"" startLine=""45"" startColumn=""9"" endLine=""45"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xe"" startLine=""46"" startColumn=""13"" endLine=""46"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x16"" startLine=""49"" startColumn=""9"" endLine=""49"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x17"" startLine=""50"" startColumn=""13"" endLine=""50"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""52"" startColumn=""5"" endLine=""52"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
@@ -4344,6 +4468,9 @@ class Test
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("Test.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -4357,21 +4484,21 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" />
-        <entry offset=""0x3"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x4"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""42"" />
-        <entry offset=""0xa"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""35"" />
-        <entry offset=""0xb"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0xc"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""21"" />
-        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x13"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""42"" />
-        <entry offset=""0x19"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" />
-        <entry offset=""0x1a"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" />
-        <entry offset=""0x1b"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""24"" />
-        <entry offset=""0x1f"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x3"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""42"" document=""1"" />
+        <entry offset=""0xa"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xb"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xc"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""21"" document=""1"" />
+        <entry offset=""0xe"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x13"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x19"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""22"" startColumn=""13"" endLine=""22"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""25"" startColumn=""5"" endLine=""25"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x21"">
         <local name=""ret"" il_index=""0"" il_start=""0x0"" il_end=""0x21"" attributes=""0"" />
@@ -4492,6 +4619,9 @@ class Test
 
             v.VerifyPdb("Test.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -4504,24 +4634,24 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""51"" />
-        <entry offset=""0x8"" hidden=""true"" />
-        <entry offset=""0x15"" startLine=""18"" startColumn=""31"" endLine=""18"" endColumn=""55"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x25"" hidden=""true"" />
-        <entry offset=""0x26"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x27"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""33"" />
-        <entry offset=""0x2d"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x3d"" startLine=""22"" startColumn=""29"" endLine=""22"" endColumn=""53"" />
-        <entry offset=""0x47"" hidden=""true"" />
-        <entry offset=""0x4d"" hidden=""true"" />
-        <entry offset=""0x4e"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""10"" />
-        <entry offset=""0x4f"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""33"" />
-        <entry offset=""0x55"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" />
-        <entry offset=""0x58"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x8"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" startLine=""18"" startColumn=""31"" endLine=""18"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x25"" hidden=""true"" document=""1"" />
+        <entry offset=""0x26"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x27"" startLine=""20"" startColumn=""13"" endLine=""20"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x2d"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3d"" startLine=""22"" startColumn=""29"" endLine=""22"" endColumn=""53"" document=""1"" />
+        <entry offset=""0x47"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4e"" startLine=""23"" startColumn=""9"" endLine=""23"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4f"" startLine=""24"" startColumn=""13"" endLine=""24"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x55"" startLine=""25"" startColumn=""9"" endLine=""25"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x58"" startLine=""26"" startColumn=""5"" endLine=""26"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x59"">
         <scope startOffset=""0x8"" endOffset=""0x30"">
@@ -4596,6 +4726,9 @@ class Test
 ", sequencePoints: "Test.Main");
 
             v.VerifyPdb("Test.Main", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -4607,17 +4740,17 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""42"" />
-        <entry offset=""0x8"" hidden=""true"" />
-        <entry offset=""0x9"" startLine=""10"" startColumn=""15"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x16"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x17"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""40"" />
-        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x20"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x8"" hidden=""true"" document=""1"" />
+        <entry offset=""0x9"" startLine=""10"" startColumn=""15"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x16"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x17"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x20"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4681,6 +4814,9 @@ class Test
 ", sequencePoints: "Test.Main");
 
             v.VerifyPdb("Test.Main", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -4692,17 +4828,17 @@ class Test
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""42"" />
-        <entry offset=""0x8"" hidden=""true"" />
-        <entry offset=""0x9"" startLine=""12"" startColumn=""15"" endLine=""12"" endColumn=""23"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x15"" hidden=""true"" />
-        <entry offset=""0x16"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x17"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""40"" />
-        <entry offset=""0x1d"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x20"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x8"" hidden=""true"" document=""1"" />
+        <entry offset=""0x9"" startLine=""12"" startColumn=""15"" endLine=""12"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x15"" hidden=""true"" document=""1"" />
+        <entry offset=""0x16"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x17"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x20"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4758,6 +4894,9 @@ class Test
 ", sequencePoints: "Test.Main");
 
             v.VerifyPdb("Test.Main", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -4766,13 +4905,13 @@ class Test
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""42"" />
-        <entry offset=""0x6"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""15"" endLine=""12"" endColumn=""23"" />
-        <entry offset=""0x11"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""40"" />
-        <entry offset=""0x17"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x19"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""42"" document=""1"" />
+        <entry offset=""0x6"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""15"" endLine=""12"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x11"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x17"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x19"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -4812,6 +4951,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -4825,21 +4967,21 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" />
-        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""50"" />
-        <entry offset=""0xa"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""22"" />
-        <entry offset=""0xf"" hidden=""true"" />
-        <entry offset=""0x12"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x13"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""35"" />
-        <entry offset=""0x19"" hidden=""true"" />
-        <entry offset=""0x1a"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x1b"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""33"" />
-        <entry offset=""0x21"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" />
-        <entry offset=""0x24"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" />
-        <entry offset=""0x25"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" />
-        <entry offset=""0x26"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
-        <entry offset=""0x29"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x3"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""50"" document=""1"" />
+        <entry offset=""0xa"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""22"" document=""1"" />
+        <entry offset=""0xf"" hidden=""true"" document=""1"" />
+        <entry offset=""0x12"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x13"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x19"" hidden=""true"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""18"" startColumn=""13"" endLine=""18"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x21"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x24"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""14"" document=""1"" />
+        <entry offset=""0x25"" startLine=""21"" startColumn=""9"" endLine=""21"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x26"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x29"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2a"">
         <namespace name=""System"" />
@@ -4898,6 +5040,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -4910,28 +5055,28 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""22"" startColumn=""16"" endLine=""22"" endColumn=""60"" />
-        <entry offset=""0xc"" startLine=""22"" startColumn=""62"" endLine=""22"" endColumn=""90"" />
-        <entry offset=""0x17"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""47"" />
-        <entry offset=""0x24"" hidden=""true"" />
-        <entry offset=""0x2e"" hidden=""true"" />
-        <entry offset=""0x2f"" hidden=""true"" />
-        <entry offset=""0x31"" hidden=""true"" />
-        <entry offset=""0x3b"" hidden=""true"" />
-        <entry offset=""0x3c"" startLine=""25"" startColumn=""16"" endLine=""25"" endColumn=""60"" />
-        <entry offset=""0x47"" startLine=""25"" startColumn=""62"" endLine=""25"" endColumn=""90"" />
-        <entry offset=""0x52"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" />
-        <entry offset=""0x53"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""48"" />
-        <entry offset=""0x5e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0x61"" hidden=""true"" />
-        <entry offset=""0x6b"" hidden=""true"" />
-        <entry offset=""0x6c"" hidden=""true"" />
-        <entry offset=""0x6e"" hidden=""true"" />
-        <entry offset=""0x78"" hidden=""true"" />
-        <entry offset=""0x79"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" />
-        <entry offset=""0x7a"" startLine=""33"" startColumn=""9"" endLine=""33"" endColumn=""10"" />
-        <entry offset=""0x7b"" startLine=""34"" startColumn=""5"" endLine=""34"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""22"" startColumn=""16"" endLine=""22"" endColumn=""60"" document=""1"" />
+        <entry offset=""0xc"" startLine=""22"" startColumn=""62"" endLine=""22"" endColumn=""90"" document=""1"" />
+        <entry offset=""0x17"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x24"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x31"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""25"" startColumn=""16"" endLine=""25"" endColumn=""60"" document=""1"" />
+        <entry offset=""0x47"" startLine=""25"" startColumn=""62"" endLine=""25"" endColumn=""90"" document=""1"" />
+        <entry offset=""0x52"" startLine=""26"" startColumn=""9"" endLine=""26"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x53"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x5e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x61"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x78"" hidden=""true"" document=""1"" />
+        <entry offset=""0x79"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7a"" startLine=""33"" startColumn=""9"" endLine=""33"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7b"" startLine=""34"" startColumn=""5"" endLine=""34"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7c"">
         <scope startOffset=""0x1"" endOffset=""0x3c"">
@@ -5354,6 +5499,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -5365,9 +5513,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""24"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x8"" attributes=""0"" />
@@ -5392,6 +5540,9 @@ class Program
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -5403,9 +5554,9 @@ class Program
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""31"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <local name=""o"" il_index=""0"" il_start=""0x0"" il_end=""0x9"" attributes=""0"" />
@@ -5441,7 +5592,11 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"<symbols>
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5456,15 +5611,15 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" />
-        <entry offset=""0xe"" startLine=""11"" startColumn=""16"" endLine=""11"" endColumn=""29"" />
-        <entry offset=""0x11"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x12"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""20"" />
-        <entry offset=""0x15"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x16"" hidden=""true"" />
-        <entry offset=""0x19"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""32"" />
-        <entry offset=""0x25"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xe"" startLine=""11"" startColumn=""16"" endLine=""11"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x11"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x12"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x15"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x16"" hidden=""true"" document=""1"" />
+        <entry offset=""0x19"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""32"" document=""1"" />
+        <entry offset=""0x25"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x26"">
         <namespace name=""System"" />
@@ -5498,6 +5653,9 @@ unsafe class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -5510,13 +5668,13 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""33"" />
-        <entry offset=""0x15"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x16"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""35"" />
-        <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x21"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x15"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x16"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x21"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x22"">
         <namespace name=""System"" />
@@ -5552,7 +5710,11 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"<symbols>
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5567,16 +5729,16 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""31"" />
-        <entry offset=""0x15"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""28"" />
-        <entry offset=""0x32"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x33"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
-        <entry offset=""0x39"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x3a"" hidden=""true"" />
-        <entry offset=""0x3c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" />
-        <entry offset=""0x4a"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x15"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x32"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x33"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x39"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x4a"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x4b"">
         <namespace name=""System"" />
@@ -5591,7 +5753,7 @@ unsafe class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -5623,7 +5785,11 @@ unsafe class C
 ";
             // NOTE: stop on each declarator.
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"<symbols>
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5640,17 +5806,17 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" />
-        <entry offset=""0xe"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""29"" />
-        <entry offset=""0x19"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""39"" />
-        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x1e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
-        <entry offset=""0x21"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""20"" />
-        <entry offset=""0x24"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x25"" hidden=""true"" />
-        <entry offset=""0x2c"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""38"" />
-        <entry offset=""0x3f"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xe"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x19"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x21"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x24"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x25"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
@@ -5687,6 +5853,9 @@ unsafe class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugDll);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -5701,15 +5870,15 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x7"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""33"" />
-        <entry offset=""0x1b"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""48"" />
-        <entry offset=""0x29"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x2a"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""31"" />
-        <entry offset=""0x32"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""31"" />
-        <entry offset=""0x3a"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x3b"" hidden=""true"" />
-        <entry offset=""0x3f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""33"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""8"" startColumn=""35"" endLine=""8"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x29"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x32"" startLine=""11"" startColumn=""13"" endLine=""11"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
@@ -5750,7 +5919,11 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"<symbols>
+            c.VerifyPdb(@"
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5767,20 +5940,20 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""31"" />
-        <entry offset=""0x15"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""31"" />
-        <entry offset=""0x23"" startLine=""14"" startColumn=""16"" endLine=""14"" endColumn=""28"" />
-        <entry offset=""0x40"" startLine=""14"" startColumn=""30"" endLine=""14"" endColumn=""37"" />
-        <entry offset=""0x60"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x61"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""20"" />
-        <entry offset=""0x64"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""20"" />
-        <entry offset=""0x67"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
-        <entry offset=""0x68"" hidden=""true"" />
-        <entry offset=""0x6d"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""31"" />
-        <entry offset=""0x7b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""31"" />
-        <entry offset=""0x89"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x15"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x23"" startLine=""14"" startColumn=""16"" endLine=""14"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x40"" startLine=""14"" startColumn=""30"" endLine=""14"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x60"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x61"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x64"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x67"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x68"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6d"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x7b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x89"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8a"">
         <namespace name=""System"" />
@@ -5796,8 +5969,8 @@ unsafe class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" />
-        <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""26"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xc"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""26"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -5829,6 +6002,9 @@ unsafe class C
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugDll);
             c.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -5846,18 +6022,18 @@ unsafe class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" />
-        <entry offset=""0xf"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0x13"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""39"" />
-        <entry offset=""0x3a"" startLine=""12"" startColumn=""41"" endLine=""12"" endColumn=""52"" />
-        <entry offset=""0x49"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x4a"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""36"" />
-        <entry offset=""0x52"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""36"" />
-        <entry offset=""0x5a"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""36"" />
-        <entry offset=""0x62"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x63"" hidden=""true"" />
-        <entry offset=""0x6d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xf"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x13"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x3a"" startLine=""12"" startColumn=""41"" endLine=""12"" endColumn=""52"" document=""1"" />
+        <entry offset=""0x49"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4a"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x52"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x5a"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x62"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x63"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x6e"">
         <namespace name=""System"" />
@@ -5874,8 +6050,8 @@ unsafe class C
         <forward declaringType=""C"" methodName=""Main"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""18"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""28"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""28"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -5951,6 +6127,9 @@ unsafe class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5960,9 +6139,9 @@ unsafe class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""26"" />
-        <entry offset=""0x8"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x8"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9"">
         <namespace name=""System"" />
@@ -6004,6 +6183,9 @@ public class C
             var compilation = CreateStandardCompilation(text1, options: TestOptions.DebugDll);
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Foo"">
       <customDebugInfo>
@@ -6023,35 +6205,35 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""7"" startColumn=""27"" endLine=""7"" endColumn=""51"" />
-        <entry offset=""0x16"" hidden=""true"" />
-        <entry offset=""0x18"" startLine=""7"" startColumn=""18"" endLine=""7"" endColumn=""23"" />
-        <entry offset=""0x1c"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x1d"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""34"" />
-        <entry offset=""0x24"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x25"" hidden=""true"" />
-        <entry offset=""0x29"" startLine=""7"" startColumn=""24"" endLine=""7"" endColumn=""26"" />
-        <entry offset=""0x2f"" hidden=""true"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x45"" hidden=""true"" />
-        <entry offset=""0x47"" hidden=""true"" />
-        <entry offset=""0x4d"" hidden=""true"" />
-        <entry offset=""0x4e"" hidden=""true"" />
-        <entry offset=""0x56"" hidden=""true"" />
-        <entry offset=""0x57"" hidden=""true"" />
-        <entry offset=""0x5d"" hidden=""true"" />
-        <entry offset=""0x64"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" />
-        <entry offset=""0x65"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""51"" />
-        <entry offset=""0x7b"" hidden=""true"" />
-        <entry offset=""0x7d"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" />
-        <entry offset=""0x84"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" />
-        <entry offset=""0x85"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""34"" />
-        <entry offset=""0x8d"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" />
-        <entry offset=""0x8e"" hidden=""true"" />
-        <entry offset=""0x94"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" />
-        <entry offset=""0x9c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""7"" startColumn=""27"" endLine=""7"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x16"" hidden=""true"" document=""1"" />
+        <entry offset=""0x18"" startLine=""7"" startColumn=""18"" endLine=""7"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1c"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1d"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x24"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x25"" hidden=""true"" document=""1"" />
+        <entry offset=""0x29"" startLine=""7"" startColumn=""24"" endLine=""7"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x2f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x30"" hidden=""true"" document=""1"" />
+        <entry offset=""0x45"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x56"" hidden=""true"" document=""1"" />
+        <entry offset=""0x57"" hidden=""true"" document=""1"" />
+        <entry offset=""0x5d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x64"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x65"" startLine=""19"" startColumn=""27"" endLine=""19"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x7b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7d"" startLine=""19"" startColumn=""18"" endLine=""19"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x84"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x85"" startLine=""21"" startColumn=""13"" endLine=""21"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x8d"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8e"" hidden=""true"" document=""1"" />
+        <entry offset=""0x94"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x9c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x9d"">
         <namespace name=""System"" />
@@ -6108,6 +6290,9 @@ class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""G"">
       <customDebugInfo>
@@ -6116,9 +6301,9 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""13"" />
-        <entry offset=""0x7"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""13"" document=""1"" />
+        <entry offset=""0x7"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <namespace name=""System"" />
@@ -6197,6 +6382,9 @@ class C
             // but it doesn't hurt and removing it would need extra effort that's unnecessary.
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -6205,9 +6393,9 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""13"" />
-        <entry offset=""0x7"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""13"" document=""1"" />
+        <entry offset=""0x7"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <namespace name=""System"" />
@@ -6300,6 +6488,9 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_P"">
       <customDebugInfo>
@@ -6308,7 +6499,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""21"" endLine=""4"" endColumn=""24"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""M"">
@@ -6316,7 +6507,7 @@ class C
         <forward declaringType=""C"" methodName=""get_P"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""18"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6341,6 +6532,9 @@ class C
 
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_Item"" parameterNames=""i"">
       <customDebugInfo>
@@ -6349,7 +6543,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""36"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""36"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
@@ -6360,7 +6554,7 @@ class C
         <forward declaringType=""C"" methodName=""get_Item"" parameterNames=""i"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6381,6 +6575,9 @@ class C
 
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_P"">
       <customDebugInfo>
@@ -6389,7 +6586,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""23"" endLine=""6"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""23"" endLine=""6"" endColumn=""24"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -6411,6 +6608,9 @@ class C
 
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""op_Increment"" parameterNames=""c"">
       <customDebugInfo>
@@ -6419,7 +6619,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""41"" endLine=""4"" endColumn=""42"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""41"" endLine=""4"" endColumn=""42"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6440,6 +6640,9 @@ class C
 
             comp.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""op_Explicit"" parameterNames=""i"">
       <customDebugInfo>
@@ -6448,7 +6651,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""51"" endLine=""6"" endColumn=""58"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""51"" endLine=""6"" endColumn=""58"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <namespace name=""System"" />
@@ -6472,6 +6675,9 @@ class C
             comp.VerifyDiagnostics();
 
             comp.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"" parameterNames=""x"">
       <customDebugInfo>
@@ -6480,8 +6686,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""22"" />
-        <entry offset=""0x6"" startLine=""7"" startColumn=""26"" endLine=""7"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""22"" document=""1"" />
+        <entry offset=""0x6"" startLine=""7"" startColumn=""26"" endLine=""7"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xe"">
         <namespace name=""System"" />
@@ -6503,6 +6709,9 @@ class C
             comp.VerifyDiagnostics();
 
             comp.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Finalize"">
       <customDebugInfo>
@@ -6511,9 +6720,9 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""13"" endLine=""5"" endColumn=""18"" />
-        <entry offset=""0x9"" hidden=""true"" />
-        <entry offset=""0x10"" hidden=""true"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""13"" endLine=""5"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x9"" hidden=""true"" document=""1"" />
+        <entry offset=""0x10"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6541,6 +6750,9 @@ class C
             comp.VerifyDiagnostics();
 
             comp.VerifyPdb(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_X"">
       <customDebugInfo>
@@ -6549,7 +6761,7 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""17"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""17"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_X"" parameterNames=""value"">
@@ -6557,7 +6769,7 @@ class C
         <forward declaringType=""C"" methodName=""get_X"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""25"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""25"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""add_E"" parameterNames=""value"">
@@ -6565,7 +6777,7 @@ class C
         <forward declaringType=""C"" methodName=""get_X"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""21"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""remove_E"" parameterNames=""value"">
@@ -6573,7 +6785,7 @@ class C
         <forward declaringType=""C"" methodName=""get_X"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""24"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6605,6 +6817,9 @@ class C
             var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
             c.VerifyPdb("C+<>c.<M>b__0_0",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_0"">
       <customDebugInfo>
@@ -6614,10 +6829,10 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""39"" />
-        <entry offset=""0x13"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""30"" />
-        <entry offset=""0x39"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x13"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x39"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x3a"">
         <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x3a"" attributes=""0"" />
@@ -6647,6 +6862,9 @@ class C
             var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
             c.VerifyPdb("C+<F>d__0.MoveNext",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -6662,20 +6880,20 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x27"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x28"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" />
-        <entry offset=""0x3f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" />
-        <entry offset=""0x40"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""43"" />
-        <entry offset=""0x7d"" hidden=""true"" />
-        <entry offset=""0x7f"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" />
-        <entry offset=""0x90"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x91"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""28"" />
-        <entry offset=""0xad"" hidden=""true"" />
-        <entry offset=""0xb5"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0xb6"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0xd1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
-        <entry offset=""0xd5"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x27"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x28"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x40"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""43"" document=""1"" />
+        <entry offset=""0x7d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7f"" startLine=""8"" startColumn=""18"" endLine=""8"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x90"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x91"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""28"" document=""1"" />
+        <entry offset=""0xad"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0xb6"" startLine=""8"" startColumn=""24"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0xd1"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xd5"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -6699,6 +6917,9 @@ class C
             var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
             c.VerifyPdb("C+<F>d__0.MoveNext",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;F&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -6712,13 +6933,13 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
-        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" />
-        <entry offset=""0x1f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" />
-        <entry offset=""0x4c"" hidden=""true"" />
-        <entry offset=""0x64"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
-        <entry offset=""0x6c"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
+        <entry offset=""0x4c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x64"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""F"" />
@@ -6748,6 +6969,9 @@ class C
             var c = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
             c.VerifyPdb("C+<>c.<M>b__0_0",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_0"">
       <customDebugInfo>
@@ -6761,6 +6985,9 @@ class C
 </symbols>");
             c.VerifyPdb("C+<>c+<<M>b__0_0>d.MoveNext",
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C+&lt;&gt;c+&lt;&lt;M&gt;b__0_0&gt;d"" name=""MoveNext"">
       <customDebugInfo>
@@ -6774,13 +7001,13 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" />
-        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" />
-        <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""39"" />
-        <entry offset=""0x1f"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""30"" />
-        <entry offset=""0x4c"" hidden=""true"" />
-        <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x6c"" hidden=""true"" />
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""39"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x4c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0x4c"" />
@@ -6801,6 +7028,9 @@ class C
             var source = @"class C { bool F(object o) => o is int i && o is 3 && o is bool; }";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.F", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"" parameterNames=""o"">
       <customDebugInfo>
@@ -6813,7 +7043,7 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x35"">
         <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
@@ -6834,6 +7064,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
             c.VerifyPdb("C.F", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -6847,10 +7080,10 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" />
-        <entry offset=""0x5"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""69"" />
-        <entry offset=""0xb"" startLine=""1"" startColumn=""70"" endLine=""1"" endColumn=""71"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x5"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""69"" document=""1"" />
+        <entry offset=""0xb"" startLine=""1"" startColumn=""70"" endLine=""1"" endColumn=""71"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xd"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0xd"" attributes=""0"" />
@@ -6914,6 +7147,9 @@ public class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
             c.VerifyPdb("C.F", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -6926,10 +7162,10 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" />
-        <entry offset=""0x10"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""103"" />
-        <entry offset=""0x31"" startLine=""1"" startColumn=""104"" endLine=""1"" endColumn=""105"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""55"" document=""1"" />
+        <entry offset=""0x10"" startLine=""1"" startColumn=""56"" endLine=""1"" endColumn=""103"" document=""1"" />
+        <entry offset=""0x31"" startLine=""1"" startColumn=""104"" endLine=""1"" endColumn=""105"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x33"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x33"" attributes=""0"" />
@@ -6947,6 +7183,9 @@ public class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
             c.VerifyPdb("C.F", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -6959,10 +7198,10 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""36"" />
-        <entry offset=""0xa"" startLine=""1"" startColumn=""37"" endLine=""1"" endColumn=""62"" />
-        <entry offset=""0x1a"" startLine=""1"" startColumn=""63"" endLine=""1"" endColumn=""64"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""36"" document=""1"" />
+        <entry offset=""0xa"" startLine=""1"" startColumn=""37"" endLine=""1"" endColumn=""62"" document=""1"" />
+        <entry offset=""0x1a"" startLine=""1"" startColumn=""63"" endLine=""1"" endColumn=""64"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <local name=""x"" il_index=""0"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
@@ -6979,6 +7218,9 @@ public class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll, references: s_valueTupleRefs);
 
             c.VerifyPdb("C.F", @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -6994,10 +7236,10 @@ public class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""47"" />
-        <entry offset=""0x9"" startLine=""1"" startColumn=""48"" endLine=""1"" endColumn=""73"" />
-        <entry offset=""0x19"" startLine=""1"" startColumn=""74"" endLine=""1"" endColumn=""75"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""19"" endLine=""1"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""21"" endLine=""1"" endColumn=""47"" document=""1"" />
+        <entry offset=""0x9"" startLine=""1"" startColumn=""48"" endLine=""1"" endColumn=""73"" document=""1"" />
+        <entry offset=""0x19"" startLine=""1"" startColumn=""74"" endLine=""1"" endColumn=""75"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1b"">
         <local name=""a"" il_index=""0"" il_start=""0x0"" il_end=""0x1b"" attributes=""0"" />
@@ -7063,6 +7305,9 @@ class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb("C.G", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""G"" parameterNames=""x"">
       <customDebugInfo>
@@ -7078,12 +7323,12 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""1"" startColumn=""28"" endLine=""1"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""1"" startColumn=""30"" endLine=""1"" endColumn=""40"" />
-        <entry offset=""0x3"" startLine=""1"" startColumn=""41"" endLine=""1"" endColumn=""54"" />
-        <entry offset=""0xc"" startLine=""1"" startColumn=""55"" endLine=""1"" endColumn=""68"" />
-        <entry offset=""0x15"" startLine=""1"" startColumn=""69"" endLine=""1"" endColumn=""82"" />
-        <entry offset=""0x1f"" startLine=""1"" startColumn=""83"" endLine=""1"" endColumn=""84"" />
+        <entry offset=""0x0"" startLine=""1"" startColumn=""28"" endLine=""1"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""30"" endLine=""1"" endColumn=""40"" document=""1"" />
+        <entry offset=""0x3"" startLine=""1"" startColumn=""41"" endLine=""1"" endColumn=""54"" document=""1"" />
+        <entry offset=""0xc"" startLine=""1"" startColumn=""55"" endLine=""1"" endColumn=""68"" document=""1"" />
+        <entry offset=""0x15"" startLine=""1"" startColumn=""69"" endLine=""1"" endColumn=""82"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""1"" startColumn=""83"" endLine=""1"" endColumn=""84"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x22"">
         <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
@@ -7360,6 +7605,9 @@ partial class C
 }");
             c.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""M"" parameterNames=""o"">
       <customDebugInfo>
@@ -7379,25 +7627,25 @@ partial class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" />
-        <entry offset=""0x3"" hidden=""true"" />
-        <entry offset=""0x56"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""34"" />
-        <entry offset=""0x5b"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""34"" />
-        <entry offset=""0x60"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""23"" />
-        <entry offset=""0x62"" startLine=""11"" startColumn=""20"" endLine=""11"" endColumn=""34"" />
-        <entry offset=""0x67"" startLine=""13"" startColumn=""20"" endLine=""13"" endColumn=""34"" />
-        <entry offset=""0x6c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""23"" />
-        <entry offset=""0x6e"" startLine=""16"" startColumn=""17"" endLine=""16"" endColumn=""23"" />
-        <entry offset=""0x70"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""23"" />
-        <entry offset=""0x72"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" />
-        <entry offset=""0x75"" hidden=""true"" />
-        <entry offset=""0xa6"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""23"" />
-        <entry offset=""0xa8"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" />
-        <entry offset=""0xaa"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""19"" />
-        <entry offset=""0xad"" hidden=""true"" />
-        <entry offset=""0xb9"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""23"" />
-        <entry offset=""0xbb"" startLine=""32"" startColumn=""5"" endLine=""32"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x3"" hidden=""true"" document=""1"" />
+        <entry offset=""0x56"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x5b"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x60"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x62"" startLine=""11"" startColumn=""20"" endLine=""11"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x67"" startLine=""13"" startColumn=""20"" endLine=""13"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x6c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x6e"" startLine=""16"" startColumn=""17"" endLine=""16"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x70"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x72"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x75"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa6"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xa8"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xaa"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""19"" document=""1"" />
+        <entry offset=""0xad"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb9"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xbb"" startLine=""32"" startColumn=""5"" endLine=""32"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -7426,6 +7674,9 @@ partial class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -7442,9 +7693,9 @@ partial class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""44"" />
-        <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""44"" document=""1"" />
+        <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Program"" name=""&lt;Main&gt;g__Local1|0_0"" parameterNames=""a"">
@@ -7452,7 +7703,7 @@ partial class C
         <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""21"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""21"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Program"" name=""&lt;Main&gt;g__Local2|0_1"" parameterNames=""a"">
@@ -7463,9 +7714,9 @@ partial class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""29"" />
-        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
@@ -23,6 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
             var comp = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugDll);
             comp.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -37,9 +40,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""103"" />
-        <entry offset=""0x1b"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""103"" document=""1"" />
+        <entry offset=""0x1b"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1c"">
         <local name=""t"" il_index=""0"" il_start=""0x0"" il_end=""0x1c"" attributes=""0"" />
@@ -67,6 +70,9 @@ class C
             var comp = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugDll);
             comp.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -78,8 +84,8 @@ class C
         </tupleElementNames>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <constant name=""c"" value=""null"" signature=""C`1{System.ValueTuple`2{Int32, Int32}}"" />
@@ -116,6 +122,9 @@ class C
             var comp = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugDll);
             comp.VerifyPdb(
 @"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -139,14 +148,14 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" />
-        <entry offset=""0x2"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
-        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0x4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x5"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x6"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
-        <entry offset=""0x7"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x4"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x5"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x6"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x7"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x8"">
         <scope startOffset=""0x1"" endOffset=""0x3"">
@@ -180,6 +189,9 @@ class C
             var comp = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugDll);
             comp.VerifyPdb(
 string.Format(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -194,9 +206,9 @@ string.Format(@"<symbols>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""70"" />
-        <entry offset=""0xa"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""70"" document=""1"" />
+        <entry offset=""0xa"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xb"">
         <local name=""{2}"" il_index=""0"" il_start=""0x0"" il_end=""0xb"" attributes=""0"" />
@@ -228,6 +240,9 @@ string.Format(@"<symbols>
             var comp = CreateStandardCompilation(source, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugDll);
             comp.VerifyPdb(
 string.Format(@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"" parameterNames=""ie"">
       <customDebugInfo>
@@ -241,17 +256,17 @@ string.Format(@"<symbols>
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" />
-        <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""15"" />
-        <entry offset=""0x9"" hidden=""true"" />
-        <entry offset=""0xb"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x1f"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x20"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
-        <entry offset=""0x2a"" hidden=""true"" />
-        <entry offset=""0x34"" hidden=""true"" />
-        <entry offset=""0x35"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" document=""1"" />
+        <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x1f"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x20"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" document=""1"" />
+        <entry offset=""0x2a"" hidden=""true"" document=""1"" />
+        <entry offset=""0x34"" hidden=""true"" document=""1"" />
+        <entry offset=""0x35"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x36"">
         <scope startOffset=""0xb"" endOffset=""0x20"">
@@ -306,6 +321,9 @@ class C
 
             c.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""F"">
       <customDebugInfo>
@@ -325,9 +343,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""36"" />
-        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" />
+        <entry offset=""0x0"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x3"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""20"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x5"">
         <local name=""v1"" il_index=""0"" il_start=""0x0"" il_end=""0x5"" attributes=""0"" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBUsingTests.cs
@@ -55,6 +55,9 @@ namespace X
 ";
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -63,8 +66,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -78,8 +81,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System.IO"" />
@@ -95,8 +98,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System.Threading"" />
@@ -132,6 +135,9 @@ namespace X
 ";
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -140,8 +146,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System"" kind=""namespace"" />
@@ -155,8 +161,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.IO"" kind=""namespace"" />
@@ -172,8 +178,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""R"" target=""System.Threading"" kind=""namespace"" />
@@ -209,6 +215,9 @@ namespace X
 ";
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -217,8 +226,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -232,8 +241,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -249,8 +258,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""R"" target=""System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -286,6 +295,9 @@ namespace X
 ";
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -294,8 +306,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -309,8 +321,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""Q"" target=""System.Collections.Generic.List`1[[System.Collections.Generic.List`1[[System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -326,8 +338,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""P"" target=""System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -388,6 +400,9 @@ namespace X
 
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -396,8 +411,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""22"" endLine=""4"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
@@ -415,8 +430,8 @@ namespace X
         <forwardToModule declaringType=""A"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""24"" endLine=""10"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""26"" endLine=""10"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
@@ -433,8 +448,8 @@ namespace X
         <forwardToModule declaringType=""A"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""30"" endLine=""16"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
@@ -473,6 +488,9 @@ class A { void M() {  } }
 
             compilation2.VerifyPdb("A.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -481,8 +499,8 @@ class A { void M() {  } }
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""U.V.W"" />
@@ -521,6 +539,9 @@ class A { void M() {  } }
 
             compilation2.VerifyPdb("A.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -529,8 +550,8 @@ class A { void M() {  } }
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" />
+        <entry offset=""0x0"" startLine=""4"" startColumn=""20"" endLine=""4"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""4"" startColumn=""23"" endLine=""4"" endColumn=""24"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""U.V.W"" />
@@ -623,6 +644,9 @@ class C { void M() { } }
 
             compilation.VerifyPdb(@"
 <symbols>
+    <files>
+      <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    </files>
     <methods>
         <method containingType=""C"" name=""M"">
             <customDebugInfo>
@@ -631,8 +655,8 @@ class C { void M() { } }
                 </using>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset=""0x0"" startLine=""8"" startColumn=""20"" endLine=""8"" endColumn=""21""/>
-                <entry offset=""0x1"" startLine=""8"" startColumn=""22"" endLine=""8"" endColumn=""23""/>
+                <entry offset=""0x0"" startLine=""8"" startColumn=""20"" endLine=""8"" endColumn=""21"" document=""1"" />
+                <entry offset=""0x1"" startLine=""8"" startColumn=""22"" endLine=""8"" endColumn=""23"" document=""1"" />
             </sequencePoints>
             <scope startOffset=""0x0"" endOffset=""0x2"">
                 <extern alias=""A""/>
@@ -680,6 +704,9 @@ namespace N
 
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""N.B"" name=""M"">
       <customDebugInfo>
@@ -689,8 +716,8 @@ namespace N
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""12"" startColumn=""26"" endLine=""12"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""12"" startColumn=""26"" endLine=""12"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
@@ -791,6 +818,9 @@ namespace X
 
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""A"" name=""M"">
       <customDebugInfo>
@@ -799,8 +829,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""21"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""21"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""22"" endLine=""7"" endColumn=""23"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""P"" />
@@ -821,8 +851,8 @@ namespace X
         <forwardToModule declaringType=""A"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""25"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""25"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
@@ -845,8 +875,8 @@ namespace X
         <forwardToModule declaringType=""A"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""25"" startColumn=""28"" endLine=""25"" endColumn=""29"" />
-        <entry offset=""0x1"" startLine=""25"" startColumn=""30"" endLine=""25"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""25"" startColumn=""28"" endLine=""25"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""25"" startColumn=""30"" endLine=""25"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
@@ -906,6 +936,9 @@ public class C
             compilation2.VerifyDiagnostics();
             compilation2.VerifyPdb(@"
 <symbols>
+    <files>
+      <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    </files>
     <methods>
         <method containingType=""C"" name=""Main"">
             <customDebugInfo>
@@ -914,12 +947,12 @@ public class C
                 </using>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6""/>
-                <entry offset=""0x1"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""43""/>
-                <entry offset=""0xc"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""43""/>
-                <entry offset=""0x17"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""45""/>
-                <entry offset=""0x22"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""45""/>
-                <entry offset=""0x2d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6""/>
+                <entry offset=""0x0"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
+                <entry offset=""0x1"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""43"" document=""1"" />
+                <entry offset=""0xc"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""43"" document=""1"" />
+                <entry offset=""0x17"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""45"" document=""1"" />
+                <entry offset=""0x22"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""45"" document=""1"" />
+                <entry offset=""0x2d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
             </sequencePoints>
             <scope startOffset=""0x0"" endOffset=""0x2e"">
                 <extern alias=""A""/>
@@ -969,6 +1002,9 @@ public class C
             compilation2.VerifyDiagnostics();
             compilation2.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -977,11 +1013,11 @@ public class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""45"" />
-        <entry offset=""0xc"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""48"" />
-        <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""48"" />
-        <entry offset=""0x22"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""45"" document=""1"" />
+        <entry offset=""0xc"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x17"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""48"" document=""1"" />
+        <entry offset=""0x22"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x23"">
         <extern alias=""A"" />
@@ -1086,6 +1122,9 @@ namespace X
 
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""X.C"" name=""M"">
       <customDebugInfo>
@@ -1095,8 +1134,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""30"" startColumn=""26"" endLine=""30"" endColumn=""27"" />
-        <entry offset=""0x1"" startLine=""30"" startColumn=""28"" endLine=""30"" endColumn=""29"" />
+        <entry offset=""0x0"" startLine=""30"" startColumn=""26"" endLine=""30"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1"" startLine=""30"" startColumn=""28"" endLine=""30"" endColumn=""29"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
@@ -1121,8 +1160,8 @@ namespace X
         <forwardToModule declaringType=""X.C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
@@ -1144,8 +1183,8 @@ namespace X
         <forwardToModule declaringType=""X.C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""31"" startColumn=""19"" endLine=""31"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""31"" startColumn=""21"" endLine=""31"" endColumn=""22"" />
+        <entry offset=""0x0"" startLine=""31"" startColumn=""19"" endLine=""31"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""31"" startColumn=""21"" endLine=""31"" endColumn=""22"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""R"" />
@@ -1274,6 +1313,9 @@ namespace X
 
             compilation.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""X.C"" name=""M"">
       <customDebugInfo>
@@ -1283,8 +1325,8 @@ namespace X
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" />
-        <entry offset=""0x1"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" />
+        <entry offset=""0x0"" startLine=""16"" startColumn=""26"" endLine=""16"" endColumn=""27"" document=""1"" />
+        <entry offset=""0x1"" startLine=""16"" startColumn=""28"" endLine=""16"" endColumn=""29"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""S"" />
@@ -1310,8 +1352,8 @@ namespace X
         <forwardToModule declaringType=""X.C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""Q"" />
@@ -1333,8 +1375,8 @@ namespace X
         <forwardToModule declaringType=""X.C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" />
-        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" />
+        <entry offset=""0x0"" startLine=""17"" startColumn=""19"" endLine=""17"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x1"" startLine=""17"" startColumn=""21"" endLine=""17"" endColumn=""22"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <extern alias=""S"" />
@@ -1380,6 +1422,9 @@ namespace X
 
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+    <files>
+      <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    </files>
     <methods>
         <method containingType=""X.C"" name="".ctor"">
             <customDebugInfo>
@@ -1389,8 +1434,8 @@ namespace X
                 </using>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19""/>
-                <entry offset=""0x7"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""19""/>
+                <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""1"" />
+                <entry offset=""0x7"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""19"" document=""1"" />
             </sequencePoints>
             <scope startOffset=""0x0"" endOffset=""0x16"">
                 <namespace name=""System""/>
@@ -1401,8 +1446,8 @@ namespace X
                 <forward declaringType=""X.C"" methodName="".ctor""/>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27""/>
-                <entry offset=""0x6"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""27""/>
+                <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" document=""1"" />
+                <entry offset=""0x6"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""27"" document=""1"" />
             </sequencePoints>
         </method>
     </methods>
@@ -1426,6 +1471,9 @@ class C
 ";
             CompileAndVerify(text, new[] { SystemCoreRef }, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name="".ctor"">
       <customDebugInfo>
@@ -1438,7 +1486,7 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""59"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""59"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x38"">
         <namespace name=""System.Linq"" />
@@ -1453,7 +1501,7 @@ class C
         </encLambdaMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""10"" endColumn=""8"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""10"" endColumn=""8"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.ctor&gt;b__2_0"" parameterNames=""x"">
@@ -1464,9 +1512,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""35"" endLine=""6"" endColumn=""36"" />
-        <entry offset=""0x1"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""55"" />
-        <entry offset=""0xa"" startLine=""6"" startColumn=""56"" endLine=""6"" endColumn=""57"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""35"" endLine=""6"" endColumn=""36"" document=""1"" />
+        <entry offset=""0x1"" startLine=""6"" startColumn=""37"" endLine=""6"" endColumn=""55"" document=""1"" />
+        <entry offset=""0xa"" startLine=""6"" startColumn=""56"" endLine=""6"" endColumn=""57"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__3_0"" parameterNames=""x"">
@@ -1477,9 +1525,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" />
-        <entry offset=""0xa"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""27"" document=""1"" />
+        <entry offset=""0xa"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1504,15 +1552,18 @@ class C
 
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_P1"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""14"" endLine=""6"" endColumn=""18"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""14"" endLine=""6"" endColumn=""18"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_P1"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""19"" endLine=""6"" endColumn=""23"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""19"" endLine=""6"" endColumn=""23"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""get_P2"">
@@ -1525,9 +1576,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""18"" endLine=""7"" endColumn=""19"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""29"" />
-        <entry offset=""0x5"" startLine=""7"" startColumn=""30"" endLine=""7"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""18"" endLine=""7"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x5"" startLine=""7"" startColumn=""30"" endLine=""7"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System"" />
@@ -1538,8 +1589,8 @@ class C
         <forward declaringType=""C"" methodName=""get_P2"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""36"" endLine=""7"" endColumn=""37"" />
-        <entry offset=""0x1"" startLine=""7"" startColumn=""38"" endLine=""7"" endColumn=""39"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""36"" endLine=""7"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x1"" startLine=""7"" startColumn=""38"" endLine=""7"" endColumn=""39"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""get_Item"" parameterNames=""x"">
@@ -1550,9 +1601,9 @@ class C
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""28"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""29"" endLine=""8"" endColumn=""38"" />
-        <entry offset=""0x5"" startLine=""8"" startColumn=""39"" endLine=""8"" endColumn=""40"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""27"" endLine=""8"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""29"" endLine=""8"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x5"" startLine=""8"" startColumn=""39"" endLine=""8"" endColumn=""40"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""set_Item"" parameterNames=""x, value"">
@@ -1560,8 +1611,8 @@ class C
         <forward declaringType=""C"" methodName=""get_P2"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""8"" startColumn=""45"" endLine=""8"" endColumn=""46"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""47"" endLine=""8"" endColumn=""48"" />
+        <entry offset=""0x0"" startLine=""8"" startColumn=""45"" endLine=""8"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""47"" endLine=""8"" endColumn=""48"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""add_E2"" parameterNames=""value"">
@@ -1569,8 +1620,8 @@ class C
         <forward declaringType=""C"" methodName=""get_P2"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""35"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""36"" endLine=""10"" endColumn=""37"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""34"" endLine=""10"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""36"" endLine=""10"" endColumn=""37"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""C"" name=""remove_E2"" parameterNames=""value"">
@@ -1578,8 +1629,8 @@ class C
         <forward declaringType=""C"" methodName=""get_P2"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""45"" endLine=""10"" endColumn=""46"" />
-        <entry offset=""0x1"" startLine=""10"" startColumn=""47"" endLine=""10"" endColumn=""48"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""45"" endLine=""10"" endColumn=""46"" document=""1"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""47"" endLine=""10"" endColumn=""48"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1605,15 +1656,18 @@ class Derived : Base
 
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Base"" name=""get_P"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""28"" endLine=""6"" endColumn=""32"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""28"" endLine=""6"" endColumn=""32"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Base"" name=""set_P"" parameterNames=""value"">
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""37"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""33"" endLine=""6"" endColumn=""37"" document=""1"" />
       </sequencePoints>
     </method>
     <method containingType=""Derived"" name=""set_P"" parameterNames=""value"">
@@ -1623,8 +1677,8 @@ class Derived : Base
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""11"" startColumn=""40"" endLine=""11"" endColumn=""41"" />
-        <entry offset=""0x1"" startLine=""11"" startColumn=""42"" endLine=""11"" endColumn=""43"" />
+        <entry offset=""0x0"" startLine=""11"" startColumn=""40"" endLine=""11"" endColumn=""41"" document=""1"" />
+        <entry offset=""0x1"" startLine=""11"" startColumn=""42"" endLine=""11"" endColumn=""43"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <namespace name=""System"" />
@@ -1660,6 +1714,9 @@ class C : I1, I2
 
             CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""get_Item"" parameterNames=""x"">
       <customDebugInfo>
@@ -1671,9 +1728,9 @@ class C : I1, I2
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""34"" endLine=""18"" endColumn=""35"" />
-        <entry offset=""0x1"" startLine=""18"" startColumn=""36"" endLine=""18"" endColumn=""45"" />
-        <entry offset=""0x5"" startLine=""18"" startColumn=""46"" endLine=""18"" endColumn=""47"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""34"" endLine=""18"" endColumn=""35"" document=""1"" />
+        <entry offset=""0x1"" startLine=""18"" startColumn=""36"" endLine=""18"" endColumn=""45"" document=""1"" />
+        <entry offset=""0x5"" startLine=""18"" startColumn=""46"" endLine=""18"" endColumn=""47"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x7"">
         <namespace name=""System.Runtime.CompilerServices"" />
@@ -1684,8 +1741,8 @@ class C : I1, I2
         <forward declaringType=""C"" methodName=""get_Item"" parameterNames=""x"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""52"" endLine=""18"" endColumn=""53"" />
-        <entry offset=""0x1"" startLine=""18"" startColumn=""54"" endLine=""18"" endColumn=""55"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""52"" endLine=""18"" endColumn=""53"" document=""1"" />
+        <entry offset=""0x1"" startLine=""18"" startColumn=""54"" endLine=""18"" endColumn=""55"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>
@@ -1766,6 +1823,9 @@ public class Test
 ";
             CompileAndVerify(source, new[] { libRef }, options: TestOptions.DebugExe).VerifyPdb("Test.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""Test"" methodName=""Main"" />
   <methods>
     <method containingType=""Test"" name=""Main"">
@@ -1775,8 +1835,8 @@ public class Test
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""I"" target=""Outer+Inner, Lib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" kind=""type"" />
@@ -1815,6 +1875,9 @@ class Test { static void Main() { } }
             // As in dev12, we drop all '@'s.
             comp.VerifyPdb("Test.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""Test"" name=""Main"">
       <customDebugInfo>
@@ -1823,7 +1886,7 @@ class Test { static void Main() { } }
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""20"" startColumn=""35"" endLine=""20"" endColumn=""36"" />
+        <entry offset=""0x0"" startLine=""20"" startColumn=""35"" endLine=""20"" endColumn=""36"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <namespace name=""namespace"" />
@@ -1862,6 +1925,9 @@ namespace N
             var comp = CreateStandardCompilation(source, new[] { libRef });
             comp.VerifyPdb("N.D.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""N.D"" name=""Main"">
       <customDebugInfo>
@@ -1871,7 +1937,7 @@ namespace N
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""31"" />
+        <entry offset=""0x0"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""31"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <namespace qualifier=""Q"" name="""" />
@@ -1901,6 +1967,9 @@ class D
             var comp = CreateStandardCompilation(source);
             comp.VerifyPdb("D.Main", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""D"" name=""Main"">
       <customDebugInfo>
@@ -1909,7 +1978,7 @@ class D
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""6"" startColumn=""26"" endLine=""6"" endColumn=""27"" />
+        <entry offset=""0x0"" startLine=""6"" startColumn=""26"" endLine=""6"" endColumn=""27"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x1"">
         <alias name=""AD"" target=""System.Action`1[[System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" kind=""type"" />
@@ -1996,6 +2065,9 @@ public class C1
 
             comp2.VerifyPdb(@"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <entryPoint declaringType=""C1"" methodName=""Main"" />
   <methods>
     <method containingType=""C1"" name=""Main"">
@@ -2005,8 +2077,8 @@ public class C1
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" />
-        <entry offset=""0x1"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""12"" startColumn=""5"" endLine=""12"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x2"">
         <alias name=""t1"" target=""Y`1[[W[], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"" kind=""type"" />
@@ -2071,6 +2143,9 @@ class D
             var comp = CreateStandardCompilation(source);
             comp.VerifyPdb("D.Main", @"
 <symbols>
+    <files>
+      <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+    </files>
     <methods>
         <method containingType=""D"" name=""Main"">
             <customDebugInfo>
@@ -2079,8 +2154,8 @@ class D
                 </using>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19""/>
-                <entry offset=""0x8"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6""/>
+                <entry offset=""0x0"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""19"" document=""1"" />
+                <entry offset=""0x8"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
             </sequencePoints>
             <scope startOffset=""0x0"" endOffset=""0x9"">
                 <type name=""System.Math, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""/>
@@ -2309,6 +2384,9 @@ class C
             // Usings of embedded types are currently omitted:
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2317,10 +2395,10 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""35"" />
-        <entry offset=""0xb"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""38"" />
-        <entry offset=""0x11"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""37"" />
-        <entry offset=""0x24"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""35"" document=""1"" />
+        <entry offset=""0xb"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x11"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""37"" document=""1"" />
+        <entry offset=""0x24"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x25"">
         <namespace name=""System"" />
@@ -2369,6 +2447,9 @@ class C
 
             v.VerifyPdb("C.M", @"
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3f5162f8-07c6-11d3-9053-00c04fa302a1"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>
@@ -2377,8 +2458,8 @@ class C
         </using>
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" />
-        <entry offset=""0x5"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x5"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0x6"">
         <namespace name=""System"" />

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -1793,16 +1793,19 @@ End Class
 
             diff1.VerifyPdb({&H06000001UI, &H06000002UI, &H06000003UI, &H06000004UI, &H06000005UI},
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method token="0x6000004">
             <sequencePoints>
-                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="30"/>
-                <entry offset="0x1" startLine="9" startColumn="13" endLine="9" endColumn="25"/>
-                <entry offset="0x7" startLine="10" startColumn="13" endLine="10" endColumn="31"/>
-                <entry offset="0xd" startLine="11" startColumn="13" endLine="11" endColumn="30"/>
-                <entry offset="0x14" startLine="12" startColumn="9" endLine="12" endColumn="13"/>
-                <entry offset="0x21" startLine="13" startColumn="9" endLine="13" endColumn="13"/>
-                <entry offset="0x28" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="30" document="1"/>
+                <entry offset="0x1" startLine="9" startColumn="13" endLine="9" endColumn="25" document="1"/>
+                <entry offset="0x7" startLine="10" startColumn="13" endLine="10" endColumn="31" document="1"/>
+                <entry offset="0xd" startLine="11" startColumn="13" endLine="11" endColumn="30" document="1"/>
+                <entry offset="0x14" startLine="12" startColumn="9" endLine="12" endColumn="13" document="1"/>
+                <entry offset="0x21" startLine="13" startColumn="9" endLine="13" endColumn="13" document="1"/>
+                <entry offset="0x28" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x29">
                 <currentnamespace name=""/>
@@ -1842,15 +1845,18 @@ End Class
 
             diff2.VerifyPdb({&H06000001UI, &H06000002UI, &H06000003UI, &H06000004UI, &H06000005UI},
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method token="0x6000004">
             <sequencePoints>
-                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="30"/>
-                <entry offset="0x1" startLine="9" startColumn="13" endLine="9" endColumn="30"/>
-                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="25"/>
-                <entry offset="0xe" startLine="11" startColumn="9" endLine="11" endColumn="13"/>
-                <entry offset="0x1b" startLine="12" startColumn="9" endLine="12" endColumn="13"/>
-                <entry offset="0x22" startLine="13" startColumn="5" endLine="13" endColumn="12"/>
+                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="30" document="1"/>
+                <entry offset="0x1" startLine="9" startColumn="13" endLine="9" endColumn="30" document="1"/>
+                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="25" document="1"/>
+                <entry offset="0xe" startLine="11" startColumn="9" endLine="11" endColumn="13" document="1"/>
+                <entry offset="0x1b" startLine="12" startColumn="9" endLine="12" endColumn="13" document="1"/>
+                <entry offset="0x22" startLine="13" startColumn="5" endLine="13" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x23">
                 <currentnamespace name=""/>
@@ -1897,15 +1903,18 @@ End Class
 
             diff3.VerifyPdb({&H06000001UI, &H06000002UI, &H06000003UI, &H06000004UI, &H06000005UI},
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method token="0x6000005">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="19"/>
-                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="30"/>
-                <entry offset="0x7" startLine="16" startColumn="13" endLine="16" endColumn="30"/>
-                <entry offset="0xd" startLine="17" startColumn="9" endLine="17" endColumn="13"/>
-                <entry offset="0x19" startLine="18" startColumn="9" endLine="18" endColumn="13"/>
-                <entry offset="0x25" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="19" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="30" document="1"/>
+                <entry offset="0x7" startLine="16" startColumn="13" endLine="16" endColumn="30" document="1"/>
+                <entry offset="0xd" startLine="17" startColumn="9" endLine="17" endColumn="13" document="1"/>
+                <entry offset="0x19" startLine="18" startColumn="9" endLine="18" endColumn="13" document="1"/>
+                <entry offset="0x25" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x26">
                 <currentnamespace name=""/>
@@ -1983,13 +1992,16 @@ End Class
 ]]>.Value)
             diff2.VerifyPdb({&H06000002UI},
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method token="0x6000002">
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="19"/>
-                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="18"/>
-                <entry offset="0x3" startLine="4" startColumn="13" endLine="4" endColumn="29"/>
-                <entry offset="0x9" startLine="5" startColumn="5" endLine="5" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="19" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="18" document="1"/>
+                <entry offset="0x3" startLine="4" startColumn="13" endLine="4" endColumn="29" document="1"/>
+                <entry offset="0x9" startLine="5" startColumn="5" endLine="5" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <currentnamespace name=""/>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
@@ -69,6 +69,9 @@ End Class
 
             v0.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M">
             <customDebugInfo>
@@ -78,16 +81,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="49"/>
-                <entry offset="0x3" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0xa" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0xe" hidden="true"/>
-                <entry offset="0x12" startLine="8" startColumn="9" endLine="8" endColumn="49"/>
-                <entry offset="0x14" startLine="9" startColumn="13" endLine="9" endColumn="33"/>
-                <entry offset="0x1b" startLine="10" startColumn="9" endLine="10" endColumn="13"/>
-                <entry offset="0x1f" hidden="true"/>
-                <entry offset="0x23" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="49" document="1"/>
+                <entry offset="0x3" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0xa" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0xe" hidden="true" document="1"/>
+                <entry offset="0x12" startLine="8" startColumn="9" endLine="8" endColumn="49" document="1"/>
+                <entry offset="0x14" startLine="9" startColumn="13" endLine="9" endColumn="33" document="1"/>
+                <entry offset="0x1b" startLine="10" startColumn="9" endLine="10" endColumn="13" document="1"/>
+                <entry offset="0x1f" hidden="true" document="1"/>
+                <entry offset="0x23" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x24">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -128,6 +128,9 @@ End Class
             ' NOTE: No <local> for the return variable "M".
             v.VerifyPdb("C+VB$StateMachine_1_M.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_M" name="MoveNext">
             <customDebugInfo>
@@ -141,16 +144,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xe" startLine="5" startColumn="5" endLine="5" endColumn="50"/>
-                <entry offset="0xf" startLine="6" startColumn="9" endLine="6" endColumn="28"/>
-                <entry offset="0x1b" hidden="true"/>
-                <entry offset="0x77" startLine="7" startColumn="9" endLine="7" endColumn="17"/>
-                <entry offset="0x7b" hidden="true"/>
-                <entry offset="0x83" hidden="true"/>
-                <entry offset="0xa0" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
-                <entry offset="0xaa" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="5" startColumn="5" endLine="5" endColumn="50" document="1"/>
+                <entry offset="0xf" startLine="6" startColumn="9" endLine="6" endColumn="28" document="1"/>
+                <entry offset="0x1b" hidden="true" document="1"/>
+                <entry offset="0x77" startLine="7" startColumn="9" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x7b" hidden="true" document="1"/>
+                <entry offset="0x83" hidden="true" document="1"/>
+                <entry offset="0xa0" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
+                <entry offset="0xaa" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb8">
                 <namespace name="System" importlevel="file"/>
@@ -207,6 +210,9 @@ End Module
 
             compilation.VerifyPdb("Module1.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="F" parameterNames="a">
             <customDebugInfo>
@@ -218,6 +224,9 @@ End Module
 
             compilation.VerifyPdb("Module1+VB$StateMachine_1_F.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_1_F" name="MoveNext">
             <customDebugInfo>
@@ -232,16 +241,16 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xe" startLine="11" startColumn="5" endLine="11" endColumn="68"/>
-                <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="25"/>
-                <entry offset="0x1e" hidden="true"/>
-                <entry offset="0x7a" startLine="13" startColumn="9" endLine="13" endColumn="17"/>
-                <entry offset="0x7e" hidden="true"/>
-                <entry offset="0x86" hidden="true"/>
-                <entry offset="0xa3" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
-                <entry offset="0xad" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="11" startColumn="5" endLine="11" endColumn="68" document="1"/>
+                <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="25" document="1"/>
+                <entry offset="0x1e" hidden="true" document="1"/>
+                <entry offset="0x7a" startLine="13" startColumn="9" endLine="13" endColumn="17" document="1"/>
+                <entry offset="0x7e" hidden="true" document="1"/>
+                <entry offset="0x86" hidden="true" document="1"/>
+                <entry offset="0xa3" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
+                <entry offset="0xad" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xbb">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
@@ -256,6 +265,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Test",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Test">
             <customDebugInfo>
@@ -267,6 +279,9 @@ End Module
 
             compilation.VerifyPdb("Module1+VB$StateMachine_2_Test.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_2_Test" name="MoveNext">
             <customDebugInfo>
@@ -287,24 +302,24 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0x5d" startLine="16" startColumn="5" endLine="16" endColumn="34"/>
-                <entry offset="0x5e" startLine="17" startColumn="9" endLine="23" endColumn="34"/>
-                <entry offset="0x70" hidden="true"/>
-                <entry offset="0xf1" hidden="true"/>
-                <entry offset="0x176" hidden="true"/>
-                <entry offset="0x1f0" hidden="true"/>
-                <entry offset="0x269" hidden="true"/>
-                <entry offset="0x2e2" hidden="true"/>
-                <entry offset="0x363" hidden="true"/>
-                <entry offset="0x3e4" hidden="true"/>
-                <entry offset="0x463" hidden="true"/>
-                <entry offset="0x4bf" startLine="24" startColumn="5" endLine="24" endColumn="17"/>
-                <entry offset="0x4c1" hidden="true"/>
-                <entry offset="0x4c9" hidden="true"/>
-                <entry offset="0x4e6" startLine="24" startColumn="5" endLine="24" endColumn="17"/>
-                <entry offset="0x4f0" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0x5d" startLine="16" startColumn="5" endLine="16" endColumn="34" document="1"/>
+                <entry offset="0x5e" startLine="17" startColumn="9" endLine="23" endColumn="34" document="1"/>
+                <entry offset="0x70" hidden="true" document="1"/>
+                <entry offset="0xf1" hidden="true" document="1"/>
+                <entry offset="0x176" hidden="true" document="1"/>
+                <entry offset="0x1f0" hidden="true" document="1"/>
+                <entry offset="0x269" hidden="true" document="1"/>
+                <entry offset="0x2e2" hidden="true" document="1"/>
+                <entry offset="0x363" hidden="true" document="1"/>
+                <entry offset="0x3e4" hidden="true" document="1"/>
+                <entry offset="0x463" hidden="true" document="1"/>
+                <entry offset="0x4bf" startLine="24" startColumn="5" endLine="24" endColumn="17" document="1"/>
+                <entry offset="0x4c1" hidden="true" document="1"/>
+                <entry offset="0x4c9" hidden="true" document="1"/>
+                <entry offset="0x4e6" startLine="24" startColumn="5" endLine="24" endColumn="17" document="1"/>
+                <entry offset="0x4f0" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4fd">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
@@ -327,6 +342,9 @@ End Module
 
             compilation.VerifyPdb("Module1.S",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="S">
             <customDebugInfo>
@@ -338,6 +356,9 @@ End Module
 
             compilation.VerifyPdb("Module1+VB$StateMachine_3_S.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1+VB$StateMachine_3_S" name="MoveNext">
             <customDebugInfo>
@@ -350,16 +371,16 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xe" startLine="26" startColumn="5" endLine="26" endColumn="18"/>
-                <entry offset="0xf" startLine="27" startColumn="9" endLine="27" endColumn="25"/>
-                <entry offset="0x1d" hidden="true"/>
-                <entry offset="0x78" startLine="28" startColumn="5" endLine="28" endColumn="12"/>
-                <entry offset="0x7a" hidden="true"/>
-                <entry offset="0x82" hidden="true"/>
-                <entry offset="0x9f" startLine="28" startColumn="5" endLine="28" endColumn="12"/>
-                <entry offset="0xa9" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="26" startColumn="5" endLine="26" endColumn="18" document="1"/>
+                <entry offset="0xf" startLine="27" startColumn="9" endLine="27" endColumn="25" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
+                <entry offset="0x78" startLine="28" startColumn="5" endLine="28" endColumn="12" document="1"/>
+                <entry offset="0x7a" hidden="true" document="1"/>
+                <entry offset="0x82" hidden="true" document="1"/>
+                <entry offset="0x9f" startLine="28" startColumn="5" endLine="28" endColumn="12" document="1"/>
+                <entry offset="0xa9" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb6">
                 <importsforward declaringType="Module1" methodName="Main" parameterNames="args"/>
@@ -405,6 +426,9 @@ End Class
             ' Goal: We're looking for "$VB$ResumableLocal_$VB$Closure_$0" and "$VB$ResumableLocal_a$1".
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_Lambda.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Async_Lambda" name="MoveNext">
             <customDebugInfo>
@@ -421,22 +445,22 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0x11" startLine="5" startColumn="5" endLine="5" endColumn="50"/>
-                <entry offset="0x12" hidden="true"/>
-                <entry offset="0x1d" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x29" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x35" startLine="9" startColumn="13" endLine="9" endColumn="53"/>
-                <entry offset="0x4c" startLine="11" startColumn="9" endLine="11" endColumn="55"/>
-                <entry offset="0x7b" hidden="true"/>
-                <entry offset="0xd9" startLine="12" startColumn="9" endLine="12" endColumn="21"/>
-                <entry offset="0xea" startLine="13" startColumn="9" endLine="13" endColumn="21"/>
-                <entry offset="0xfb" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
-                <entry offset="0xfd" hidden="true"/>
-                <entry offset="0x105" hidden="true"/>
-                <entry offset="0x122" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
-                <entry offset="0x12c" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0x11" startLine="5" startColumn="5" endLine="5" endColumn="50" document="1"/>
+                <entry offset="0x12" hidden="true" document="1"/>
+                <entry offset="0x1d" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x29" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x35" startLine="9" startColumn="13" endLine="9" endColumn="53" document="1"/>
+                <entry offset="0x4c" startLine="11" startColumn="9" endLine="11" endColumn="55" document="1"/>
+                <entry offset="0x7b" hidden="true" document="1"/>
+                <entry offset="0xd9" startLine="12" startColumn="9" endLine="12" endColumn="21" document="1"/>
+                <entry offset="0xea" startLine="13" startColumn="9" endLine="13" endColumn="21" document="1"/>
+                <entry offset="0xfb" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
+                <entry offset="0xfd" hidden="true" document="1"/>
+                <entry offset="0x105" hidden="true" document="1"/>
+                <entry offset="0x122" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
+                <entry offset="0x12c" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x139">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
@@ -483,6 +507,9 @@ End Class
             ' Goal: We're looking for "$VB$ResumableLocal_$VB$Closure_$0" but not "$VB$ResumableLocal_a$1".
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_Lambda.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Async_Lambda" name="MoveNext">
             <customDebugInfo>
@@ -491,20 +518,20 @@ End Class
                 </hoistedLocalScopes>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xa" hidden="true"/>
-                <entry offset="0x15" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x21" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="55"/>
-                <entry offset="0x5c" hidden="true"/>
-                <entry offset="0xb3" startLine="12" startColumn="9" endLine="12" endColumn="21"/>
-                <entry offset="0xc4" startLine="13" startColumn="9" endLine="13" endColumn="21"/>
-                <entry offset="0xd5" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
-                <entry offset="0xd7" hidden="true"/>
-                <entry offset="0xde" hidden="true"/>
-                <entry offset="0xf9" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
-                <entry offset="0x103" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xa" hidden="true" document="1"/>
+                <entry offset="0x15" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x21" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="55" document="1"/>
+                <entry offset="0x5c" hidden="true" document="1"/>
+                <entry offset="0xb3" startLine="12" startColumn="9" endLine="12" endColumn="21" document="1"/>
+                <entry offset="0xc4" startLine="13" startColumn="9" endLine="13" endColumn="21" document="1"/>
+                <entry offset="0xd5" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
+                <entry offset="0xd7" hidden="true" document="1"/>
+                <entry offset="0xde" hidden="true" document="1"/>
+                <entry offset="0xf9" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
+                <entry offset="0x103" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10f">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
@@ -548,6 +575,9 @@ End Class
             ' Goal: We're looking for the single-mangled names "$VB$ResumableLocal_x$1" and "$VB$ResumableLocal_y$2".
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_NoLambda.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Async_NoLambda" name="MoveNext">
             <customDebugInfo>
@@ -564,20 +594,20 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xe" startLine="5" startColumn="5" endLine="5" endColumn="52"/>
-                <entry offset="0xf" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x16" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x1d" startLine="9" startColumn="9" endLine="9" endColumn="55"/>
-                <entry offset="0x42" hidden="true"/>
-                <entry offset="0xa0" startLine="10" startColumn="9" endLine="10" endColumn="21"/>
-                <entry offset="0xac" startLine="11" startColumn="9" endLine="11" endColumn="21"/>
-                <entry offset="0xb8" startLine="12" startColumn="5" endLine="12" endColumn="17"/>
-                <entry offset="0xba" hidden="true"/>
-                <entry offset="0xc2" hidden="true"/>
-                <entry offset="0xdf" startLine="12" startColumn="5" endLine="12" endColumn="17"/>
-                <entry offset="0xe9" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="5" startColumn="5" endLine="5" endColumn="52" document="1"/>
+                <entry offset="0xf" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x16" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x1d" startLine="9" startColumn="9" endLine="9" endColumn="55" document="1"/>
+                <entry offset="0x42" hidden="true" document="1"/>
+                <entry offset="0xa0" startLine="10" startColumn="9" endLine="10" endColumn="21" document="1"/>
+                <entry offset="0xac" startLine="11" startColumn="9" endLine="11" endColumn="21" document="1"/>
+                <entry offset="0xb8" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
+                <entry offset="0xba" hidden="true" document="1"/>
+                <entry offset="0xc2" hidden="true" document="1"/>
+                <entry offset="0xdf" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
+                <entry offset="0xe9" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xf6">
                 <namespace name="System" importlevel="file"/>
@@ -624,6 +654,9 @@ End Class
             ' Goal: We're looking for the single-mangled names "$VB$ResumableLocal_x$0" and "$VB$ResumableLocal_y$1".
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_NoLambda.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Async_NoLambda" name="MoveNext">
             <customDebugInfo>
@@ -633,19 +666,19 @@ End Class
                 </hoistedLocalScopes>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" hidden="true"/>
-                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x11" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x18" startLine="9" startColumn="9" endLine="9" endColumn="55"/>
-                <entry offset="0x3d" hidden="true"/>
-                <entry offset="0x91" startLine="10" startColumn="9" endLine="10" endColumn="21"/>
-                <entry offset="0x9d" startLine="11" startColumn="9" endLine="11" endColumn="21"/>
-                <entry offset="0xa9" startLine="12" startColumn="5" endLine="12" endColumn="17"/>
-                <entry offset="0xab" hidden="true"/>
-                <entry offset="0xb2" hidden="true"/>
-                <entry offset="0xcd" startLine="12" startColumn="5" endLine="12" endColumn="17"/>
-                <entry offset="0xd7" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" hidden="true" document="1"/>
+                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x11" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x18" startLine="9" startColumn="9" endLine="9" endColumn="55" document="1"/>
+                <entry offset="0x3d" hidden="true" document="1"/>
+                <entry offset="0x91" startLine="10" startColumn="9" endLine="10" endColumn="21" document="1"/>
+                <entry offset="0x9d" startLine="11" startColumn="9" endLine="11" endColumn="21" document="1"/>
+                <entry offset="0xa9" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
+                <entry offset="0xab" hidden="true" document="1"/>
+                <entry offset="0xb2" hidden="true" document="1"/>
+                <entry offset="0xcd" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
+                <entry offset="0xd7" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xe3">
                 <namespace name="System" importlevel="file"/>
@@ -686,6 +719,9 @@ End Class
             ' NOTE: No <local> for the return variable "M".
             c.VerifyPdb("C+VB$StateMachine_1_M.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_M" name="MoveNext">
             <customDebugInfo>
@@ -697,13 +733,13 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" startLine="5" startColumn="5" endLine="5" endColumn="50"/>
-                <entry offset="0x8" startLine="6" startColumn="9" endLine="6" endColumn="17"/>
-                <entry offset="0xc" hidden="true"/>
-                <entry offset="0x13" hidden="true"/>
-                <entry offset="0x2f" startLine="7" startColumn="5" endLine="7" endColumn="17"/>
-                <entry offset="0x39" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="5" endLine="5" endColumn="50" document="1"/>
+                <entry offset="0x8" startLine="6" startColumn="9" endLine="6" endColumn="17" document="1"/>
+                <entry offset="0xc" hidden="true" document="1"/>
+                <entry offset="0x13" hidden="true" document="1"/>
+                <entry offset="0x2f" startLine="7" startColumn="5" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x39" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x47">
                 <namespace name="System" importlevel="file"/>
@@ -876,6 +912,9 @@ End Class
             Dim v = CompileAndVerify(compilation)
             v.VerifyPdb("C.M", "
 <symbols>
+  <files>
+    <file id=""1"" name="""" language=""3a12d0b8-c26c-11d0-b442-00a0244a1dd2"" languageVendor=""994b45c4-e6e9-11d2-903f-00c04fa302a1"" documentType=""5a869d0b-6611-11d3-bd2a-0000f80849bd"" />
+  </files>
   <methods>
     <method containingType=""C"" name=""M"">
       <customDebugInfo>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBCollectionInitializerTests.vb
@@ -30,6 +30,9 @@ End Class
 
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -39,9 +42,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
-                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="91"/>
-                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="91" document="1"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
@@ -78,6 +81,9 @@ End Class
 
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -87,9 +93,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
-                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="73"/>
-                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="73" document="1"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
@@ -125,6 +131,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -134,9 +143,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
-                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="107"/>
-                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="107" document="1"/>
+                <entry offset="0x2b" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2c">
                 <namespace name="System" importlevel="file"/>
@@ -172,6 +181,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -182,10 +194,10 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29"/>
-                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="19"/>
-                <entry offset="0x2b" startLine="10" startColumn="21" endLine="10" endColumn="27"/>
-                <entry offset="0x55" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="10" startColumn="13" endLine="10" endColumn="19" document="1"/>
+                <entry offset="0x2b" startLine="10" startColumn="21" endLine="10" endColumn="27" document="1"/>
+                <entry offset="0x55" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x56">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBConstLocalTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBConstLocalTests.vb
@@ -32,12 +32,15 @@ end class
 
             compilation.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="19"/>
-                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="33"/>
-                <entry offset="0x8" startLine="7" startColumn="5" endLine="7" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="19" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0x8" startLine="7" startColumn="5" endLine="7" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <namespace name="System" importlevel="file"/>
@@ -76,6 +79,9 @@ end class
 
             c.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M" parameterNames="a">
             <customDebugInfo>
@@ -85,9 +91,9 @@ end class
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="30"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="11" endColumn="11"/>
-                <entry offset="0x2c" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="30" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="11" endColumn="11" document="1"/>
+                <entry offset="0x2c" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2d">
                 <namespace name="System" importlevel="file"/>
@@ -97,9 +103,9 @@ end class
         </method>
         <method containingType="C+_Closure$__" name="_Lambda$__1-0">
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="13" endLine="6" endColumn="18"/>
-                <entry offset="0x1" startLine="9" startColumn="17" endLine="9" endColumn="45"/>
-                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="20"/>
+                <entry offset="0x0" startLine="6" startColumn="13" endLine="6" endColumn="18" document="1"/>
+                <entry offset="0x1" startLine="9" startColumn="17" endLine="9" endColumn="45" document="1"/>
+                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="C" methodName="M" parameterNames="a"/>
@@ -160,11 +166,14 @@ End Class
 
             compilation.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="12"/>
-                <entry offset="0x1" startLine="10" startColumn="5" endLine="10" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="10" startColumn="5" endLine="10" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBForEachTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBForEachTests.vb
@@ -30,6 +30,9 @@ End Class
 
             compilation.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M" parameterNames="c">
             <customDebugInfo>
@@ -43,18 +46,18 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="48"/>
-                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="24"/>
-                <entry offset="0x5" hidden="true"/>
-                <entry offset="0x10" startLine="5" startColumn="13" endLine="5" endColumn="36"/>
-                <entry offset="0x16" hidden="true"/>
-                <entry offset="0x1a" startLine="5" startColumn="37" endLine="5" endColumn="48"/>
-                <entry offset="0x1e" startLine="6" startColumn="9" endLine="6" endColumn="13"/>
-                <entry offset="0x1f" hidden="true"/>
-                <entry offset="0x23" hidden="true"/>
-                <entry offset="0x2b" hidden="true"/>
-                <entry offset="0x2f" startLine="7" startColumn="9" endLine="7" endColumn="21"/>
-                <entry offset="0x33" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="48" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="24" document="1"/>
+                <entry offset="0x5" hidden="true" document="1"/>
+                <entry offset="0x10" startLine="5" startColumn="13" endLine="5" endColumn="36" document="1"/>
+                <entry offset="0x16" hidden="true" document="1"/>
+                <entry offset="0x1a" startLine="5" startColumn="37" endLine="5" endColumn="48" document="1"/>
+                <entry offset="0x1e" startLine="6" startColumn="9" endLine="6" endColumn="13" document="1"/>
+                <entry offset="0x1f" hidden="true" document="1"/>
+                <entry offset="0x23" hidden="true" document="1"/>
+                <entry offset="0x2b" hidden="true" document="1"/>
+                <entry offset="0x2f" startLine="7" startColumn="9" endLine="7" endColumn="21" document="1"/>
+                <entry offset="0x33" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x35">
                 <currentnamespace name=""/>
@@ -94,6 +97,9 @@ Imports System
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -107,18 +113,18 @@ Imports System
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="13" endLine="6" endColumn="37"/>
-                <entry offset="0x1" startLine="7" startColumn="21" endLine="7" endColumn="57"/>
-                <entry offset="0x8" startLine="8" startColumn="17" endLine="8" endColumn="28"/>
-                <entry offset="0xd" startLine="9" startColumn="17" endLine="9" endColumn="28"/>
-                <entry offset="0x12" startLine="11" startColumn="17" endLine="11" endColumn="51"/>
-                <entry offset="0x16" hidden="true"/>
-                <entry offset="0x1c" startLine="12" startColumn="21" endLine="12" endColumn="47"/>
-                <entry offset="0x23" startLine="13" startColumn="17" endLine="13" endColumn="21"/>
-                <entry offset="0x24" hidden="true"/>
-                <entry offset="0x28" hidden="true"/>
-                <entry offset="0x30" hidden="true"/>
-                <entry offset="0x34" startLine="14" startColumn="13" endLine="14" endColumn="20"/>
+                <entry offset="0x0" startLine="6" startColumn="13" endLine="6" endColumn="37" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="21" endLine="7" endColumn="57" document="1"/>
+                <entry offset="0x8" startLine="8" startColumn="17" endLine="8" endColumn="28" document="1"/>
+                <entry offset="0xd" startLine="9" startColumn="17" endLine="9" endColumn="28" document="1"/>
+                <entry offset="0x12" startLine="11" startColumn="17" endLine="11" endColumn="51" document="1"/>
+                <entry offset="0x16" hidden="true" document="1"/>
+                <entry offset="0x1c" startLine="12" startColumn="21" endLine="12" endColumn="47" document="1"/>
+                <entry offset="0x23" startLine="13" startColumn="17" endLine="13" endColumn="21" document="1"/>
+                <entry offset="0x24" hidden="true" document="1"/>
+                <entry offset="0x28" hidden="true" document="1"/>
+                <entry offset="0x30" hidden="true" document="1"/>
+                <entry offset="0x34" startLine="14" startColumn="13" endLine="14" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x35">
                 <namespace name="System" importlevel="file"/>
@@ -157,6 +163,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -170,16 +179,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="29"/>
-                <entry offset="0x1" startLine="7" startColumn="13" endLine="7" endColumn="36"/>
-                <entry offset="0x7" startLine="9" startColumn="9" endLine="9" endColumn="40"/>
-                <entry offset="0xb" hidden="true"/>
-                <entry offset="0x15" startLine="10" startColumn="13" endLine="10" endColumn="39"/>
-                <entry offset="0x1c" startLine="11" startColumn="9" endLine="11" endColumn="13"/>
-                <entry offset="0x1d" hidden="true"/>
-                <entry offset="0x21" hidden="true"/>
-                <entry offset="0x2c" hidden="true"/>
-                <entry offset="0x30" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="13" endLine="7" endColumn="36" document="1"/>
+                <entry offset="0x7" startLine="9" startColumn="9" endLine="9" endColumn="40" document="1"/>
+                <entry offset="0xb" hidden="true" document="1"/>
+                <entry offset="0x15" startLine="10" startColumn="13" endLine="10" endColumn="39" document="1"/>
+                <entry offset="0x1c" startLine="11" startColumn="9" endLine="11" endColumn="13" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
+                <entry offset="0x21" hidden="true" document="1"/>
+                <entry offset="0x2c" hidden="true" document="1"/>
+                <entry offset="0x30" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x31">
                 <namespace name="System" importlevel="file"/>
@@ -233,6 +242,9 @@ End Structure
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C" methodName="Main"/>
     <methods>
         <method containingType="C" name="Main">
@@ -244,14 +256,14 @@ End Structure
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="29"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39"/>
-                <entry offset="0xc" hidden="true"/>
-                <entry offset="0x16" startLine="6" startColumn="13" endLine="6" endColumn="40"/>
-                <entry offset="0x1d" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0x1e" hidden="true"/>
-                <entry offset="0x26" hidden="true"/>
-                <entry offset="0x29" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39" document="1"/>
+                <entry offset="0xc" hidden="true" document="1"/>
+                <entry offset="0x16" startLine="6" startColumn="13" endLine="6" endColumn="40" document="1"/>
+                <entry offset="0x1d" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0x1e" hidden="true" document="1"/>
+                <entry offset="0x26" hidden="true" document="1"/>
+                <entry offset="0x29" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2a">
                 <currentnamespace name=""/>
@@ -301,6 +313,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C" methodName="Main"/>
     <methods>
         <method containingType="C" name="Main">
@@ -312,15 +327,15 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="29"/>
-                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="54"/>
-                <entry offset="0x1d" hidden="true"/>
-                <entry offset="0x26" startLine="9" startColumn="13" endLine="9" endColumn="33"/>
-                <entry offset="0x2d" startLine="10" startColumn="9" endLine="10" endColumn="13"/>
-                <entry offset="0x2e" hidden="true"/>
-                <entry offset="0x35" hidden="true"/>
-                <entry offset="0x3a" hidden="true"/>
-                <entry offset="0x45" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="54" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
+                <entry offset="0x26" startLine="9" startColumn="13" endLine="9" endColumn="33" document="1"/>
+                <entry offset="0x2d" startLine="10" startColumn="9" endLine="10" endColumn="13" document="1"/>
+                <entry offset="0x2e" hidden="true" document="1"/>
+                <entry offset="0x35" hidden="true" document="1"/>
+                <entry offset="0x3a" hidden="true" document="1"/>
+                <entry offset="0x45" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x46">
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -367,6 +382,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C" methodName="Main"/>
     <methods>
         <method containingType="C" name="Main">
@@ -378,15 +396,15 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="29"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39"/>
-                <entry offset="0xc" hidden="true"/>
-                <entry offset="0x1a" startLine="6" startColumn="13" endLine="6" endColumn="40"/>
-                <entry offset="0x26" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0x27" hidden="true"/>
-                <entry offset="0x2e" hidden="true"/>
-                <entry offset="0x33" hidden="true"/>
-                <entry offset="0x48" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39" document="1"/>
+                <entry offset="0xc" hidden="true" document="1"/>
+                <entry offset="0x1a" startLine="6" startColumn="13" endLine="6" endColumn="40" document="1"/>
+                <entry offset="0x26" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0x27" hidden="true" document="1"/>
+                <entry offset="0x2e" hidden="true" document="1"/>
+                <entry offset="0x33" hidden="true" document="1"/>
+                <entry offset="0x48" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x49">
                 <currentnamespace name=""/>
@@ -430,6 +448,9 @@ End Module
             ' It's now the scope of the complete loop and not just the body
             compilation.VerifyPdb("M1.Main",
  <symbols>
+     <files>
+         <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+     </files>
      <entryPoint declaringType="M1" methodName="Main"/>
      <methods>
          <method containingType="M1" name="Main">
@@ -440,13 +461,13 @@ End Module
                  </encLocalSlotMap>
              </customDebugInfo>
              <sequencePoints>
-                 <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15"/>
-                 <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="22"/>
-                 <entry offset="0x8" startLine="8" startColumn="9" endLine="8" endColumn="23"/>
-                 <entry offset="0xa" startLine="9" startColumn="13" endLine="9" endColumn="26"/>
-                 <entry offset="0xe" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
-                 <entry offset="0x13" hidden="true"/>
-                 <entry offset="0x17" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                 <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15" document="1"/>
+                 <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="22" document="1"/>
+                 <entry offset="0x8" startLine="8" startColumn="9" endLine="8" endColumn="23" document="1"/>
+                 <entry offset="0xa" startLine="9" startColumn="13" endLine="9" endColumn="26" document="1"/>
+                 <entry offset="0xe" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
+                 <entry offset="0x13" hidden="true" document="1"/>
+                 <entry offset="0x17" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
              </sequencePoints>
              <scope startOffset="0x0" endOffset="0x18">
                  <namespace name="System" importlevel="file"/>
@@ -484,6 +505,9 @@ End Module
             ' It 's now the scope of the complete loop and not just the body            
             compilation.VerifyPdb("M1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="M1" methodName="Main"/>
     <methods>
         <method containingType="M1" name="Main">
@@ -496,13 +520,13 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="3" endLine="5" endColumn="13"/>
-                <entry offset="0x1" startLine="6" startColumn="5" endLine="6" endColumn="36"/>
-                <entry offset="0x1e" hidden="true"/>
-                <entry offset="0x21" startLine="7" startColumn="5" endLine="7" endColumn="31"/>
-                <entry offset="0x2c" startLine="8" startColumn="5" endLine="8" endColumn="9"/>
-                <entry offset="0x36" hidden="true"/>
-                <entry offset="0x39" startLine="9" startColumn="4" endLine="9" endColumn="11"/>
+                <entry offset="0x0" startLine="5" startColumn="3" endLine="5" endColumn="13" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="5" endLine="6" endColumn="36" document="1"/>
+                <entry offset="0x1e" hidden="true" document="1"/>
+                <entry offset="0x21" startLine="7" startColumn="5" endLine="7" endColumn="31" document="1"/>
+                <entry offset="0x2c" startLine="8" startColumn="5" endLine="8" endColumn="9" document="1"/>
+                <entry offset="0x36" hidden="true" document="1"/>
+                <entry offset="0x39" startLine="9" startColumn="4" endLine="9" endColumn="11" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3a">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -105,6 +105,9 @@ End Module
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("Program+_Closure$__+VB$StateMachine___Lambda$__0-0.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="Program" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Program+_Closure$__+VB$StateMachine___Lambda$__0-0" name="MoveNext">
@@ -116,11 +119,11 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x2c" startLine="7" startColumn="13" endLine="7" endColumn="33"/>
-                <entry offset="0x2d" startLine="8" startColumn="17" endLine="8" endColumn="24"/>
-                <entry offset="0x48" startLine="9" startColumn="17" endLine="9" endColumn="24"/>
-                <entry offset="0x68" startLine="10" startColumn="13" endLine="10" endColumn="25"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x2c" startLine="7" startColumn="13" endLine="7" endColumn="33" document="1"/>
+                <entry offset="0x2d" startLine="8" startColumn="17" endLine="8" endColumn="24" document="1"/>
+                <entry offset="0x48" startLine="9" startColumn="17" endLine="9" endColumn="24" document="1"/>
+                <entry offset="0x68" startLine="10" startColumn="13" endLine="10" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6a">
                 <importsforward declaringType="Program" methodName="Main" parameterNames="args"/>
@@ -172,6 +175,9 @@ End Module
             '                    Even though they do not really exist in IL, EE will rely on them for scoping     
             compilation.VerifyPdb("Module1+VB$StateMachine_1_Goo.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1+VB$StateMachine_1_Goo" name="MoveNext">
@@ -193,27 +199,27 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x41" startLine="12" startColumn="5" endLine="12" endColumn="55"/>
-                <entry offset="0x42" startLine="13" startColumn="13" endLine="13" endColumn="19"/>
-                <entry offset="0x4e" startLine="14" startColumn="9" endLine="14" endColumn="20"/>
-                <entry offset="0x58" startLine="16" startColumn="9" endLine="16" endColumn="26"/>
-                <entry offset="0x6b" hidden="true"/>
-                <entry offset="0x80" startLine="17" startColumn="13" endLine="17" endColumn="20"/>
-                <entry offset="0xa0" startLine="18" startColumn="13" endLine="18" endColumn="20"/>
-                <entry offset="0xc0" startLine="19" startColumn="9" endLine="19" endColumn="13"/>
-                <entry offset="0xc1" hidden="true"/>
-                <entry offset="0xcf" hidden="true"/>
-                <entry offset="0xe0" hidden="true"/>
-                <entry offset="0xe3" startLine="21" startColumn="9" endLine="21" endColumn="28"/>
-                <entry offset="0xf5" hidden="true"/>
-                <entry offset="0x10e" startLine="22" startColumn="13" endLine="22" endColumn="44"/>
-                <entry offset="0x133" startLine="23" startColumn="13" endLine="23" endColumn="44"/>
-                <entry offset="0x158" startLine="24" startColumn="9" endLine="24" endColumn="13"/>
-                <entry offset="0x159" hidden="true"/>
-                <entry offset="0x167" hidden="true"/>
-                <entry offset="0x17b" hidden="true"/>
-                <entry offset="0x181" startLine="26" startColumn="5" endLine="26" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x41" startLine="12" startColumn="5" endLine="12" endColumn="55" document="1"/>
+                <entry offset="0x42" startLine="13" startColumn="13" endLine="13" endColumn="19" document="1"/>
+                <entry offset="0x4e" startLine="14" startColumn="9" endLine="14" endColumn="20" document="1"/>
+                <entry offset="0x58" startLine="16" startColumn="9" endLine="16" endColumn="26" document="1"/>
+                <entry offset="0x6b" hidden="true" document="1"/>
+                <entry offset="0x80" startLine="17" startColumn="13" endLine="17" endColumn="20" document="1"/>
+                <entry offset="0xa0" startLine="18" startColumn="13" endLine="18" endColumn="20" document="1"/>
+                <entry offset="0xc0" startLine="19" startColumn="9" endLine="19" endColumn="13" document="1"/>
+                <entry offset="0xc1" hidden="true" document="1"/>
+                <entry offset="0xcf" hidden="true" document="1"/>
+                <entry offset="0xe0" hidden="true" document="1"/>
+                <entry offset="0xe3" startLine="21" startColumn="9" endLine="21" endColumn="28" document="1"/>
+                <entry offset="0xf5" hidden="true" document="1"/>
+                <entry offset="0x10e" startLine="22" startColumn="13" endLine="22" endColumn="44" document="1"/>
+                <entry offset="0x133" startLine="23" startColumn="13" endLine="23" endColumn="44" document="1"/>
+                <entry offset="0x158" startLine="24" startColumn="9" endLine="24" endColumn="13" document="1"/>
+                <entry offset="0x159" hidden="true" document="1"/>
+                <entry offset="0x167" hidden="true" document="1"/>
+                <entry offset="0x17b" hidden="true" document="1"/>
+                <entry offset="0x181" startLine="26" startColumn="5" endLine="26" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x183">
                 <importsforward declaringType="Module1" methodName="Main"/>
@@ -262,6 +268,9 @@ End Class
             ' Goal: We're looking for the double-mangled name "$VB$ResumableLocal_$VB$Closure_$0".
             compilation.VerifyPdb("C+VB$StateMachine_1_Iterator_Lambda_Hoisted.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Iterator_Lambda_Hoisted" name="MoveNext">
             <customDebugInfo>
@@ -270,15 +279,15 @@ End Class
                 </hoistedLocalScopes>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x19" hidden="true"/>
-                <entry offset="0x24" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x30" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x3c" startLine="9" startColumn="13" endLine="9" endColumn="53"/>
-                <entry offset="0x43" startLine="11" startColumn="9" endLine="11" endColumn="20"/>
-                <entry offset="0x74" startLine="12" startColumn="9" endLine="12" endColumn="21"/>
-                <entry offset="0x85" startLine="13" startColumn="9" endLine="13" endColumn="21"/>
-                <entry offset="0x96" startLine="14" startColumn="5" endLine="14" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x19" hidden="true" document="1"/>
+                <entry offset="0x24" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x30" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x3c" startLine="9" startColumn="13" endLine="9" endColumn="53" document="1"/>
+                <entry offset="0x43" startLine="11" startColumn="9" endLine="11" endColumn="20" document="1"/>
+                <entry offset="0x74" startLine="12" startColumn="9" endLine="12" endColumn="21" document="1"/>
+                <entry offset="0x85" startLine="13" startColumn="9" endLine="13" endColumn="21" document="1"/>
+                <entry offset="0x96" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x98">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
@@ -319,15 +328,18 @@ End Class
             ' Goal: We're looking for the single-mangled name "$VB$Closure_0".
             compilation.VerifyPdb("C+VB$StateMachine_1_Iterator_Lambda_NotHoisted.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Iterator_Lambda_NotHoisted" name="MoveNext">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x19" hidden="true"/>
-                <entry offset="0x1f" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x26" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="20"/>
-                <entry offset="0x54" startLine="12" startColumn="5" endLine="12" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x19" hidden="true" document="1"/>
+                <entry offset="0x1f" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x26" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x2d" startLine="11" startColumn="9" endLine="11" endColumn="20" document="1"/>
+                <entry offset="0x54" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x56">
                 <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
@@ -365,6 +377,9 @@ End Class
             ' Goal: We're looking for the single-mangled names "$VB$ResumableLocal_x$0" and "$VB$ResumableLocal_y$1".
             compilation.VerifyPdb("C+VB$StateMachine_1_Iterator_NoLambda_Hoisted.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Iterator_NoLambda_Hoisted" name="MoveNext">
             <customDebugInfo>
@@ -374,13 +389,13 @@ End Class
                 </hoistedLocalScopes>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x19" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x20" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x27" startLine="8" startColumn="9" endLine="8" endColumn="20"/>
-                <entry offset="0x4e" startLine="9" startColumn="9" endLine="9" endColumn="21"/>
-                <entry offset="0x5a" startLine="10" startColumn="9" endLine="10" endColumn="21"/>
-                <entry offset="0x66" startLine="11" startColumn="5" endLine="11" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x19" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x20" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x27" startLine="8" startColumn="9" endLine="8" endColumn="20" document="1"/>
+                <entry offset="0x4e" startLine="9" startColumn="9" endLine="9" endColumn="21" document="1"/>
+                <entry offset="0x5a" startLine="10" startColumn="9" endLine="10" endColumn="21" document="1"/>
+                <entry offset="0x66" startLine="11" startColumn="5" endLine="11" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x68">
                 <namespace name="System" importlevel="file"/>
@@ -419,14 +434,17 @@ End Class
             ' Goal: We're looking for the unmangled names "x" and "y".
             compilation.VerifyPdb("C+VB$StateMachine_1_Iterator_NoLambda_NotHoisted.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_Iterator_NoLambda_NotHoisted" name="MoveNext">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x19" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x1b" startLine="7" startColumn="13" endLine="7" endColumn="29"/>
-                <entry offset="0x1d" startLine="8" startColumn="9" endLine="8" endColumn="20"/>
-                <entry offset="0x3a" startLine="9" startColumn="5" endLine="9" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x19" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x1b" startLine="7" startColumn="13" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x1d" startLine="8" startColumn="9" endLine="8" endColumn="20" document="1"/>
+                <entry offset="0x3a" startLine="9" startColumn="5" endLine="9" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3c">
                 <namespace name="System" importlevel="file"/>
@@ -475,6 +493,9 @@ End Module
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("Module1+VB$StateMachine_1_Goo.MoveNext",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1+VB$StateMachine_1_Goo" name="MoveNext">
@@ -485,11 +506,11 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x2c" startLine="13" startColumn="5" endLine="13" endColumn="55"/>
-                <entry offset="0x2d" startLine="14" startColumn="9" endLine="14" endColumn="16"/>
-                <entry offset="0x48" startLine="15" startColumn="9" endLine="15" endColumn="16"/>
-                <entry offset="0x63" startLine="16" startColumn="5" endLine="16" endColumn="17"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x2c" startLine="13" startColumn="5" endLine="13" endColumn="55" document="1"/>
+                <entry offset="0x2d" startLine="14" startColumn="9" endLine="14" endColumn="16" document="1"/>
+                <entry offset="0x48" startLine="15" startColumn="9" endLine="15" endColumn="16" document="1"/>
+                <entry offset="0x63" startLine="16" startColumn="5" endLine="16" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x65">
                 <importsforward declaringType="Module1" methodName="Main"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -123,6 +123,9 @@ End Module
 
             compilation.VerifyPdb("M1+C1`1+_Closure$__3-1`2._Lambda$__0",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="M1" methodName="Main"/>
     <methods>
         <method containingType="M1+C1`1+_Closure$__3-1`2" name="_Lambda$__0" parameterNames="lifted, notLifted">
@@ -134,13 +137,13 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="17" endLine="16" endColumn="61"/>
-                <entry offset="0x1" hidden="true"/>
-                <entry offset="0x15" startLine="17" startColumn="25" endLine="17" endColumn="60"/>
-                <entry offset="0x1e" startLine="18" startColumn="21" endLine="18" endColumn="43"/>
-                <entry offset="0x25" startLine="20" startColumn="25" endLine="24" endColumn="32"/>
-                <entry offset="0x32" startLine="26" startColumn="21" endLine="26" endColumn="33"/>
-                <entry offset="0x3f" startLine="27" startColumn="17" endLine="27" endColumn="24"/>
+                <entry offset="0x0" startLine="16" startColumn="17" endLine="16" endColumn="61" document="1"/>
+                <entry offset="0x1" hidden="true" document="1"/>
+                <entry offset="0x15" startLine="17" startColumn="25" endLine="17" endColumn="60" document="1"/>
+                <entry offset="0x1e" startLine="18" startColumn="21" endLine="18" endColumn="43" document="1"/>
+                <entry offset="0x25" startLine="20" startColumn="25" endLine="24" endColumn="32" document="1"/>
+                <entry offset="0x32" startLine="26" startColumn="21" endLine="26" endColumn="33" document="1"/>
+                <entry offset="0x3f" startLine="27" startColumn="17" endLine="27" endColumn="24" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x40">
                 <importsforward declaringType="M1" methodName="Main"/>
@@ -201,6 +204,9 @@ End Module
 
             compilation.VerifyPdb("Module1+_Closure$__._Lambda$__0-0",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1+_Closure$__" name="_Lambda$__0-0">
@@ -211,10 +217,10 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="17" endLine="5" endColumn="27"/>
-                <entry offset="0x1" startLine="6" startColumn="25" endLine="6" endColumn="31"/>
-                <entry offset="0x4" startLine="7" startColumn="21" endLine="7" endColumn="29"/>
-                <entry offset="0x8" startLine="8" startColumn="12" endLine="8" endColumn="24"/>
+                <entry offset="0x0" startLine="5" startColumn="17" endLine="5" endColumn="27" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="25" endLine="6" endColumn="31" document="1"/>
+                <entry offset="0x4" startLine="7" startColumn="21" endLine="7" endColumn="29" document="1"/>
+                <entry offset="0x8" startLine="8" startColumn="12" endLine="8" endColumn="24" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Main"/>
@@ -509,6 +515,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -517,9 +526,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="47"/>
-                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="25"/>
-                <entry offset="0x15" startLine="7" startColumn="5" endLine="7" endColumn="17"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="25" document="1"/>
+                <entry offset="0x15" startLine="7" startColumn="5" endLine="7" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x17">
                 <namespace name="System.Collections.Generic" importlevel="file"/>
@@ -547,12 +556,12 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="15"/>
-                <entry offset="0x1" startLine="12" startColumn="13" endLine="15" endColumn="64"/>
-                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="20"/>
-                <entry offset="0xa8" startLine="19" startColumn="13" endLine="20" endColumn="38"/>
-                <entry offset="0x100" startLine="22" startColumn="9" endLine="22" endColumn="21"/>
-                <entry offset="0x107" startLine="23" startColumn="5" endLine="23" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="12" startColumn="13" endLine="15" endColumn="64" document="1"/>
+                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="20" document="1"/>
+                <entry offset="0xa8" startLine="19" startColumn="13" endLine="20" endColumn="38" document="1"/>
+                <entry offset="0x100" startLine="22" startColumn="9" endLine="22" endColumn="21" document="1"/>
+                <entry offset="0x107" startLine="23" startColumn="5" endLine="23" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x108">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -562,7 +571,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="13" startColumn="26" endLine="13" endColumn="27"/>
+                <entry offset="0x0" startLine="13" startColumn="26" endLine="13" endColumn="27" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -570,7 +579,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="60" endLine="14" endColumn="67"/>
+                <entry offset="0x0" startLine="14" startColumn="60" endLine="14" endColumn="67" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -578,8 +587,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="27" endLine="14" endColumn="33"/>
-                <entry offset="0x4" startLine="14" startColumn="39" endLine="14" endColumn="46"/>
+                <entry offset="0x0" startLine="14" startColumn="27" endLine="14" endColumn="33" document="1"/>
+                <entry offset="0x4" startLine="14" startColumn="39" endLine="14" endColumn="46" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xe">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -587,9 +596,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="evenOdd, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x1" startLine="15" startColumn="30" endLine="15" endColumn="44"/>
-                <entry offset="0x2b" startLine="15" startColumn="50" endLine="15" endColumn="64"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="30" endLine="15" endColumn="44" document="1"/>
+                <entry offset="0x2b" startLine="15" startColumn="50" endLine="15" endColumn="64" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x5b">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -597,7 +606,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="43"/>
+                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="43" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -605,7 +614,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-5" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="54" endLine="15" endColumn="63"/>
+                <entry offset="0x0" startLine="15" startColumn="54" endLine="15" endColumn="63" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -613,7 +622,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-6" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="19" startColumn="25" endLine="19" endColumn="32"/>
+                <entry offset="0x0" startLine="19" startColumn="25" endLine="19" endColumn="32" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -621,7 +630,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-7" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="20" startColumn="26" endLine="20" endColumn="27"/>
+                <entry offset="0x0" startLine="20" startColumn="26" endLine="20" endColumn="27" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -662,6 +671,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -670,9 +682,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -694,10 +706,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="37"/>
-                <entry offset="0x30" startLine="15" startColumn="9" endLine="15" endColumn="36"/>
-                <entry offset="0x3c" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="37" document="1"/>
+                <entry offset="0x30" startLine="15" startColumn="9" endLine="15" endColumn="36" document="1"/>
+                <entry offset="0x3c" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -740,6 +752,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -748,9 +763,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -775,10 +790,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="74"/>
-                <entry offset="0x7d" startLine="15" startColumn="9" endLine="15" endColumn="35"/>
-                <entry offset="0x89" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="74" document="1"/>
+                <entry offset="0x7d" startLine="15" startColumn="9" endLine="15" endColumn="35" document="1"/>
+                <entry offset="0x89" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -788,7 +803,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="28" endLine="14" endColumn="35"/>
+                <entry offset="0x0" startLine="14" startColumn="28" endLine="14" endColumn="35" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -796,7 +811,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="68" endLine="14" endColumn="74"/>
+                <entry offset="0x0" startLine="14" startColumn="68" endLine="14" endColumn="74" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -804,7 +819,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="57" endLine="14" endColumn="64"/>
+                <entry offset="0x0" startLine="14" startColumn="57" endLine="14" endColumn="64" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -846,6 +861,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -854,9 +872,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -878,10 +896,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="42"/>
-                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="42" document="1"/>
+                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -891,7 +909,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="29" endLine="15" endColumn="42"/>
+                <entry offset="0x0" startLine="15" startColumn="29" endLine="15" endColumn="42" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -933,6 +951,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -941,9 +962,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -966,10 +987,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="85"/>
-                <entry offset="0x59" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x65" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="85" document="1"/>
+                <entry offset="0x59" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x65" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -979,7 +1000,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="37" endLine="15" endColumn="50"/>
+                <entry offset="0x0" startLine="15" startColumn="37" endLine="15" endColumn="50" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -987,7 +1008,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="64" endLine="15" endColumn="85"/>
+                <entry offset="0x0" startLine="15" startColumn="64" endLine="15" endColumn="85" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x20">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1029,6 +1050,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1037,9 +1061,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1061,10 +1085,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="45"/>
-                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36"/>
-                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="45" document="1"/>
+                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36" document="1"/>
+                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1074,7 +1098,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45"/>
+                <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1116,6 +1140,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1124,9 +1151,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1148,10 +1175,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="33"/>
-                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36"/>
-                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="33" document="1"/>
+                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="36" document="1"/>
+                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1161,7 +1188,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="33"/>
+                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="33" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1203,6 +1230,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1211,9 +1241,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1235,10 +1265,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="72"/>
-                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="72" document="1"/>
+                <entry offset="0x30" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x3c" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1248,8 +1278,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45"/>
-                <entry offset="0x3" startLine="15" startColumn="59" endLine="15" endColumn="72"/>
+                <entry offset="0x0" startLine="15" startColumn="32" endLine="15" endColumn="45" document="1"/>
+                <entry offset="0x3" startLine="15" startColumn="59" endLine="15" endColumn="72" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x15">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1291,6 +1321,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1299,9 +1332,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1326,10 +1359,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="67"/>
-                <entry offset="0xa6" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0xb2" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="67" document="1"/>
+                <entry offset="0xa6" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0xb2" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1339,7 +1372,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="53" endLine="14" endColumn="60"/>
+                <entry offset="0x0" startLine="14" startColumn="53" endLine="14" endColumn="60" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1347,7 +1380,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50"/>
+                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1355,7 +1388,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67"/>
+                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1399,6 +1432,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1407,9 +1443,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1436,10 +1472,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="106"/>
-                <entry offset="0xf3" startLine="18" startColumn="9" endLine="18" endColumn="35"/>
-                <entry offset="0xff" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="106" document="1"/>
+                <entry offset="0xf3" startLine="18" startColumn="9" endLine="18" endColumn="35" document="1"/>
+                <entry offset="0xff" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x100">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1449,7 +1485,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="63" endLine="16" endColumn="72"/>
+                <entry offset="0x0" startLine="16" startColumn="63" endLine="16" endColumn="72" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1457,7 +1493,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="46" endLine="16" endColumn="55"/>
+                <entry offset="0x0" startLine="16" startColumn="46" endLine="16" endColumn="55" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1465,8 +1501,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="41" endLine="17" endColumn="50"/>
-                <entry offset="0x1" startLine="17" startColumn="93" endLine="17" endColumn="106"/>
+                <entry offset="0x0" startLine="17" startColumn="41" endLine="17" endColumn="50" document="1"/>
+                <entry offset="0x1" startLine="17" startColumn="93" endLine="17" endColumn="106" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1474,8 +1510,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="58" endLine="17" endColumn="67"/>
-                <entry offset="0x6" startLine="17" startColumn="72" endLine="17" endColumn="85"/>
+                <entry offset="0x0" startLine="17" startColumn="58" endLine="17" endColumn="67" document="1"/>
+                <entry offset="0x6" startLine="17" startColumn="72" endLine="17" endColumn="85" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x14">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1518,6 +1554,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1526,9 +1565,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1553,10 +1592,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="48"/>
-                <entry offset="0xa6" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0xb2" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="48" document="1"/>
+                <entry offset="0xa6" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0xb2" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1566,7 +1605,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66"/>
+                <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1574,7 +1613,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50"/>
+                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1582,7 +1621,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67"/>
+                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1628,6 +1667,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1636,9 +1678,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1669,10 +1711,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="19" endColumn="57"/>
-                <entry offset="0x145" startLine="20" startColumn="9" endLine="20" endColumn="35"/>
-                <entry offset="0x151" startLine="21" startColumn="5" endLine="21" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="19" endColumn="57" document="1"/>
+                <entry offset="0x145" startLine="20" startColumn="9" endLine="20" endColumn="35" document="1"/>
+                <entry offset="0x151" startLine="21" startColumn="5" endLine="21" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x152">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1682,7 +1724,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66"/>
+                <entry offset="0x0" startLine="14" startColumn="59" endLine="14" endColumn="66" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1690,7 +1732,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="63" endLine="15" endColumn="70"/>
+                <entry offset="0x0" startLine="15" startColumn="63" endLine="15" endColumn="70" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1698,7 +1740,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="69" endLine="16" endColumn="78"/>
+                <entry offset="0x0" startLine="16" startColumn="69" endLine="16" endColumn="78" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1706,7 +1748,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="52" endLine="16" endColumn="61"/>
+                <entry offset="0x0" startLine="16" startColumn="52" endLine="16" endColumn="61" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1714,8 +1756,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="rangeVar2, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x1" startLine="17" startColumn="47" endLine="17" endColumn="61"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x1" startLine="17" startColumn="47" endLine="17" endColumn="61" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1723,7 +1765,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-5" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="51" endLine="17" endColumn="60"/>
+                <entry offset="0x0" startLine="17" startColumn="51" endLine="17" endColumn="60" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1731,7 +1773,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-6" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="18" startColumn="41" endLine="18" endColumn="50"/>
+                <entry offset="0x0" startLine="18" startColumn="41" endLine="18" endColumn="50" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1739,7 +1781,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-7" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="18" startColumn="58" endLine="18" endColumn="67"/>
+                <entry offset="0x0" startLine="18" startColumn="58" endLine="18" endColumn="67" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1747,8 +1789,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-8" parameterNames="rangeVar1, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x1" startLine="19" startColumn="43" endLine="19" endColumn="57"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x1" startLine="19" startColumn="43" endLine="19" endColumn="57" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1756,7 +1798,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-9" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="19" startColumn="47" endLine="19" endColumn="56"/>
+                <entry offset="0x0" startLine="19" startColumn="47" endLine="19" endColumn="56" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1799,6 +1841,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1807,9 +1852,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1834,10 +1879,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="79"/>
-                <entry offset="0x7d" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x89" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="79" document="1"/>
+                <entry offset="0x7d" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x89" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1847,8 +1892,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50"/>
-                <entry offset="0x1" startLine="15" startColumn="93" endLine="15" endColumn="106"/>
+                <entry offset="0x0" startLine="15" startColumn="41" endLine="15" endColumn="50" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="93" endLine="15" endColumn="106" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1856,8 +1901,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67"/>
-                <entry offset="0x1" startLine="15" startColumn="72" endLine="15" endColumn="85"/>
+                <entry offset="0x0" startLine="15" startColumn="58" endLine="15" endColumn="67" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="72" endLine="15" endColumn="85" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1865,9 +1910,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar1, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x2" startLine="16" startColumn="56" endLine="16" endColumn="70"/>
-                <entry offset="0x2c" startLine="16" startColumn="72" endLine="16" endColumn="79"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x2" startLine="16" startColumn="56" endLine="16" endColumn="70" document="1"/>
+                <entry offset="0x2c" startLine="16" startColumn="72" endLine="16" endColumn="79" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x38">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1875,7 +1920,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="60" endLine="16" endColumn="69"/>
+                <entry offset="0x0" startLine="16" startColumn="60" endLine="16" endColumn="69" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1917,6 +1962,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -1925,9 +1973,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -1951,10 +1999,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="73"/>
-                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="73" document="1"/>
+                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1964,7 +2012,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -1972,7 +2020,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="19" endLine="15" endColumn="73"/>
+                <entry offset="0x0" startLine="15" startColumn="19" endLine="15" endColumn="73" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2014,6 +2062,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2022,9 +2073,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2048,10 +2099,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="78"/>
-                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="78" document="1"/>
+                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2061,7 +2112,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2069,7 +2120,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78"/>
+                <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2111,6 +2162,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2119,9 +2173,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2145,10 +2199,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="78"/>
-                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="78" document="1"/>
+                <entry offset="0x7d" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x89" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2158,7 +2212,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2166,7 +2220,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78"/>
+                <entry offset="0x0" startLine="15" startColumn="24" endLine="15" endColumn="78" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x22">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2208,6 +2262,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2216,9 +2273,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2236,10 +2293,10 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="19"/>
-                <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="19" document="1"/>
+                <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2283,6 +2340,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2291,9 +2351,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2311,10 +2371,10 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="19"/>
-                <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35"/>
-                <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="15" endColumn="19" document="1"/>
+                <entry offset="0xd" startLine="16" startColumn="9" endLine="16" endColumn="35" document="1"/>
+                <entry offset="0x19" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1a">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2359,6 +2419,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2367,9 +2430,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2394,10 +2457,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="23"/>
-                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="23" document="1"/>
+                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2407,7 +2470,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2415,7 +2478,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="22" endLine="15" endColumn="31"/>
+                <entry offset="0x0" startLine="15" startColumn="22" endLine="15" endColumn="31" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2458,6 +2521,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2466,9 +2532,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2494,10 +2560,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="32"/>
-                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="32" document="1"/>
+                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2507,7 +2573,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2515,7 +2581,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47"/>
+                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2523,8 +2589,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x1" startLine="16" startColumn="18" endLine="16" endColumn="32"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x1" startLine="16" startColumn="18" endLine="16" endColumn="32" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x31">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2532,7 +2598,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="31"/>
+                <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="31" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2575,6 +2641,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2583,9 +2652,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2611,10 +2680,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="54"/>
-                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="54" document="1"/>
+                <entry offset="0xa1" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0xad" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xae">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2624,7 +2693,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58"/>
+                <entry offset="0x0" startLine="14" startColumn="52" endLine="14" endColumn="58" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2632,8 +2701,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47"/>
-                <entry offset="0x8" startLine="15" startColumn="61" endLine="15" endColumn="74"/>
+                <entry offset="0x0" startLine="15" startColumn="34" endLine="15" endColumn="47" document="1"/>
+                <entry offset="0x8" startLine="15" startColumn="61" endLine="15" endColumn="74" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2641,9 +2710,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="$VB$It, $VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0xd" startLine="16" startColumn="31" endLine="16" endColumn="45"/>
-                <entry offset="0x37" startLine="16" startColumn="47" endLine="16" endColumn="54"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0xd" startLine="16" startColumn="31" endLine="16" endColumn="45" document="1"/>
+                <entry offset="0x37" startLine="16" startColumn="47" endLine="16" endColumn="54" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x43">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2651,7 +2720,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="35" endLine="16" endColumn="44"/>
+                <entry offset="0x0" startLine="16" startColumn="35" endLine="16" endColumn="44" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2694,6 +2763,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2702,9 +2774,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2728,10 +2800,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="36"/>
-                <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="36" document="1"/>
+                <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2741,7 +2813,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="36"/>
+                <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="36" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x5e">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2749,7 +2821,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40"/>
+                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2757,7 +2829,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="35"/>
+                <entry offset="0x0" startLine="16" startColumn="22" endLine="16" endColumn="35" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2800,6 +2872,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2808,9 +2883,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2836,10 +2911,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="50"/>
-                <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="50" document="1"/>
+                <entry offset="0x30" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x3c" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3d">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2849,7 +2924,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="50"/>
+                <entry offset="0x0" startLine="15" startColumn="13" endLine="16" endColumn="50" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xab">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2857,7 +2932,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40"/>
+                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2865,7 +2940,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71"/>
+                <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2873,7 +2948,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="49"/>
+                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="49" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xf">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2917,6 +2992,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -2925,9 +3003,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -2952,10 +3030,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="36"/>
-                <entry offset="0x59" startLine="18" startColumn="9" endLine="18" endColumn="35"/>
-                <entry offset="0x65" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="36" document="1"/>
+                <entry offset="0x59" startLine="18" startColumn="9" endLine="18" endColumn="35" document="1"/>
+                <entry offset="0x65" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2965,7 +3043,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21"/>
+                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2973,7 +3051,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="13" endLine="17" endColumn="36"/>
+                <entry offset="0x0" startLine="16" startColumn="13" endLine="17" endColumn="36" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x58">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2981,7 +3059,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40"/>
+                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -2989,7 +3067,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="22" endLine="17" endColumn="35"/>
+                <entry offset="0x0" startLine="17" startColumn="22" endLine="17" endColumn="35" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3032,6 +3110,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3040,9 +3121,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3066,10 +3147,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47"/>
-                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47" document="1"/>
+                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3079,7 +3160,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="42"/>
+                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="42" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3087,9 +3168,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38"/>
-                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="1"/>
+                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3097,7 +3178,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37"/>
+                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3140,6 +3221,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3148,9 +3232,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3177,10 +3261,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47"/>
-                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47" document="1"/>
+                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3190,7 +3274,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="71"/>
+                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x82">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3198,7 +3282,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40"/>
+                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3206,7 +3290,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71"/>
+                <entry offset="0x0" startLine="15" startColumn="65" endLine="15" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3214,9 +3298,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38"/>
-                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="1"/>
+                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3224,7 +3308,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-5" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37"/>
+                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3267,6 +3351,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3275,9 +3362,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3305,10 +3392,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47"/>
-                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35"/>
-                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="16" endColumn="47" document="1"/>
+                <entry offset="0x59" startLine="17" startColumn="9" endLine="17" endColumn="35" document="1"/>
+                <entry offset="0x65" startLine="18" startColumn="5" endLine="18" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x66">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3318,7 +3405,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="105"/>
+                <entry offset="0x0" startLine="15" startColumn="13" endLine="15" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xab">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3326,7 +3413,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40"/>
+                <entry offset="0x0" startLine="15" startColumn="33" endLine="15" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3334,7 +3421,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="79" endLine="15" endColumn="88"/>
+                <entry offset="0x0" startLine="15" startColumn="79" endLine="15" endColumn="88" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3342,7 +3429,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="96" endLine="15" endColumn="105"/>
+                <entry offset="0x0" startLine="15" startColumn="96" endLine="15" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3350,9 +3437,9 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-5" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38"/>
-                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x6" startLine="16" startColumn="24" endLine="16" endColumn="38" document="1"/>
+                <entry offset="0x35" startLine="16" startColumn="40" endLine="16" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3360,7 +3447,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-6" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37"/>
+                <entry offset="0x0" startLine="16" startColumn="28" endLine="16" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3404,6 +3491,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3412,9 +3502,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3439,10 +3529,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47"/>
-                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35"/>
-                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47" document="1"/>
+                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="1"/>
+                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3452,7 +3542,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21"/>
+                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3460,7 +3550,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="42"/>
+                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="42" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3468,8 +3558,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="$VB$Group">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38"/>
-                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47"/>
+                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="1"/>
+                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3477,7 +3567,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37"/>
+                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3521,6 +3611,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3529,9 +3622,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3559,10 +3652,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47"/>
-                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35"/>
-                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47" document="1"/>
+                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="1"/>
+                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3572,7 +3665,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21"/>
+                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3580,7 +3673,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="71"/>
+                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7c">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3588,7 +3681,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40"/>
+                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3596,7 +3689,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="65" endLine="16" endColumn="71"/>
+                <entry offset="0x0" startLine="16" startColumn="65" endLine="16" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3604,8 +3697,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-5" parameterNames="$VB$Group">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38"/>
-                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47"/>
+                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="1"/>
+                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3613,7 +3706,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-6" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37"/>
+                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3657,6 +3750,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3665,9 +3761,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3696,10 +3792,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47"/>
-                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35"/>
-                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="17" endColumn="47" document="1"/>
+                <entry offset="0x82" startLine="18" startColumn="9" endLine="18" endColumn="35" document="1"/>
+                <entry offset="0x8e" startLine="19" startColumn="5" endLine="19" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3709,7 +3805,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21"/>
+                <entry offset="0x0" startLine="15" startColumn="20" endLine="15" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3717,7 +3813,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="$VB$ItAnonymous">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="105"/>
+                <entry offset="0x0" startLine="16" startColumn="13" endLine="16" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa5">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3725,7 +3821,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-2" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40"/>
+                <entry offset="0x0" startLine="16" startColumn="33" endLine="16" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3733,7 +3829,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="79" endLine="16" endColumn="88"/>
+                <entry offset="0x0" startLine="16" startColumn="79" endLine="16" endColumn="88" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3741,7 +3837,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-4" parameterNames="rangeVar3">
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="96" endLine="16" endColumn="105"/>
+                <entry offset="0x0" startLine="16" startColumn="96" endLine="16" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3749,8 +3845,8 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-6" parameterNames="$VB$Group">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38"/>
-                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47"/>
+                <entry offset="0x0" startLine="17" startColumn="24" endLine="17" endColumn="38" document="1"/>
+                <entry offset="0x2a" startLine="17" startColumn="40" endLine="17" endColumn="47" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x36">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3758,7 +3854,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-7" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37"/>
+                <entry offset="0x0" startLine="17" startColumn="28" endLine="17" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3797,6 +3893,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3805,9 +3904,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3829,9 +3928,9 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="36"/>
-                <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="36" document="1"/>
+                <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x5f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3840,7 +3939,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="12" startColumn="33" endLine="12" endColumn="40"/>
+                <entry offset="0x0" startLine="12" startColumn="33" endLine="12" endColumn="40" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3848,7 +3947,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="13" startColumn="22" endLine="13" endColumn="35"/>
+                <entry offset="0x0" startLine="13" startColumn="22" endLine="13" endColumn="35" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3887,6 +3986,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1" name="Nums">
             <customDebugInfo>
@@ -3895,9 +3997,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="47" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="5" endLine="8" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <namespace name="System.Collections" importlevel="file"/>
@@ -3922,9 +4024,9 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15"/>
-                <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="47"/>
-                <entry offset="0x8a" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="12" startColumn="9" endLine="13" endColumn="47" document="1"/>
+                <entry offset="0x8a" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8b">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3933,7 +4035,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-0" parameterNames="rangeVar1">
             <sequencePoints>
-                <entry offset="0x0" startLine="12" startColumn="65" endLine="12" endColumn="71"/>
+                <entry offset="0x0" startLine="12" startColumn="65" endLine="12" endColumn="71" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2f">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3941,7 +4043,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-1" parameterNames="rangeVar2">
             <sequencePoints>
-                <entry offset="0x0" startLine="12" startColumn="54" endLine="12" endColumn="61"/>
+                <entry offset="0x0" startLine="12" startColumn="54" endLine="12" endColumn="61" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x3">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3949,7 +4051,7 @@ End Module
         </method>
         <method containingType="Module1+_Closure$__" name="_Lambda$__1-3" parameterNames="$VB$It">
             <sequencePoints>
-                <entry offset="0x0" startLine="13" startColumn="28" endLine="13" endColumn="37"/>
+                <entry offset="0x0" startLine="13" startColumn="28" endLine="13" endColumn="37" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="Module1" methodName="Nums"/>
@@ -3984,10 +4086,13 @@ End Module
 
             compilation.VerifyPdb("Module1+_Closure$__._Lambda$__0-0",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="Module1+_Closure$__" name="_Lambda$__0-0" parameterNames="a">
             <sequencePoints>
-                <entry offset="0x0" startLine="8" startColumn="25" endLine="8" endColumn="30"/>
+                <entry offset="0x0" startLine="8" startColumn="25" endLine="8" endColumn="30" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xa">
                 <importsforward declaringType="Module1" methodName="Main"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBNamespaceScopes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBNamespaceScopes.vb
@@ -475,14 +475,17 @@ End Class
             ' Imports of embedded types are currently omitted:
             v.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" startLine="13" startColumn="5" endLine="13" endColumn="10"/>
-                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="34"/>
-                <entry offset="0x8" startLine="15" startColumn="9" endLine="15" endColumn="37"/>
-                <entry offset="0xf" startLine="16" startColumn="9" endLine="16" endColumn="36"/>
-                <entry offset="0x23" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="13" startColumn="5" endLine="13" endColumn="10" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="9" endLine="14" endColumn="34" document="1"/>
+                <entry offset="0x8" startLine="15" startColumn="9" endLine="15" endColumn="37" document="1"/>
+                <entry offset="0xf" startLine="16" startColumn="9" endLine="16" endColumn="36" document="1"/>
+                <entry offset="0x23" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x24">
                 <namespace name="System" importlevel="file"/>
@@ -542,11 +545,14 @@ End Class
 
             v.VerifyPdb("C.M",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="M">
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="9" endLine="6" endColumn="28"/>
-                <entry offset="0x5" startLine="7" startColumn="5" endLine="7" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="9" endLine="6" endColumn="28" document="1"/>
+                <entry offset="0x5" startLine="7" startColumn="5" endLine="7" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <alias name="X" target="N.B" kind="namespace" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBObjectInitializerTests.vb
@@ -35,6 +35,9 @@ End Class
 
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -44,9 +47,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
-                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="78"/>
-                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="78" document="1"/>
+                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x18">
                 <namespace name="System" importlevel="file"/>
@@ -87,6 +90,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -96,9 +102,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
-                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="68"/>
-                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="68" document="1"/>
+                <entry offset="0x17" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x18">
                 <namespace name="System" importlevel="file"/>
@@ -138,6 +144,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -147,9 +156,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="13" startColumn="5" endLine="13" endColumn="29"/>
-                <entry offset="0x1" startLine="14" startColumn="13" endLine="14" endColumn="90"/>
-                <entry offset="0x19" startLine="15" startColumn="5" endLine="15" endColumn="12"/>
+                <entry offset="0x0" startLine="13" startColumn="5" endLine="13" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="13" endLine="14" endColumn="90" document="1"/>
+                <entry offset="0x19" startLine="15" startColumn="5" endLine="15" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1a">
                 <namespace name="System" importlevel="file"/>
@@ -190,6 +199,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -200,10 +212,10 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29"/>
-                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="18"/>
-                <entry offset="0x17" startLine="15" startColumn="20" endLine="15" endColumn="25"/>
-                <entry offset="0x2d" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="14" startColumn="5" endLine="14" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="15" startColumn="13" endLine="15" endColumn="18" document="1"/>
+                <entry offset="0x17" startLine="15" startColumn="20" endLine="15" endColumn="25" document="1"/>
+                <entry offset="0x2d" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2e">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBSyncLockTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBSyncLockTests.vb
@@ -94,6 +94,9 @@ End Class
 
             v.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -106,19 +109,19 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="29"/>
-                <entry offset="0x1" startLine="11" startColumn="9" endLine="11" endColumn="12"/>
-                <entry offset="0x2" startLine="12" startColumn="17" endLine="12" endColumn="37"/>
-                <entry offset="0xd" startLine="13" startColumn="13" endLine="13" endColumn="35"/>
-                <entry offset="0xe" startLine="13" startColumn="22" endLine="13" endColumn="35"/>
-                <entry offset="0x21" startLine="14" startColumn="21" endLine="14" endColumn="38"/>
-                <entry offset="0x24" startLine="15" startColumn="17" endLine="15" endColumn="38"/>
-                <entry offset="0x2a" hidden="true"/>
-                <entry offset="0x34" startLine="17" startColumn="13" endLine="17" endColumn="25"/>
-                <entry offset="0x36" hidden="true"/>
-                <entry offset="0x3b" startLine="18" startColumn="9" endLine="18" endColumn="14"/>
-                <entry offset="0x43" startLine="19" startColumn="9" endLine="19" endColumn="16"/>
-                <entry offset="0x44" startLine="20" startColumn="5" endLine="20" endColumn="12"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="11" startColumn="9" endLine="11" endColumn="12" document="1"/>
+                <entry offset="0x2" startLine="12" startColumn="17" endLine="12" endColumn="37" document="1"/>
+                <entry offset="0xd" startLine="13" startColumn="13" endLine="13" endColumn="35" document="1"/>
+                <entry offset="0xe" startLine="13" startColumn="22" endLine="13" endColumn="35" document="1"/>
+                <entry offset="0x21" startLine="14" startColumn="21" endLine="14" endColumn="38" document="1"/>
+                <entry offset="0x24" startLine="15" startColumn="17" endLine="15" endColumn="38" document="1"/>
+                <entry offset="0x2a" hidden="true" document="1"/>
+                <entry offset="0x34" startLine="17" startColumn="13" endLine="17" endColumn="25" document="1"/>
+                <entry offset="0x36" hidden="true" document="1"/>
+                <entry offset="0x3b" startLine="18" startColumn="9" endLine="18" endColumn="14" document="1"/>
+                <entry offset="0x43" startLine="19" startColumn="9" endLine="19" endColumn="16" document="1"/>
+                <entry offset="0x44" startLine="20" startColumn="5" endLine="20" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x45">
                 <importsforward declaringType="C1" methodName="Something" parameterNames="x"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -60,8 +60,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
 <symbols>
     <files>
         <file id="1" name="Goo.vb" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" checkSumAlgorithmId="ff1816ec-aa5e-4d10-87f7-6f4963833460" checkSum=<%= checksum1 %>/>
-        <file id="2" name="Bar.vb" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" checkSumAlgorithmId="ff1816ec-aa5e-4d10-87f7-6f4963833460" checkSum=<%= checksum3 %>/>
-        <file id="3" name="Baz.vb" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" checkSumAlgorithmId="ff1816ec-aa5e-4d10-87f7-6f4963833460" checkSum=<%= checksum4 %>/>
+        <file id="2" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+        <file id="3" name="Bar.vb" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" checkSumAlgorithmId="ff1816ec-aa5e-4d10-87f7-6f4963833460" checkSum=<%= checksum3 %>/>
+        <file id="4" name="Baz.vb" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" checkSumAlgorithmId="ff1816ec-aa5e-4d10-87f7-6f4963833460" checkSum=<%= checksum4 %>/>
     </files>
 </symbols>, options:=PdbToXmlOptions.ExcludeMethods)
 
@@ -80,6 +81,9 @@ End Class
             Dim f = c.GetMember(Of MethodSymbol)("C.F")
             c.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C" methodName="F"/>
     <methods/>
 </symbols>, debugEntryPoint:=f, options:=PdbToXmlOptions.ExcludeScopes Or PdbToXmlOptions.ExcludeSequencePoints Or PdbToXmlOptions.ExcludeCustomDebugInformation)
@@ -107,6 +111,9 @@ End Class
             Dim f = c.GetMember(Of MethodSymbol)("C.F")
             c.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="C" methodName="F"/>
     <methods/>
 </symbols>, debugEntryPoint:=f, options:=PdbToXmlOptions.ExcludeScopes Or PdbToXmlOptions.ExcludeSequencePoints Or PdbToXmlOptions.ExcludeCustomDebugInformation)
@@ -195,12 +202,15 @@ End Class
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="My.MyComputer" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="107" startColumn="9" endLine="107" endColumn="25"/>
-                <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25"/>
-                <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16"/>
+                <entry offset="0x0" startLine="107" startColumn="9" endLine="107" endColumn="25" document="1"/>
+                <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25" document="1"/>
+                <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name="My"/>
@@ -208,10 +218,10 @@ End Class
         </method>
         <method containingType="My.MyProject" name=".cctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="126" startColumn="26" endLine="126" endColumn="97"/>
-                <entry offset="0xa" startLine="137" startColumn="26" endLine="137" endColumn="95"/>
-                <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136"/>
-                <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105"/>
+                <entry offset="0x0" startLine="126" startColumn="26" endLine="126" endColumn="97" document="1"/>
+                <entry offset="0xa" startLine="137" startColumn="26" endLine="137" endColumn="95" document="1"/>
+                <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136" document="1"/>
+                <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x29">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -224,9 +234,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="121" startColumn="13" endLine="121" endColumn="16"/>
-                <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62"/>
-                <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20"/>
+                <entry offset="0x0" startLine="121" startColumn="13" endLine="121" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62" document="1"/>
+                <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -240,9 +250,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="133" startColumn="13" endLine="133" endColumn="16"/>
-                <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57"/>
-                <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20"/>
+                <entry offset="0x0" startLine="133" startColumn="13" endLine="133" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57" document="1"/>
+                <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -256,9 +266,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="144" startColumn="13" endLine="144" endColumn="16"/>
-                <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58"/>
-                <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20"/>
+                <entry offset="0x0" startLine="144" startColumn="13" endLine="144" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58" document="1"/>
+                <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -272,9 +282,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="237" startColumn="14" endLine="237" endColumn="17"/>
-                <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67"/>
-                <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20"/>
+                <entry offset="0x0" startLine="237" startColumn="14" endLine="237" endColumn="17" document="1"/>
+                <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67" document="1"/>
+                <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -283,9 +293,9 @@ End Class
         </method>
         <method containingType="C1" name="Method">
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17"/>
-                <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="50"/>
-                <entry offset="0xc" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="50" document="1"/>
+                <entry offset="0xc" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <currentnamespace name=""/>
@@ -298,9 +308,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="247" startColumn="13" endLine="247" endColumn="75"/>
-                <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40"/>
-                <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25"/>
+                <entry offset="0x0" startLine="247" startColumn="13" endLine="247" endColumn="75" document="1"/>
+                <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40" document="1"/>
+                <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x12">
                 <currentnamespace name="My"/>
@@ -314,9 +324,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="251" startColumn="13" endLine="251" endColumn="63"/>
-                <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42"/>
-                <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25"/>
+                <entry offset="0x0" startLine="251" startColumn="13" endLine="251" endColumn="63" document="1"/>
+                <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42" document="1"/>
+                <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -330,9 +340,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="255" startColumn="13" endLine="255" endColumn="72"/>
-                <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46"/>
-                <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25"/>
+                <entry offset="0x0" startLine="255" startColumn="13" endLine="255" endColumn="72" document="1"/>
+                <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46" document="1"/>
+                <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -346,9 +356,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="259" startColumn="13" endLine="259" endColumn="59"/>
-                <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39"/>
-                <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25"/>
+                <entry offset="0x0" startLine="259" startColumn="13" endLine="259" endColumn="59" document="1"/>
+                <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39" document="1"/>
+                <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -363,13 +373,13 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="264" startColumn="12" endLine="264" endColumn="95"/>
-                <entry offset="0x1" startLine="265" startColumn="17" endLine="265" endColumn="44"/>
-                <entry offset="0xb" hidden="true"/>
-                <entry offset="0xe" startLine="266" startColumn="21" endLine="266" endColumn="35"/>
-                <entry offset="0x16" startLine="267" startColumn="17" endLine="267" endColumn="21"/>
-                <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36"/>
-                <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25"/>
+                <entry offset="0x0" startLine="264" startColumn="12" endLine="264" endColumn="95" document="1"/>
+                <entry offset="0x1" startLine="265" startColumn="17" endLine="265" endColumn="44" document="1"/>
+                <entry offset="0xb" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="266" startColumn="21" endLine="266" endColumn="35" document="1"/>
+                <entry offset="0x16" startLine="267" startColumn="17" endLine="267" endColumn="21" document="1"/>
+                <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36" document="1"/>
+                <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1d">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -378,9 +388,9 @@ End Class
         </method>
         <method containingType="My.MyProject+MyWebServices" name="Dispose__Instance__" parameterNames="instance">
             <sequencePoints>
-                <entry offset="0x0" startLine="273" startColumn="13" endLine="273" endColumn="71"/>
-                <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35"/>
-                <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20"/>
+                <entry offset="0x0" startLine="273" startColumn="13" endLine="273" endColumn="71" document="1"/>
+                <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35" document="1"/>
+                <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -388,9 +398,9 @@ End Class
         </method>
         <method containingType="My.MyProject+MyWebServices" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="279" startColumn="13" endLine="279" endColumn="29"/>
-                <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28"/>
-                <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20"/>
+                <entry offset="0x0" startLine="279" startColumn="13" endLine="279" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28" document="1"/>
+                <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -404,12 +414,12 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="341" startColumn="17" endLine="341" endColumn="20"/>
-                <entry offset="0x1" startLine="342" startColumn="21" endLine="342" endColumn="59"/>
-                <entry offset="0xf" hidden="true"/>
-                <entry offset="0x12" startLine="342" startColumn="60" endLine="342" endColumn="87"/>
-                <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47"/>
-                <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24"/>
+                <entry offset="0x0" startLine="341" startColumn="17" endLine="341" endColumn="20" document="1"/>
+                <entry offset="0x1" startLine="342" startColumn="21" endLine="342" endColumn="59" document="1"/>
+                <entry offset="0xf" hidden="true" document="1"/>
+                <entry offset="0x12" startLine="342" startColumn="60" endLine="342" endColumn="87" document="1"/>
+                <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47" document="1"/>
+                <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x26">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -418,9 +428,9 @@ End Class
         </method>
         <method containingType="My.MyProject+ThreadSafeObjectProvider`1" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="350" startColumn="13" endLine="350" endColumn="29"/>
-                <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29"/>
-                <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20"/>
+                <entry offset="0x0" startLine="350" startColumn="13" endLine="350" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29" document="1"/>
+                <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -448,6 +458,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlib(source, TestOptions.DebugDll)
             compilation.VerifyPdb("C..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name=".ctor">
             <customDebugInfo>
@@ -456,8 +469,8 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14"/>
-                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14" document="1"/>
+                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name=""/>
@@ -471,9 +484,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="25"/>
-                <entry offset="0x8" startLine="6" startColumn="13" endLine="6" endColumn="28"/>
-                <entry offset="0xf" startLine="7" startColumn="5" endLine="7" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="25" document="1"/>
+                <entry offset="0x8" startLine="6" startColumn="13" endLine="6" endColumn="28" document="1"/>
+                <entry offset="0xf" startLine="7" startColumn="5" endLine="7" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="C" methodName=".ctor"/>
@@ -504,6 +517,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlib(source, TestOptions.DebugDll)
             compilation.VerifyPdb("C..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name=".ctor">
             <customDebugInfo>
@@ -512,9 +528,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="14"/>
-                <entry offset="0x8" startLine="3" startColumn="13" endLine="3" endColumn="28"/>
-                <entry offset="0x18" startLine="6" startColumn="5" endLine="6" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="14" document="1"/>
+                <entry offset="0x8" startLine="3" startColumn="13" endLine="3" endColumn="28" document="1"/>
+                <entry offset="0x18" startLine="6" startColumn="5" endLine="6" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x19">
                 <importsforward declaringType="C" methodName=".cctor"/>
@@ -528,10 +544,10 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="25"/>
-                <entry offset="0x8" startLine="3" startColumn="13" endLine="3" endColumn="28"/>
-                <entry offset="0x18" startLine="8" startColumn="13" endLine="8" endColumn="28"/>
-                <entry offset="0x1f" startLine="9" startColumn="5" endLine="9" endColumn="12"/>
+                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="25" document="1"/>
+                <entry offset="0x8" startLine="3" startColumn="13" endLine="3" endColumn="28" document="1"/>
+                <entry offset="0x18" startLine="8" startColumn="13" endLine="8" endColumn="28" document="1"/>
+                <entry offset="0x1f" startLine="9" startColumn="5" endLine="9" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x20">
                 <importsforward declaringType="C" methodName=".cctor"/>
@@ -581,6 +597,9 @@ End Module
 
             compilation.VerifyPdb("M1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="M1" methodName="Main"/>
     <methods>
         <method containingType="M1" name="Main">
@@ -595,29 +614,29 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" startLine="7" startColumn="9" endLine="7" endColumn="12"/>
-                <entry offset="0x4" startLine="8" startColumn="17" endLine="8" endColumn="34"/>
-                <entry offset="0xa" startLine="9" startColumn="1" endLine="9" endColumn="8"/>
-                <entry offset="0xb" startLine="10" startColumn="1" endLine="10" endColumn="8"/>
-                <entry offset="0xc" startLine="11" startColumn="13" endLine="11" endColumn="26"/>
-                <entry offset="0x11" hidden="true"/>
-                <entry offset="0x14" startLine="12" startColumn="17" endLine="12" endColumn="38"/>
-                <entry offset="0x1a" startLine="13" startColumn="13" endLine="13" endColumn="19"/>
-                <entry offset="0x1d" hidden="true"/>
-                <entry offset="0x24" startLine="14" startColumn="9" endLine="14" endColumn="30"/>
-                <entry offset="0x25" startLine="15" startColumn="17" endLine="15" endColumn="34"/>
-                <entry offset="0x2c" startLine="16" startColumn="13" endLine="16" endColumn="33"/>
-                <entry offset="0x33" startLine="17" startColumn="13" endLine="17" endColumn="18"/>
-                <entry offset="0x35" startLine="18" startColumn="13" endLine="18" endColumn="24"/>
-                <entry offset="0x3c" hidden="true"/>
-                <entry offset="0x3e" startLine="19" startColumn="9" endLine="19" endColumn="16"/>
-                <entry offset="0x3f" startLine="20" startColumn="17" endLine="20" endColumn="34"/>
-                <entry offset="0x46" startLine="21" startColumn="13" endLine="21" endColumn="33"/>
-                <entry offset="0x4e" startLine="22" startColumn="9" endLine="22" endColumn="16"/>
-                <entry offset="0x4f" startLine="24" startColumn="9" endLine="24" endColumn="29"/>
-                <entry offset="0x56" startLine="26" startColumn="5" endLine="26" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" startLine="7" startColumn="9" endLine="7" endColumn="12" document="1"/>
+                <entry offset="0x4" startLine="8" startColumn="17" endLine="8" endColumn="34" document="1"/>
+                <entry offset="0xa" startLine="9" startColumn="1" endLine="9" endColumn="8" document="1"/>
+                <entry offset="0xb" startLine="10" startColumn="1" endLine="10" endColumn="8" document="1"/>
+                <entry offset="0xc" startLine="11" startColumn="13" endLine="11" endColumn="26" document="1"/>
+                <entry offset="0x11" hidden="true" document="1"/>
+                <entry offset="0x14" startLine="12" startColumn="17" endLine="12" endColumn="38" document="1"/>
+                <entry offset="0x1a" startLine="13" startColumn="13" endLine="13" endColumn="19" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
+                <entry offset="0x24" startLine="14" startColumn="9" endLine="14" endColumn="30" document="1"/>
+                <entry offset="0x25" startLine="15" startColumn="17" endLine="15" endColumn="34" document="1"/>
+                <entry offset="0x2c" startLine="16" startColumn="13" endLine="16" endColumn="33" document="1"/>
+                <entry offset="0x33" startLine="17" startColumn="13" endLine="17" endColumn="18" document="1"/>
+                <entry offset="0x35" startLine="18" startColumn="13" endLine="18" endColumn="24" document="1"/>
+                <entry offset="0x3c" hidden="true" document="1"/>
+                <entry offset="0x3e" startLine="19" startColumn="9" endLine="19" endColumn="16" document="1"/>
+                <entry offset="0x3f" startLine="20" startColumn="17" endLine="20" endColumn="34" document="1"/>
+                <entry offset="0x46" startLine="21" startColumn="13" endLine="21" endColumn="33" document="1"/>
+                <entry offset="0x4e" startLine="22" startColumn="9" endLine="22" endColumn="16" document="1"/>
+                <entry offset="0x4f" startLine="24" startColumn="9" endLine="24" endColumn="29" document="1"/>
+                <entry offset="0x56" startLine="26" startColumn="5" endLine="26" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x57">
                 <namespace name="System" importlevel="file"/>
@@ -759,6 +778,9 @@ End Module
 
             v.VerifyPdb("M1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="M1" methodName="Main"/>
     <methods>
         <method containingType="M1" name="Main">
@@ -773,28 +795,28 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" startLine="7" startColumn="9" endLine="7" endColumn="12"/>
-                <entry offset="0x4" startLine="8" startColumn="17" endLine="8" endColumn="34"/>
-                <entry offset="0xa" startLine="9" startColumn="1" endLine="9" endColumn="8"/>
-                <entry offset="0xb" startLine="10" startColumn="1" endLine="10" endColumn="8"/>
-                <entry offset="0xc" startLine="11" startColumn="13" endLine="11" endColumn="22"/>
-                <entry offset="0x12" hidden="true"/>
-                <entry offset="0x25" startLine="12" startColumn="9" endLine="12" endColumn="60"/>
-                <entry offset="0x2f" hidden="true"/>
-                <entry offset="0x35" hidden="true"/>
-                <entry offset="0x36" startLine="13" startColumn="17" endLine="13" endColumn="34"/>
-                <entry offset="0x3d" startLine="14" startColumn="13" endLine="14" endColumn="33"/>
-                <entry offset="0x44" startLine="15" startColumn="13" endLine="15" endColumn="18"/>
-                <entry offset="0x46" startLine="16" startColumn="13" endLine="16" endColumn="24"/>
-                <entry offset="0x4d" hidden="true"/>
-                <entry offset="0x4f" startLine="17" startColumn="9" endLine="17" endColumn="16"/>
-                <entry offset="0x50" startLine="18" startColumn="17" endLine="18" endColumn="34"/>
-                <entry offset="0x57" startLine="19" startColumn="13" endLine="19" endColumn="33"/>
-                <entry offset="0x5f" startLine="20" startColumn="9" endLine="20" endColumn="16"/>
-                <entry offset="0x60" startLine="22" startColumn="9" endLine="22" endColumn="29"/>
-                <entry offset="0x67" startLine="24" startColumn="5" endLine="24" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" startLine="7" startColumn="9" endLine="7" endColumn="12" document="1"/>
+                <entry offset="0x4" startLine="8" startColumn="17" endLine="8" endColumn="34" document="1"/>
+                <entry offset="0xa" startLine="9" startColumn="1" endLine="9" endColumn="8" document="1"/>
+                <entry offset="0xb" startLine="10" startColumn="1" endLine="10" endColumn="8" document="1"/>
+                <entry offset="0xc" startLine="11" startColumn="13" endLine="11" endColumn="22" document="1"/>
+                <entry offset="0x12" hidden="true" document="1"/>
+                <entry offset="0x25" startLine="12" startColumn="9" endLine="12" endColumn="60" document="1"/>
+                <entry offset="0x2f" hidden="true" document="1"/>
+                <entry offset="0x35" hidden="true" document="1"/>
+                <entry offset="0x36" startLine="13" startColumn="17" endLine="13" endColumn="34" document="1"/>
+                <entry offset="0x3d" startLine="14" startColumn="13" endLine="14" endColumn="33" document="1"/>
+                <entry offset="0x44" startLine="15" startColumn="13" endLine="15" endColumn="18" document="1"/>
+                <entry offset="0x46" startLine="16" startColumn="13" endLine="16" endColumn="24" document="1"/>
+                <entry offset="0x4d" hidden="true" document="1"/>
+                <entry offset="0x4f" startLine="17" startColumn="9" endLine="17" endColumn="16" document="1"/>
+                <entry offset="0x50" startLine="18" startColumn="17" endLine="18" endColumn="34" document="1"/>
+                <entry offset="0x57" startLine="19" startColumn="13" endLine="19" endColumn="33" document="1"/>
+                <entry offset="0x5f" startLine="20" startColumn="9" endLine="20" endColumn="16" document="1"/>
+                <entry offset="0x60" startLine="22" startColumn="9" endLine="22" endColumn="29" document="1"/>
+                <entry offset="0x67" startLine="24" startColumn="5" endLine="24" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x68">
                 <namespace name="System" importlevel="file"/>
@@ -935,6 +957,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -946,15 +971,15 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="15"/>
-                <entry offset="0x1" startLine="5" startColumn="13" endLine="5" endColumn="29"/>
-                <entry offset="0x3" hidden="true"/>
-                <entry offset="0x5" startLine="7" startColumn="17" endLine="7" endColumn="37"/>
-                <entry offset="0x9" startLine="8" startColumn="13" endLine="8" endColumn="18"/>
-                <entry offset="0xb" startLine="9" startColumn="9" endLine="9" endColumn="13"/>
-                <entry offset="0xc" startLine="6" startColumn="9" endLine="6" endColumn="26"/>
-                <entry offset="0x14" hidden="true"/>
-                <entry offset="0x17" startLine="10" startColumn="5" endLine="10" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="13" endLine="5" endColumn="29" document="1"/>
+                <entry offset="0x3" hidden="true" document="1"/>
+                <entry offset="0x5" startLine="7" startColumn="17" endLine="7" endColumn="37" document="1"/>
+                <entry offset="0x9" startLine="8" startColumn="13" endLine="8" endColumn="18" document="1"/>
+                <entry offset="0xb" startLine="9" startColumn="9" endLine="9" endColumn="13" document="1"/>
+                <entry offset="0xc" startLine="6" startColumn="9" endLine="6" endColumn="26" document="1"/>
+                <entry offset="0x14" hidden="true" document="1"/>
+                <entry offset="0x17" startLine="10" startColumn="5" endLine="10" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x18">
                 <currentnamespace name=""/>
@@ -985,12 +1010,15 @@ End Class
 
             compilation.VerifyPdb("C1..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C1" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14"/>
-                <entry offset="0x8" startLine="3" startColumn="9" endLine="3" endColumn="50"/>
-                <entry offset="0x13" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14" document="1"/>
+                <entry offset="0x8" startLine="3" startColumn="9" endLine="3" endColumn="50" document="1"/>
+                <entry offset="0x13" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x14">
                 <currentnamespace name=""/>
@@ -1021,14 +1049,17 @@ End Class
 
             compilation.VerifyPdb("C1..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C1" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14"/>
-                <entry offset="0x8" startLine="3" startColumn="9" endLine="3" endColumn="16"/>
-                <entry offset="0x9" startLine="4" startColumn="9" endLine="4" endColumn="16"/>
-                <entry offset="0xa" startLine="5" startColumn="9" endLine="5" endColumn="16"/>
-                <entry offset="0xb" startLine="7" startColumn="9" endLine="7" endColumn="20"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="14" document="1"/>
+                <entry offset="0x8" startLine="3" startColumn="9" endLine="3" endColumn="16" document="1"/>
+                <entry offset="0x9" startLine="4" startColumn="9" endLine="4" endColumn="16" document="1"/>
+                <entry offset="0xa" startLine="5" startColumn="9" endLine="5" endColumn="16" document="1"/>
+                <entry offset="0xb" startLine="7" startColumn="9" endLine="7" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <currentnamespace name=""/>
@@ -1097,6 +1128,9 @@ End Class
 
             v.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -1105,16 +1139,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="20"/>
-                <entry offset="0x8" hidden="true"/>
-                <entry offset="0xb" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0x12" startLine="9" startColumn="9" endLine="9" endColumn="15"/>
-                <entry offset="0x15" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0x16" startLine="8" startColumn="13" endLine="8" endColumn="33"/>
-                <entry offset="0x1d" startLine="9" startColumn="9" endLine="9" endColumn="15"/>
-                <entry offset="0x1e" startLine="11" startColumn="9" endLine="11" endColumn="29"/>
-                <entry offset="0x25" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="20" document="1"/>
+                <entry offset="0x8" hidden="true" document="1"/>
+                <entry offset="0xb" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0x12" startLine="9" startColumn="9" endLine="9" endColumn="15" document="1"/>
+                <entry offset="0x15" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0x16" startLine="8" startColumn="13" endLine="8" endColumn="33" document="1"/>
+                <entry offset="0x1d" startLine="9" startColumn="9" endLine="9" endColumn="15" document="1"/>
+                <entry offset="0x1e" startLine="11" startColumn="9" endLine="11" endColumn="29" document="1"/>
+                <entry offset="0x25" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x26">
                 <namespace name="System" importlevel="file"/>
@@ -1173,6 +1207,9 @@ End Class
 
             v.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -1181,13 +1218,13 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" hidden="true"/>
-                <entry offset="0x3" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0xa" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0xb" startLine="5" startColumn="9" endLine="5" endColumn="21"/>
-                <entry offset="0x12" hidden="true"/>
-                <entry offset="0x15" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" hidden="true" document="1"/>
+                <entry offset="0x3" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0xa" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0xb" startLine="5" startColumn="9" endLine="5" endColumn="21" document="1"/>
+                <entry offset="0x12" hidden="true" document="1"/>
+                <entry offset="0x15" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x16">
                 <namespace name="System" importlevel="file"/>
@@ -1247,6 +1284,9 @@ End Class
 
             v.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -1255,12 +1295,12 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="11"/>
-                <entry offset="0x2" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0x9" startLine="7" startColumn="9" endLine="7" endColumn="23"/>
-                <entry offset="0x11" hidden="true"/>
-                <entry offset="0x14" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="11" document="1"/>
+                <entry offset="0x2" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0x9" startLine="7" startColumn="9" endLine="7" endColumn="23" document="1"/>
+                <entry offset="0x11" hidden="true" document="1"/>
+                <entry offset="0x14" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x15">
                 <namespace name="System" importlevel="file"/>
@@ -1345,6 +1385,9 @@ End Class
 
             v.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -1356,13 +1399,13 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39"/>
-                <entry offset="0x1b" hidden="true"/>
-                <entry offset="0x1d" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0x24" startLine="7" startColumn="9" endLine="7" endColumn="13"/>
-                <entry offset="0x28" hidden="true"/>
-                <entry offset="0x36" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="39" document="1"/>
+                <entry offset="0x1b" hidden="true" document="1"/>
+                <entry offset="0x1d" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0x24" startLine="7" startColumn="9" endLine="7" endColumn="13" document="1"/>
+                <entry offset="0x28" hidden="true" document="1"/>
+                <entry offset="0x36" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x37">
                 <namespace name="System" importlevel="file"/>
@@ -1557,6 +1600,9 @@ End Class
 
             v.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -1566,16 +1612,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="25"/>
-                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="22"/>
-                <entry offset="0x15" hidden="true"/>
-                <entry offset="0x18" startLine="7" startColumn="17" endLine="7" endColumn="37"/>
-                <entry offset="0x21" startLine="8" startColumn="13" endLine="8" endColumn="22"/>
-                <entry offset="0x2c" hidden="true"/>
-                <entry offset="0x2f" startLine="9" startColumn="17" endLine="9" endColumn="37"/>
-                <entry offset="0x36" startLine="10" startColumn="9" endLine="10" endColumn="19"/>
-                <entry offset="0x37" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="25" document="1"/>
+                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="22" document="1"/>
+                <entry offset="0x15" hidden="true" document="1"/>
+                <entry offset="0x18" startLine="7" startColumn="17" endLine="7" endColumn="37" document="1"/>
+                <entry offset="0x21" startLine="8" startColumn="13" endLine="8" endColumn="22" document="1"/>
+                <entry offset="0x2c" hidden="true" document="1"/>
+                <entry offset="0x2f" startLine="9" startColumn="17" endLine="9" endColumn="37" document="1"/>
+                <entry offset="0x36" startLine="10" startColumn="9" endLine="10" endColumn="19" document="1"/>
+                <entry offset="0x37" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x38">
                 <namespace name="System" importlevel="file"/>
@@ -1630,6 +1676,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Module1" name="Main" parameterNames="args">
@@ -1652,48 +1701,48 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" startLine="6" startColumn="31" endLine="6" endColumn="49"/>
-                <entry offset="0xb" startLine="8" startColumn="9" endLine="8" endColumn="23"/>
-                <entry offset="0x11" hidden="true"/>
-                <entry offset="0x14" startLine="8" startColumn="28" endLine="8" endColumn="46"/>
-                <entry offset="0x1a" startLine="8" startColumn="49" endLine="8" endColumn="69"/>
-                <entry offset="0x23" startLine="8" startColumn="70" endLine="8" endColumn="74"/>
-                <entry offset="0x24" startLine="8" startColumn="75" endLine="8" endColumn="99"/>
-                <entry offset="0x2f" startLine="8" startColumn="102" endLine="8" endColumn="127"/>
-                <entry offset="0x3a" startLine="9" startColumn="9" endLine="9" endColumn="23"/>
-                <entry offset="0x41" hidden="true"/>
-                <entry offset="0x45" startLine="9" startColumn="24" endLine="9" endColumn="47"/>
-                <entry offset="0x50" startLine="9" startColumn="50" endLine="9" endColumn="74"/>
-                <entry offset="0x5d" startLine="9" startColumn="75" endLine="9" endColumn="79"/>
-                <entry offset="0x5e" startLine="9" startColumn="84" endLine="9" endColumn="103"/>
-                <entry offset="0x65" startLine="9" startColumn="106" endLine="9" endColumn="126"/>
-                <entry offset="0x6d" hidden="true"/>
-                <entry offset="0x6f" startLine="12" startColumn="13" endLine="12" endColumn="26"/>
-                <entry offset="0x75" hidden="true"/>
-                <entry offset="0x79" startLine="13" startColumn="17" endLine="13" endColumn="40"/>
-                <entry offset="0x84" startLine="23" startColumn="13" endLine="23" endColumn="19"/>
-                <entry offset="0x87" startLine="14" startColumn="13" endLine="14" endColumn="30"/>
-                <entry offset="0x8d" hidden="true"/>
-                <entry offset="0x91" startLine="15" startColumn="21" endLine="15" endColumn="40"/>
-                <entry offset="0x98" startLine="16" startColumn="17" endLine="16" endColumn="38"/>
-                <entry offset="0xa0" startLine="23" startColumn="13" endLine="23" endColumn="19"/>
-                <entry offset="0xa3" startLine="17" startColumn="13" endLine="17" endColumn="30"/>
-                <entry offset="0xa9" hidden="true"/>
-                <entry offset="0xad" startLine="18" startColumn="21" endLine="18" endColumn="40"/>
-                <entry offset="0xb4" startLine="19" startColumn="17" endLine="19" endColumn="38"/>
-                <entry offset="0xbc" startLine="23" startColumn="13" endLine="23" endColumn="19"/>
-                <entry offset="0xbf" startLine="20" startColumn="13" endLine="20" endColumn="17"/>
-                <entry offset="0xc0" startLine="21" startColumn="21" endLine="21" endColumn="42"/>
-                <entry offset="0xc7" startLine="22" startColumn="17" endLine="22" endColumn="38"/>
-                <entry offset="0xcf" startLine="23" startColumn="13" endLine="23" endColumn="19"/>
-                <entry offset="0xd0" startLine="25" startColumn="17" endLine="25" endColumn="40"/>
-                <entry offset="0xd5" startLine="26" startColumn="13" endLine="26" endColumn="21"/>
-                <entry offset="0xd8" startLine="27" startColumn="9" endLine="27" endColumn="13"/>
-                <entry offset="0xd9" startLine="11" startColumn="9" endLine="11" endColumn="23"/>
-                <entry offset="0xdf" hidden="true"/>
-                <entry offset="0xe3" startLine="29" startColumn="5" endLine="29" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" startLine="6" startColumn="31" endLine="6" endColumn="49" document="1"/>
+                <entry offset="0xb" startLine="8" startColumn="9" endLine="8" endColumn="23" document="1"/>
+                <entry offset="0x11" hidden="true" document="1"/>
+                <entry offset="0x14" startLine="8" startColumn="28" endLine="8" endColumn="46" document="1"/>
+                <entry offset="0x1a" startLine="8" startColumn="49" endLine="8" endColumn="69" document="1"/>
+                <entry offset="0x23" startLine="8" startColumn="70" endLine="8" endColumn="74" document="1"/>
+                <entry offset="0x24" startLine="8" startColumn="75" endLine="8" endColumn="99" document="1"/>
+                <entry offset="0x2f" startLine="8" startColumn="102" endLine="8" endColumn="127" document="1"/>
+                <entry offset="0x3a" startLine="9" startColumn="9" endLine="9" endColumn="23" document="1"/>
+                <entry offset="0x41" hidden="true" document="1"/>
+                <entry offset="0x45" startLine="9" startColumn="24" endLine="9" endColumn="47" document="1"/>
+                <entry offset="0x50" startLine="9" startColumn="50" endLine="9" endColumn="74" document="1"/>
+                <entry offset="0x5d" startLine="9" startColumn="75" endLine="9" endColumn="79" document="1"/>
+                <entry offset="0x5e" startLine="9" startColumn="84" endLine="9" endColumn="103" document="1"/>
+                <entry offset="0x65" startLine="9" startColumn="106" endLine="9" endColumn="126" document="1"/>
+                <entry offset="0x6d" hidden="true" document="1"/>
+                <entry offset="0x6f" startLine="12" startColumn="13" endLine="12" endColumn="26" document="1"/>
+                <entry offset="0x75" hidden="true" document="1"/>
+                <entry offset="0x79" startLine="13" startColumn="17" endLine="13" endColumn="40" document="1"/>
+                <entry offset="0x84" startLine="23" startColumn="13" endLine="23" endColumn="19" document="1"/>
+                <entry offset="0x87" startLine="14" startColumn="13" endLine="14" endColumn="30" document="1"/>
+                <entry offset="0x8d" hidden="true" document="1"/>
+                <entry offset="0x91" startLine="15" startColumn="21" endLine="15" endColumn="40" document="1"/>
+                <entry offset="0x98" startLine="16" startColumn="17" endLine="16" endColumn="38" document="1"/>
+                <entry offset="0xa0" startLine="23" startColumn="13" endLine="23" endColumn="19" document="1"/>
+                <entry offset="0xa3" startLine="17" startColumn="13" endLine="17" endColumn="30" document="1"/>
+                <entry offset="0xa9" hidden="true" document="1"/>
+                <entry offset="0xad" startLine="18" startColumn="21" endLine="18" endColumn="40" document="1"/>
+                <entry offset="0xb4" startLine="19" startColumn="17" endLine="19" endColumn="38" document="1"/>
+                <entry offset="0xbc" startLine="23" startColumn="13" endLine="23" endColumn="19" document="1"/>
+                <entry offset="0xbf" startLine="20" startColumn="13" endLine="20" endColumn="17" document="1"/>
+                <entry offset="0xc0" startLine="21" startColumn="21" endLine="21" endColumn="42" document="1"/>
+                <entry offset="0xc7" startLine="22" startColumn="17" endLine="22" endColumn="38" document="1"/>
+                <entry offset="0xcf" startLine="23" startColumn="13" endLine="23" endColumn="19" document="1"/>
+                <entry offset="0xd0" startLine="25" startColumn="17" endLine="25" endColumn="40" document="1"/>
+                <entry offset="0xd5" startLine="26" startColumn="13" endLine="26" endColumn="21" document="1"/>
+                <entry offset="0xd8" startLine="27" startColumn="9" endLine="27" endColumn="13" document="1"/>
+                <entry offset="0xd9" startLine="11" startColumn="9" endLine="11" endColumn="23" document="1"/>
+                <entry offset="0xdf" hidden="true" document="1"/>
+                <entry offset="0xe3" startLine="29" startColumn="5" endLine="29" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xe4">
                 <namespace name="System" importlevel="file"/>
@@ -1762,6 +1811,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Module1" name="Main" parameterNames="args">
@@ -1779,33 +1831,33 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" hidden="true"/>
-                <entry offset="0x5" startLine="8" startColumn="13" endLine="8" endColumn="26"/>
-                <entry offset="0xa" hidden="true"/>
-                <entry offset="0xd" startLine="9" startColumn="17" endLine="9" endColumn="40"/>
-                <entry offset="0x18" startLine="19" startColumn="13" endLine="19" endColumn="19"/>
-                <entry offset="0x1b" startLine="10" startColumn="13" endLine="10" endColumn="30"/>
-                <entry offset="0x20" hidden="true"/>
-                <entry offset="0x23" startLine="11" startColumn="21" endLine="11" endColumn="40"/>
-                <entry offset="0x2a" startLine="12" startColumn="17" endLine="12" endColumn="38"/>
-                <entry offset="0x32" startLine="19" startColumn="13" endLine="19" endColumn="19"/>
-                <entry offset="0x35" startLine="13" startColumn="13" endLine="13" endColumn="30"/>
-                <entry offset="0x3b" hidden="true"/>
-                <entry offset="0x3f" startLine="14" startColumn="21" endLine="14" endColumn="40"/>
-                <entry offset="0x46" startLine="15" startColumn="17" endLine="15" endColumn="38"/>
-                <entry offset="0x4e" startLine="19" startColumn="13" endLine="19" endColumn="19"/>
-                <entry offset="0x51" startLine="16" startColumn="13" endLine="16" endColumn="17"/>
-                <entry offset="0x52" startLine="17" startColumn="21" endLine="17" endColumn="42"/>
-                <entry offset="0x59" startLine="18" startColumn="17" endLine="18" endColumn="38"/>
-                <entry offset="0x61" startLine="19" startColumn="13" endLine="19" endColumn="19"/>
-                <entry offset="0x62" startLine="21" startColumn="17" endLine="21" endColumn="40"/>
-                <entry offset="0x66" startLine="22" startColumn="13" endLine="22" endColumn="21"/>
-                <entry offset="0x68" startLine="23" startColumn="9" endLine="23" endColumn="13"/>
-                <entry offset="0x69" startLine="7" startColumn="9" endLine="7" endColumn="23"/>
-                <entry offset="0x6f" hidden="true"/>
-                <entry offset="0x73" startLine="25" startColumn="5" endLine="25" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" hidden="true" document="1"/>
+                <entry offset="0x5" startLine="8" startColumn="13" endLine="8" endColumn="26" document="1"/>
+                <entry offset="0xa" hidden="true" document="1"/>
+                <entry offset="0xd" startLine="9" startColumn="17" endLine="9" endColumn="40" document="1"/>
+                <entry offset="0x18" startLine="19" startColumn="13" endLine="19" endColumn="19" document="1"/>
+                <entry offset="0x1b" startLine="10" startColumn="13" endLine="10" endColumn="30" document="1"/>
+                <entry offset="0x20" hidden="true" document="1"/>
+                <entry offset="0x23" startLine="11" startColumn="21" endLine="11" endColumn="40" document="1"/>
+                <entry offset="0x2a" startLine="12" startColumn="17" endLine="12" endColumn="38" document="1"/>
+                <entry offset="0x32" startLine="19" startColumn="13" endLine="19" endColumn="19" document="1"/>
+                <entry offset="0x35" startLine="13" startColumn="13" endLine="13" endColumn="30" document="1"/>
+                <entry offset="0x3b" hidden="true" document="1"/>
+                <entry offset="0x3f" startLine="14" startColumn="21" endLine="14" endColumn="40" document="1"/>
+                <entry offset="0x46" startLine="15" startColumn="17" endLine="15" endColumn="38" document="1"/>
+                <entry offset="0x4e" startLine="19" startColumn="13" endLine="19" endColumn="19" document="1"/>
+                <entry offset="0x51" startLine="16" startColumn="13" endLine="16" endColumn="17" document="1"/>
+                <entry offset="0x52" startLine="17" startColumn="21" endLine="17" endColumn="42" document="1"/>
+                <entry offset="0x59" startLine="18" startColumn="17" endLine="18" endColumn="38" document="1"/>
+                <entry offset="0x61" startLine="19" startColumn="13" endLine="19" endColumn="19" document="1"/>
+                <entry offset="0x62" startLine="21" startColumn="17" endLine="21" endColumn="40" document="1"/>
+                <entry offset="0x66" startLine="22" startColumn="13" endLine="22" endColumn="21" document="1"/>
+                <entry offset="0x68" startLine="23" startColumn="9" endLine="23" endColumn="13" document="1"/>
+                <entry offset="0x69" startLine="7" startColumn="9" endLine="7" endColumn="23" document="1"/>
+                <entry offset="0x6f" hidden="true" document="1"/>
+                <entry offset="0x73" startLine="25" startColumn="5" endLine="25" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x74">
                 <namespace name="System" importlevel="file"/>
@@ -1870,6 +1922,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Module1" name="Main" parameterNames="args">
@@ -1887,32 +1942,32 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" startLine="8" startColumn="9" endLine="8" endColumn="11"/>
-                <entry offset="0x4" startLine="9" startColumn="13" endLine="9" endColumn="26"/>
-                <entry offset="0x9" hidden="true"/>
-                <entry offset="0xc" startLine="10" startColumn="17" endLine="10" endColumn="40"/>
-                <entry offset="0x17" startLine="20" startColumn="13" endLine="20" endColumn="19"/>
-                <entry offset="0x1a" startLine="11" startColumn="13" endLine="11" endColumn="30"/>
-                <entry offset="0x1f" hidden="true"/>
-                <entry offset="0x22" startLine="12" startColumn="21" endLine="12" endColumn="40"/>
-                <entry offset="0x29" startLine="13" startColumn="17" endLine="13" endColumn="38"/>
-                <entry offset="0x31" startLine="20" startColumn="13" endLine="20" endColumn="19"/>
-                <entry offset="0x34" startLine="14" startColumn="13" endLine="14" endColumn="30"/>
-                <entry offset="0x3a" hidden="true"/>
-                <entry offset="0x3e" startLine="15" startColumn="21" endLine="15" endColumn="40"/>
-                <entry offset="0x45" startLine="16" startColumn="17" endLine="16" endColumn="38"/>
-                <entry offset="0x4d" startLine="20" startColumn="13" endLine="20" endColumn="19"/>
-                <entry offset="0x50" startLine="17" startColumn="13" endLine="17" endColumn="17"/>
-                <entry offset="0x51" startLine="18" startColumn="21" endLine="18" endColumn="42"/>
-                <entry offset="0x58" startLine="19" startColumn="17" endLine="19" endColumn="38"/>
-                <entry offset="0x60" startLine="20" startColumn="13" endLine="20" endColumn="19"/>
-                <entry offset="0x61" startLine="22" startColumn="17" endLine="22" endColumn="40"/>
-                <entry offset="0x65" startLine="23" startColumn="13" endLine="23" endColumn="21"/>
-                <entry offset="0x67" startLine="24" startColumn="9" endLine="24" endColumn="25"/>
-                <entry offset="0x6e" hidden="true"/>
-                <entry offset="0x72" startLine="26" startColumn="5" endLine="26" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" startLine="8" startColumn="9" endLine="8" endColumn="11" document="1"/>
+                <entry offset="0x4" startLine="9" startColumn="13" endLine="9" endColumn="26" document="1"/>
+                <entry offset="0x9" hidden="true" document="1"/>
+                <entry offset="0xc" startLine="10" startColumn="17" endLine="10" endColumn="40" document="1"/>
+                <entry offset="0x17" startLine="20" startColumn="13" endLine="20" endColumn="19" document="1"/>
+                <entry offset="0x1a" startLine="11" startColumn="13" endLine="11" endColumn="30" document="1"/>
+                <entry offset="0x1f" hidden="true" document="1"/>
+                <entry offset="0x22" startLine="12" startColumn="21" endLine="12" endColumn="40" document="1"/>
+                <entry offset="0x29" startLine="13" startColumn="17" endLine="13" endColumn="38" document="1"/>
+                <entry offset="0x31" startLine="20" startColumn="13" endLine="20" endColumn="19" document="1"/>
+                <entry offset="0x34" startLine="14" startColumn="13" endLine="14" endColumn="30" document="1"/>
+                <entry offset="0x3a" hidden="true" document="1"/>
+                <entry offset="0x3e" startLine="15" startColumn="21" endLine="15" endColumn="40" document="1"/>
+                <entry offset="0x45" startLine="16" startColumn="17" endLine="16" endColumn="38" document="1"/>
+                <entry offset="0x4d" startLine="20" startColumn="13" endLine="20" endColumn="19" document="1"/>
+                <entry offset="0x50" startLine="17" startColumn="13" endLine="17" endColumn="17" document="1"/>
+                <entry offset="0x51" startLine="18" startColumn="21" endLine="18" endColumn="42" document="1"/>
+                <entry offset="0x58" startLine="19" startColumn="17" endLine="19" endColumn="38" document="1"/>
+                <entry offset="0x60" startLine="20" startColumn="13" endLine="20" endColumn="19" document="1"/>
+                <entry offset="0x61" startLine="22" startColumn="17" endLine="22" endColumn="40" document="1"/>
+                <entry offset="0x65" startLine="23" startColumn="13" endLine="23" endColumn="21" document="1"/>
+                <entry offset="0x67" startLine="24" startColumn="9" endLine="24" endColumn="25" document="1"/>
+                <entry offset="0x6e" hidden="true" document="1"/>
+                <entry offset="0x72" startLine="26" startColumn="5" endLine="26" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x73">
                 <namespace name="System" importlevel="file"/>
@@ -1962,6 +2017,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Module1" name="Main" parameterNames="args">
@@ -1972,12 +2030,12 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31"/>
-                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29"/>
-                <entry offset="0x3" startLine="8" startColumn="9" endLine="8" endColumn="11"/>
-                <entry offset="0x4" startLine="9" startColumn="17" endLine="9" endColumn="40"/>
-                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="21"/>
-                <entry offset="0xa" startLine="11" startColumn="9" endLine="11" endColumn="13"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="13" endLine="6" endColumn="29" document="1"/>
+                <entry offset="0x3" startLine="8" startColumn="9" endLine="8" endColumn="11" document="1"/>
+                <entry offset="0x4" startLine="9" startColumn="17" endLine="9" endColumn="40" document="1"/>
+                <entry offset="0x8" startLine="10" startColumn="13" endLine="10" endColumn="21" document="1"/>
+                <entry offset="0xa" startLine="11" startColumn="9" endLine="11" endColumn="13" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xd">
                 <namespace name="System" importlevel="file"/>
@@ -2018,9 +2076,12 @@ End Module
                     source,
                     TestOptions.DebugExe)
 
-            ' By Design (better than Dev10): <entry offset="0x19" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
+            ' By Design (better than Dev10): <entry offset="0x19" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
             compilation.VerifyPdb("MyMod.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="MyMod" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="MyMod" name="Main" parameterNames="args">
@@ -2030,15 +2091,15 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="38"/>
-                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="37"/>
-                <entry offset="0x6" hidden="true"/>
-                <entry offset="0x9" startLine="7" startColumn="13" endLine="7" endColumn="38"/>
-                <entry offset="0x14" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
-                <entry offset="0x17" startLine="8" startColumn="9" endLine="8" endColumn="13"/>
-                <entry offset="0x18" startLine="9" startColumn="13" endLine="9" endColumn="38"/>
-                <entry offset="0x23" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
-                <entry offset="0x24" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="38" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="37" document="1"/>
+                <entry offset="0x6" hidden="true" document="1"/>
+                <entry offset="0x9" startLine="7" startColumn="13" endLine="7" endColumn="38" document="1"/>
+                <entry offset="0x14" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x17" startLine="8" startColumn="9" endLine="8" endColumn="13" document="1"/>
+                <entry offset="0x18" startLine="9" startColumn="13" endLine="9" endColumn="38" document="1"/>
+                <entry offset="0x23" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x24" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x25">
                 <namespace name="System" importlevel="file"/>
@@ -2106,6 +2167,9 @@ End Module
 
             compilation.VerifyPdb("MyMod.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="MyMod" methodName="Main"/>
     <methods>
         <method containingType="MyMod" name="Main">
@@ -2116,14 +2180,14 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22"/>
-                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="31"/>
-                <entry offset="0xc" startLine="8" startColumn="9" endLine="8" endColumn="28"/>
-                <entry offset="0x10" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
-                <entry offset="0x11" startLine="12" startColumn="9" endLine="12" endColumn="29"/>
-                <entry offset="0x15" startLine="14" startColumn="9" endLine="14" endColumn="15"/>
-                <entry offset="0x16" startLine="16" startColumn="9" endLine="16" endColumn="31"/>
-                <entry offset="0x21" startLine="17" startColumn="5" endLine="17" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="22" document="1"/>
+                <entry offset="0x1" startLine="6" startColumn="9" endLine="6" endColumn="31" document="1"/>
+                <entry offset="0xc" startLine="8" startColumn="9" endLine="8" endColumn="28" document="1"/>
+                <entry offset="0x10" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0x11" startLine="12" startColumn="9" endLine="12" endColumn="29" document="1"/>
+                <entry offset="0x15" startLine="14" startColumn="9" endLine="14" endColumn="15" document="1"/>
+                <entry offset="0x16" startLine="16" startColumn="9" endLine="16" endColumn="31" document="1"/>
+                <entry offset="0x21" startLine="17" startColumn="5" endLine="17" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x22">
                 <namespace name="System" importlevel="file"/>
@@ -2181,6 +2245,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2194,20 +2261,20 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15"/>
-                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="24"/>
-                <entry offset="0x5" startLine="11" startColumn="9" endLine="11" endColumn="15"/>
-                <entry offset="0x6" startLine="14" startColumn="9" endLine="14" endColumn="24"/>
-                <entry offset="0xa" hidden="true"/>
-                <entry offset="0xb" startLine="16" startColumn="9" endLine="16" endColumn="12"/>
-                <entry offset="0xe" hidden="true"/>
-                <entry offset="0x15" startLine="17" startColumn="9" endLine="17" endColumn="30"/>
-                <entry offset="0x1d" hidden="true"/>
-                <entry offset="0x1f" startLine="18" startColumn="9" endLine="18" endColumn="16"/>
-                <entry offset="0x20" startLine="20" startColumn="13" endLine="20" endColumn="28"/>
-                <entry offset="0x25" hidden="true"/>
-                <entry offset="0x26" startLine="21" startColumn="9" endLine="21" endColumn="16"/>
-                <entry offset="0x27" startLine="23" startColumn="5" endLine="23" endColumn="12"/>
+                <entry offset="0x0" startLine="5" startColumn="5" endLine="5" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="24" document="1"/>
+                <entry offset="0x5" startLine="11" startColumn="9" endLine="11" endColumn="15" document="1"/>
+                <entry offset="0x6" startLine="14" startColumn="9" endLine="14" endColumn="24" document="1"/>
+                <entry offset="0xa" hidden="true" document="1"/>
+                <entry offset="0xb" startLine="16" startColumn="9" endLine="16" endColumn="12" document="1"/>
+                <entry offset="0xe" hidden="true" document="1"/>
+                <entry offset="0x15" startLine="17" startColumn="9" endLine="17" endColumn="30" document="1"/>
+                <entry offset="0x1d" hidden="true" document="1"/>
+                <entry offset="0x1f" startLine="18" startColumn="9" endLine="18" endColumn="16" document="1"/>
+                <entry offset="0x20" startLine="20" startColumn="13" endLine="20" endColumn="28" document="1"/>
+                <entry offset="0x25" hidden="true" document="1"/>
+                <entry offset="0x26" startLine="21" startColumn="9" endLine="21" endColumn="16" document="1"/>
+                <entry offset="0x27" startLine="23" startColumn="5" endLine="23" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x28">
                 <namespace name="System" importlevel="file"/>
@@ -2273,6 +2340,9 @@ End Module
             ' startLine="33"
             compilation.VerifyPdb("MyMod.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="MyMod" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="MyMod" name="Main" parameterNames="args">
@@ -2293,43 +2363,43 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="31"/>
-                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="15"/>
-                <entry offset="0x5" startLine="9" startColumn="9" endLine="9" endColumn="15"/>
-                <entry offset="0x9" startLine="10" startColumn="9" endLine="10" endColumn="15"/>
-                <entry offset="0xd" startLine="11" startColumn="9" endLine="11" endColumn="14"/>
-                <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="14"/>
-                <entry offset="0x12" startLine="13" startColumn="9" endLine="13" endColumn="14"/>
-                <entry offset="0x15" startLine="14" startColumn="13" endLine="14" endColumn="32"/>
-                <entry offset="0x19" startLine="15" startColumn="9" endLine="15" endColumn="11"/>
-                <entry offset="0x1a" startLine="16" startColumn="13" endLine="16" endColumn="44"/>
-                <entry offset="0x2b" startLine="17" startColumn="13" endLine="17" endColumn="22"/>
-                <entry offset="0x43" hidden="true"/>
-                <entry offset="0x48" hidden="true"/>
-                <entry offset="0x4d" startLine="20" startColumn="21" endLine="20" endColumn="30"/>
-                <entry offset="0x54" startLine="21" startColumn="21" endLine="21" endColumn="49"/>
-                <entry offset="0x66" hidden="true"/>
-                <entry offset="0x68" startLine="23" startColumn="25" endLine="23" endColumn="53"/>
-                <entry offset="0x79" startLine="24" startColumn="25" endLine="24" endColumn="27"/>
-                <entry offset="0x7a" startLine="25" startColumn="29" endLine="25" endColumn="57"/>
-                <entry offset="0x8c" startLine="26" startColumn="29" endLine="26" endColumn="38"/>
-                <entry offset="0x93" startLine="27" startColumn="25" endLine="27" endColumn="47"/>
-                <entry offset="0xa8" hidden="true"/>
-                <entry offset="0xac" startLine="28" startColumn="25" endLine="28" endColumn="34"/>
-                <entry offset="0xc4" startLine="29" startColumn="21" endLine="29" endColumn="25"/>
-                <entry offset="0xc5" startLine="22" startColumn="21" endLine="22" endColumn="41"/>
-                <entry offset="0xdc" hidden="true"/>
-                <entry offset="0xe0" startLine="30" startColumn="17" endLine="30" endColumn="21"/>
-                <entry offset="0xe1" startLine="19" startColumn="17" endLine="19" endColumn="46"/>
-                <entry offset="0xf1" hidden="true"/>
-                <entry offset="0xf8" startLine="31" startColumn="17" endLine="31" endColumn="26"/>
-                <entry offset="0x110" startLine="32" startColumn="17" endLine="32" endColumn="46"/>
-                <entry offset="0x121" startLine="33" startColumn="13" endLine="33" endColumn="22"/>
-                <entry offset="0x122" startLine="18" startColumn="13" endLine="18" endColumn="26"/>
-                <entry offset="0x138" hidden="true"/>
-                <entry offset="0x13f" startLine="34" startColumn="9" endLine="34" endColumn="28"/>
-                <entry offset="0x158" hidden="true"/>
-                <entry offset="0x15f" startLine="35" startColumn="5" endLine="35" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="8" startColumn="9" endLine="8" endColumn="15" document="1"/>
+                <entry offset="0x5" startLine="9" startColumn="9" endLine="9" endColumn="15" document="1"/>
+                <entry offset="0x9" startLine="10" startColumn="9" endLine="10" endColumn="15" document="1"/>
+                <entry offset="0xd" startLine="11" startColumn="9" endLine="11" endColumn="14" document="1"/>
+                <entry offset="0xf" startLine="12" startColumn="9" endLine="12" endColumn="14" document="1"/>
+                <entry offset="0x12" startLine="13" startColumn="9" endLine="13" endColumn="14" document="1"/>
+                <entry offset="0x15" startLine="14" startColumn="13" endLine="14" endColumn="32" document="1"/>
+                <entry offset="0x19" startLine="15" startColumn="9" endLine="15" endColumn="11" document="1"/>
+                <entry offset="0x1a" startLine="16" startColumn="13" endLine="16" endColumn="44" document="1"/>
+                <entry offset="0x2b" startLine="17" startColumn="13" endLine="17" endColumn="22" document="1"/>
+                <entry offset="0x43" hidden="true" document="1"/>
+                <entry offset="0x48" hidden="true" document="1"/>
+                <entry offset="0x4d" startLine="20" startColumn="21" endLine="20" endColumn="30" document="1"/>
+                <entry offset="0x54" startLine="21" startColumn="21" endLine="21" endColumn="49" document="1"/>
+                <entry offset="0x66" hidden="true" document="1"/>
+                <entry offset="0x68" startLine="23" startColumn="25" endLine="23" endColumn="53" document="1"/>
+                <entry offset="0x79" startLine="24" startColumn="25" endLine="24" endColumn="27" document="1"/>
+                <entry offset="0x7a" startLine="25" startColumn="29" endLine="25" endColumn="57" document="1"/>
+                <entry offset="0x8c" startLine="26" startColumn="29" endLine="26" endColumn="38" document="1"/>
+                <entry offset="0x93" startLine="27" startColumn="25" endLine="27" endColumn="47" document="1"/>
+                <entry offset="0xa8" hidden="true" document="1"/>
+                <entry offset="0xac" startLine="28" startColumn="25" endLine="28" endColumn="34" document="1"/>
+                <entry offset="0xc4" startLine="29" startColumn="21" endLine="29" endColumn="25" document="1"/>
+                <entry offset="0xc5" startLine="22" startColumn="21" endLine="22" endColumn="41" document="1"/>
+                <entry offset="0xdc" hidden="true" document="1"/>
+                <entry offset="0xe0" startLine="30" startColumn="17" endLine="30" endColumn="21" document="1"/>
+                <entry offset="0xe1" startLine="19" startColumn="17" endLine="19" endColumn="46" document="1"/>
+                <entry offset="0xf1" hidden="true" document="1"/>
+                <entry offset="0xf8" startLine="31" startColumn="17" endLine="31" endColumn="26" document="1"/>
+                <entry offset="0x110" startLine="32" startColumn="17" endLine="32" endColumn="46" document="1"/>
+                <entry offset="0x121" startLine="33" startColumn="13" endLine="33" endColumn="22" document="1"/>
+                <entry offset="0x122" startLine="18" startColumn="13" endLine="18" endColumn="26" document="1"/>
+                <entry offset="0x138" hidden="true" document="1"/>
+                <entry offset="0x13f" startLine="34" startColumn="9" endLine="34" endColumn="28" document="1"/>
+                <entry offset="0x158" hidden="true" document="1"/>
+                <entry offset="0x15f" startLine="35" startColumn="5" endLine="35" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x160">
                 <namespace name="System" importlevel="file"/>
@@ -2378,6 +2448,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2391,19 +2464,19 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="15"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="20"/>
-                <entry offset="0x7" startLine="8" startColumn="13" endLine="8" endColumn="34"/>
-                <entry offset="0xd" startLine="9" startColumn="9" endLine="9" endColumn="15"/>
-                <entry offset="0xf" hidden="true"/>
-                <entry offset="0x11" startLine="11" startColumn="13" endLine="11" endColumn="48"/>
-                <entry offset="0x23" startLine="12" startColumn="13" endLine="12" endColumn="33"/>
-                <entry offset="0x2a" startLine="13" startColumn="13" endLine="13" endColumn="26"/>
-                <entry offset="0x30" startLine="14" startColumn="13" endLine="14" endColumn="23"/>
-                <entry offset="0x34" startLine="15" startColumn="9" endLine="15" endColumn="18"/>
-                <entry offset="0x35" startLine="10" startColumn="9" endLine="10" endColumn="20"/>
-                <entry offset="0x3b" hidden="true"/>
-                <entry offset="0x3f" startLine="16" startColumn="5" endLine="16" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="20" document="1"/>
+                <entry offset="0x7" startLine="8" startColumn="13" endLine="8" endColumn="34" document="1"/>
+                <entry offset="0xd" startLine="9" startColumn="9" endLine="9" endColumn="15" document="1"/>
+                <entry offset="0xf" hidden="true" document="1"/>
+                <entry offset="0x11" startLine="11" startColumn="13" endLine="11" endColumn="48" document="1"/>
+                <entry offset="0x23" startLine="12" startColumn="13" endLine="12" endColumn="33" document="1"/>
+                <entry offset="0x2a" startLine="13" startColumn="13" endLine="13" endColumn="26" document="1"/>
+                <entry offset="0x30" startLine="14" startColumn="13" endLine="14" endColumn="23" document="1"/>
+                <entry offset="0x34" startLine="15" startColumn="9" endLine="15" endColumn="18" document="1"/>
+                <entry offset="0x35" startLine="10" startColumn="9" endLine="10" endColumn="20" document="1"/>
+                <entry offset="0x3b" hidden="true" document="1"/>
+                <entry offset="0x3f" startLine="16" startColumn="5" endLine="16" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x40">
                 <namespace name="System" importlevel="file"/>
@@ -2447,6 +2520,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main" parameterNames="args"/>
     <methods>
         <method containingType="Module1" name="Main" parameterNames="args">
@@ -2461,13 +2537,13 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31"/>
-                <entry offset="0x1" startLine="5" startColumn="13" endLine="6" endColumn="74"/>
-                <entry offset="0x26" startLine="8" startColumn="13" endLine="8" endColumn="45"/>
-                <entry offset="0x31" startLine="10" startColumn="9" endLine="10" endColumn="41"/>
-                <entry offset="0x39" startLine="11" startColumn="9" endLine="11" endColumn="44"/>
-                <entry offset="0x41" startLine="13" startColumn="9" endLine="13" endColumn="28"/>
-                <entry offset="0x48" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="13" endLine="6" endColumn="74" document="1"/>
+                <entry offset="0x26" startLine="8" startColumn="13" endLine="8" endColumn="45" document="1"/>
+                <entry offset="0x31" startLine="10" startColumn="9" endLine="10" endColumn="41" document="1"/>
+                <entry offset="0x39" startLine="11" startColumn="9" endLine="11" endColumn="44" document="1"/>
+                <entry offset="0x41" startLine="13" startColumn="9" endLine="13" endColumn="28" document="1"/>
+                <entry offset="0x48" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x49">
                 <namespace name="System" importlevel="file"/>
@@ -2500,6 +2576,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2509,11 +2588,11 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x4" startLine="6" startColumn="9" endLine="6" endColumn="19"/>
-                <entry offset="0x5" startLine="7" startColumn="5" endLine="7" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x4" startLine="6" startColumn="9" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0x5" startLine="7" startColumn="5" endLine="7" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6">
                 <namespace name="System" importlevel="file"/>
@@ -2552,6 +2631,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2561,15 +2643,15 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0xd" startLine="7" startColumn="9" endLine="7" endColumn="19"/>
-                <entry offset="0xe" startLine="9" startColumn="9" endLine="9" endColumn="24"/>
-                <entry offset="0x11" startLine="10" startColumn="13" endLine="10" endColumn="22"/>
-                <entry offset="0x14" startLine="11" startColumn="9" endLine="11" endColumn="19"/>
-                <entry offset="0x15" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0xd" startLine="7" startColumn="9" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0xe" startLine="9" startColumn="9" endLine="9" endColumn="24" document="1"/>
+                <entry offset="0x11" startLine="10" startColumn="13" endLine="10" endColumn="22" document="1"/>
+                <entry offset="0x14" startLine="11" startColumn="9" endLine="11" endColumn="19" document="1"/>
+                <entry offset="0x15" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x16">
                 <namespace name="System" importlevel="file"/>
@@ -2658,6 +2740,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2669,18 +2754,18 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x6" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0xb" hidden="true"/>
-                <entry offset="0x10" startLine="7" startColumn="13" endLine="7" endColumn="19"/>
-                <entry offset="0x15" hidden="true"/>
-                <entry offset="0x1a" startLine="8" startColumn="13" endLine="8" endColumn="27"/>
-                <entry offset="0x2f" hidden="true"/>
-                <entry offset="0x34" startLine="9" startColumn="13" endLine="9" endColumn="22"/>
-                <entry offset="0x35" startLine="10" startColumn="9" endLine="10" endColumn="19"/>
-                <entry offset="0x36" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x6" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0xb" hidden="true" document="1"/>
+                <entry offset="0x10" startLine="7" startColumn="13" endLine="7" endColumn="19" document="1"/>
+                <entry offset="0x15" hidden="true" document="1"/>
+                <entry offset="0x1a" startLine="8" startColumn="13" endLine="8" endColumn="27" document="1"/>
+                <entry offset="0x2f" hidden="true" document="1"/>
+                <entry offset="0x34" startLine="9" startColumn="13" endLine="9" endColumn="22" document="1"/>
+                <entry offset="0x35" startLine="10" startColumn="9" endLine="10" endColumn="19" document="1"/>
+                <entry offset="0x36" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x37">
                 <namespace name="System" importlevel="file"/>
@@ -2720,6 +2805,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2729,18 +2817,18 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x30" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0x31" startLine="7" startColumn="17" endLine="7" endColumn="39"/>
-                <entry offset="0x3e" startLine="8" startColumn="13" endLine="8" endColumn="19"/>
-                <entry offset="0x3f" startLine="9" startColumn="17" endLine="9" endColumn="39"/>
-                <entry offset="0x4c" startLine="10" startColumn="13" endLine="10" endColumn="42"/>
-                <entry offset="0x4f" startLine="11" startColumn="13" endLine="11" endColumn="22"/>
-                <entry offset="0x50" startLine="12" startColumn="17" endLine="12" endColumn="42"/>
-                <entry offset="0x5d" startLine="13" startColumn="9" endLine="13" endColumn="19"/>
-                <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x30" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0x31" startLine="7" startColumn="17" endLine="7" endColumn="39" document="1"/>
+                <entry offset="0x3e" startLine="8" startColumn="13" endLine="8" endColumn="19" document="1"/>
+                <entry offset="0x3f" startLine="9" startColumn="17" endLine="9" endColumn="39" document="1"/>
+                <entry offset="0x4c" startLine="10" startColumn="13" endLine="10" endColumn="42" document="1"/>
+                <entry offset="0x4f" startLine="11" startColumn="13" endLine="11" endColumn="22" document="1"/>
+                <entry offset="0x50" startLine="12" startColumn="17" endLine="12" endColumn="42" document="1"/>
+                <entry offset="0x5d" startLine="13" startColumn="9" endLine="13" endColumn="19" document="1"/>
+                <entry offset="0x5e" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x5f">
                 <namespace name="System" importlevel="file"/>
@@ -2782,6 +2870,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2792,19 +2883,19 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="28"/>
-                <entry offset="0x34" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0x35" startLine="7" startColumn="17" endLine="7" endColumn="38"/>
-                <entry offset="0x42" startLine="8" startColumn="13" endLine="8" endColumn="19"/>
-                <entry offset="0x43" startLine="9" startColumn="17" endLine="9" endColumn="39"/>
-                <entry offset="0x50" startLine="10" startColumn="13" endLine="10" endColumn="42"/>
-                <entry offset="0x51" startLine="11" startColumn="17" endLine="11" endColumn="39"/>
-                <entry offset="0x5e" startLine="12" startColumn="13" endLine="12" endColumn="22"/>
-                <entry offset="0x5f" startLine="13" startColumn="17" endLine="13" endColumn="42"/>
-                <entry offset="0x6c" startLine="14" startColumn="9" endLine="14" endColumn="19"/>
-                <entry offset="0x6d" startLine="15" startColumn="5" endLine="15" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="28" document="1"/>
+                <entry offset="0x34" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0x35" startLine="7" startColumn="17" endLine="7" endColumn="38" document="1"/>
+                <entry offset="0x42" startLine="8" startColumn="13" endLine="8" endColumn="19" document="1"/>
+                <entry offset="0x43" startLine="9" startColumn="17" endLine="9" endColumn="39" document="1"/>
+                <entry offset="0x50" startLine="10" startColumn="13" endLine="10" endColumn="42" document="1"/>
+                <entry offset="0x51" startLine="11" startColumn="17" endLine="11" endColumn="39" document="1"/>
+                <entry offset="0x5e" startLine="12" startColumn="13" endLine="12" endColumn="22" document="1"/>
+                <entry offset="0x5f" startLine="13" startColumn="17" endLine="13" endColumn="42" document="1"/>
+                <entry offset="0x6c" startLine="14" startColumn="9" endLine="14" endColumn="19" document="1"/>
+                <entry offset="0x6d" startLine="15" startColumn="5" endLine="15" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x6e">
                 <namespace name="System" importlevel="file"/>
@@ -2845,6 +2936,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2856,20 +2950,20 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x6" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0xb" hidden="true"/>
-                <entry offset="0xe" startLine="7" startColumn="17" endLine="7" endColumn="39"/>
-                <entry offset="0x1b" startLine="8" startColumn="13" endLine="8" endColumn="19"/>
-                <entry offset="0x20" hidden="true"/>
-                <entry offset="0x23" startLine="9" startColumn="17" endLine="9" endColumn="39"/>
-                <entry offset="0x30" startLine="10" startColumn="13" endLine="10" endColumn="31"/>
-                <entry offset="0x42" hidden="true"/>
-                <entry offset="0x47" startLine="12" startColumn="17" endLine="12" endColumn="42"/>
-                <entry offset="0x52" startLine="13" startColumn="9" endLine="13" endColumn="19"/>
-                <entry offset="0x53" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x6" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0xb" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="7" startColumn="17" endLine="7" endColumn="39" document="1"/>
+                <entry offset="0x1b" startLine="8" startColumn="13" endLine="8" endColumn="19" document="1"/>
+                <entry offset="0x20" hidden="true" document="1"/>
+                <entry offset="0x23" startLine="9" startColumn="17" endLine="9" endColumn="39" document="1"/>
+                <entry offset="0x30" startLine="10" startColumn="13" endLine="10" endColumn="31" document="1"/>
+                <entry offset="0x42" hidden="true" document="1"/>
+                <entry offset="0x47" startLine="12" startColumn="17" endLine="12" endColumn="42" document="1"/>
+                <entry offset="0x52" startLine="13" startColumn="9" endLine="13" endColumn="19" document="1"/>
+                <entry offset="0x53" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x54">
                 <namespace name="System" importlevel="file"/>
@@ -2911,6 +3005,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2922,21 +3019,21 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31"/>
-                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="28"/>
-                <entry offset="0x8" startLine="6" startColumn="13" endLine="6" endColumn="19"/>
-                <entry offset="0xd" hidden="true"/>
-                <entry offset="0x10" startLine="7" startColumn="17" endLine="7" endColumn="38"/>
-                <entry offset="0x1d" startLine="8" startColumn="13" endLine="8" endColumn="19"/>
-                <entry offset="0x22" hidden="true"/>
-                <entry offset="0x25" startLine="9" startColumn="17" endLine="9" endColumn="39"/>
-                <entry offset="0x32" startLine="10" startColumn="13" endLine="10" endColumn="31"/>
-                <entry offset="0x44" hidden="true"/>
-                <entry offset="0x47" startLine="11" startColumn="17" endLine="11" endColumn="39"/>
-                <entry offset="0x54" startLine="13" startColumn="17" endLine="13" endColumn="42"/>
-                <entry offset="0x5f" startLine="14" startColumn="9" endLine="14" endColumn="19"/>
-                <entry offset="0x60" startLine="15" startColumn="5" endLine="15" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x3" startLine="5" startColumn="9" endLine="5" endColumn="28" document="1"/>
+                <entry offset="0x8" startLine="6" startColumn="13" endLine="6" endColumn="19" document="1"/>
+                <entry offset="0xd" hidden="true" document="1"/>
+                <entry offset="0x10" startLine="7" startColumn="17" endLine="7" endColumn="38" document="1"/>
+                <entry offset="0x1d" startLine="8" startColumn="13" endLine="8" endColumn="19" document="1"/>
+                <entry offset="0x22" hidden="true" document="1"/>
+                <entry offset="0x25" startLine="9" startColumn="17" endLine="9" endColumn="39" document="1"/>
+                <entry offset="0x32" startLine="10" startColumn="13" endLine="10" endColumn="31" document="1"/>
+                <entry offset="0x44" hidden="true" document="1"/>
+                <entry offset="0x47" startLine="11" startColumn="17" endLine="11" endColumn="39" document="1"/>
+                <entry offset="0x54" startLine="13" startColumn="17" endLine="13" endColumn="42" document="1"/>
+                <entry offset="0x5f" startLine="14" startColumn="9" endLine="14" endColumn="19" document="1"/>
+                <entry offset="0x60" startLine="15" startColumn="5" endLine="15" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x61">
                 <namespace name="System" importlevel="file"/>
@@ -2977,6 +3074,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -2987,18 +3087,18 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33"/>
-                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x135" startLine="6" startColumn="13" endLine="6" endColumn="22"/>
-                <entry offset="0x136" startLine="7" startColumn="17" endLine="7" endColumn="40"/>
-                <entry offset="0x143" startLine="8" startColumn="13" endLine="8" endColumn="22"/>
-                <entry offset="0x144" startLine="9" startColumn="17" endLine="9" endColumn="40"/>
-                <entry offset="0x151" startLine="10" startColumn="13" endLine="10" endColumn="58"/>
-                <entry offset="0x154" startLine="11" startColumn="13" endLine="11" endColumn="22"/>
-                <entry offset="0x155" startLine="12" startColumn="17" endLine="12" endColumn="42"/>
-                <entry offset="0x162" startLine="13" startColumn="9" endLine="13" endColumn="19"/>
-                <entry offset="0x163" startLine="14" startColumn="5" endLine="14" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x135" startLine="6" startColumn="13" endLine="6" endColumn="22" document="1"/>
+                <entry offset="0x136" startLine="7" startColumn="17" endLine="7" endColumn="40" document="1"/>
+                <entry offset="0x143" startLine="8" startColumn="13" endLine="8" endColumn="22" document="1"/>
+                <entry offset="0x144" startLine="9" startColumn="17" endLine="9" endColumn="40" document="1"/>
+                <entry offset="0x151" startLine="10" startColumn="13" endLine="10" endColumn="58" document="1"/>
+                <entry offset="0x154" startLine="11" startColumn="13" endLine="11" endColumn="22" document="1"/>
+                <entry offset="0x155" startLine="12" startColumn="17" endLine="12" endColumn="42" document="1"/>
+                <entry offset="0x162" startLine="13" startColumn="9" endLine="13" endColumn="19" document="1"/>
+                <entry offset="0x163" startLine="14" startColumn="5" endLine="14" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x164">
                 <namespace name="System" importlevel="file"/>
@@ -3038,6 +3138,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -3047,17 +3150,17 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33"/>
-                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0x34" startLine="6" startColumn="13" endLine="6" endColumn="22"/>
-                <entry offset="0x35" startLine="7" startColumn="17" endLine="7" endColumn="40"/>
-                <entry offset="0x42" startLine="8" startColumn="13" endLine="8" endColumn="22"/>
-                <entry offset="0x45" startLine="9" startColumn="13" endLine="9" endColumn="22"/>
-                <entry offset="0x46" startLine="10" startColumn="17" endLine="10" endColumn="40"/>
-                <entry offset="0x53" startLine="11" startColumn="13" endLine="11" endColumn="22"/>
-                <entry offset="0x56" startLine="12" startColumn="9" endLine="12" endColumn="19"/>
-                <entry offset="0x57" startLine="13" startColumn="5" endLine="13" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x34" startLine="6" startColumn="13" endLine="6" endColumn="22" document="1"/>
+                <entry offset="0x35" startLine="7" startColumn="17" endLine="7" endColumn="40" document="1"/>
+                <entry offset="0x42" startLine="8" startColumn="13" endLine="8" endColumn="22" document="1"/>
+                <entry offset="0x45" startLine="9" startColumn="13" endLine="9" endColumn="22" document="1"/>
+                <entry offset="0x46" startLine="10" startColumn="17" endLine="10" endColumn="40" document="1"/>
+                <entry offset="0x53" startLine="11" startColumn="13" endLine="11" endColumn="22" document="1"/>
+                <entry offset="0x56" startLine="12" startColumn="9" endLine="12" endColumn="19" document="1"/>
+                <entry offset="0x57" startLine="13" startColumn="5" endLine="13" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x58">
                 <namespace name="System" importlevel="file"/>
@@ -3096,6 +3199,9 @@ End Module
 
             compilation.VerifyPdb("Module1.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Module1" methodName="Main"/>
     <methods>
         <method containingType="Module1" name="Main">
@@ -3108,19 +3214,19 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33"/>
-                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24"/>
-                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="22"/>
-                <entry offset="0x1a" hidden="true"/>
-                <entry offset="0x1d" startLine="7" startColumn="17" endLine="7" endColumn="40"/>
-                <entry offset="0x2a" startLine="8" startColumn="13" endLine="8" endColumn="36"/>
-                <entry offset="0x4f" hidden="true"/>
-                <entry offset="0x54" startLine="9" startColumn="13" endLine="9" endColumn="22"/>
-                <entry offset="0x64" hidden="true"/>
-                <entry offset="0x67" startLine="10" startColumn="17" endLine="10" endColumn="40"/>
-                <entry offset="0x72" startLine="11" startColumn="9" endLine="11" endColumn="19"/>
-                <entry offset="0x73" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="33" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="9" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0xa" startLine="6" startColumn="13" endLine="6" endColumn="22" document="1"/>
+                <entry offset="0x1a" hidden="true" document="1"/>
+                <entry offset="0x1d" startLine="7" startColumn="17" endLine="7" endColumn="40" document="1"/>
+                <entry offset="0x2a" startLine="8" startColumn="13" endLine="8" endColumn="36" document="1"/>
+                <entry offset="0x4f" hidden="true" document="1"/>
+                <entry offset="0x54" startLine="9" startColumn="13" endLine="9" endColumn="22" document="1"/>
+                <entry offset="0x64" hidden="true" document="1"/>
+                <entry offset="0x67" startLine="10" startColumn="17" endLine="10" endColumn="40" document="1"/>
+                <entry offset="0x72" startLine="11" startColumn="9" endLine="11" endColumn="19" document="1"/>
+                <entry offset="0x73" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x74">
                 <namespace name="System" importlevel="file"/>
@@ -3151,6 +3257,9 @@ End Class
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C1" name="Method">
             <customDebugInfo>
@@ -3159,9 +3268,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17"/>
-                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="36"/>
-                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="36" document="1"/>
+                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name=""/>
@@ -3189,6 +3298,9 @@ End Class
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C1" name="Method">
             <customDebugInfo>
@@ -3197,9 +3309,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17"/>
-                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="40"/>
-                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="17" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="40" document="1"/>
+                <entry offset="0x8" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name=""/>
@@ -3259,6 +3371,9 @@ End Module
 
             compilation.VerifyPdb("GooDerived.ComputeMatrix",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="Variety" methodName="Main"/>
     <methods>
         <method containingType="GooDerived" name="ComputeMatrix" parameterNames="rank">
@@ -3273,18 +3388,18 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="52"/>
-                <entry offset="0x1" startLine="14" startColumn="15" endLine="14" endColumn="22"/>
-                <entry offset="0xa" startLine="15" startColumn="15" endLine="15" endColumn="25"/>
-                <entry offset="0x14" startLine="18" startColumn="9" endLine="18" endColumn="18"/>
-                <entry offset="0x17" startLine="19" startColumn="9" endLine="19" endColumn="30"/>
-                <entry offset="0x1e" hidden="true"/>
-                <entry offset="0x20" startLine="20" startColumn="13" endLine="20" endColumn="21"/>
-                <entry offset="0x25" startLine="21" startColumn="13" endLine="21" endColumn="34"/>
-                <entry offset="0x3f" startLine="22" startColumn="13" endLine="22" endColumn="29"/>
-                <entry offset="0x46" startLine="23" startColumn="9" endLine="23" endColumn="15"/>
-                <entry offset="0x4a" hidden="true"/>
-                <entry offset="0x4f" startLine="24" startColumn="5" endLine="24" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="52" document="1"/>
+                <entry offset="0x1" startLine="14" startColumn="15" endLine="14" endColumn="22" document="1"/>
+                <entry offset="0xa" startLine="15" startColumn="15" endLine="15" endColumn="25" document="1"/>
+                <entry offset="0x14" startLine="18" startColumn="9" endLine="18" endColumn="18" document="1"/>
+                <entry offset="0x17" startLine="19" startColumn="9" endLine="19" endColumn="30" document="1"/>
+                <entry offset="0x1e" hidden="true" document="1"/>
+                <entry offset="0x20" startLine="20" startColumn="13" endLine="20" endColumn="21" document="1"/>
+                <entry offset="0x25" startLine="21" startColumn="13" endLine="21" endColumn="34" document="1"/>
+                <entry offset="0x3f" startLine="22" startColumn="13" endLine="22" endColumn="29" document="1"/>
+                <entry offset="0x46" startLine="23" startColumn="9" endLine="23" endColumn="15" document="1"/>
+                <entry offset="0x4a" hidden="true" document="1"/>
+                <entry offset="0x4f" startLine="24" startColumn="5" endLine="24" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x50">
                 <namespace name="System" importlevel="file"/>
@@ -3326,18 +3441,21 @@ End Module
 
             compilation.VerifyPdb("SubMod.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="SubMod" methodName="Main"/>
     <methods>
         <method containingType="SubMod" name="Main">
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="1" endLine="4" endColumn="4"/>
-                <entry offset="0x2" startLine="5" startColumn="9" endLine="5" endColumn="16"/>
-                <entry offset="0x4" startLine="6" startColumn="1" endLine="6" endColumn="4"/>
-                <entry offset="0x5" startLine="7" startColumn="9" endLine="7" endColumn="17"/>
-                <entry offset="0x7" startLine="8" startColumn="1" endLine="8" endColumn="4"/>
-                <entry offset="0x8" startLine="9" startColumn="9" endLine="9" endColumn="16"/>
-                <entry offset="0xa" startLine="10" startColumn="5" endLine="10" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="1" endLine="4" endColumn="4" document="1"/>
+                <entry offset="0x2" startLine="5" startColumn="9" endLine="5" endColumn="16" document="1"/>
+                <entry offset="0x4" startLine="6" startColumn="1" endLine="6" endColumn="4" document="1"/>
+                <entry offset="0x5" startLine="7" startColumn="9" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x7" startLine="8" startColumn="1" endLine="8" endColumn="4" document="1"/>
+                <entry offset="0x8" startLine="9" startColumn="9" endLine="9" endColumn="16" document="1"/>
+                <entry offset="0xa" startLine="10" startColumn="5" endLine="10" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xb">
                 <namespace name="System" importlevel="file"/>
@@ -3373,12 +3491,15 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="M1" name="Main">
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15"/>
-                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="12"/>
-                <entry offset="0x7" startLine="5" startColumn="5" endLine="5" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="12" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="5" endLine="5" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8">
                 <namespace name="System" importlevel="file"/>
@@ -3387,8 +3508,8 @@ End Module
         </method>
         <method containingType="M1" name="S">
             <sequencePoints>
-                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="19"/>
-                <entry offset="0x1" startLine="11" startColumn="5" endLine="11" endColumn="12"/>
+                <entry offset="0x0" startLine="9" startColumn="5" endLine="9" endColumn="19" document="1"/>
+                <entry offset="0x1" startLine="11" startColumn="5" endLine="11" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <importsforward declaringType="M1" methodName="Main"/>
@@ -3431,6 +3552,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="Main">
             <customDebugInfo>
@@ -3440,10 +3564,10 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="17" startColumn="5" endLine="17" endColumn="15"/>
-                <entry offset="0x1" startLine="18" startColumn="13" endLine="18" endColumn="30"/>
-                <entry offset="0x4" startLine="19" startColumn="13" endLine="19" endColumn="25"/>
-                <entry offset="0xb" startLine="20" startColumn="5" endLine="20" endColumn="12"/>
+                <entry offset="0x0" startLine="17" startColumn="5" endLine="17" endColumn="15" document="1"/>
+                <entry offset="0x1" startLine="18" startColumn="13" endLine="18" endColumn="30" document="1"/>
+                <entry offset="0x4" startLine="19" startColumn="13" endLine="19" endColumn="25" document="1"/>
+                <entry offset="0xb" startLine="20" startColumn="5" endLine="20" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <namespace name="System" importlevel="file"/>
@@ -3454,9 +3578,9 @@ End Module
         </method>
         <method containingType="Module1+B2" name=".ctor" parameterNames="x">
             <sequencePoints>
-                <entry offset="0x0" startLine="8" startColumn="9" endLine="8" endColumn="37"/>
-                <entry offset="0x8" startLine="9" startColumn="13" endLine="9" endColumn="18"/>
-                <entry offset="0xf" startLine="10" startColumn="9" endLine="10" endColumn="16"/>
+                <entry offset="0x0" startLine="8" startColumn="9" endLine="8" endColumn="37" document="1"/>
+                <entry offset="0x8" startLine="9" startColumn="13" endLine="9" endColumn="18" document="1"/>
+                <entry offset="0xf" startLine="10" startColumn="9" endLine="10" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="Module1" methodName="Main"/>
@@ -3469,9 +3593,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="12" startColumn="9" endLine="12" endColumn="59"/>
-                <entry offset="0x1" startLine="13" startColumn="13" endLine="13" endColumn="29"/>
-                <entry offset="0xa" startLine="14" startColumn="9" endLine="14" endColumn="21"/>
+                <entry offset="0x0" startLine="12" startColumn="9" endLine="12" endColumn="59" document="1"/>
+                <entry offset="0x1" startLine="13" startColumn="13" endLine="13" endColumn="29" document="1"/>
+                <entry offset="0xa" startLine="14" startColumn="9" endLine="14" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="Module1" methodName="Main"/>
@@ -3515,13 +3639,16 @@ End Module
 
             compilation.VerifyPdb("CLAZZ..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="CLAZZ" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="21"/>
-                <entry offset="0x1b" startLine="4" startColumn="12" endLine="4" endColumn="31"/>
-                <entry offset="0x22" startLine="6" startColumn="12" endLine="6" endColumn="31"/>
-                <entry offset="0x29" startLine="10" startColumn="5" endLine="10" endColumn="12"/>
+                <entry offset="0x0" startLine="8" startColumn="5" endLine="8" endColumn="21" document="1"/>
+                <entry offset="0x1b" startLine="4" startColumn="12" endLine="4" endColumn="31" document="1"/>
+                <entry offset="0x22" startLine="6" startColumn="12" endLine="6" endColumn="31" document="1"/>
+                <entry offset="0x29" startLine="10" startColumn="5" endLine="10" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2a">
                 <namespace name="System" importlevel="file"/>
@@ -3600,6 +3727,9 @@ End Class
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F" parameterNames="z">
             <customDebugInfo>
@@ -3608,9 +3738,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="51"/>
-                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="23"/>
-                <entry offset="0xa" startLine="6" startColumn="5" endLine="6" endColumn="17"/>
+                <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="51" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="23" document="1"/>
+                <entry offset="0xa" startLine="6" startColumn="5" endLine="6" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <type name="Microsoft.VisualBasic.Strings" importlevel="file"/>
@@ -3646,6 +3776,9 @@ End Module
 
             compilation.VerifyPdb("Module1.MakeIncrementer",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="Module1" name="MakeIncrementer" parameterNames="n">
             <customDebugInfo>
@@ -3660,10 +3793,10 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="72"/>
-                <entry offset="0x1" hidden="true"/>
-                <entry offset="0xe" startLine="8" startColumn="9" endLine="10" endColumn="21"/>
-                <entry offset="0x1d" startLine="11" startColumn="5" endLine="11" endColumn="17"/>
+                <entry offset="0x0" startLine="7" startColumn="5" endLine="7" endColumn="72" document="1"/>
+                <entry offset="0x1" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="8" startColumn="9" endLine="10" endColumn="21" document="1"/>
+                <entry offset="0x1d" startLine="11" startColumn="5" endLine="11" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="Module1" methodName="Main"/>
@@ -3696,11 +3829,14 @@ End Class
 
             compilation.VerifyPdb("C..ctor",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" startLine="2" startColumn="13" endLine="2" endColumn="39"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" startLine="2" startColumn="13" endLine="2" endColumn="39" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x18">
                 <currentnamespace name=""/>
@@ -3734,6 +3870,9 @@ End Module
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="M" name=".cctor">
             <customDebugInfo>
@@ -3747,7 +3886,7 @@ End Module
                 </encLambdaMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="13" endLine="7" endColumn="21"/>
+                <entry offset="0x0" startLine="3" startColumn="13" endLine="7" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x16">
                 <namespace name="System" importlevel="file"/>
@@ -3761,8 +3900,8 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="96" endLine="5" endColumn="107"/>
-                <entry offset="0x1" startLine="5" startColumn="108" endLine="5" endColumn="112"/>
+                <entry offset="0x0" startLine="5" startColumn="96" endLine="5" endColumn="107" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="108" endLine="5" endColumn="112" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x17">
                 <importsforward declaringType="M" methodName=".cctor"/>
@@ -3777,11 +3916,11 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="46" endLine="3" endColumn="57"/>
-                <entry offset="0x1" startLine="4" startColumn="17" endLine="4" endColumn="62"/>
-                <entry offset="0x26" startLine="5" startColumn="17" endLine="5" endColumn="112"/>
-                <entry offset="0x4b" startLine="6" startColumn="13" endLine="6" endColumn="33"/>
-                <entry offset="0x5b" startLine="7" startColumn="9" endLine="7" endColumn="21"/>
+                <entry offset="0x0" startLine="3" startColumn="46" endLine="3" endColumn="57" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="17" endLine="4" endColumn="62" document="1"/>
+                <entry offset="0x26" startLine="5" startColumn="17" endLine="5" endColumn="112" document="1"/>
+                <entry offset="0x4b" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                <entry offset="0x5b" startLine="7" startColumn="9" endLine="7" endColumn="21" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x5d">
                 <importsforward declaringType="M" methodName=".cctor"/>
@@ -3796,8 +3935,8 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="49" endLine="4" endColumn="60"/>
-                <entry offset="0x1" startLine="4" startColumn="61" endLine="4" endColumn="62"/>
+                <entry offset="0x0" startLine="4" startColumn="49" endLine="4" endColumn="60" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="61" endLine="4" endColumn="62" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x7">
                 <importsforward declaringType="M" methodName=".cctor"/>
@@ -3811,9 +3950,9 @@ End Module
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="84" endLine="5" endColumn="95"/>
-                <entry offset="0x1" hidden="true"/>
-                <entry offset="0xe" startLine="5" startColumn="96" endLine="5" endColumn="112"/>
+                <entry offset="0x0" startLine="5" startColumn="84" endLine="5" endColumn="95" document="1"/>
+                <entry offset="0x1" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="5" startColumn="96" endLine="5" endColumn="112" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1f">
                 <importsforward declaringType="M" methodName=".cctor"/>
@@ -3871,12 +4010,15 @@ End Class
 
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="My.MyComputer" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="107" startColumn="9" endLine="107" endColumn="25"/>
-                <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25"/>
-                <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16"/>
+                <entry offset="0x0" startLine="107" startColumn="9" endLine="107" endColumn="25" document="1"/>
+                <entry offset="0x1" startLine="108" startColumn="13" endLine="108" endColumn="25" document="1"/>
+                <entry offset="0x8" startLine="109" startColumn="9" endLine="109" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <currentnamespace name="My"/>
@@ -3884,10 +4026,10 @@ End Class
         </method>
         <method containingType="My.MyProject" name=".cctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="126" startColumn="26" endLine="126" endColumn="97"/>
-                <entry offset="0xa" startLine="137" startColumn="26" endLine="137" endColumn="95"/>
-                <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136"/>
-                <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105"/>
+                <entry offset="0x0" startLine="126" startColumn="26" endLine="126" endColumn="97" document="1"/>
+                <entry offset="0xa" startLine="137" startColumn="26" endLine="137" endColumn="95" document="1"/>
+                <entry offset="0x14" startLine="148" startColumn="26" endLine="148" endColumn="136" document="1"/>
+                <entry offset="0x1e" startLine="284" startColumn="26" endLine="284" endColumn="105" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x29">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -3900,9 +4042,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="121" startColumn="13" endLine="121" endColumn="16"/>
-                <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62"/>
-                <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20"/>
+                <entry offset="0x0" startLine="121" startColumn="13" endLine="121" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="122" startColumn="17" endLine="122" endColumn="62" document="1"/>
+                <entry offset="0xe" startLine="123" startColumn="13" endLine="123" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -3916,9 +4058,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="133" startColumn="13" endLine="133" endColumn="16"/>
-                <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57"/>
-                <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20"/>
+                <entry offset="0x0" startLine="133" startColumn="13" endLine="133" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="134" startColumn="17" endLine="134" endColumn="57" document="1"/>
+                <entry offset="0xe" startLine="135" startColumn="13" endLine="135" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -3932,9 +4074,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="144" startColumn="13" endLine="144" endColumn="16"/>
-                <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58"/>
-                <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20"/>
+                <entry offset="0x0" startLine="144" startColumn="13" endLine="144" endColumn="16" document="1"/>
+                <entry offset="0x1" startLine="145" startColumn="17" endLine="145" endColumn="58" document="1"/>
+                <entry offset="0xe" startLine="146" startColumn="13" endLine="146" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -3948,9 +4090,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="237" startColumn="14" endLine="237" endColumn="17"/>
-                <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67"/>
-                <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20"/>
+                <entry offset="0x0" startLine="237" startColumn="14" endLine="237" endColumn="17" document="1"/>
+                <entry offset="0x1" startLine="238" startColumn="17" endLine="238" endColumn="67" document="1"/>
+                <entry offset="0xe" startLine="239" startColumn="13" endLine="239" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyComputer" methodName=".ctor"/>
@@ -3959,9 +4101,9 @@ End Class
         </method>
         <method containingType="IntervalUpdate" name="Update">
             <sequencePoints>
-                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="31"/>
-                <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="37"/>
-                <entry offset="0x11" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="31" document="1"/>
+                <entry offset="0x1" startLine="3" startColumn="9" endLine="3" endColumn="37" document="1"/>
+                <entry offset="0x11" startLine="4" startColumn="5" endLine="4" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x12">
                 <currentnamespace name=""/>
@@ -3969,9 +4111,9 @@ End Class
         </method>
         <method containingType="IntervalUpdate" name="Main">
             <sequencePoints>
-                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="22"/>
-                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="17"/>
-                <entry offset="0x7" startLine="8" startColumn="5" endLine="8" endColumn="12"/>
+                <entry offset="0x0" startLine="6" startColumn="5" endLine="6" endColumn="22" document="1"/>
+                <entry offset="0x1" startLine="7" startColumn="9" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x7" startLine="8" startColumn="5" endLine="8" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8">
                 <importsforward declaringType="IntervalUpdate" methodName="Update"/>
@@ -3984,9 +4126,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="247" startColumn="13" endLine="247" endColumn="75"/>
-                <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40"/>
-                <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25"/>
+                <entry offset="0x0" startLine="247" startColumn="13" endLine="247" endColumn="75" document="1"/>
+                <entry offset="0x1" startLine="248" startColumn="17" endLine="248" endColumn="40" document="1"/>
+                <entry offset="0x10" startLine="249" startColumn="13" endLine="249" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x12">
                 <currentnamespace name="My"/>
@@ -4000,9 +4142,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="251" startColumn="13" endLine="251" endColumn="63"/>
-                <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42"/>
-                <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25"/>
+                <entry offset="0x0" startLine="251" startColumn="13" endLine="251" endColumn="63" document="1"/>
+                <entry offset="0x1" startLine="252" startColumn="17" endLine="252" endColumn="42" document="1"/>
+                <entry offset="0xa" startLine="253" startColumn="13" endLine="253" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4016,9 +4158,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="255" startColumn="13" endLine="255" endColumn="72"/>
-                <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46"/>
-                <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25"/>
+                <entry offset="0x0" startLine="255" startColumn="13" endLine="255" endColumn="72" document="1"/>
+                <entry offset="0x1" startLine="256" startColumn="17" endLine="256" endColumn="46" document="1"/>
+                <entry offset="0xe" startLine="257" startColumn="13" endLine="257" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4032,9 +4174,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="259" startColumn="13" endLine="259" endColumn="59"/>
-                <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39"/>
-                <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25"/>
+                <entry offset="0x0" startLine="259" startColumn="13" endLine="259" endColumn="59" document="1"/>
+                <entry offset="0x1" startLine="260" startColumn="17" endLine="260" endColumn="39" document="1"/>
+                <entry offset="0xa" startLine="261" startColumn="13" endLine="261" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0xc">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4049,13 +4191,13 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="264" startColumn="12" endLine="264" endColumn="95"/>
-                <entry offset="0x1" startLine="265" startColumn="17" endLine="265" endColumn="44"/>
-                <entry offset="0xb" hidden="true"/>
-                <entry offset="0xe" startLine="266" startColumn="21" endLine="266" endColumn="35"/>
-                <entry offset="0x16" startLine="267" startColumn="17" endLine="267" endColumn="21"/>
-                <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36"/>
-                <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25"/>
+                <entry offset="0x0" startLine="264" startColumn="12" endLine="264" endColumn="95" document="1"/>
+                <entry offset="0x1" startLine="265" startColumn="17" endLine="265" endColumn="44" document="1"/>
+                <entry offset="0xb" hidden="true" document="1"/>
+                <entry offset="0xe" startLine="266" startColumn="21" endLine="266" endColumn="35" document="1"/>
+                <entry offset="0x16" startLine="267" startColumn="17" endLine="267" endColumn="21" document="1"/>
+                <entry offset="0x17" startLine="268" startColumn="21" endLine="268" endColumn="36" document="1"/>
+                <entry offset="0x1b" startLine="270" startColumn="13" endLine="270" endColumn="25" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1d">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4064,9 +4206,9 @@ End Class
         </method>
         <method containingType="My.MyProject+MyWebServices" name="Dispose__Instance__" parameterNames="instance">
             <sequencePoints>
-                <entry offset="0x0" startLine="273" startColumn="13" endLine="273" endColumn="71"/>
-                <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35"/>
-                <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20"/>
+                <entry offset="0x0" startLine="273" startColumn="13" endLine="273" endColumn="71" document="1"/>
+                <entry offset="0x1" startLine="274" startColumn="17" endLine="274" endColumn="35" document="1"/>
+                <entry offset="0x8" startLine="275" startColumn="13" endLine="275" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4074,9 +4216,9 @@ End Class
         </method>
         <method containingType="My.MyProject+MyWebServices" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="279" startColumn="13" endLine="279" endColumn="29"/>
-                <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28"/>
-                <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20"/>
+                <entry offset="0x0" startLine="279" startColumn="13" endLine="279" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="280" startColumn="16" endLine="280" endColumn="28" document="1"/>
+                <entry offset="0x8" startLine="281" startColumn="13" endLine="281" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4090,12 +4232,12 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="341" startColumn="17" endLine="341" endColumn="20"/>
-                <entry offset="0x1" startLine="342" startColumn="21" endLine="342" endColumn="59"/>
-                <entry offset="0xf" hidden="true"/>
-                <entry offset="0x12" startLine="342" startColumn="60" endLine="342" endColumn="87"/>
-                <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47"/>
-                <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24"/>
+                <entry offset="0x0" startLine="341" startColumn="17" endLine="341" endColumn="20" document="1"/>
+                <entry offset="0x1" startLine="342" startColumn="21" endLine="342" endColumn="59" document="1"/>
+                <entry offset="0xf" hidden="true" document="1"/>
+                <entry offset="0x12" startLine="342" startColumn="60" endLine="342" endColumn="87" document="1"/>
+                <entry offset="0x1c" startLine="343" startColumn="21" endLine="343" endColumn="47" document="1"/>
+                <entry offset="0x24" startLine="344" startColumn="17" endLine="344" endColumn="24" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x26">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4104,9 +4246,9 @@ End Class
         </method>
         <method containingType="My.MyProject+ThreadSafeObjectProvider`1" name=".ctor">
             <sequencePoints>
-                <entry offset="0x0" startLine="350" startColumn="13" endLine="350" endColumn="29"/>
-                <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29"/>
-                <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20"/>
+                <entry offset="0x0" startLine="350" startColumn="13" endLine="350" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="351" startColumn="17" endLine="351" endColumn="29" document="1"/>
+                <entry offset="0x8" startLine="352" startColumn="13" endLine="352" endColumn="20" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <importsforward declaringType="My.MyProject+MyWebServices" methodName="Equals" parameterNames="o"/>
@@ -4174,17 +4316,20 @@ End Class
             ' Just care that there's at least one non-hidden sequence point.
             comp.VerifyPdb("My.MyApplication.Main",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <entryPoint declaringType="My.MyApplication" methodName="Main" parameterNames="Args"/>
     <methods>
         <method containingType="My.MyApplication" name="Main" parameterNames="Args">
             <sequencePoints>
-                <entry offset="0x0" startLine="76" startColumn="9" endLine="76" endColumn="55"/>
-                <entry offset="0x1" startLine="77" startColumn="13" endLine="77" endColumn="16"/>
-                <entry offset="0x2" startLine="78" startColumn="16" endLine="78" endColumn="133"/>
-                <entry offset="0xf" startLine="79" startColumn="13" endLine="79" endColumn="20"/>
-                <entry offset="0x11" startLine="80" startColumn="13" endLine="80" endColumn="20"/>
-                <entry offset="0x12" startLine="81" startColumn="13" endLine="81" endColumn="37"/>
-                <entry offset="0x1e" startLine="82" startColumn="9" endLine="82" endColumn="16"/>
+                <entry offset="0x0" startLine="76" startColumn="9" endLine="76" endColumn="55" document="1"/>
+                <entry offset="0x1" startLine="77" startColumn="13" endLine="77" endColumn="16" document="1"/>
+                <entry offset="0x2" startLine="78" startColumn="16" endLine="78" endColumn="133" document="1"/>
+                <entry offset="0xf" startLine="79" startColumn="13" endLine="79" endColumn="20" document="1"/>
+                <entry offset="0x11" startLine="80" startColumn="13" endLine="80" endColumn="20" document="1"/>
+                <entry offset="0x12" startLine="81" startColumn="13" endLine="81" endColumn="37" document="1"/>
+                <entry offset="0x1e" startLine="82" startColumn="9" endLine="82" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1f">
                 <currentnamespace name="My"/>
@@ -4219,6 +4364,9 @@ End Class
             c.VerifyDiagnostics()
             c.VerifyPdb("C.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C" name="F" parameterNames="args">
             <customDebugInfo>
@@ -4227,16 +4375,16 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="28"/>
-                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="28"/>
-                <entry offset="0x32" startLine="5" startColumn="13" endLine="5" endColumn="21"/>
-                <entry offset="0x33" startLine="6" startColumn="17" endLine="6" endColumn="37"/>
-                <entry offset="0x3c" startLine="7" startColumn="13" endLine="7" endColumn="21"/>
-                <entry offset="0x3d" startLine="8" startColumn="17" endLine="8" endColumn="37"/>
-                <entry offset="0x46" startLine="9" startColumn="13" endLine="9" endColumn="21"/>
-                <entry offset="0x47" startLine="10" startColumn="17" endLine="10" endColumn="37"/>
-                <entry offset="0x50" startLine="11" startColumn="9" endLine="11" endColumn="19"/>
-                <entry offset="0x51" startLine="12" startColumn="5" endLine="12" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="28" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="9" endLine="4" endColumn="28" document="1"/>
+                <entry offset="0x32" startLine="5" startColumn="13" endLine="5" endColumn="21" document="1"/>
+                <entry offset="0x33" startLine="6" startColumn="17" endLine="6" endColumn="37" document="1"/>
+                <entry offset="0x3c" startLine="7" startColumn="13" endLine="7" endColumn="21" document="1"/>
+                <entry offset="0x3d" startLine="8" startColumn="17" endLine="8" endColumn="37" document="1"/>
+                <entry offset="0x46" startLine="9" startColumn="13" endLine="9" endColumn="21" document="1"/>
+                <entry offset="0x47" startLine="10" startColumn="17" endLine="10" endColumn="37" document="1"/>
+                <entry offset="0x50" startLine="11" startColumn="9" endLine="11" endColumn="19" document="1"/>
+                <entry offset="0x51" startLine="12" startColumn="5" endLine="12" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x52">
                 <namespace name="System" importlevel="file"/>
@@ -4309,11 +4457,14 @@ End Class
 
             c.VerifyPdb("C`1.F",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C`1" name="F">
             <sequencePoints>
-                <entry offset="0x0" startLine="18" startColumn="5" endLine="18" endColumn="25"/>
-                <entry offset="0x1" startLine="48" startColumn="5" endLine="48" endColumn="12"/>
+                <entry offset="0x0" startLine="18" startColumn="5" endLine="18" endColumn="25" document="1"/>
+                <entry offset="0x1" startLine="48" startColumn="5" endLine="48" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <namespace name="System" importlevel="file"/>
@@ -4364,6 +4515,9 @@ End Class"
             Dim c = CreateCompilationWithMscorlib45AndVBRuntime({Parse(source)}, options:=TestOptions.DebugDll, references:={SystemCoreRef})
             c.VerifyPdb("C+VB$StateMachine_1_F.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+VB$StateMachine_1_F" name="MoveNext">
             <customDebugInfo>
@@ -4376,15 +4530,15 @@ End Class"
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" startLine="4" startColumn="5" endLine="4" endColumn="38"/>
-                <entry offset="0x8" startLine="5" startColumn="13" endLine="5" endColumn="26"/>
-                <entry offset="0x1f" startLine="6" startColumn="9" endLine="6" endColumn="32"/>
-                <entry offset="0x4f" startLine="7" startColumn="5" endLine="7" endColumn="17"/>
-                <entry offset="0x51" hidden="true"/>
-                <entry offset="0x58" hidden="true"/>
-                <entry offset="0x74" startLine="7" startColumn="5" endLine="7" endColumn="17"/>
-                <entry offset="0x7e" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" startLine="4" startColumn="5" endLine="4" endColumn="38" document="1"/>
+                <entry offset="0x8" startLine="5" startColumn="13" endLine="5" endColumn="26" document="1"/>
+                <entry offset="0x1f" startLine="6" startColumn="9" endLine="6" endColumn="32" document="1"/>
+                <entry offset="0x4f" startLine="7" startColumn="5" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x51" hidden="true" document="1"/>
+                <entry offset="0x58" hidden="true" document="1"/>
+                <entry offset="0x74" startLine="7" startColumn="5" endLine="7" endColumn="17" document="1"/>
+                <entry offset="0x7e" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8b">
                 <importsforward declaringType="C+_Closure$__" methodName="_Lambda$__1-0" parameterNames="i"/>
@@ -4414,6 +4568,9 @@ End Class"
             Dim c = CreateCompilationWithMscorlib45AndVBRuntime({Parse(source)}, options:=TestOptions.DebugDll, references:={SystemCoreRef})
             c.VerifyPdb("C+_Closure$__+VB$StateMachine___Lambda$__1-0.MoveNext",
 <symbols>
+    <files>
+        <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd"/>
+    </files>
     <methods>
         <method containingType="C+_Closure$__+VB$StateMachine___Lambda$__1-0" name="MoveNext">
             <customDebugInfo>
@@ -4426,14 +4583,14 @@ End Class"
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" hidden="true"/>
-                <entry offset="0x7" startLine="5" startColumn="13" endLine="5" endColumn="24"/>
-                <entry offset="0x8" startLine="6" startColumn="21" endLine="6" endColumn="34"/>
-                <entry offset="0x1f" startLine="7" startColumn="17" endLine="7" endColumn="40"/>
-                <entry offset="0x4f" startLine="8" startColumn="13" endLine="8" endColumn="20"/>
-                <entry offset="0x51" hidden="true"/>
-                <entry offset="0x58" hidden="true"/>
-                <entry offset="0x74" hidden="true"/>
+                <entry offset="0x0" hidden="true" document="1"/>
+                <entry offset="0x7" startLine="5" startColumn="13" endLine="5" endColumn="24" document="1"/>
+                <entry offset="0x8" startLine="6" startColumn="21" endLine="6" endColumn="34" document="1"/>
+                <entry offset="0x1f" startLine="7" startColumn="17" endLine="7" endColumn="40" document="1"/>
+                <entry offset="0x4f" startLine="8" startColumn="13" endLine="8" endColumn="20" document="1"/>
+                <entry offset="0x51" hidden="true" document="1"/>
+                <entry offset="0x58" hidden="true" document="1"/>
+                <entry offset="0x74" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8b">
                 <importsforward declaringType="C" methodName="M"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
@@ -20,6 +20,9 @@ End Class
             Dim comp = CreateCompilationWithMscorlib(source, references:={ValueTupleRef, SystemRuntimeFacadeRef}, options:=TestOptions.DebugDll)
             comp.VerifyPdb("C.F",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C" name="F">
             <customDebugInfo>
@@ -31,9 +34,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="19"/>
-                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="163"/>
-                <entry offset="0x1c" startLine="5" startColumn="5" endLine="5" endColumn="12"/>
+                <entry offset="0x0" startLine="3" startColumn="5" endLine="3" endColumn="19" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="13" endLine="4" endColumn="163" document="1"/>
+                <entry offset="0x1c" startLine="5" startColumn="5" endLine="5" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x1d">
                 <currentnamespace name=""/>
@@ -91,6 +94,9 @@ End Class
 
             c.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="C`1" name="F">
             <customDebugInfo>
@@ -107,9 +113,9 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="12"/>
-                <entry offset="0x1" startLine="11" startColumn="13" endLine="11" endColumn="65"/>
-                <entry offset="0x3" startLine="14" startColumn="9" endLine="14" endColumn="30"/>
+                <entry offset="0x0" startLine="10" startColumn="5" endLine="10" endColumn="12" document="1"/>
+                <entry offset="0x1" startLine="11" startColumn="13" endLine="11" endColumn="65" document="1"/>
+                <entry offset="0x3" startLine="14" startColumn="9" endLine="14" endColumn="30" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x9">
                 <namespace name="System" importlevel="file"/>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBUsingTests.vb
@@ -41,6 +41,9 @@ End Class
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(source, TestOptions.DebugExe)
             compilation.VerifyPdb("C1.Main",
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main">
@@ -52,19 +55,19 @@ End Class
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="16" startColumn="5" endLine="16" endColumn="29"/>
-                <entry offset="0x1" startLine="18" startColumn="9" endLine="18" endColumn="101"/>
-                <entry offset="0x2" startLine="18" startColumn="15" endLine="18" endColumn="41"/>
-                <entry offset="0x8" startLine="18" startColumn="43" endLine="18" endColumn="69"/>
-                <entry offset="0xe" startLine="18" startColumn="71" endLine="18" endColumn="101"/>
-                <entry offset="0x10" startLine="19" startColumn="13" endLine="19" endColumn="47"/>
-                <entry offset="0x1b" hidden="true"/>
-                <entry offset="0x1d" startLine="20" startColumn="9" endLine="20" endColumn="18"/>
-                <entry offset="0x29" hidden="true"/>
-                <entry offset="0x2b" startLine="20" startColumn="9" endLine="20" endColumn="18"/>
-                <entry offset="0x37" hidden="true"/>
-                <entry offset="0x39" startLine="20" startColumn="9" endLine="20" endColumn="18"/>
-                <entry offset="0x45" startLine="21" startColumn="5" endLine="21" endColumn="12"/>
+                <entry offset="0x0" startLine="16" startColumn="5" endLine="16" endColumn="29" document="1"/>
+                <entry offset="0x1" startLine="18" startColumn="9" endLine="18" endColumn="101" document="1"/>
+                <entry offset="0x2" startLine="18" startColumn="15" endLine="18" endColumn="41" document="1"/>
+                <entry offset="0x8" startLine="18" startColumn="43" endLine="18" endColumn="69" document="1"/>
+                <entry offset="0xe" startLine="18" startColumn="71" endLine="18" endColumn="101" document="1"/>
+                <entry offset="0x10" startLine="19" startColumn="13" endLine="19" endColumn="47" document="1"/>
+                <entry offset="0x1b" hidden="true" document="1"/>
+                <entry offset="0x1d" startLine="20" startColumn="9" endLine="20" endColumn="18" document="1"/>
+                <entry offset="0x29" hidden="true" document="1"/>
+                <entry offset="0x2b" startLine="20" startColumn="9" endLine="20" endColumn="18" document="1"/>
+                <entry offset="0x37" hidden="true" document="1"/>
+                <entry offset="0x39" startLine="20" startColumn="9" endLine="20" endColumn="18" document="1"/>
+                <entry offset="0x45" startLine="21" startColumn="5" endLine="21" endColumn="12" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x46">
                 <importsforward declaringType="MyDisposable" methodName="Dispose"/>
@@ -320,6 +323,9 @@ End Namespace
 
             v.VerifyPdb(
 <symbols>
+    <files>
+      <file id="1" name="" language="3a12d0b8-c26c-11d0-b442-00a0244a1dd2" languageVendor="994b45c4-e6e9-11d2-903f-00c04fa302a1" documentType="5a869d0b-6611-11d3-bd2a-0000f80849bd" />
+    </files>
     <methods>
         <method containingType="N1.C" name="M">
             <customDebugInfo>
@@ -328,9 +334,9 @@ End Namespace
                 </encLocalSlotMap>
             </customDebugInfo>
             <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="9" endLine="4" endColumn="23"/>
-                <entry offset="0x1" startLine="5" startColumn="17" endLine="5" endColumn="33"/>
-                <entry offset="0x3" startLine="6" startColumn="9" endLine="6" endColumn="16"/>
+                <entry offset="0x0" startLine="4" startColumn="9" endLine="4" endColumn="23" document="1"/>
+                <entry offset="0x1" startLine="5" startColumn="17" endLine="5" endColumn="33" document="1"/>
+                <entry offset="0x3" startLine="6" startColumn="9" endLine="6" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x4">
                 <defunct name="&amp;PIA"/>
@@ -340,8 +346,8 @@ End Namespace
         </method>
         <method containingType="N2.D" name="M">
             <sequencePoints>
-                <entry offset="0x0" startLine="12" startColumn="9" endLine="12" endColumn="23"/>
-                <entry offset="0x1" startLine="13" startColumn="9" endLine="13" endColumn="16"/>
+                <entry offset="0x0" startLine="12" startColumn="9" endLine="12" endColumn="23" document="1"/>
+                <entry offset="0x1" startLine="13" startColumn="9" endLine="13" endColumn="16" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x2">
                 <defunct name="&amp;PIA"/>


### PR DESCRIPTION
Update Microsoft.DiaSymReader.Native to 1.7.0-beta-25631. This new build supports Windows PDB determinism. It also fixes an bug in SymReader that caused it to skip documents with an empty name when reading them. The SymWriter wrote them into the PDB but the reader wasn't able to read them back. As a consequence it was possible for sequence points to point to a non-existing document. Although this only affects tests since in real projects there are no documents with an empty name, it makes round-trip testing of conversion between Windows and Portable PDBs possible. 