### PR TITLE
Do not fail to place breakpoint in presence of syntax errors

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -287,8 +287,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                         {
                             // If we have a non-empty span then it means that the debugger is asking us to adjust an
                             // existing span.  In Everett we didn't do this so we had some good and some bad
-                            // behavior.  For example if you had a breakpoint on: "int i;" and you changed it to "int
-                            // i = 4;", then the breakpoint wouldn't adjust.  That was bad.  However, if you had the
+                            // behavior.  For example if you had a breakpoint on: "int i = 1;" and you changed it to "int
+                            // i = 1, j = 2;", then the breakpoint wouldn't adjust.  That was bad.  However, if you had the
                             // breakpoint on an open or close curly brace then it would always "stick" to that brace
                             // which was good.
                             //
@@ -308,7 +308,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                                 var tree = document.GetSyntaxTreeSynchronously(cancellationToken);
                                 if (tree.GetDiagnostics(cancellationToken).Any(d => d.Severity == DiagnosticSeverity.Error))
                                 {
-                                    return VSConstants.E_FAIL;
+                                    // Keep the span as is.
+                                    return VSConstants.S_OK;
                                 }
                             }
 
@@ -325,7 +326,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                         // NOTE(cyrusn): we need to wait here because ValidateBreakpointLocation is
                         // synchronous.  In the future, it would be nice for the debugger to provide
                         // an async entry point for this.
-                        var breakpoint = _breakpointService.ResolveBreakpointAsync(document, new CodeAnalysis.Text.TextSpan(point.Position, length), cancellationToken).WaitAndGetResult(cancellationToken);
+                        var breakpoint = _breakpointService.ResolveBreakpointAsync(document, new TextSpan(point.Position, length), cancellationToken).WaitAndGetResult(cancellationToken);
                         if (breakpoint == null)
                         {
                             // There should *not* be a breakpoint here.  E_FAIL to let the debugger know


### PR DESCRIPTION
Fixes VSO bug [417424](https://devdiv.visualstudio.com/DevDiv/_workitems?id=417424&_a=edit): No breakpoint could be placed in code with a syntax error.

```C#
class Program
{
    static void Main()
    {
        syntax error
    } // place breakpoint here
}
```

The breakpoint was calculated correctly but then the debugger called the language service again to adjust the BP (not sure why that happens even when there are no source changes) and we reported an E_FAIL if there were syntax errors. Instead, do not adjust the existing breakpoint span in presence of errors, return S_OK and keep it as is.