### PR TITLE
Fix issue with merging parameters

### DIFF
--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             var builder = new CommandLineBuilderExtension();
             builder.AppendFileNameIfNotNull(pathToTool);
-            builder.AppendTextUnquoted(commandLineArgs);
+            builder.AppendTextUnquoted(" " + commandLineArgs);
             return builder.ToString();
         }
     }

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -66,7 +66,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             var builder = new CommandLineBuilderExtension();
             builder.AppendFileNameIfNotNull(pathToTool);
-            builder.AppendTextUnquoted(" " + commandLineArgs);
+            builder.AppendTextUnquoted(" ");
+            builder.AppendTextUnquoted(commandLineArgs);
             return builder.ToString();
         }
     }


### PR DESCRIPTION
After merging https://github.com/dotnet/roslyn/pull/21673 and integrating it with the CLI, I discovered that `AppendTextUnquoted` has this documentation: `This method does not append a space to the command line before executing.`. This causes the first flag to merge with the `pathToTool`. (This doesn't happen on Windows, as the flag starts with `/`, and `one/two` is processed with `/two` as a flag, even though there's no space)

Ping @agocke @dotnet/roslyn-infrastructure - I don't think this is a full-out build break, as it should only be hit when `DOTNET_HOST_PATH` is defined (which won't happen until https://github.com/dotnet/cli/pull/7311 is merged), but I should probably have the squirrel regardless 😅)