### PR TITLE
Add SupportsSyntaxTree check in DefaultDiagnosticAnalyzerService's AnalyzeSyntaxAsync

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // right now, there is no way to observe diagnostics for closed file.
                 if (!_workspace.IsDocumentOpen(document.Id) ||
-                    !_workspace.Options.GetOption(InternalRuntimeDiagnosticOptions.Syntax))
+                    !_workspace.Options.GetOption(InternalRuntimeDiagnosticOptions.Syntax) ||
+                    !document.SupportsSyntaxTree)
                 {
                     return;
                 }


### PR DESCRIPTION
Add SupportsSyntaxTree check in DefaultDiagnosticAnalyzerService's AnalyzeSyntaxAsync
(required for TypeScript in the remote LS scenario)

TS documents do not support syntax tree so the call to document.GetSyntaxTreeAsync leads to an exception. Adding the SupportsSyntaxTree check here similar to what we've done in other places for TS. 

In the non-remote workspace TSLS scenario this code path is never hit so there will be some additional investigation required to figure out why the DefaultDiagnosticAnalyzerService is being invoked here. This change is being made to unblock scenarios in the interim.
