### PR TITLE
VB: Fix formatting on nullable tuple

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
@@ -285,6 +285,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                     End If
             End Select
 
+            ' nullable ? case
+            If FormattingHelpers.IsQuestionInNullableType(currentToken) Then
+                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
+            End If
+
             ' { *
             ' ( *
             ' ) *
@@ -326,11 +331,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             If (previousToken.Kind = SyntaxKind.PlusToken OrElse
                 previousToken.Kind = SyntaxKind.MinusToken) AndAlso
                 TypeOf previousToken.Parent Is UnaryExpressionSyntax Then
-                Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
-            End If
-
-            ' nullable ? case
-            If FormattingHelpers.IsQuestionInNullableType(currentToken) Then
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -4368,6 +4368,24 @@ End Module
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
+        <WorkItem(21923, "https://github.com/dotnet/roslyn/issues/21923")>
+        Public Async Function FormatNullableTuple() As Task
+            Dim code = <Code>
+Class C
+    Dim x As (Integer, Integer)  ?
+End Class
+</Code>
+
+            Dim expected = <Code>
+Class C
+    Dim x As (Integer, Integer)?
+End Class
+</Code>
+
+            Await AssertFormatLf2CrLfAsync(code.Value, expected.Value)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
         <WorkItem(2822, "https://github.com/dotnet/roslyn/issues/2822")>
         Public Async Function FormatOmittedArgument() As Task
             Dim code = <Code>


### PR DESCRIPTION
Illustration of the problem:

![image](https://user-images.githubusercontent.com/12466233/30086808-0242a25a-9252-11e7-937a-22a1c7e914ba.png)

![image](https://user-images.githubusercontent.com/12466233/30086848-283678ba-9252-11e7-9a94-2d24afc652e7.png)

The fix is to move the formatting rule for the question mark in a nullable *before* the rule for a token following a closing paren.

Fixes https://github.com/dotnet/roslyn/issues/21923

@dotnet/roslyn-ide for review. Thanks