### PR TITLE
Type inference with nullable reference types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination: conversion.BestUserDefinedConversionAnalysis.FromType,
                 diagnostics: diagnostics);
 
-            TypeSymbol conversionParameterType = conversion.BestUserDefinedConversionAnalysis.Operator.ParameterTypes[0];
+            TypeSymbol conversionParameterType = conversion.BestUserDefinedConversionAnalysis.Operator.ParameterTypes[0].TypeSymbol;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
             if (conversion.BestUserDefinedConversionAnalysis.Kind == UserDefinedConversionAnalysisKind.ApplicableInNormalForm &&
@@ -366,14 +366,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arguments = sourceTuple.Arguments;
             var convertedArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Length);
 
-            ImmutableArray<TypeSymbol> targetElementTypes = targetType.GetElementTypesOfTupleOrCompatible();
+            var targetElementTypes = targetType.GetElementTypesOfTupleOrCompatible();
             Debug.Assert(targetElementTypes.Length == arguments.Length, "converting a tuple literal to incompatible type?");
             var underlyingConversions = conversionWithoutNullable.UnderlyingConversions;
 
             for (int i = 0; i < arguments.Length; i++)
             {
                 var argument = arguments[i];
-                var destType = targetElementTypes[i];
+                var destType = targetElementTypes[i].TypeSymbol;
                 var elementConversion = underlyingConversions[i];
 
                 convertedArguments.Add(CreateConversion(argument.Syntax, argument, elementConversion, isCast, destType, diagnostics));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // constructs the final tuple type and checks constraints.
             return TupleTypeSymbol.Create(
                 locationOpt: null,
-                elementTypes: typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations),
+                elementTypes: typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations), // PROTOTYPE(NullableTypeReferences): Not including nullability.
                 elementLocations: default(ImmutableArray<Location>),
                 elementNames: default(ImmutableArray<string>),
                 compilation: compilation,
@@ -509,25 +509,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             int count = variables.Count;
             var valuesBuilder = ArrayBuilder<BoundExpression>.GetInstance(count);
-            var typesBuilder = ArrayBuilder<TypeSymbol>.GetInstance(count);
+            var typesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(count);
             var locationsBuilder = ArrayBuilder<Location>.GetInstance(count);
             var namesBuilder = ArrayBuilder<string>.GetInstance(count);
+            bool includeNullability = Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
+
             foreach (var variable in variables)
             {
+                BoundExpression value;
                 if (variable.HasNestedVariables)
                 {
-                    var nestedTuple = DeconstructionVariablesAsTuple(variable.Syntax, variable.NestedVariables, diagnostics, ignoreDiagnosticsFromTuple);
-                    valuesBuilder.Add(nestedTuple);
-                    typesBuilder.Add(nestedTuple.Type);
+                    value = DeconstructionVariablesAsTuple(variable.Syntax, variable.NestedVariables, diagnostics, ignoreDiagnosticsFromTuple);
                     namesBuilder.Add(null);
                 }
                 else
                 {
-                    var single = variable.Single;
-                    valuesBuilder.Add(single);
-                    typesBuilder.Add(single.Type);
-                    namesBuilder.Add(ExtractDeconstructResultElementName(single));
+                    value = variable.Single;
+                    namesBuilder.Add(ExtractDeconstructResultElementName(value));
                 }
+                valuesBuilder.Add(value);
+                typesBuilder.Add(value.GetTypeAndNullability(includeNullability));
                 locationsBuilder.Add(variable.Syntax.Location);
             }
 
@@ -540,7 +541,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var inferredPositions = tupleNames.SelectAsArray(n => n != null);
 
             var type = TupleTypeSymbol.Create(syntax.Location,
-                typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations),
+                typesBuilder.ToImmutableAndFree(),
                 locationsBuilder.ToImmutableAndFree(),
                 tupleNames, this.Compilation,
                 shouldCheckConstraints: !ignoreDiagnosticsFromTuple,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (type.IsTupleType)
             {
                 // tuple literal such as `(1, 2)`, `(null, null)`, `(x.P, y.M())`
-                tupleOrDeconstructedTypes = type.TupleElementTypes;
+                tupleOrDeconstructedTypes = type.TupleElementTypes.SelectAsArray(TypeMap.AsTypeSymbol);
                 SetInferredTypes(variables, tupleOrDeconstructedTypes, diagnostics);
 
                 if (variables.Count != tupleOrDeconstructedTypes.Length)
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // constructs the final tuple type and checks constraints.
             return TupleTypeSymbol.Create(
                 locationOpt: null,
-                elementTypes: typesBuilder.ToImmutableAndFree(),
+                elementTypes: typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations),
                 elementLocations: default(ImmutableArray<Location>),
                 elementNames: default(ImmutableArray<string>),
                 compilation: compilation,
@@ -540,7 +540,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var inferredPositions = tupleNames.SelectAsArray(n => n != null);
 
             var type = TupleTypeSymbol.Create(syntax.Location,
-                typesBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
+                typesBuilder.ToImmutableAndFree().SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations),
+                locationsBuilder.ToImmutableAndFree(),
                 tupleNames, this.Compilation,
                 shouldCheckConstraints: !ignoreDiagnosticsFromTuple,
                 errorPositions: disallowInferredNames ? inferredPositions : default,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -803,6 +803,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
             var elementTypes = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(arguments.Count);
             var elementLocations = ArrayBuilder<Location>.GetInstance(arguments.Count);
+            // PROTOTYPE(NullableReferenceTypes): Could we track nullability always
+            // (even in C#7) but only report warnings when the feature is enabled?
             bool includeNullability = Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
 
             // prepare names

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -803,8 +803,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
             var elementTypes = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(arguments.Count);
             var elementLocations = ArrayBuilder<Location>.GetInstance(arguments.Count);
-            // PROTOTYPE(NullableReferenceTypes): Could we track nullability always
-            // (even in C#7) but only report warnings when the feature is enabled?
             bool includeNullability = Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
 
             // prepare names

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var op = operators[i];
                     if (op.ParameterCount == 1 && op.DeclaredAccessibility == Accessibility.Public)
                     {
-                        var conversion = this.Conversions.ClassifyConversionFromType(argumentType, op.ParameterTypes[0], ref useSiteDiagnostics);
+                        var conversion = this.Conversions.ClassifyConversionFromType(argumentType, op.ParameterTypes[0].TypeSymbol, ref useSiteDiagnostics);
                         if (conversion.IsImplicit)
                         {
                             @operator = op;
@@ -3543,7 +3543,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 bool hadMultipleCandidates;
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                TypeSymbol bestType = BestTypeInferrer.InferBestTypeForConditionalOperator(trueExpr, falseExpr, this.Conversions, out hadMultipleCandidates, ref useSiteDiagnostics);
+                var bestType = BestTypeInferrer.InferBestTypeForConditionalOperator(
+                    trueExpr,
+                    falseExpr,
+                    this.Conversions,
+                    this.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking),
+                    out hadMultipleCandidates,
+                    ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
 
                 if ((object)bestType == null)
@@ -3576,13 +3582,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (bestType.IsErrorType())
                 {
-                    type = bestType;
+                    type = bestType.TypeSymbol;
                     hasErrors = true;
                 }
                 else
                 {
-                    trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
-                    falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
+                    trueExpr = GenerateConversionForAssignment(bestType.TypeSymbol, trueExpr, diagnostics);
+                    falseExpr = GenerateConversionForAssignment(bestType.TypeSymbol, falseExpr, diagnostics);
 
                     if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
                     {
@@ -3593,7 +3599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        type = bestType;
+                        type = bestType.TypeSymbol;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hasErrors = true;
                     }
 
-                    if (!declTypeOpt.TypeSymbol.IsErrorType())
+                    if (!declTypeOpt.IsErrorType())
                     {
                         if (declTypeOpt.IsStatic)
                         {
@@ -2627,7 +2627,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int i = 0; i < anonymousFunction.ParameterCount; ++i)
                 {
-                    if (anonymousFunction.ParameterType(i).TypeSymbol.IsErrorType())
+                    if (anonymousFunction.ParameterType(i).IsErrorType())
                     {
                         return;
                     }
@@ -2824,7 +2824,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (operand.Kind == BoundKind.TupleLiteral)
             {
                 var tuple = (BoundTupleLiteral)operand;
-                var targetElementTypes = default(ImmutableArray<TypeSymbol>);
+                var targetElementTypes = default(ImmutableArray<TypeSymbolWithAnnotations>);
 
                 // If target is a tuple or compatible type with the same number of elements,
                 // report errors for tuple arguments that failed to convert, which would be more useful.
@@ -2903,7 +2903,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void GenerateImplicitConversionErrorsForTupleLiteralArguments(
             DiagnosticBag diagnostics,
             ImmutableArray<BoundExpression> tupleArguments,
-            ImmutableArray<TypeSymbol> targetElementTypes)
+            ImmutableArray<TypeSymbolWithAnnotations> targetElementTypes)
         {
             var argLength = tupleArguments.Length;
 
@@ -2917,7 +2917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < targetElementTypes.Length; i++)
             {
                 var argument = tupleArguments[i];
-                var targetElementType = targetElementTypes[i];
+                var targetElementType = targetElementTypes[i].TypeSymbol;
 
                 var elementConversion = Conversions.ClassifyImplicitConversionFromExpression(argument, targetElementType, ref usDiagsUnused);
                 if (!elementConversion.IsValid)
@@ -3621,7 +3621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (local?.DeclarationKind == LocalDeclarationKind.CatchVariable)
             {
-                Debug.Assert(local.Type.TypeSymbol.IsErrorType() || (local.Type.TypeSymbol == type));
+                Debug.Assert(local.Type.IsErrorType() || (local.Type.TypeSymbol == type));
 
                 // Check for local variable conflicts in the *enclosing* binder, not the *current* binder;
                 // obviously we will find a local of the given name in the current binder.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -440,7 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private TypeSymbol BindTupleType(TupleTypeSyntax syntax, DiagnosticBag diagnostics)
         {
             int numElements = syntax.Elements.Count;
-            var types = ArrayBuilder<TypeSymbol>.GetInstance(numElements);
+            var types = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(numElements);
             var locations = ArrayBuilder<Location>.GetInstance(numElements);
             ArrayBuilder<string> elementNames = null;
 
@@ -453,7 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var argumentSyntax = syntax.Elements[i];
 
                 var argumentType = BindType(argumentSyntax.Type, diagnostics);
-                types.Add(argumentType.TypeSymbol);
+                types.Add(argumentType);
 
                 string name =  null;
                 SyntaxToken nameToken = argumentSyntax.Identifier;
@@ -494,8 +494,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ImmutableArray<TypeSymbol> typesArray = types.ToImmutableAndFree();
-            ImmutableArray<Location> locationsArray = locations.ToImmutableAndFree();
+            var typesArray = types.ToImmutableAndFree();
+            var locationsArray = locations.ToImmutableAndFree();
 
             if (typesArray.Length < 2)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:    Finally, X is fixed and, if successful, the resulting type S is the resulting best common type for the expressions.
             // SPEC:    If no such S exists, the expressions have no best common type.
 
+            // All non-null types are candidates for best type inference.
             var candidateTypes = new HashSet<TypeSymbolWithAnnotations>(TypeSymbolWithAnnotations.EqualsComparer.Instance);
             foreach (BoundExpression expr in exprs)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -187,6 +187,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // If any of the types are null, the result should be nullable.
+            // PROTOTYPE(NullableReferenceTypes): Should ignore untyped
+            // expressions such as unbound lambdas and typeless tuples.
+            // See StaticNullChecking.LocalVar_Array_02 test.
             if (includeNullability &&
                 types.Any(t => (object)t == null) &&
                 best.IsReferenceType &&

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // PROTOTYPE(NullableReferenceTypes): Should be a two-pass approach
         // similar to MethodTypeInferrer which compares with nullability and
-        // without, and prefers the result with nullability.
+        // without and prefers the result with nullability.
         private TypeSymbolWithAnnotations GetBestType(ImmutableArray<TypeSymbolWithAnnotations> types, bool includeNullability, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // This code assumes that the types in the list are unique. 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -16,17 +17,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             _conversions = conversions;
         }
 
-        public static TypeSymbol InferBestType(ImmutableArray<TypeSymbol> types, Conversions conversions, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public static TypeSymbolWithAnnotations InferBestType(ImmutableArray<TypeSymbolWithAnnotations> types, Conversions conversions, bool includeNullability, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             var inferrer = new BestTypeInferrer(conversions);
-            return inferrer.GetBestType(types, ref useSiteDiagnostics);
+            return inferrer.GetBestType(types, includeNullability, ref useSiteDiagnostics);
         }
 
         /// <remarks>
         /// This method finds the best common type of a set of expressions as per section 7.5.2.14 of the specification.
         /// NOTE: If some or all of the expressions have error types, we return error type as the inference result.
         /// </remarks>
-        public static TypeSymbol InferBestType(ImmutableArray<BoundExpression> exprs, Conversions conversions, out bool hadMultipleCandidates, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public static TypeSymbolWithAnnotations InferBestType(ImmutableArray<BoundExpression> exprs, Conversions conversions, bool includeNullability, out bool hadMultipleCandidates, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // SPEC:    7.5.2.14 Finding the best common type of a set of expressions
             // SPEC:    In some cases, a common type needs to be inferred for a set of expressions. In particular, the element types of implicitly typed arrays and
@@ -38,11 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:    Finally, X is fixed and, if successful, the resulting type S is the resulting best common type for the expressions.
             // SPEC:    If no such S exists, the expressions have no best common type.
 
-            // All non-null types are candidates for best type inference.
-            HashSet<TypeSymbol> candidateTypes = new HashSet<TypeSymbol>();
+            var candidateTypes = new HashSet<TypeSymbolWithAnnotations>(TypeSymbolWithAnnotations.EqualsComparer.Instance);
             foreach (BoundExpression expr in exprs)
             {
-                TypeSymbol type = expr.Type;
+                var type = expr.GetTypeAndNullability(includeNullability);
 
                 if ((object)type != null)
                 {
@@ -51,22 +51,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                         hadMultipleCandidates = false;
                         return type;
                     }
-
-                    candidateTypes.Add(type);
                 }
+
+                candidateTypes.Add(type);
             }
 
             hadMultipleCandidates = candidateTypes.Count > 1;
 
             // Perform best type inference on candidate types.
-            return InferBestType(candidateTypes.AsImmutableOrEmpty(), conversions, ref useSiteDiagnostics);
+            return InferBestType(candidateTypes.AsImmutableOrEmpty(), conversions, includeNullability, ref useSiteDiagnostics);
         }
 
         /// <remarks>
         /// This method implements best type inference for the conditional operator ?:.
         /// NOTE: If either expression is an error type, we return error type as the inference result.
         /// </remarks>
-        public static TypeSymbol InferBestTypeForConditionalOperator(BoundExpression expr1, BoundExpression expr2, Conversions conversions, out bool hadMultipleCandidates, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public static TypeSymbolWithAnnotations InferBestTypeForConditionalOperator(BoundExpression expr1, BoundExpression expr2, Conversions conversions, bool includeNullability, out bool hadMultipleCandidates, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // SPEC:    The second and third operands, x and y, of the ?: operator control the type of the conditional expression. 
             // SPEC:    •	If x has type X and y has type Y then
@@ -77,9 +77,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:    •	Otherwise, no expression type can be determined, and a compile-time error occurs.
 
             // A type is a candidate if all expressions are convertible to that type.
-            ArrayBuilder<TypeSymbol> candidateTypes = ArrayBuilder<TypeSymbol>.GetInstance();
+            var candidateTypes = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
 
-            TypeSymbol type1 = expr1.Type;
+            var type1 = expr1.GetTypeAndNullability(includeNullability);
 
             if ((object)type1 != null)
             {
@@ -90,15 +90,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return type1;
                 }
 
-                if (conversions.ClassifyImplicitConversionFromExpression(expr2, type1, ref useSiteDiagnostics).Exists)
+                // PROTOTYPE(NullableReferenceTypes): Consider nullability in conversion.
+                if (conversions.ClassifyImplicitConversionFromExpression(expr2, type1.TypeSymbol, ref useSiteDiagnostics).Exists)
                 {
                     candidateTypes.Add(type1);
                 }
             }
 
-            TypeSymbol type2 = expr2.Type;
+            var type2 = expr2.GetTypeAndNullability(includeNullability);
 
-            if ((object)type2 != null && type2 != type1)
+            if ((object)type2 != null && !type2.Equals(type1, TypeCompareKind.ConsiderEverything))
             {
                 if (type2.IsErrorType())
                 {
@@ -107,7 +108,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return type2;
                 }
 
-                if (conversions.ClassifyImplicitConversionFromExpression(expr1, type2, ref useSiteDiagnostics).Exists)
+                // PROTOTYPE(NullableReferenceTypes): Consider nullability in conversion.
+                if (conversions.ClassifyImplicitConversionFromExpression(expr1, type2.TypeSymbol, ref useSiteDiagnostics).Exists)
                 {
                     candidateTypes.Add(type2);
                 }
@@ -115,10 +117,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             hadMultipleCandidates = candidateTypes.Count > 1;
 
-            return InferBestType(candidateTypes.ToImmutableAndFree(), conversions, ref useSiteDiagnostics);
+            return InferBestType(candidateTypes.ToImmutableAndFree(), conversions, includeNullability, ref useSiteDiagnostics);
         }
 
-        private TypeSymbol GetBestType(ImmutableArray<TypeSymbol> types, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        // PROTOTYPE(NullableReferenceTypes): Should be a two-pass approach
+        // similar to MethodTypeInferrer which compares with nullability and
+        // without, and prefers the result with nullability.
+        private TypeSymbolWithAnnotations GetBestType(ImmutableArray<TypeSymbolWithAnnotations> types, bool includeNullability, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // This code assumes that the types in the list are unique. 
 
@@ -136,11 +141,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return types[0];
             }
 
-            TypeSymbol best = null;
+            TypeSymbolWithAnnotations best = null;
             int bestIndex = -1;
             for(int i = 0; i < types.Length; i++)
             {
-                TypeSymbol type = types[i];
+                var type = types[i];
                 if ((object)best == null)
                 {
                     best = type;
@@ -171,13 +176,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             // that every type *before* best was also worse.
             for (int i = 0; i < bestIndex; i++)
             {
-                TypeSymbol type = types[i];
-                TypeSymbol better = Better(best, type, ref useSiteDiagnostics);
+                var type = types[i];
+                var better = Better(best, type, ref useSiteDiagnostics);
 
-                if (better != best)
+                if (!best.Equals(better, TypeCompareKind.ConsiderEverything))
                 {
                     return null;
                 }
+            }
+
+            // If any of the types are null, the result should be nullable.
+            if (includeNullability &&
+                types.Any(t => (object)t == null) &&
+                best.IsReferenceType &&
+                best.IsNullable == false)
+            {
+                best = best.AsNullableReferenceType();
             }
 
             return best;
@@ -186,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Returns the better type amongst the two, with some possible modifications (dynamic/object or tuple names).
         /// </summary>
-        private TypeSymbol Better(TypeSymbol type1, TypeSymbol type2, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private TypeSymbolWithAnnotations Better(TypeSymbolWithAnnotations type1, TypeSymbolWithAnnotations type2, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // Anything is better than an error sym.
             if (type1.IsErrorType())
@@ -199,8 +213,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return type1;
             }
 
-            var t1tot2 = _conversions.ClassifyImplicitConversionFromType(type1, type2, ref useSiteDiagnostics).Exists;
-            var t2tot1 = _conversions.ClassifyImplicitConversionFromType(type2, type1, ref useSiteDiagnostics).Exists;
+            var t1tot2 = _conversions.ClassifyImplicitConversionFromType(type1.TypeSymbol, type2.TypeSymbol, ref useSiteDiagnostics).Exists;
+            var t2tot1 = _conversions.ClassifyImplicitConversionFromType(type2.TypeSymbol, type1.TypeSymbol, ref useSiteDiagnostics).Exists;
 
             if (t1tot2 && t2tot1)
             {
@@ -216,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (type1.Equals(type2, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
-                    return MethodTypeInferrer.MergeTupleNames(MethodTypeInferrer.MergeDynamic(type1, type2, _conversions.CorLibrary), type2);
+                    return MethodTypeInferrer.Merge(type1, type2, _conversions.CorLibrary);
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1809,7 +1809,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Conversion.NoConversion;
             }
 
-            ImmutableArray<TypeSymbol> targetElementTypes = destination.GetElementTypesOfTupleOrCompatible();
+            var targetElementTypes = destination.GetElementTypesOfTupleOrCompatible();
             Debug.Assert(arguments.Length == targetElementTypes.Length);
 
             // check arguments against flattened list of target element types 
@@ -1817,7 +1817,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < arguments.Length; i++)
             {
                 var argument = arguments[i];
-                var result = classifyConversion(this, argument, targetElementTypes[i], ref useSiteDiagnostics, arg);
+                var result = classifyConversion(this, argument, targetElementTypes[i].TypeSymbol, ref useSiteDiagnostics, arg);
                 if (!result.Exists)
                 {
                     argumentConversions.Free();
@@ -1860,8 +1860,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ClassifyConversionFromTypeDelegate classifyConversion,
             bool arg)
         {
-            ImmutableArray<TypeSymbol> sourceTypes;
-            ImmutableArray<TypeSymbol> destTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> sourceTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> destTypes;
 
             if (!source.TryGetElementTypesIfTupleOrCompatible(out sourceTypes) ||
                 !destination.TryGetElementTypesIfTupleOrCompatible(out destTypes) ||
@@ -1873,7 +1873,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var nestedConversions = ArrayBuilder<Conversion>.GetInstance(sourceTypes.Length);
             for (int i = 0; i < sourceTypes.Length; i++)
             {
-                var conversion = classifyConversion(this, sourceTypes[i], destTypes[i], ref useSiteDiagnostics, arg);
+                var conversion = classifyConversion(this, sourceTypes[i].TypeSymbol, destTypes[i].TypeSymbol, ref useSiteDiagnostics, arg);
                 if (!conversion.Exists)
                 {
                     nestedConversions.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedExplicitConversions.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                TypeSymbol convertsFrom = op.ParameterTypes[0];
+                TypeSymbol convertsFrom = op.ParameterTypes[0].TypeSymbol;
                 TypeSymbol convertsTo = op.ReturnType.TypeSymbol;
                 Conversion fromConversion = EncompassingExplicitConversion(sourceExpression, source, convertsFrom, ref useSiteDiagnostics);
                 Conversion toConversion = EncompassingExplicitConversion(null, convertsTo, target, ref useSiteDiagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     }
 
-                    TypeSymbol convertsFrom = op.ParameterTypes[0];
+                    TypeSymbol convertsFrom = op.ParameterTypes[0].TypeSymbol;
                     TypeSymbol convertsTo = op.ReturnType.TypeSymbol;
                     Conversion fromConversion = EncompassingImplicitConversion(sourceExpression, source, convertsFrom, ref useSiteDiagnostics);
                     Conversion toConversion = allowAnyTarget ? Conversion.Identity :
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static int LiftingCount(UserDefinedConversionAnalysis conv)
         {
             int count = 0;
-            if (conv.FromType != conv.Operator.ParameterTypes[0])
+            if (conv.FromType != conv.Operator.ParameterTypes[0].TypeSymbol)
             {
                 count += 1;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -711,8 +711,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                TypeSymbol leftOperandType = op.ParameterTypes[0];
-                TypeSymbol rightOperandType = op.ParameterTypes[1];
+                TypeSymbol leftOperandType = op.ParameterTypes[0].TypeSymbol;
+                TypeSymbol rightOperandType = op.ParameterTypes[1].TypeSymbol;
                 TypeSymbol resultType = op.ReturnType.TypeSymbol;
 
                 operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UserDefined | kind, leftOperandType, rightOperandType, resultType, op));

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                TypeSymbol operandType = op.ParameterTypes[0];
+                TypeSymbol operandType = op.ParameterTypes[0].TypeSymbol;
                 TypeSymbol resultType = op.ReturnType.TypeSymbol;
 
                 operators.Add(new UnaryOperatorSignature(UnaryOperatorKind.UserDefined | kind, operandType, resultType, op));

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -87,14 +87,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ConversionsBase _conversions;
         private readonly ImmutableArray<TypeParameterSymbol> _methodTypeParameters;
         private readonly NamedTypeSymbol _constructedContainingTypeOfMethod;
-        private readonly ImmutableArray<TypeSymbol> _formalParameterTypes;
+        private readonly ImmutableArray<TypeSymbolWithAnnotations> _formalParameterTypes;
         private readonly ImmutableArray<RefKind> _formalParameterRefKinds;
         private readonly ImmutableArray<BoundExpression> _arguments;
+        private readonly bool _includeNullability;
 
-        private readonly TypeSymbol[] _fixedResults;
-        private readonly HashSet<TypeSymbol>[] _exactBounds;
-        private readonly HashSet<TypeSymbol>[] _upperBounds;
-        private readonly HashSet<TypeSymbol>[] _lowerBounds;
+        private readonly TypeSymbolWithAnnotations[] _fixedResults;
+        private readonly HashSet<TypeSymbolWithAnnotations>[] _exactBounds;
+        private readonly HashSet<TypeSymbolWithAnnotations>[] _upperBounds;
+        private readonly HashSet<TypeSymbolWithAnnotations>[] _lowerBounds;
         private Dependency[,] _dependencies; // Initialized lazily
         private bool _dependenciesDirty;
 
@@ -111,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to inferred type arguments.
 
             NamedTypeSymbol constructedContainingTypeOfMethod,
-            ImmutableArray<TypeSymbol> formalParameterTypes,
+            ImmutableArray<TypeSymbolWithAnnotations> formalParameterTypes,
 
             // We have some unusual requirements for the types that flow into the inference engine.
             // Consider the following inference problems:
@@ -235,7 +236,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 constructedContainingTypeOfMethod,
                 formalParameterTypes,
                 formalParameterRefKinds,
-                arguments);
+                arguments,
+                binder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking));
             return inferrer.InferTypeArgs(binder, ref useSiteDiagnostics);
         }
 
@@ -252,9 +254,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConversionsBase conversions,
             ImmutableArray<TypeParameterSymbol> methodTypeParameters,
             NamedTypeSymbol constructedContainingTypeOfMethod,
-            ImmutableArray<TypeSymbol> formalParameterTypes,
+            ImmutableArray<TypeSymbolWithAnnotations> formalParameterTypes,
             ImmutableArray<RefKind> formalParameterRefKinds,
-            ImmutableArray<BoundExpression> arguments)
+            ImmutableArray<BoundExpression> arguments,
+            bool includeNullability)
         {
             _conversions = conversions;
             _methodTypeParameters = methodTypeParameters;
@@ -262,10 +265,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             _formalParameterTypes = formalParameterTypes;
             _formalParameterRefKinds = formalParameterRefKinds;
             _arguments = arguments;
-            _fixedResults = new TypeSymbol[methodTypeParameters.Length];
-            _exactBounds = new HashSet<TypeSymbol>[methodTypeParameters.Length];
-            _upperBounds = new HashSet<TypeSymbol>[methodTypeParameters.Length];
-            _lowerBounds = new HashSet<TypeSymbol>[methodTypeParameters.Length];
+            _includeNullability = includeNullability;
+            _fixedResults = new TypeSymbolWithAnnotations[methodTypeParameters.Length];
+            _exactBounds = new HashSet<TypeSymbolWithAnnotations>[methodTypeParameters.Length];
+            _upperBounds = new HashSet<TypeSymbolWithAnnotations>[methodTypeParameters.Length];
+            _lowerBounds = new HashSet<TypeSymbolWithAnnotations>[methodTypeParameters.Length];
             _dependencies = null;
             _dependenciesDirty = false;
         }
@@ -398,20 +402,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     }
                 }
-                _fixedResults[i] = new ExtendedErrorTypeSymbol(_constructedContainingTypeOfMethod, _methodTypeParameters[i].Name, 0, null, false);
+                _fixedResults[i] = TypeSymbolWithAnnotations.Create(new ExtendedErrorTypeSymbol(_constructedContainingTypeOfMethod, _methodTypeParameters[i].Name, 0, null, false));
             }
 
-            // For now erase all notion about nullability of reference types as the algorithm is not taking it into account yet.
-            var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(_fixedResults.Length);
-            foreach (TypeSymbol t in _fixedResults)
-            {
-                var result = eraseNullability ?
-                    TypeSymbolWithAnnotations.Create(t.SetUnknownNullabilityForReferenceTypes(), isNullableIfReferenceType: null) :
-                    TypeSymbolWithAnnotations.Create(t);
-                builder.Add(result);
-            }
-
-            return builder.ToImmutableAndFree();
+            return _fixedResults.AsImmutable();
         }
 
         private bool ValidIndex(int index)
@@ -425,13 +419,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (object)_fixedResults[methodTypeParameterIndex] == null;
         }
 
-        private bool IsUnfixedTypeParameter(TypeSymbol type)
+        private bool IsUnfixedTypeParameter(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert((object)source != null);
+            Debug.Assert((object)target != null);
 
-            if (type.TypeKind != TypeKind.TypeParameter) return false;
+            if (target.TypeKind != TypeKind.TypeParameter) return false;
 
-            TypeParameterSymbol typeParameter = (TypeParameterSymbol)type;
+            if (source.IsNullable == true && target.IsNullable == true)
+            {
+                return false;
+            }
+
+            TypeParameterSymbol typeParameter = (TypeParameterSymbol)target.TypeSymbol;
             int ordinal = typeParameter.Ordinal;
             return ValidIndex(ordinal) &&
                 typeParameter == _methodTypeParameters[ordinal] &&
@@ -450,32 +450,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        private void AddBound(TypeSymbol addedBound, HashSet<TypeSymbol>[] collectedBounds, TypeParameterSymbol methodTypeParameter)
+        private void AddBound(TypeSymbolWithAnnotations addedBound, HashSet<TypeSymbolWithAnnotations>[] collectedBounds, TypeSymbolWithAnnotations methodTypeParameterWithAnnotations)
         {
-            Debug.Assert(IsUnfixedTypeParameter(methodTypeParameter));
+            Debug.Assert(IsUnfixedTypeParameter(addedBound, methodTypeParameterWithAnnotations));
+
+            var methodTypeParameter = (TypeParameterSymbol)methodTypeParameterWithAnnotations.TypeSymbol;
             int methodTypeParameterIndex = methodTypeParameter.Ordinal;
 
             if (collectedBounds[methodTypeParameterIndex] == null)
             {
-                collectedBounds[methodTypeParameterIndex] = new HashSet<TypeSymbol>();
+                collectedBounds[methodTypeParameterIndex] = new HashSet<TypeSymbolWithAnnotations>(TypeSymbolWithAnnotations.EqualsComparer.Instance);
             }
 
             collectedBounds[methodTypeParameterIndex].Add(addedBound);
-        }
-
-        private void AddLowerBound(TypeParameterSymbol methodTypeParameter, TypeSymbol lowerBound)
-        {
-            AddBound(lowerBound, _lowerBounds, methodTypeParameter);
-        }
-
-        private void AddUpperBound(TypeParameterSymbol methodTypeParameter, TypeSymbol upperBound)
-        {
-            AddBound(upperBound, _upperBounds, methodTypeParameter);
-        }
-
-        private void AddExactBound(TypeParameterSymbol methodTypeParameter, TypeSymbol exactBound)
-        {
-            AddBound(exactBound, _exactBounds, methodTypeParameter);
         }
 
         private bool HasBound(int methodTypeParameterIndex)
@@ -500,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var fixedArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(_methodTypeParameters.Length);
             for (int iParam = 0; iParam < _methodTypeParameters.Length; iParam++)
             {
-                fixedArguments.Add(TypeSymbolWithAnnotations.Create(IsUnfixed(iParam) ? _methodTypeParameters[iParam] : _fixedResults[iParam]));
+                fixedArguments.Add(IsUnfixed(iParam) ? TypeSymbolWithAnnotations.Create(_methodTypeParameters[iParam]) : _fixedResults[iParam]);
             }
 
             TypeMap typeMap = new TypeMap(_constructedContainingTypeOfMethod, _methodTypeParameters, fixedArguments.ToImmutableAndFree());
@@ -543,15 +530,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int arg = 0, length = this.NumberArgumentsToProcess; arg < length; arg++)
             {
                 var argument = _arguments[arg];
-
-                bool isExactInference = GetRefKind(arg) != RefKind.None;
-
-                TypeSymbol target = _formalParameterTypes[arg];
-                MakeExplicitParameterTypeInferences(binder, argument, target, isExactInference, ref useSiteDiagnostics);
+                var isNullable = IsNullable(argument);
+                var kind = GetRefKind(arg) == RefKind.None ? ExactOrBoundsKind.LowerBound : ExactOrBoundsKind.Exact;
+                var target = _formalParameterTypes[arg];
+                MakeExplicitParameterTypeInferences(binder, argument, isNullable, target, kind, ref useSiteDiagnostics);
             }
         }
 
-        private void MakeExplicitParameterTypeInferences(Binder binder, BoundExpression argument, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundExpression argument, bool? isNullable, TypeSymbolWithAnnotations target, ExactOrBoundsKind kind, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // If the argument is a TYPEORNAMESPACEERROR and the pSource is an
             // error type, then we want to set it to the generic error type 
@@ -601,22 +587,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (argument.Kind == BoundKind.TupleLiteral)
             {
-                MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, isExactInference, ref useSiteDiagnostics);
+                MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, isNullable, target, kind, ref useSiteDiagnostics);
             }
-            else if (IsReallyAType(source))
+            else
             {
-                if (isExactInference)
+                if (IsReallyAType(source))
                 {
-                    ExactInference(source, target, ref useSiteDiagnostics);
-                }
-                else
-                {
-                    LowerBoundInference(source, target, ref useSiteDiagnostics);
+                    ExactOrBoundsInference(kind, TypeSymbolWithAnnotations.Create(source, isNullable), target, ref useSiteDiagnostics);
                 }
             }
         }
 
-        private void MakeExplicitParameterTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundTupleLiteral argument, bool? isNullable, TypeSymbolWithAnnotations target, ExactOrBoundsKind kind, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // if tuple has a type we will try to match the type as a single input
             // Example:
@@ -625,26 +607,31 @@ namespace Microsoft.CodeAnalysis.CSharp
             var source = argument.Type;
             if (IsReallyAType(source))
             {
-                if (isExactInference)
-                {
-                    // SPEC: * If V is one of the unfixed Xi then U is added to the set of
-                    // SPEC:   exact bounds for Xi.
-                    if (ExactTypeParameterInference(source, target))
-                    {
-                        return;
-                    }
-                }
-                else
-                {
-                    // SPEC: A lower-bound inference from a type U to a type V is made as follows:
+                var sourceWithAnnotations = TypeSymbolWithAnnotations.Create(source, isNullable);
 
-                    // SPEC: * If V is one of the unfixed Xi then U is added to the set of 
-                    // SPEC:   lower bounds for Xi.
+                switch (kind)
+                {
+                    case ExactOrBoundsKind.Exact:
+                        // SPEC: * If V is one of the unfixed Xi then U is added to the set of
+                        // SPEC:   exact bounds for Xi.
+                        if (ExactTypeParameterInference(sourceWithAnnotations, target))
+                        {
+                            return;
+                        }
+                        break;
+                    case ExactOrBoundsKind.LowerBound:
+                        // SPEC: A lower-bound inference from a type U to a type V is made as follows:
 
-                    if (LowerBoundTypeParameterInference(source, target))
-                    {
-                        return;
-                    }
+                        // SPEC: * If V is one of the unfixed Xi then U is added to the set of 
+                        // SPEC:   lower bounds for Xi.
+
+                        if (LowerBoundTypeParameterInference(sourceWithAnnotations, target))
+                        {
+                            return;
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(kind);
                 }
             }
 
@@ -658,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            var destination = (NamedTypeSymbol)target;
+            var destination = (NamedTypeSymbol)target.TypeSymbol;
             var sourceArguments = argument.Arguments;
 
             // check if the type is actually compatible type for a tuple of given cardinality
@@ -678,8 +665,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < sourceArguments.Length; i++)
             {
                 var sourceArgument = sourceArguments[i];
+                bool? sourceIsNullable = IsNullable(sourceArgument);
                 var destType = destTypes[i];
-                MakeExplicitParameterTypeInferences(binder, sourceArgument, destType, isExactInference, ref useSiteDiagnostics);
+                MakeExplicitParameterTypeInferences(binder, sourceArgument, sourceIsNullable, destType, kind, ref useSiteDiagnostics);
             }
         }
 
@@ -796,12 +784,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var formalType = _formalParameterTypes[arg];
                 var argument = _arguments[arg];
-
-                MakeOutputTypeInferences(binder, argument, formalType, ref useSiteDiagnostics);
+                var isNullable = IsNullable(argument);
+                MakeOutputTypeInferences(binder, argument, isNullable, formalType, ref useSiteDiagnostics);
             }
         }
 
-        private void MakeOutputTypeInferences(Binder binder, BoundExpression argument, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeOutputTypeInferences(Binder binder, BoundExpression argument, bool? isNullable, TypeSymbolWithAnnotations formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             if (argument.Kind == BoundKind.TupleLiteral && (object)argument.Type == null)
             {
@@ -809,18 +797,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (HasUnfixedParamInOutputType(argument, formalType) && !HasUnfixedParamInInputType(argument, formalType))
+                if (HasUnfixedParamInOutputType(argument, formalType.TypeSymbol) && !HasUnfixedParamInInputType(argument, formalType.TypeSymbol))
                 {
                     //UNDONE: if (argument->isTYPEORNAMESPACEERROR() && argumentType->IsErrorType())
                     //UNDONE: {
                     //UNDONE:     argumentType = GetTypeManager().GetErrorSym();
                     //UNDONE: }
-                    OutputTypeInference(binder, argument, formalType, ref useSiteDiagnostics);
+                    OutputTypeInference(binder, argument, isNullable, formalType, ref useSiteDiagnostics);
                 }
             }
         }
 
-        private void MakeOutputTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeOutputTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbolWithAnnotations formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             if (formalType.Kind != SymbolKind.NamedType)
             {
@@ -828,7 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            var destination = (NamedTypeSymbol)formalType;
+            var destination = (NamedTypeSymbol)formalType.TypeSymbol;
 
             Debug.Assert(argument.Type == null, "should not need to dig into elements if tuple has natural type");
             var sourceArguments = argument.Arguments;
@@ -845,8 +833,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < sourceArguments.Length; i++)
             {
                 var sourceArgument = sourceArguments[i];
+                bool? sourceIsNullable = IsNullable(sourceArgument);
                 var destType = destTypes[i];
-                MakeOutputTypeInferences(binder, sourceArgument, destType, ref useSiteDiagnostics);
+                MakeOutputTypeInferences(binder, sourceArgument, sourceIsNullable, destType, ref useSiteDiagnostics);
             }
         }
 
@@ -1054,7 +1043,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int iArg = 0, length = this.NumberArgumentsToProcess; iArg < length; iArg++)
             {
-                var formalParameterType = _formalParameterTypes[iArg];
+                var formalParameterType = _formalParameterTypes[iArg].TypeSymbol;
                 var argument = _arguments[iArg];
                 if (DoesInputTypeContain(argument, formalParameterType, _methodTypeParameters[jParam]) &&
                     DoesOutputTypeContain(argument, formalParameterType, _methodTypeParameters[iParam]))
@@ -1277,7 +1266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         ////////////////////////////////////////////////////////////////////////////////
 
-        private void OutputTypeInference(Binder binder, BoundExpression expression, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void OutputTypeInference(Binder binder, BoundExpression expression, bool? isNullable, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(expression != null);
             Debug.Assert((object)target != null);
@@ -1296,13 +1285,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   type Tb and overload resolution of E with the types T1...Tk
             // SPEC:   yields a single method with return type U then a lower-bound
             // SPEC:   inference is made from U to Tb.
-            if (MethodGroupReturnTypeInference(binder, expression, target, ref useSiteDiagnostics))
+            if (MethodGroupReturnTypeInference(binder, expression, target.TypeSymbol, ref useSiteDiagnostics))
             {
                 return;
             }
             // SPEC: * Otherwise, if E is an expression with type U then a lower-bound
             // SPEC:   inference is made from U to T.
-            var sourceType = expression.Type;
+            var sourceType = TypeSymbolWithAnnotations.Create(expression.Type, isNullable);
             if ((object)sourceType != null)
             {
                 LowerBoundInference(sourceType, target, ref useSiteDiagnostics);
@@ -1310,7 +1299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, no inferences are made.
         }
 
-        private bool InferredReturnTypeInference(BoundExpression source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool InferredReturnTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
             Debug.Assert((object)target != null);
@@ -1318,7 +1307,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   T is a delegate type or expression tree with return type Tb
             // SPEC:   then a lower bound inference is made from U to Tb.
 
-            var delegateType = target.GetDelegateType();
+            var delegateType = target.TypeSymbol.GetDelegateType();
             if ((object)delegateType == null)
             {
                 return false;
@@ -1328,7 +1317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // this will be checked earlier.
             Debug.Assert((object)delegateType.DelegateInvokeMethod != null && !delegateType.DelegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types.");
-            var returnType = delegateType.DelegateInvokeMethod.ReturnType.TypeSymbol;
+            var returnType = delegateType.DelegateInvokeMethod.ReturnType;
             if ((object)returnType == null || returnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
@@ -1370,7 +1359,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)delegateType.DelegateInvokeMethod != null && !delegateType.DelegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types");
 
-            TypeSymbol delegateReturnType = delegateType.DelegateInvokeMethod.ReturnType.TypeSymbol;
+            var delegateReturnType = delegateType.DelegateInvokeMethod.ReturnType;
             if ((object)delegateReturnType == null || delegateReturnType.SpecialType == SpecialType.System_Void)
             {
                 return false;
@@ -1390,7 +1379,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            LowerBoundInference(returnType, delegateReturnType, ref useSiteDiagnostics);
+            bool? returnIsNullable = null; // PROTOTYPE(NullableReferenceTypes)
+            LowerBoundInference(TypeSymbolWithAnnotations.Create(returnType, returnIsNullable), delegateReturnType, ref useSiteDiagnostics);
 
             return true;
         }
@@ -1423,7 +1413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         // Explicit parameter type inferences
         //
-        private void ExplicitParameterTypeInference(BoundExpression source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void ExplicitParameterTypeInference(BoundExpression source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(source != null);
             Debug.Assert((object)target != null);
@@ -1447,7 +1437,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            var delegateType = target.GetDelegateType();
+            var delegateType = target.TypeSymbol.GetDelegateType();
             if ((object)delegateType == null)
             {
                 return;
@@ -1474,7 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < size; ++i)
             {
-                ExactInference(anonymousFunction.ParameterType(i).TypeSymbol, delegateParameters[i].Type.TypeSymbol, ref useSiteDiagnostics);
+                ExactInference(anonymousFunction.ParameterType(i), delegateParameters[i].Type, ref useSiteDiagnostics);
             }
         }
 
@@ -1482,7 +1472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         // Exact inferences
         //
-        private void ExactInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void ExactInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -1528,59 +1518,94 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise no inferences are made.
         }
 
-        private bool ExactTypeParameterInference(TypeSymbol source, TypeSymbol target)
+        private bool ExactTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
-            if (IsUnfixedTypeParameter(target))
+            if (IsUnfixedTypeParameter(source, target))
             {
-                AddExactBound((TypeParameterSymbol)target, source);
+                AddBound(source, _exactBounds, target);
                 return true;
             }
             return false;
         }
 
-        private bool ExactArrayInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool ExactArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
             // SPEC: * Otherwise, if U is an array type UE[...] and V is an array type VE[...]
             // SPEC:   of the same rank then an exact inference from UE to VE is made.
-            if (!source.IsArray() || !target.IsArray())
+            if (!source.TypeSymbol.IsArray() || !target.TypeSymbol.IsArray())
             {
                 return false;
             }
 
-            var arraySource = (ArrayTypeSymbol)source;
-            var arrayTarget = (ArrayTypeSymbol)target;
+            var arraySource = (ArrayTypeSymbol)source.TypeSymbol;
+            var arrayTarget = (ArrayTypeSymbol)target.TypeSymbol;
             if (!arraySource.HasSameShapeAs(arrayTarget))
             {
                 return false;
             }
 
-            ExactInference(arraySource.ElementType.TypeSymbol, arrayTarget.ElementType.TypeSymbol, ref useSiteDiagnostics);
+            ExactInference(arraySource.ElementType, arrayTarget.ElementType, ref useSiteDiagnostics);
             return true;
         }
 
-        private bool ExactNullableInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        enum ExactOrBoundsKind
+        {
+            Exact,
+            LowerBound,
+            UpperBound,
+        }
+
+        private void ExactOrBoundsInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            switch (kind)
+            {
+                case ExactOrBoundsKind.Exact:
+                    ExactInference(source, target, ref useSiteDiagnostics);
+                    break;
+                case ExactOrBoundsKind.LowerBound:
+                    LowerBoundInference(source, target, ref useSiteDiagnostics);
+                    break;
+                case ExactOrBoundsKind.UpperBound:
+                    UpperBoundInference(source, target, ref useSiteDiagnostics);
+                    break;
+            }
+        }
+
+        private bool ExactOrBoundsNullableInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
-            if (!source.IsNullableType() || !target.IsNullableType())
+            if (source.IsNullableType() && target.IsNullableType())
             {
-                return false;
+                ExactOrBoundsInference(kind, ((NamedTypeSymbol)source.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics[0], ((NamedTypeSymbol)target.TypeSymbol).TypeArgumentsNoUseSiteDiagnostics[0], ref useSiteDiagnostics);
+                return true;
             }
 
-            ExactInference(source.GetNullableUnderlyingType(), target.GetNullableUnderlyingType(), ref useSiteDiagnostics);
-            return true;
+            if (source.IsNullable == true && target.IsNullable == true)
+            {
+                ExactOrBoundsInference(kind, source.AsNotNullableReferenceType(), target.AsNotNullableReferenceType(), ref useSiteDiagnostics);
+                return true;
+            }
+
+            return false;
         }
 
-        private bool ExactTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+
+        private bool ExactNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            return ExactOrBoundsNullableInference(ExactOrBoundsKind.Exact, source, target, ref useSiteDiagnostics);
+        }
+
+        private bool ExactOrBoundsTupleInference(ExactOrBoundsKind kind, TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -1589,11 +1614,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             //       that is ok, because we are inferring type parameters used in the matching elements, 
             //       This is not the situation where entire tuple type used to infer a single type param
 
-            ImmutableArray<TypeSymbol> sourceTypes;
-            ImmutableArray<TypeSymbol> targetTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> sourceTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> targetTypes;
 
-            if (!source.TryGetElementTypesIfTupleOrCompatible(out sourceTypes) ||
-                !target.TryGetElementTypesIfTupleOrCompatible(out targetTypes) ||
+            if (!source.TypeSymbol.TryGetElementTypesIfTupleOrCompatible(out sourceTypes) ||
+                !target.TypeSymbol.TryGetElementTypesIfTupleOrCompatible(out targetTypes) ||
                 sourceTypes.Length != targetTypes.Length)
             {
                 return false;
@@ -1601,13 +1626,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < sourceTypes.Length; i++)
             {
-                ExactInference(sourceTypes[i], targetTypes[i], ref useSiteDiagnostics);
+                ExactOrBoundsInference(kind, sourceTypes[i], targetTypes[i], ref useSiteDiagnostics);
             }
 
             return true;
         }
 
-        private bool ExactConstructedInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool ExactTupleInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            return ExactOrBoundsTupleInference(ExactOrBoundsKind.Exact, source, target, ref useSiteDiagnostics);
+        }
+
+        private bool ExactConstructedInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -1616,13 +1646,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   type C<U1...Uk> then an exact inference 
             // SPEC:   is made from each Ui to the corresponding Vi.
 
-            var namedSource = source as NamedTypeSymbol;
+            var namedSource = source.TypeSymbol as NamedTypeSymbol;
             if ((object)namedSource == null)
             {
                 return false;
             }
 
-            var namedTarget = target as NamedTypeSymbol;
+            var namedTarget = target.TypeSymbol as NamedTypeSymbol;
             if ((object)namedTarget == null)
             {
                 return false;
@@ -1643,8 +1673,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)target != null);
             Debug.Assert(source.OriginalDefinition == target.OriginalDefinition);
 
-            var sourceTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
-            var targetTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
+            var sourceTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
+            var targetTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
 
             source.GetAllTypeArguments(sourceTypeArguments, ref useSiteDiagnostics);
             target.GetAllTypeArguments(targetTypeArguments, ref useSiteDiagnostics);
@@ -1664,7 +1694,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         // Lower-bound inferences
         //
-        private void LowerBoundInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void LowerBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -1687,7 +1717,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:     from Ue to Ve is made.
             // SPEC:   * otherwise an exact inference from Ue to Ve is made.
 
-            if (LowerBoundArrayInference(source, target, ref useSiteDiagnostics))
+            if (LowerBoundArrayInference(source.TypeSymbol, target.TypeSymbol, ref useSiteDiagnostics))
             {
                 return;
             }
@@ -1738,7 +1768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // SPEC: Otherwise... many cases for constructed generic types.
-            if (LowerBoundConstructedInference(source, target, ref useSiteDiagnostics))
+            if (LowerBoundConstructedInference(source.TypeSymbol, target.TypeSymbol, ref useSiteDiagnostics))
             {
                 return;
             }
@@ -1746,22 +1776,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, no inferences are made.
         }
 
-        private bool LowerBoundTypeParameterInference(TypeSymbol source, TypeSymbol target)
+        private bool LowerBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of bounds
             // SPEC:   for Xi.
-            if (IsUnfixedTypeParameter(target))
+            if (IsUnfixedTypeParameter(source, target))
             {
-                AddLowerBound((TypeParameterSymbol)target, source);
+                AddBound(source, _lowerBounds, target);
                 return true;
             }
             return false;
         }
 
-        private static TypeSymbol GetMatchingElementType(ArrayTypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private static TypeSymbolWithAnnotations GetMatchingElementType(ArrayTypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -1774,7 +1804,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return null;
                 }
-                return arrayTarget.ElementType.TypeSymbol;
+                return arrayTarget.ElementType;
             }
 
             // Or it might be IEnum<T> and source is rank one.
@@ -1793,7 +1823,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            return ((NamedTypeSymbol)target).TypeArgumentWithDefinitionUseSiteDiagnostics(0, ref useSiteDiagnostics).TypeSymbol;
+            return ((NamedTypeSymbol)target).TypeArgumentWithDefinitionUseSiteDiagnostics(0, ref useSiteDiagnostics);
         }
 
         private bool LowerBoundArrayInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -1816,7 +1846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var arraySource = (ArrayTypeSymbol)source;
             var elementSource = arraySource.ElementType;
-            TypeSymbol elementTarget = GetMatchingElementType(arraySource, target, ref useSiteDiagnostics);
+            var elementTarget = GetMatchingElementType(arraySource, target, ref useSiteDiagnostics);
             if ((object)elementTarget == null)
             {
                 return false;
@@ -1824,55 +1854,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (elementSource.IsReferenceType)
             {
-                LowerBoundInference(elementSource.TypeSymbol, elementTarget, ref useSiteDiagnostics);
+                LowerBoundInference(elementSource, elementTarget, ref useSiteDiagnostics);
             }
             else
             {
-                ExactInference(elementSource.TypeSymbol, elementTarget, ref useSiteDiagnostics);
+                ExactInference(elementSource, elementTarget, ref useSiteDiagnostics);
             }
 
             return true;
         }
 
-        private bool LowerBoundNullableInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool LowerBoundNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
-
-            if (!source.IsNullableType() || !target.IsNullableType())
-            {
-                return false;
-            }
-
-            LowerBoundInference(source.GetNullableUnderlyingType(), target.GetNullableUnderlyingType(), ref useSiteDiagnostics);
-            return true;
+            return ExactOrBoundsNullableInference(ExactOrBoundsKind.LowerBound, source, target, ref useSiteDiagnostics);
         }
 
-        private bool LowerBoundTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool LowerBoundTupleInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
-
-            // NOTE: we are losing tuple element names when unwrapping tuple types to underlying types.
-            //       that is ok, because we are inferring type parameters used in the matching elements, 
-            //       This is not the situation where entire tuple type used to infer a single type param
-
-            ImmutableArray<TypeSymbol> sourceTypes;
-            ImmutableArray<TypeSymbol> targetTypes;
-
-            if (!source.TryGetElementTypesIfTupleOrCompatible(out sourceTypes) ||
-                !target.TryGetElementTypesIfTupleOrCompatible(out targetTypes) ||
-                sourceTypes.Length != targetTypes.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < sourceTypes.Length; i++)
-            {
-                LowerBoundInference(sourceTypes[i], targetTypes[i], ref useSiteDiagnostics);
-            }
-
-            return true;
+            return ExactOrBoundsTupleInference(ExactOrBoundsKind.LowerBound, source, target, ref useSiteDiagnostics);
         }
 
         private bool LowerBoundConstructedInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -2047,8 +2046,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(source.OriginalDefinition == target.OriginalDefinition);
 
             var typeParameters = ArrayBuilder<TypeParameterSymbol>.GetInstance();
-            var sourceTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
-            var targetTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
+            var sourceTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
+            var targetTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
 
             source.OriginalDefinition.GetAllTypeParameters(typeParameters);
             source.GetAllTypeArguments(sourceTypeArguments, ref useSiteDiagnostics);
@@ -2086,7 +2085,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         // Upper-bound inferences
         //
-        private void UpperBoundInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void UpperBoundInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -2119,13 +2118,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(source.IsReferenceType);
 
+            if (UpperBoundNullableInference(source, target, ref useSiteDiagnostics))
+            {
+                return;
+            }
+
             // NOTE: spec would ask us to do the following checks, but since the value types
             //       are trivially handled as exact inference in the callers, we do not have to.
-
-            //if (ExactNullableInference(source, target, ref useSiteDiagnostics))
-            //{
-            //    return;
-            //}
 
             //if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             //{
@@ -2142,21 +2141,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, no inferences are made.
         }
 
-        private bool UpperBoundTypeParameterInference(TypeSymbol source, TypeSymbol target)
+        private bool UpperBoundTypeParameterInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
             // SPEC: * If V is one of the unfixed Xi then U is added to the set of upper bounds
             // SPEC:   for Xi.
-            if (IsUnfixedTypeParameter(target))
+            if (IsUnfixedTypeParameter(source, target))
             {
-                AddUpperBound((TypeParameterSymbol)target, source);
+                AddBound(source, _upperBounds, target);
                 return true;
             }
             return false;
         }
 
-        private bool UpperBoundArrayInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool UpperBoundArrayInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
@@ -2169,13 +2168,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:     from Ue to Ve is made.
             // SPEC:   * otherwise an exact inference from Ue to Ve is made.
 
-            if (!target.IsArray())
+            if (!target.TypeSymbol.IsArray())
             {
                 return false;
             }
-            var arrayTarget = (ArrayTypeSymbol)target;
-            var elementTarget = arrayTarget.ElementType.TypeSymbol;
-            var elementSource = GetMatchingElementType(arrayTarget, source, ref useSiteDiagnostics);
+            var arrayTarget = (ArrayTypeSymbol)target.TypeSymbol;
+            var elementTarget = arrayTarget.ElementType;
+            var elementSource = GetMatchingElementType(arrayTarget, source.TypeSymbol, ref useSiteDiagnostics);
             if ((object)elementSource == null)
             {
                 return false;
@@ -2193,12 +2192,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        private bool UpperBoundConstructedInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private bool UpperBoundNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            return ExactOrBoundsNullableInference(ExactOrBoundsKind.UpperBound, source, target, ref useSiteDiagnostics);
+        }
+
+        private bool UpperBoundConstructedInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
-            var constructedSource = source as NamedTypeSymbol;
+            var constructedSource = source.TypeSymbol as NamedTypeSymbol;
             if ((object)constructedSource == null)
             {
                 return false;
@@ -2214,10 +2218,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   lower bound inference or upper bound inference
             // SPEC:   is made from each Ui to the corresponding Vi.
 
-            var constructedTarget = target as NamedTypeSymbol;
+            var constructedTarget = target.TypeSymbol as NamedTypeSymbol;
 
             if ((object)constructedTarget != null &&
-                constructedSource.OriginalDefinition == target.OriginalDefinition)
+                constructedSource.OriginalDefinition == target.TypeSymbol.OriginalDefinition)
             {
                 if (constructedTarget.IsInterface || constructedTarget.IsDelegateType())
                 {
@@ -2233,7 +2237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * Otherwise, if U is a class type C<U1...Uk> and V is a class type which
             // SPEC:   inherits directly or indirectly from C<V1...Vk> then an exact ...
 
-            if (UpperBoundClassInference(constructedSource, target, ref useSiteDiagnostics))
+            if (UpperBoundClassInference(constructedSource, target.TypeSymbol, ref useSiteDiagnostics))
             {
                 return true;
             }
@@ -2243,7 +2247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   or indirectly implements C<V1...Vk> then an exact ...
             // SPEC: * ... and U is an interface type ...
 
-            if (UpperBoundInterfaceInference(constructedSource, target, ref useSiteDiagnostics))
+            if (UpperBoundInterfaceInference(constructedSource, target.TypeSymbol, ref useSiteDiagnostics))
             {
                 return true;
             }
@@ -2332,8 +2336,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(source.OriginalDefinition == target.OriginalDefinition);
 
             var typeParameters = ArrayBuilder<TypeParameterSymbol>.GetInstance();
-            var sourceTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
-            var targetTypeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
+            var sourceTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
+            var targetTypeArguments = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
 
             source.OriginalDefinition.GetAllTypeParameters(typeParameters);
             source.GetAllTypeArguments(sourceTypeArguments, ref useSiteDiagnostics);
@@ -2373,9 +2377,56 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         private bool Fix(int iParam, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            // UNDONE: This method makes a lot of garbage.
-
             Debug.Assert(IsUnfixed(iParam));
+
+            var exact = _exactBounds[iParam];
+            var lower = _lowerBounds[iParam];
+            var upper = _upperBounds[iParam];
+
+            // Fix considering nullability, if possible, otherwise fix ignoring nullability.
+            // PROTOTYPE(NullableReferenceTypes): Avoid calling Fix ignoring nullability if the nullability call succeeds.
+
+            HashSet<DiagnosticInfo> ignoredDiagnostics = null;
+            var withNullability = Fix(exact, lower, upper, ref ignoredDiagnostics, _conversions, includeNullability: true);
+            var withoutNullability = Fix(exact, lower, upper, ref useSiteDiagnostics, _conversions, includeNullability: false);
+
+            var best = withNullability;
+            if ((object)best == null)
+            {
+                best = withoutNullability;
+            }
+            else
+            {
+                // If the first attempt succeeded, the result should be the same as
+                // the second attempt, although perhaps with different nullability.
+                if (!withNullability.TypeSymbol.Equals(withoutNullability.TypeSymbol))
+                {
+                    // The two results differ other than nullability.
+                    // Use the second result, for compatibility.
+                    Debug.Assert(false);
+                    best = withoutNullability;
+                }
+            }
+
+            if ((object)best == null)
+            {
+                return false;
+            }
+
+            _fixedResults[iParam] = best;
+            UpdateDependenciesAfterFix(iParam);
+            return true;
+        }
+
+        private static TypeSymbolWithAnnotations Fix(
+            HashSet<TypeSymbolWithAnnotations> exact,
+            HashSet<TypeSymbolWithAnnotations> lower,
+            HashSet<TypeSymbolWithAnnotations> upper,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+            ConversionsBase conversions,
+            bool includeNullability)
+        {
+            // UNDONE: This method makes a lot of garbage.
 
             // SPEC: An unfixed type parameter with a set of bounds is fixed as follows:
 
@@ -2387,11 +2438,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Optimization: if we have two or more exact bounds, fixing is impossible.
 
-            var exact = _exactBounds[iParam];
-            var lower = _lowerBounds[iParam];
-            var upper = _upperBounds[iParam];
-
-            var candidates = new Dictionary<TypeSymbol, TypeSymbol>(EqualsIgnoringDynamicAndTupleNamesComparer.Instance);
+            var candidates = new Dictionary<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations>(
+                includeNullability ?
+                    EqualsIgnoringDynamicAndTupleNamesComparer.WithNullability :
+                    EqualsIgnoringDynamicAndTupleNamesComparer.WithoutNullability);
 
             // Optimization: if we have one exact bound then we need not add any
             // inexact bounds; we're just going to remove them anyway.
@@ -2400,35 +2450,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (lower != null)
                 {
-                    foreach (var lowerBound in lower)
-                    {
-                        AddOrMerge(candidates, lowerBound);
-                    }
+                    AddOrMergeAll(candidates, lower, conversions);
                 }
                 if (upper != null)
                 {
-                    foreach (var upperBound in upper)
-                    {
-                        AddOrMerge(candidates, upperBound);
-                    }
+                    AddOrMergeAll(candidates, upper, conversions);
                 }
             }
             else
             {
-                foreach (var exactBound in exact)
-                {
-                    AddOrMerge(candidates, exactBound);
-                }
-
+                AddOrMergeAll(candidates, exact, conversions);
                 if (candidates.Count >= 2)
                 {
-                    return false;
+                    return null;
                 }
             }
 
             if (candidates.Count == 0)
             {
-                return false;
+                return null;
             }
 
             // Don't mutate the collection as we're iterating it.
@@ -2444,15 +2484,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Make a copy; don't modify the collection as we're iterating it.
                     foreach (var candidate in initialCandidates)
                     {
-                        if (!bound.Equals(candidate))
+                        if (!bound.Equals(candidate, TypeCompareKind.AllAspects))
                         {
-                            if (!ImplicitConversionExists(bound, candidate, ref useSiteDiagnostics))
+                            if (!ImplicitConversionExists(bound, candidate, ref useSiteDiagnostics, conversions, includeNullability))
                             {
                                 candidates.Remove(candidate);
                             }
-                            else if (bound.Equals(candidate, TypeCompareKind.IgnoreDynamicAndTupleNames))
+                            else
                             {
-                                MergeAndReplaceIfStillCandidate(candidates, candidate, bound);
+                                MergeAndReplaceIfStillCandidate(candidates, bound, conversions);
                             }
                         }
                     }
@@ -2468,15 +2508,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     foreach (var candidate in initialCandidates)
                     {
-                        if (!bound.Equals(candidate))
+                        if (!bound.Equals(candidate, TypeCompareKind.AllAspects))
                         {
-                            if (!ImplicitConversionExists(candidate, bound, ref useSiteDiagnostics))
+                            if (!ImplicitConversionExists(candidate, bound, ref useSiteDiagnostics, conversions, includeNullability))
                             {
                                 candidates.Remove(candidate);
                             }
-                            else if (bound.Equals(candidate, TypeCompareKind.IgnoreDynamicAndTupleNames))
+                            else
                             {
-                                MergeAndReplaceIfStillCandidate(candidates, candidate, bound);
+                                MergeAndReplaceIfStillCandidate(candidates, bound, conversions);
                             }
                         }
                     }
@@ -2486,12 +2526,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * If among the remaining candidate types there is a unique type V to
             // SPEC:   which there is an implicit conversion from all the other candidate
             // SPEC:   types, then the parameter is fixed to V.
-            TypeSymbol best = null;
+            TypeSymbolWithAnnotations best = null;
             foreach (var candidate in candidates.Keys)
             {
                 foreach (var candidate2 in candidates.Keys)
                 {
-                    if (!candidate.Equals(candidate2) && !ImplicitConversionExists(candidate2, candidate, ref useSiteDiagnostics))
+                    if (!candidate.Equals(candidate2, TypeCompareKind.AllAspects) &&
+                        !ImplicitConversionExists(candidate2, candidate, ref useSiteDiagnostics, conversions, includeNullability))
                     {
                         goto OuterBreak;
                     }
@@ -2501,7 +2542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     best = candidate;
                 }
-                else if (best.Equals(candidate, TypeCompareKind.IgnoreDynamicAndTupleNames))
+                else if (best.Equals(candidate, GetComparison(includeNullability)))
                 {
                     // SPEC: 4.7 The Dynamic Type
                     //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
@@ -2512,56 +2553,69 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(!(best.IsObjectType() && candidate.IsDynamic()));
                     Debug.Assert(!(best.IsDynamic() && candidate.IsObjectType()));
 
-                    best = MergeTupleNames(MergeDynamic(best, candidate, _conversions.CorLibrary), candidate);
+                    best = Merge(best, candidate, conversions.CorLibrary);
                 }
                 else
                 {
                     // best candidate is not unique
-                    return false;
+                    return null;
                 }
 
                 OuterBreak:
                 ;
             }
 
-            if ((object)best == null)
+            return best;
+        }
+
+        private bool? IsNullable(BoundExpression expr)
+        {
+            if (!_includeNullability)
             {
-                // no best candidate
                 return false;
             }
+            return expr.IsNullable();
+        }
 
-            _fixedResults[iParam] = best;
-            UpdateDependenciesAfterFix(iParam);
-            return true;
+        internal static TypeSymbolWithAnnotations Merge(TypeSymbolWithAnnotations first, TypeSymbolWithAnnotations second, AssemblySymbol corLibrary)
+        {
+            return MergeNullability(MergeTupleNames(MergeDynamic(first, second, corLibrary), second), second);
         }
 
         /// <summary>
         /// Returns first or a modified version of first with merged dynamic flags from both types.
         /// </summary>
-        internal static TypeSymbol MergeDynamic(TypeSymbol first, TypeSymbol second, AssemblySymbol corLibrary)
+        private static TypeSymbolWithAnnotations MergeDynamic(TypeSymbolWithAnnotations firstWithAnnotations, TypeSymbolWithAnnotations secondWithAnnotations, AssemblySymbol corLibrary)
         {
+            var first = firstWithAnnotations.TypeSymbol;
+            var second = secondWithAnnotations.TypeSymbol;
+
             // SPEC: 4.7 The Dynamic Type
             //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
             if (first.Equals(second, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreDynamic))
             {
-                return first;
+                return firstWithAnnotations;
             }
             ImmutableArray<bool> flags1 = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(first, RefKind.None);
             ImmutableArray<bool> flags2 = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(second, RefKind.None);
             ImmutableArray<bool> mergedFlags = flags1.ZipAsArray(flags2, (f1, f2) => f1 | f2);
 
-            return DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(first, corLibrary, RefKind.None, mergedFlags);
+            var result = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(first, corLibrary, RefKind.None, mergedFlags);
+            return TypeSymbolWithAnnotations.Create(result); // PROTOTYPE(NullableReferenceTypes): Handle nullability.
         }
 
         /// <summary>
         /// Returns first or a modified version of first with common tuple names from both types.
         /// </summary>
-        internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second)
+        private static TypeSymbolWithAnnotations MergeTupleNames(TypeSymbolWithAnnotations firstWithAnnotations, TypeSymbolWithAnnotations secondWithAnnotations)
         {
+            var first = firstWithAnnotations.TypeSymbol;
+            var second = secondWithAnnotations.TypeSymbol;
+
             if (first.Equals(second, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames) ||
                 !first.ContainsTupleNames())
             {
-                return first;
+                return firstWithAnnotations;
             }
 
             Debug.Assert(first.ContainsTuple());
@@ -2585,25 +2639,50 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return TupleTypeDecoder.DecodeTupleTypesIfApplicable(first, mergedNames);
+            var result = TupleTypeDecoder.DecodeTupleTypesIfApplicable(first, mergedNames);
+            return TypeSymbolWithAnnotations.Create(result); // PROTOTYPE(NullableReferenceTypes): Handle nullability.
         }
 
-        private bool ImplicitConversionExists(TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        /// <summary>
+        /// Returns first or a nullable version of first if the second is nullable.
+        /// </summary>
+        private static TypeSymbolWithAnnotations MergeNullability(TypeSymbolWithAnnotations first, TypeSymbolWithAnnotations second)
         {
+            // Merge top-level nullability only.
+            if (first.IsNullable == false && second.IsNullable == true)
+            {
+                return first.AsNullableReferenceType();
+            }
+            return first;
+        }
+
+        private static bool ImplicitConversionExists(TypeSymbolWithAnnotations sourceWithAnnotations, TypeSymbolWithAnnotations destinationWithAnnotations, ref HashSet<DiagnosticInfo> useSiteDiagnostics, ConversionsBase conversions, bool includeNullability)
+        {
+            var source = sourceWithAnnotations.TypeSymbol;
+            var destination = destinationWithAnnotations.TypeSymbol;
+
             // SPEC VIOLATION: For the purpose of algorithm in Fix method, dynamic type is not considered convertible to any other type, including object.
             if (source.IsDynamic() && !destination.IsDynamic())
             {
                 return false;
             }
 
-            return _conversions.ClassifyImplicitConversionFromType(source, destination, ref useSiteDiagnostics).Exists;
+            if (includeNullability &&
+                sourceWithAnnotations.IsNullable == true &&
+                destinationWithAnnotations.IsNullable == false)
+            {
+                return false;
+            }
+
+            // PROTOTYPE(NullableReferenceTypes): Pass includeNullability to ClassifyImplicitConversionFromType.
+            return conversions.ClassifyImplicitConversionFromType(source, destination, ref useSiteDiagnostics).Exists;
         }
 
         ////////////////////////////////////////////////////////////////////////////////
         //
         // Inferred return type
         //
-        private TypeSymbol InferReturnType(BoundExpression source, NamedTypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private TypeSymbolWithAnnotations InferReturnType(BoundExpression source, NamedTypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)target != null);
             Debug.Assert(target.IsDelegateType());
@@ -2743,11 +2822,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConversionsBase conversions,
             MethodSymbol method,
             ImmutableArray<BoundExpression> arguments,
+            bool includeNullability,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)method != null);
             Debug.Assert(method.Arity > 0);
             Debug.Assert(!arguments.IsDefault);
+
             // We need at least one formal parameter type and at least one argument.
             if ((method.ParameterCount < 1) || (arguments.Length < 1))
             {
@@ -2764,7 +2845,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 constructedFromMethod.ContainingType,
                 constructedFromMethod.GetParameterTypes(),
                 constructedFromMethod.ParameterRefKinds,
-                arguments);
+                arguments,
+                includeNullability);
 
             if (!inferrer.InferTypeArgumentsFromFirstArgument(ref useSiteDiagnostics))
             {
@@ -2782,20 +2864,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(_formalParameterTypes.Length >= 1);
             Debug.Assert(!_arguments.IsDefault);
             Debug.Assert(_arguments.Length >= 1);
-            TypeSymbol dest = _formalParameterTypes[0];
-            TypeSymbol source = _arguments[0].Type;
+            var dest = _formalParameterTypes[0];
+            var argument = _arguments[0];
+            TypeSymbol source = argument.Type;
             // Rule out lambdas, nulls, and so on.
             if (!IsReallyAType(source))
             {
                 return false;
             }
-            LowerBoundInference(source, dest, ref useSiteDiagnostics);
+            var isNullable = IsNullable(argument);
+            LowerBoundInference(TypeSymbolWithAnnotations.Create(source, isNullable), dest, ref useSiteDiagnostics);
             // Now check to see that every type parameter used by the first
             // formal parameter type was successfully inferred.
             for (int iParam = 0; iParam < _methodTypeParameters.Length; ++iParam)
             {
                 TypeParameterSymbol pParam = _methodTypeParameters[iParam];
-                if (!dest.ContainsTypeParameter(pParam))
+                if (!dest.TypeSymbol.ContainsTypeParameter(pParam))
                 {
                     continue;
                 }
@@ -2814,7 +2898,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ImmutableArray<TypeSymbol> GetInferredTypeArguments()
         {
-            return _fixedResults.AsImmutable();
+            var builder = ArrayBuilder<TypeSymbol>.GetInstance();
+            foreach (var fixedResult in _fixedResults)
+            {
+                builder.Add(fixedResult?.TypeSymbol);
+            }
+            return builder.ToImmutableAndFree();
         }
 
         private static bool IsReallyAType(TypeSymbol type)
@@ -2824,56 +2913,76 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (type.SpecialType != SpecialType.System_Void);
         }
 
-        private void AddOrMerge(Dictionary<TypeSymbol, TypeSymbol> candidates, TypeSymbol @new)
+        private static void AddOrMergeAll(Dictionary<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> candidates, HashSet<TypeSymbolWithAnnotations> set, ConversionsBase conversions)
         {
-            if (candidates.TryGetValue(@new, out TypeSymbol old))
+            foreach (var candidate in set)
             {
-                MergeAndReplaceIfStillCandidate(candidates, old, @new);
+                AddOrMerge(candidates, candidate, conversions);
             }
-            else
+        }
+
+        private static void AddOrMerge(Dictionary<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> candidates, TypeSymbolWithAnnotations @new, ConversionsBase conversions)
+        {
+            if (!MergeAndReplaceIfStillCandidate(candidates, @new, conversions))
             {
                 candidates.Add(@new, @new);
             }
         }
 
-        private void MergeAndReplaceIfStillCandidate(Dictionary<TypeSymbol, TypeSymbol> dict, TypeSymbol old, TypeSymbol @new)
+        private static bool MergeAndReplaceIfStillCandidate(Dictionary<TypeSymbolWithAnnotations, TypeSymbolWithAnnotations> dict, TypeSymbolWithAnnotations @new, ConversionsBase conversions)
         {
             // We make an exception when @new is dynamic, for backwards compatibility 
             if (@new.IsDynamic())
             {
-                return;
+                return false;
             }
 
-            if (dict.TryGetValue(old, out TypeSymbol latest))
+            if (!dict.TryGetValue(@new, out TypeSymbolWithAnnotations latest))
             {
-                dict.Remove(old);
-                TypeSymbol merged = MergeTupleNames(MergeDynamic(latest, @new, _conversions.CorLibrary), @new);
-                dict.Add(merged, merged);
+                return false;
             }
+
+            dict.Remove(@new);
+            var merged = Merge(latest, @new, conversions.CorLibrary);
+            dict[merged] = merged;
+            return true;
+        }
+
+        private static TypeCompareKind GetComparison(bool includeNullability)
+        {
+            return includeNullability?
+                TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.CompareNullableModifiersForReferenceTypes :
+                TypeCompareKind.IgnoreDynamicAndTupleNames;
         }
 
         /// <summary>
         /// This is a comparer that ignores differences in dynamic-ness and tuple names.
         /// But it has a special case for top-level object vs. dynamic for purpose of method type inference.
         /// </summary>
-        private sealed class EqualsIgnoringDynamicAndTupleNamesComparer : EqualityComparer<TypeSymbol>
+        private sealed class EqualsIgnoringDynamicAndTupleNamesComparer : EqualityComparer<TypeSymbolWithAnnotations>
         {
-            public static EqualsIgnoringDynamicAndTupleNamesComparer Instance { get; } = new EqualsIgnoringDynamicAndTupleNamesComparer();
+            internal static readonly EqualsIgnoringDynamicAndTupleNamesComparer WithNullability = new EqualsIgnoringDynamicAndTupleNamesComparer(GetComparison(includeNullability: true));
+            internal static readonly EqualsIgnoringDynamicAndTupleNamesComparer WithoutNullability = new EqualsIgnoringDynamicAndTupleNamesComparer(GetComparison(includeNullability: false));
 
-            public override int GetHashCode(TypeSymbol obj)
+            private readonly TypeCompareKind _comparison;
+
+            private EqualsIgnoringDynamicAndTupleNamesComparer(TypeCompareKind comparison)
             {
-                return (object)obj == null ? 0 : obj.GetHashCode();
+                _comparison = comparison;
             }
 
-            public override bool Equals(TypeSymbol x, TypeSymbol y)
+            public override int GetHashCode(TypeSymbolWithAnnotations obj)
+            {
+                return obj.TypeSymbol.GetHashCode();
+            }
+
+            public override bool Equals(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
             {
                 // We do a equality test ignoring dynamic and tuple names differences,
                 // but dynamic and object are not considered equal for backwards compatibility.
                 if (x.IsDynamic() ^ y.IsDynamic()) { return false; }
 
-                return
-                    (object)x == null ? (object)y == null :
-                    x.Equals(y, TypeCompareKind.IgnoreDynamicAndTupleNames);
+                return x.Equals(y, _comparison);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2399,7 +2399,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If the first attempt succeeded, the result should be the same as
                 // the second attempt, although perhaps with different nullability.
-                if (!withNullability.TypeSymbol.Equals(withoutNullability.TypeSymbol))
+
+                // PROTOTYPE(NullableReferenceTypes): Currently, the results
+                // can differ by tuple names (or presumably, dynamic).
+                // See StaticNullChecking.TypeInference_DifferByName test.
+                if (!withNullability.TypeSymbol.Equals(withoutNullability.TypeSymbol, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
                     // The two results differ other than nullability.
                     // Use the second result, for compatibility.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _formalParameterRefKinds.IsDefault ? RefKind.None : _formalParameterRefKinds[index];
         }
 
-        private ImmutableArray<TypeSymbolWithAnnotations> GetResults(bool eraseNullability)
+        private ImmutableArray<TypeSymbolWithAnnotations> GetResults()
         {
             // Anything we didn't infer a type for, give the error type.
             // Note: the error type will have the same name as the name
@@ -508,8 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: bounds. The second phase may have to be repeated a number of times.
             InferTypeArgsFirstPhase(binder, ref useSiteDiagnostics);
             bool success = InferTypeArgsSecondPhase(binder, ref useSiteDiagnostics);
-            bool eraseNullability = binder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
-            return new MethodTypeInferenceResult(success, GetResults(eraseNullability));
+            return new MethodTypeInferenceResult(success, GetResults());
         }
 
         ////////////////////////////////////////////////////////////////////////////////

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2400,9 +2400,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If the first attempt succeeded, the result should be the same as
                 // the second attempt, although perhaps with different nullability.
 
-                // PROTOTYPE(NullableReferenceTypes): Currently, the results
-                // can differ by tuple names (or presumably, dynamic).
-                // See StaticNullChecking.TypeInference_DifferByName test.
+                // PROTOTYPE(NullableReferenceTypes): Results may differ by tuple names or dynamic.
+                // See StaticNullChecking.TypeInference_TupleNameDifferences_01 for example.
                 if (!withNullability.TypeSymbol.Equals(withoutNullability.TypeSymbol, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
                     // The two results differ other than nullability.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1539,7 +1539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // SPEC: * Otherwise, if U is an array type UE[...] and V is an array type VE[...]
             // SPEC:   of the same rank then an exact inference from UE to VE is made.
-            if (!source.TypeSymbol.IsArray() || !target.TypeSymbol.IsArray())
+            if (!source.IsArray() || !target.IsArray())
             {
                 return false;
             }
@@ -1555,7 +1555,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        enum ExactOrBoundsKind
+        private enum ExactOrBoundsKind
         {
             Exact,
             LowerBound,
@@ -1597,7 +1597,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
         }
-
 
         private bool ExactNullableInference(TypeSymbolWithAnnotations source, TypeSymbolWithAnnotations target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
@@ -2167,7 +2166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:     from Ue to Ve is made.
             // SPEC:   * otherwise an exact inference from Ue to Ve is made.
 
-            if (!target.TypeSymbol.IsArray())
+            if (!target.IsArray())
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // without being violated on the method. Report that the constraint is violated on the 
             // formal parameter type.
 
-            TypeSymbol formalParameterType = method.ParameterTypes[result.Result.BadParameter];
+            TypeSymbol formalParameterType = method.ParameterTypes[result.Result.BadParameter].TypeSymbol;
             formalParameterType.CheckAllConstraints(conversions, location, diagnostics);
 
             return true;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -174,6 +175,65 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol receiverType = expressionOpt.Type;
             return (object)receiverType != null && receiverType.Kind == SymbolKind.NamedType && ((NamedTypeSymbol)receiverType).IsComImport;
+        }
+
+        internal static TypeSymbolWithAnnotations GetTypeAndNullability(this BoundExpression expr, bool includeNullability)
+        {
+            var type = expr.Type;
+            if ((object)type == null)
+            {
+                return null;
+            }
+            var isNullable = includeNullability ? expr.IsNullable() : null;
+            return TypeSymbolWithAnnotations.Create(type, expr.IsNullable());
+        }
+
+        internal static bool? IsNullable(this BoundExpression expr)
+        {
+            switch (expr.Kind)
+            {
+                case BoundKind.SuppressNullableWarningExpression:
+                    return false;
+                case BoundKind.Local:
+                    return ((BoundLocal)expr).LocalSymbol.Type.IsNullable;
+                case BoundKind.Parameter:
+                    return ((BoundParameter)expr).ParameterSymbol.Type.IsNullable;
+                case BoundKind.FieldAccess:
+                    return ((BoundFieldAccess)expr).FieldSymbol.Type.IsNullable;
+                case BoundKind.PropertyAccess:
+                    return ((BoundPropertyAccess)expr).PropertySymbol.Type.IsNullable;
+                case BoundKind.Call:
+                    return ((BoundCall)expr).Method.ReturnType.IsNullable;
+                case BoundKind.BinaryOperator:
+                    return ((BoundBinaryOperator)expr).MethodOpt?.ReturnType.IsNullable;
+                case BoundKind.NullCoalescingOperator:
+                    {
+                        var op = (BoundNullCoalescingOperator)expr;
+                        var left = op.LeftOperand.IsNullable();
+                        var right = op.RightOperand.IsNullable();
+                        return (left == true) ? right : left;
+                    }
+                case BoundKind.ObjectCreationExpression:
+                    return false;
+                case BoundKind.TupleLiteral:
+                    return false;
+                case BoundKind.DefaultExpression:
+                case BoundKind.Literal:
+                case BoundKind.UnboundLambda:
+                    break;
+                default:
+                    // PROTOTYPE(NullableReferenceTypes): Handle all expression kinds.
+                    //Debug.Assert(false, "Unhandled expression: " + expr.Kind);
+                    break;
+            }
+
+            var constant = expr.ConstantValue;
+            if (constant != null && constant.IsNull)
+            {
+                return true;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -214,6 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return (left == true) ? right : left;
                     }
                 case BoundKind.ObjectCreationExpression:
+                case BoundKind.DelegateCreationExpression:
                     return false;
                 case BoundKind.TupleLiteral:
                     return false;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
             var isNullable = includeNullability ? expr.IsNullable() : null;
-            return TypeSymbolWithAnnotations.Create(type, expr.IsNullable());
+            return TypeSymbolWithAnnotations.Create(type, isNullable);
         }
 
         internal static bool? IsNullable(this BoundExpression expr)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -184,6 +184,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return null;
             }
+            // PROTOTYPE(NullableReferenceTypes): Could we track nullability always,
+            // even in C#7, but only report warnings when the feature is enabled?
             var isNullable = includeNullability ? expr.IsNullable() : null;
             return TypeSymbolWithAnnotations.Create(type, isNullable);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     //      is undefined.
                     if ((object)optionalParametersMethod == null 
                         || n.HasAnyErrors
-                        || parameters.Any(p => p.Type.TypeSymbol.IsErrorType())
+                        || parameters.Any(p => p.Type.IsErrorType())
                         || optionalParametersMethod.GetUseSiteDiagnostic()?.DefaultSeverity == DiagnosticSeverity.Error)
                     {
                         // optionalParametersMethod can be null if we are writing to a readonly indexer or reading from an writeonly indexer,

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private readonly bool _inferredFromSingleType;
         private readonly RefKind _refKind;
-        private readonly TypeSymbol _inferredReturnType;
+        private readonly TypeSymbolWithAnnotations _inferredReturnType;
         private readonly HashSet<DiagnosticInfo> _inferredReturnTypeUseSiteDiagnostics;
 
 #if DEBUG
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             );
         }
 
-        public TypeSymbol InferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public TypeSymbolWithAnnotations InferredReturnType(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
 #if DEBUG
             Debug.Assert(_hasInferredReturnType);
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Behavior of this function should be kept aligned with <see cref="UnboundLambdaState.ReturnInferenceCacheKey"/>.
         /// </summary>
-        private static TypeSymbol InferReturnType(
+        private static TypeSymbolWithAnnotations InferReturnType(
             BoundBlock block,
             Binder binder,
             TypeSymbol delegateType,
@@ -124,11 +124,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool inferredFromSingleType)
         {
             int numberOfDistinctReturns;
-            var resultTypes = BlockReturns.GetReturnTypes(block, out refKind, out numberOfDistinctReturns);
+            bool includeNullability = binder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking);
+            var resultTypes = BlockReturns.GetReturnTypes(includeNullability, block, out refKind, out numberOfDistinctReturns);
 
             inferredFromSingleType = numberOfDistinctReturns < 2;
 
-            TypeSymbol bestResultType;
+            TypeSymbolWithAnnotations bestResultType;
             if (resultTypes.IsDefaultOrEmpty)
             {
                 bestResultType = null;
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                bestResultType = BestTypeInferrer.InferBestType(resultTypes, binder.Conversions, ref useSiteDiagnostics);
+                bestResultType = BestTypeInferrer.InferBestType(resultTypes, binder.Conversions, includeNullability, ref useSiteDiagnostics);
             }
 
             if (!isAsync)
@@ -165,9 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // No return statements have expressions; use delegate InvokeMethod
                 // or infer type Task if delegate type not available.
-                return (object)taskType != null && taskType.Arity == 0 ?
-                    taskType :
-                    binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                return TypeSymbolWithAnnotations.Create(
+                    (object)taskType != null && taskType.Arity == 0 ?
+                        taskType :
+                        binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
             }
 
             if ((object)bestResultType == null || bestResultType.SpecialType == SpecialType.System_Void)
@@ -182,26 +184,29 @@ namespace Microsoft.CodeAnalysis.CSharp
             var taskTypeT = (object)taskType != null && taskType.Arity == 1 ?
                 taskType :
                 binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
-            return taskTypeT.Construct(bestResultType);
+            return TypeSymbolWithAnnotations.Create(taskTypeT.Construct(ImmutableArray.Create(bestResultType)));
         }
 
         internal sealed class BlockReturns : BoundTreeWalker
         {
-            private readonly ArrayBuilder<TypeSymbol> _types;
+            private readonly bool _includeNullability;
+            private readonly HashSet<TypeSymbolWithAnnotations> _types;
             private bool _hasReturnWithoutArgument;
             private RefKind refKind;
 
-            private BlockReturns()
+            private BlockReturns(bool includeNullability, HashSet<TypeSymbolWithAnnotations> types)
             {
-                _types = ArrayBuilder<TypeSymbol>.GetInstance();
+                _includeNullability = includeNullability;
+                _types = types;
             }
 
-            public static ImmutableArray<TypeSymbol> GetReturnTypes(BoundBlock block, out RefKind refKind, out int numberOfDistinctReturns)
+            public static ImmutableArray<TypeSymbolWithAnnotations> GetReturnTypes(bool includeNullability, BoundBlock block, out RefKind refKind, out int numberOfDistinctReturns)
             {
-                var inferrer = new BlockReturns();
+                var types = new HashSet<TypeSymbolWithAnnotations>(TypeSymbolWithAnnotations.EqualsComparer.Instance);
+                var inferrer = new BlockReturns(includeNullability, types);
                 inferrer.Visit(block);
                 refKind = inferrer.refKind;
-                var result = inferrer._types.ToImmutableAndFree();
+                var result = types.AsImmutableOrEmpty();
                 numberOfDistinctReturns = result.Length;
                 if (inferrer._hasReturnWithoutArgument)
                 {
@@ -242,9 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var expression = node.ExpressionOpt;
                 if (expression != null)
                 {
-                    var returnType = expression.Type;
-                    // This is potentially inefficient if there are a large number of returns each with
-                    // a different type. This seems unlikely.
+                    var returnType = expression.GetTypeAndNullability(_includeNullability);
                     if (!_types.Contains(returnType))
                     {
                         _types.Add(returnType);
@@ -284,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool HasSignature { get { return Data.HasSignature; } }
         public bool HasExplicitlyTypedParameterList { get { return Data.HasExplicitlyTypedParameterList; } }
         public int ParameterCount { get { return Data.ParameterCount; } }
-        public TypeSymbol InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics) { return Data.InferReturnType(delegateType, ref useSiteDiagnostics); }
+        public TypeSymbolWithAnnotations InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics) { return Data.InferReturnType(delegateType, ref useSiteDiagnostics); }
         public RefKind RefKind(int index) { return Data.RefKind(index); }
         public void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, TypeSymbol targetType) { Data.GenerateAnonymousFunctionConversionError(diagnostics, targetType); }
         public bool GenerateSummaryErrors(DiagnosticBag diagnostics) { return Data.GenerateSummaryErrors(diagnostics); }
@@ -363,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)type != null)
                 {
                     any = true;
-                    yield return type;
+                    yield return type.TypeSymbol;
                 }
             }
 
@@ -372,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var type = BindForErrorRecovery().InferredReturnType(ref useSiteDiagnostics);
                 if ((object)type != null)
                 {
-                    yield return type;
+                    yield return type.TypeSymbol;
                 }
             }
         }
@@ -531,7 +534,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             { WasCompilerGenerated = _unboundLambda.WasCompilerGenerated };
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null; // TODO: figure out if this should be somehow merged into BoundLambda.Diagnostics.
-            TypeSymbol returnType = result.InferredReturnType(ref useSiteDiagnostics) ?? LambdaSymbol.InferenceFailureReturnType.TypeSymbol;
+            var returnType = result.InferredReturnType(ref useSiteDiagnostics) ?? LambdaSymbol.InferenceFailureReturnType;
             lambdaSymbol.SetInferredReturnType(result.RefKind, returnType);
 
             return result;
@@ -657,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public TypeSymbol InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public TypeSymbolWithAnnotations InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             return BindForReturnTypeInference(delegateType).InferredReturnType(ref useSiteDiagnostics);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -166,10 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // No return statements have expressions; use delegate InvokeMethod
                 // or infer type Task if delegate type not available.
-                return TypeSymbolWithAnnotations.Create(
-                    (object)taskType != null && taskType.Arity == 0 ?
-                        taskType :
-                        binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
+                var resultType = (object)taskType != null && taskType.Arity == 0 ?
+                    taskType :
+                    binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                return TypeSymbolWithAnnotations.Create(resultType);
             }
 
             if ((object)bestResultType == null || bestResultType.SpecialType == SpecialType.System_Void)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2883,10 +2883,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<string> elementNames,
             ImmutableArray<Location> elementLocations)
         {
-            var typesBuilder = ArrayBuilder<TypeSymbol>.GetInstance(elementTypes.Length);
+            var typesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(elementTypes.Length);
             for (int i = 0; i < elementTypes.Length; i++)
             {
-                typesBuilder.Add(elementTypes[i].EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>($"{nameof(elementTypes)}[{i}]"));
+                var elementType = elementTypes[i].EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>($"{nameof(elementTypes)}[{i}]");
+                typesBuilder.Add(TypeSymbolWithAnnotations.Create(elementType));
             }
 
             return TupleTypeSymbol.Create(

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -230,10 +230,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     bool hasUnacceptableParameterType = false;
 
-                    foreach (TypeSymbol paramType in constructor.ParameterTypes) // Public caller would select type out of parameters.
+                    foreach (var paramType in constructor.ParameterTypes) // Public caller would select type out of parameters.
                     {
                         if (paramType.TypeKind == TypeKind.Array ||
-                            paramType.GetAttributeParameterTypedConstantKind(_compilation) == TypedConstantKind.Error)
+                            paramType.TypeSymbol.GetAttributeParameterTypedConstantKind(_compilation) == TypedConstantKind.Error)
                         {
                             hasUnacceptableParameterType = true;
                             break;
@@ -1282,8 +1282,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             code = ErrorCode.Void;
 
-            ImmutableArray<TypeSymbol> xParameterTypes;
-            ImmutableArray<TypeSymbol> yParameterTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> xParameterTypes;
+            ImmutableArray<TypeSymbolWithAnnotations> yParameterTypes;
             ImmutableArray<RefKind> xRefKinds;
             ImmutableArray<RefKind> yRefKinds;
             switch (x.Kind)
@@ -1326,8 +1326,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < numParams; i++)
             {
-                TypeSymbol xType = xParameterTypes[i];
-                TypeSymbol yType = yParameterTypes[i];
+                TypeSymbol xType = xParameterTypes[i].TypeSymbol;
+                TypeSymbol yType = yParameterTypes[i].TypeSymbol;
 
                 TypeKind typeKind = xType.TypeKind;
                 if (yType.TypeKind != typeKind)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         @checked);
                 }
 
-                if (rewrittenOperand.Type != conversion.Method.ParameterTypes[0])
+                if (rewrittenOperand.Type != conversion.Method.ParameterTypes[0].TypeSymbol)
                 {
                     rewrittenOperand = MakeConversionNode(
                         rewrittenOperand,
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Lifted conversion, wrap return type in Nullable
                 // The conversion only needs to happen for non-nullable valuetypes
                 if (rewrittenOperand.Type.IsNullableType() &&
-                        conversion.Method.ParameterTypes[0].Equals(rewrittenOperand.Type.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions) &&
+                        conversion.Method.ParameterTypes[0].TypeSymbol.Equals(rewrittenOperand.Type.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions) &&
                         !userDefinedConversionRewrittenType.IsNullableType() &&
                         userDefinedConversionRewrittenType.IsValueType)
                 {
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < numElements; i++)
             {
                 var fieldAccess = MakeTupleFieldAccessAndReportUseSiteDiagnostics(savedTuple, syntax, srcElementFields[i]);
-                var convertedFieldAccess = MakeConversionNode(syntax, fieldAccess, elementConversions[i], destElementTypes[i], @checked, explicitCastInCode);
+                var convertedFieldAccess = MakeConversionNode(syntax, fieldAccess, elementConversions[i], destElementTypes[i].TypeSymbol, @checked, explicitCastInCode);
                 fieldAccessorsBuilder.Add(convertedFieldAccess);
             }
 
@@ -1001,7 +1001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)conversion.Method != null && !conversion.Method.ReturnsVoid && conversion.Method.ParameterCount == 1);
             if (rewrittenOperand.Type.IsNullableType())
             {
-                var parameterType = conversion.Method.ParameterTypes[0];
+                var parameterType = conversion.Method.ParameterTypes[0].TypeSymbol;
                 if (parameterType.Equals(rewrittenOperand.Type.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions) &&
                     !parameterType.IsNullableType() &&
                     parameterType.IsValueType)
@@ -1147,7 +1147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenOperand = MakeConversionNode(rewrittenOperand, source.StrippedType(), @checked);
             }
 
-            rewrittenOperand = MakeConversionNode(rewrittenOperand, method.ParameterTypes[0], @checked);
+            rewrittenOperand = MakeConversionNode(rewrittenOperand, method.ParameterTypes[0].TypeSymbol, @checked);
 
             var returnType = method.ReturnType.TypeSymbol;
             Debug.Assert((object)returnType != null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (isUsed)
             {
-                var tupleType = TupleTypeSymbol.Create(locationOpt: null, elementTypes: builder.SelectAsArray(e => e.Type),
+                var tupleType = TupleTypeSymbol.Create(locationOpt: null, elementTypes: builder.SelectAsArray(e => TypeSymbolWithAnnotations.Create(e.Type)),
                     elementLocations: default, elementNames: default,
                     compilation: _compilation, shouldCheckConstraints: false, errorPositions: default);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -588,11 +588,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rewrittenArgument = rewrittenValueToIncrement;
             SyntaxNode syntax = node.Syntax;
 
-            TypeSymbol type = node.MethodOpt.ParameterTypes[0];
+            TypeSymbol type = node.MethodOpt.ParameterTypes[0].TypeSymbol;
             if (isLifted)
             {
                 type = _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(type);
-                Debug.Assert(node.MethodOpt.ParameterTypes[0] == node.MethodOpt.ReturnType.TypeSymbol);
+                Debug.Assert(node.MethodOpt.ParameterTypes[0].TypeSymbol == node.MethodOpt.ReturnType.TypeSymbol);
             }
 
             if (!node.OperandConversion.IsIdentity)

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // The type parameters must be original definitions of type parameters from the containing symbol.
             Debug.Assert(ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition));
 
-            if (typeArgument.TypeSymbol.IsErrorType())
+            if (typeArgument.IsErrorType())
             {
                 return true;
             }
@@ -906,7 +906,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbolWithAnnotations constraintType,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            if (constraintType.TypeSymbol.IsErrorType())
+            if (constraintType.IsErrorType())
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return hash;
             }
-            hash = Hash.Combine(member.ParameterTypes[0].GetHashCode(), hash);
+            hash = Hash.Combine(member.ParameterTypes[0].TypeSymbol.GetHashCode(), hash);
             return hash;
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -388,7 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 for (int i = arity -1; i >= 0; i--)
                 {
-                    builder.Add(IndexedTypeParameterSymbolForOverriding.GetTypeParameter(i, typeParameters2[i].IsReferenceType));
+                    builder.Add(IndexedTypeParameterSymbolForOverriding.GetTypeParameter(i, typeParameters2[i].IsValueType));
                 }
 
                 var indexed = builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Get the types of the parameters of a member symbol.  Should be a method, property, or event.
         /// </summary>
-        internal static ImmutableArray<TypeSymbol> GetParameterTypes(this Symbol member)
+        internal static ImmutableArray<TypeSymbolWithAnnotations> GetParameterTypes(this Symbol member)
         {
             switch (member.Kind)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Property:
                     return ((PropertySymbol)member).ParameterTypes;
                 case SymbolKind.Event:
-                    return ImmutableArray<TypeSymbol>.Empty;
+                    return ImmutableArray<TypeSymbolWithAnnotations>.Empty;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static bool HasUnsafeParameter(this Symbol member)
         {
-            foreach (TypeSymbol parameterType in member.GetParameterTypes())
+            foreach (var parameterType in member.GetParameterTypes())
             {
                 if (parameterType.IsUnsafe())
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// As a performance optimization, cache parameter types and refkinds - overload resolution uses them a lot.
         /// </summary>
         private ParameterSignature _lazyParameterSignature;
-        internal ImmutableArray<TypeSymbol> ParameterTypes
+        internal ImmutableArray<TypeSymbolWithAnnotations> ParameterTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -56,18 +56,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var otherArgumentValue = new BoundLiteral(syntax, ConstantValue.Bad, otherArgumentType) { WasCompilerGenerated = true };
 
             var paramCount = method.ParameterCount;
-            var arguments = ArrayBuilder<BoundExpression>.GetInstance(paramCount);
+            var arguments = new BoundExpression[paramCount];
 
             for (int i = 0; i < paramCount; i++)
             {
                 var argument = (i == 0) ? thisArgumentValue : otherArgumentValue;
-                arguments.Add(argument);
+                arguments[i] = argument;
             }
 
             var typeArgs = MethodTypeInferrer.InferTypeArgumentsFromFirstArgument(
                 conversions,
                 method,
-                arguments.ToImmutableAndFree(),
+                arguments.AsImmutable(),
                 includeNullability: false, // PROTOTYPE(NullableReferenceTypes): Support nullability if feature enabled.
                 useSiteDiagnostics: ref useSiteDiagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -56,18 +56,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var otherArgumentValue = new BoundLiteral(syntax, ConstantValue.Bad, otherArgumentType) { WasCompilerGenerated = true };
 
             var paramCount = method.ParameterCount;
-            var arguments = new BoundExpression[paramCount];
+            var arguments = ArrayBuilder<BoundExpression>.GetInstance(paramCount);
+
             for (int i = 0; i < paramCount; i++)
             {
                 var argument = (i == 0) ? thisArgumentValue : otherArgumentValue;
-                arguments[i] = argument;
+                arguments.Add(argument);
             }
 
             var typeArgs = MethodTypeInferrer.InferTypeArgumentsFromFirstArgument(
                 conversions,
                 method,
-                arguments.AsImmutable(),
-                ref useSiteDiagnostics);
+                arguments.ToImmutableAndFree(),
+                includeNullability: false, // PROTOTYPE(NullableReferenceTypes): Support nullability if feature enabled.
+                useSiteDiagnostics: ref useSiteDiagnostics);
 
             if (typeArgs.IsDefault)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -910,24 +910,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsNullFunction = type => (object)type == null;
 
-        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => (object)type != null && type.TypeSymbol.IsErrorType();
+        internal static readonly Func<TypeSymbolWithAnnotations, bool> TypeSymbolIsErrorType = type => (object)type != null && type.IsErrorType();
 
-        internal NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> arguments, bool unbound)
+        internal NamedTypeSymbol ConstructWithoutModifiers(ImmutableArray<TypeSymbol> typeArguments, bool unbound)
         {
             ImmutableArray<TypeSymbolWithAnnotations> modifiedArguments;
 
-            if (arguments.IsDefault)
+            if (typeArguments.IsDefault)
             {
                 modifiedArguments = default(ImmutableArray<TypeSymbolWithAnnotations>);
             }
-            else if (arguments.IsEmpty)
+            else if (typeArguments.IsEmpty)
             {
                 modifiedArguments = ImmutableArray<TypeSymbolWithAnnotations>.Empty;
             }
             else
             {
-                var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(arguments.Length);
-                foreach (TypeSymbol t in arguments)
+                var builder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(typeArguments.Length);
+                foreach (TypeSymbol t in typeArguments)
                 {
                     builder.Add((object)t == null ? null : TypeSymbolWithAnnotations.Create(t));
                 }
@@ -938,41 +938,41 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Construct(modifiedArguments, unbound);
         }
 
-        internal NamedTypeSymbol Construct(ImmutableArray<TypeSymbolWithAnnotations> arguments)
+        internal NamedTypeSymbol Construct(ImmutableArray<TypeSymbolWithAnnotations> typeArguments)
         {
-            return Construct(arguments, unbound: false);
+            return Construct(typeArguments, unbound: false);
         }
 
-        internal NamedTypeSymbol Construct(ImmutableArray<TypeSymbolWithAnnotations> arguments, bool unbound)
+        internal NamedTypeSymbol Construct(ImmutableArray<TypeSymbolWithAnnotations> typeArguments, bool unbound)
         {
             if (!ReferenceEquals(this, ConstructedFrom) || this.Arity == 0)
             {
                 throw new InvalidOperationException();
             }
 
-            if (arguments.IsDefault)
+            if (typeArguments.IsDefault)
             {
-                throw new ArgumentNullException(nameof(arguments));
+                throw new ArgumentNullException(nameof(typeArguments));
             }
 
-            if (arguments.Any(TypeSymbolIsNullFunction))
+            if (typeArguments.Any(TypeSymbolIsNullFunction))
             {
-                throw new ArgumentException(CSharpResources.TypeArgumentCannotBeNull, "typeArguments");
+                throw new ArgumentException(CSharpResources.TypeArgumentCannotBeNull, nameof(typeArguments));
             }
 
-            if (arguments.Length != this.Arity)
+            if (typeArguments.Length != this.Arity)
             {
-                throw new ArgumentException(CSharpResources.WrongNumberOfTypeArguments, "typeArguments");
+                throw new ArgumentException(CSharpResources.WrongNumberOfTypeArguments, nameof(typeArguments));
             }
 
-            Debug.Assert(!unbound || arguments.All(TypeSymbolIsErrorType));
+            Debug.Assert(!unbound || typeArguments.All(TypeSymbolIsErrorType));
 
-            if (ConstructedNamedTypeSymbol.TypeParametersMatchTypeArguments(this.TypeParameters, arguments))
+            if (ConstructedNamedTypeSymbol.TypeParametersMatchTypeArguments(this.TypeParameters, typeArguments))
             {
                 return this;
             }
 
-            return this.ConstructCore(arguments, unbound);
+            return this.ConstructCore(typeArguments, unbound);
         }
 
         protected virtual NamedTypeSymbol ConstructCore(ImmutableArray<TypeSymbolWithAnnotations> typeArguments, bool unbound)

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSignature.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSignature.cs
@@ -11,13 +11,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal class ParameterSignature
     {
-        internal readonly ImmutableArray<TypeSymbol> parameterTypes;
+        internal readonly ImmutableArray<TypeSymbolWithAnnotations> parameterTypes;
         internal readonly ImmutableArray<RefKind> parameterRefKinds;
 
         internal static readonly ParameterSignature NoParams =
-            new ParameterSignature(ImmutableArray<TypeSymbol>.Empty, default(ImmutableArray<RefKind>));
+            new ParameterSignature(ImmutableArray<TypeSymbolWithAnnotations>.Empty, default(ImmutableArray<RefKind>));
 
-        private ParameterSignature(ImmutableArray<TypeSymbol> parameterTypes,
+        private ParameterSignature(ImmutableArray<TypeSymbolWithAnnotations> parameterTypes,
                                             ImmutableArray<RefKind> parameterRefKinds)
         {
             this.parameterTypes = parameterTypes;
@@ -31,13 +31,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return NoParams;
             }
 
-            var types = ArrayBuilder<TypeSymbol>.GetInstance();
+            var types = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
             ArrayBuilder<RefKind> refs = null;
 
             for (int parm = 0; parm < parameters.Length; ++parm)
             {
                 var parameter = parameters[parm];
-                types.Add(parameter.Type.TypeSymbol);
+                types.Add(parameter.Type);
 
                 var refKind = parameter.RefKind;
                 if (refs == null)

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal ImmutableArray<TypeSymbol> ParameterTypes
+        internal ImmutableArray<TypeSymbolWithAnnotations> ParameterTypes
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // always deduce the same type, unless the cached type is an error.
 
             Debug.Assert((object)originalType == null ||
-                originalType.TypeSymbol.IsErrorType() ||
+                originalType.IsErrorType() ||
                 originalType.TypeSymbol == type.TypeSymbol);
 
             if ((object)Interlocked.CompareExchange(ref _lazyType, type, null) == null)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbolForOverriding.cs
@@ -17,16 +17,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class IndexedTypeParameterSymbolForOverriding : TypeParameterSymbol
     {
-        private static TypeParameterSymbol[] s_parameterPoolHasReferenceTypeConstraint = Array.Empty<TypeParameterSymbol>();
-        private static TypeParameterSymbol[] s_parameterPoolHasNoReferenceTypeConstraint = Array.Empty<TypeParameterSymbol>();
+        private static TypeParameterSymbol[] s_parameterPoolHasValueTypeConstraint = Array.Empty<TypeParameterSymbol>();
+        private static TypeParameterSymbol[] s_parameterPoolHasNoValueTypeConstraint = Array.Empty<TypeParameterSymbol>();
 
         private readonly int _index;
-        private readonly bool _hasReferenceTypeConstraint;
+        private readonly bool _hasValueTypeConstraint;
 
-        private IndexedTypeParameterSymbolForOverriding(int index, bool hasReferenceTypeConstraint)
+        private IndexedTypeParameterSymbolForOverriding(int index, bool hasValueTypeConstraint)
         {
             _index = index;
-            _hasReferenceTypeConstraint = hasReferenceTypeConstraint;
+            _hasValueTypeConstraint = hasValueTypeConstraint;
         }
 
         public override TypeParameterKind TypeParameterKind
@@ -37,34 +37,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static TypeParameterSymbol GetTypeParameter(int index, bool hasReferenceTypeConstraint)
+        internal static TypeParameterSymbol GetTypeParameter(int index, bool hasValueTypeConstraint)
         {
             TypeParameterSymbol result;
 
-            if (hasReferenceTypeConstraint)
+            if (hasValueTypeConstraint)
             {
-                result = GetTypeParameter(ref s_parameterPoolHasReferenceTypeConstraint, index, hasReferenceTypeConstraint);
+                result = GetTypeParameter(ref s_parameterPoolHasValueTypeConstraint, index, hasValueTypeConstraint);
             }
             else
             {
-                result = GetTypeParameter(ref s_parameterPoolHasNoReferenceTypeConstraint, index, hasReferenceTypeConstraint);
+                result = GetTypeParameter(ref s_parameterPoolHasNoValueTypeConstraint, index, hasValueTypeConstraint);
             }
 
-            Debug.Assert(result.HasReferenceTypeConstraint == hasReferenceTypeConstraint);
+            Debug.Assert(result.HasValueTypeConstraint == hasValueTypeConstraint);
             return result;
         }
 
-        private static TypeParameterSymbol GetTypeParameter(ref TypeParameterSymbol[] parameterPool, int index, bool hasReferenceTypeConstraint)
+        private static TypeParameterSymbol GetTypeParameter(ref TypeParameterSymbol[] parameterPool, int index, bool hasValueTypeConstraint)
         {
             if (index >= parameterPool.Length)
             {
-                GrowPool(ref parameterPool, index + 1, hasReferenceTypeConstraint);
+                GrowPool(ref parameterPool, index + 1, hasValueTypeConstraint);
             }
 
             return parameterPool[index];
         }
 
-        private static void GrowPool(ref TypeParameterSymbol[] parameterPool, int count, bool hasReferenceTypeConstraint)
+        private static void GrowPool(ref TypeParameterSymbol[] parameterPool, int count, bool hasValueTypeConstraint)
         {
             var initialPool = parameterPool;
             while (count > initialPool.Length)
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 for (int i = initialPool.Length; i < newPool.Length; i++)
                 {
-                    newPool[i] = new IndexedTypeParameterSymbolForOverriding(i, hasReferenceTypeConstraint);
+                    newPool[i] = new IndexedTypeParameterSymbolForOverriding(i, hasValueTypeConstraint);
                 }
 
                 Interlocked.CompareExchange(ref parameterPool, newPool, initialPool);
@@ -110,12 +110,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool HasValueTypeConstraint
         {
-            get { return false; }
+            get { return _hasValueTypeConstraint; }
         }
 
         public override bool HasReferenceTypeConstraint
         {
-            get { return _hasReferenceTypeConstraint; }
+            get { throw ExceptionUtilities.Unreachable; }
         }
 
         public override bool HasConstructorConstraint

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -197,12 +197,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // until after the body is bound, but the symbol is created before the body
         // is bound.  Fill in the return type post hoc in these scenarios; the
         // IDE might inspect the symbol and want to know the return type.
-        internal void SetInferredReturnType(RefKind refKind, TypeSymbol inferredReturnType)
+        internal void SetInferredReturnType(RefKind refKind, TypeSymbolWithAnnotations inferredReturnType)
         {
             Debug.Assert((object)inferredReturnType != null);
             Debug.Assert((object)_returnType == ReturnTypeIsBeingInferred);
             _refKind = refKind;
-            _returnType = TypeSymbolWithAnnotations.Create(inferredReturnType);
+            _returnType = inferredReturnType;
         }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 && lambda._syntax == _syntax
                 && lambda._refKind == _refKind
                 && lambda.ReturnType.TypeSymbol == this.ReturnType.TypeSymbol
-                && System.Linq.ImmutableArrayExtensions.SequenceEqual(lambda.ParameterTypes, this.ParameterTypes)
+                && System.Linq.ImmutableArrayExtensions.SequenceEqual(lambda.ParameterTypes, this.ParameterTypes, (p1, p2) => p1.TypeSymbol.Equals(p2.TypeSymbol))
                 && Equals(lambda.ContainingSymbol, this.ContainingSymbol);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 diagnostics.Add(ErrorCode.ERR_BadVisEventType, location, this, this.Type.TypeSymbol);
             }
-            else if (!this.Type.TypeSymbol.IsDelegateType() && !this.Type.TypeSymbol.IsErrorType())
+            else if (!this.Type.TypeSymbol.IsDelegateType() && !this.Type.IsErrorType())
             {
                 // Suppressed for error types.
                 diagnostics.Add(ErrorCode.ERR_EventNotDelegate, location, this);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // always deduce the same type, or deduce that the type is an error.
 
             Debug.Assert((object)originalType == null ||
-                originalType.TypeSymbol.IsErrorType() && newType.TypeSymbol.IsErrorType() ||
+                originalType.IsErrorType() && newType.IsErrorType() ||
                 originalType.TypeSymbol == newType.TypeSymbol);
 
             if ((object)originalType == null)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // SPEC: nullable types let S0 and T0 refer to their underlying types,
             // SPEC: otherwise, S0 and T0 are equal to S and T, respectively.
 
-            var source = this.ParameterTypes[0];
+            var source = this.ParameterTypes[0].TypeSymbol;
             var target = this.ReturnType.TypeSymbol;
             var source0 = source.StrippedType();
             var target0 = target.StrippedType();
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // SPEC: A unary + - ! ~ operator must take a single parameter of type
             // SPEC: T or T? and can return any type.
 
-            if (this.ParameterTypes[0].StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
+            if (this.ParameterTypes[0].TypeSymbol.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
             {
                 // The parameter of a unary operator must be the containing type
                 diagnostics.Add(ErrorCode.ERR_BadUnaryOperatorSignature, this.Locations[0]);
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_OpTFRetType, this.Locations[0]);
             }
 
-            if (this.ParameterTypes[0].StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
+            if (this.ParameterTypes[0].TypeSymbol.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
             {
                 // The parameter of a unary operator must be the containing type
                 diagnostics.Add(ErrorCode.ERR_BadUnaryOperatorSignature, this.Locations[0]);
@@ -483,7 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // parameter type is *good* do we then go on to try to report an error against
             // the return type.
 
-            var parameterType = this.ParameterTypes[0];
+            var parameterType = this.ParameterTypes[0].TypeSymbol;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
             if (parameterType.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
@@ -507,8 +507,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // SPEC: of which must have type T or T? and the second of which must
             // SPEC: have type int or int?, and can return any type.
 
-            if (this.ParameterTypes[0].StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType ||
-                this.ParameterTypes[1].StrippedType().SpecialType != SpecialType.System_Int32)
+            if (this.ParameterTypes[0].TypeSymbol.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType ||
+                this.ParameterTypes[1].TypeSymbol.StrippedType().SpecialType != SpecialType.System_Int32)
             {
                 // CS0546: The first operand of an overloaded shift operator must have the 
                 //         same type as the containing type, and the type of the second 
@@ -528,8 +528,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // SPEC: A binary nonshift operator must take two parameters, at least
             // SPEC: one of which must have the type T or T?, and can return any type.
-            if (this.ParameterTypes[0].StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType &&
-                this.ParameterTypes[1].StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
+            if (this.ParameterTypes[0].TypeSymbol.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType &&
+                this.ParameterTypes[1].TypeSymbol.StrippedType().TupleUnderlyingTypeOrSelf() != this.ContainingType)
             {
                 // CS0563: One of the parameters of a binary operator must be the containing type
                 diagnostics.Add(ErrorCode.ERR_BadBinaryOperatorSignature, this.Locations[0]);

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -317,6 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public bool IsEnumType() => TypeSymbol.IsEnumType();
         public bool IsDynamic() => TypeSymbol.IsDynamic();
         public bool IsObjectType() => TypeSymbol.IsObjectType();
+        public bool IsArray() => TypeSymbol.IsArray();
         public virtual bool IsRestrictedType() => TypeSymbol.IsRestrictedType();
         public bool IsPointerType() => TypeSymbol.IsPointerType();
         public bool IsErrorType() => TypeSymbol.IsErrorType();

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -175,18 +175,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol)
         {
+            if (typeSymbol is null)
+            {
+                return null;
+            }
+
             // TODO: Consider if it makes sense to cache and reuse instances, at least for definitions.
             return new WithoutCustomModifiers(typeSymbol);
         }
 
         public static TypeSymbolWithAnnotations CreateNullableReferenceType(TypeSymbol typeSymbol)
         {
+            if (typeSymbol is null)
+            {
+                return null;
+            }
+
             // TODO: Consider if it makes sense to cache and reuse instances, at least for definitions.
             return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
         }
 
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, ImmutableArray<CustomModifier> customModifiers)
         {
+            if (typeSymbol is null)
+            {
+                return null;
+            }
+
             if (customModifiers.IsDefaultOrEmpty)
             {
                 return new WithoutCustomModifiers(typeSymbol);
@@ -197,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType)
         {
-            if ((object)typeSymbol == null)
+            if (typeSymbol is null)
             {
                 return null;
             }
@@ -348,7 +363,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override int GetHashCode(TypeSymbolWithAnnotations obj)
             {
-                if ((object)obj == null)
+                if (obj is null)
                 {
                     return 0;
                 }
@@ -357,9 +372,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool Equals(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
             {
-                if ((object)x == null)
+                if (x is null)
                 {
-                    return (object)y == null;
+                    return y is null;
                 }
                 return x.Equals(y, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -180,7 +180,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            // TODO: Consider if it makes sense to cache and reuse instances, at least for definitions.
+            // PROTOTYPE(NullableReferenceTypes): Consider if it makes
+            // sense to cache and reuse instances, at least for definitions.
             return new WithoutCustomModifiers(typeSymbol);
         }
 
@@ -191,7 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            // TODO: Consider if it makes sense to cache and reuse instances, at least for definitions.
+            // PROTOTYPE(NullableReferenceTypes): Consider if it makes
+            // sense to cache and reuse instances, at least for definitions.
             return new NullableReferenceTypeWithoutCustomModifiers(typeSymbol);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolWithAnnotations.cs
@@ -14,18 +14,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// A simple class that combines a single symbol with annotations
     /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal abstract class SymbolWithAnnotations : IMessageSerializable 
     {
         public abstract Symbol Symbol { get; }
 
-        public override string ToString() => Symbol.ToString();
+        public sealed override string ToString() => Symbol.ToString();
         public string ToDisplayString(SymbolDisplayFormat format = null) => Symbol.ToDisplayString(format);
         public string Name => Symbol.Name;
         public SymbolKind Kind => Symbol.Kind;
 
 #pragma warning disable CS0809
         [Obsolete("Unsupported", error: true)]
-        public override bool Equals(object other)
+        public sealed override bool Equals(object other)
 #pragma warning restore CS0809
         {
             throw ExceptionUtilities.Unreachable;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
 #pragma warning disable CS0809
         [Obsolete("Unsupported", error: true)]
-        public override int GetHashCode()
+        public sealed override int GetHashCode()
 #pragma warning restore CS0809
         {
             throw ExceptionUtilities.Unreachable;
@@ -73,6 +74,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool operator !=(SymbolWithAnnotations x, Symbol y)
         {
             throw ExceptionUtilities.Unreachable;
+        }
+
+        internal virtual string GetDebuggerDisplay()
+        {
+            return ToString();
         }
     }
 
@@ -191,6 +197,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static TypeSymbolWithAnnotations Create(TypeSymbol typeSymbol, bool? isNullableIfReferenceType)
         {
+            if ((object)typeSymbol == null)
+            {
+                return null;
+            }
+
             if (isNullableIfReferenceType == false || !typeSymbol.IsReferenceType || typeSymbol.IsNullableType())
             {
                 return Create(typeSymbol);
@@ -288,8 +299,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public Cci.PrimitiveTypeCode PrimitiveTypeCode => TypeSymbol.PrimitiveTypeCode;
         public bool IsEnumType() => TypeSymbol.IsEnumType();
         public bool IsDynamic() => TypeSymbol.IsDynamic();
+        public bool IsObjectType() => TypeSymbol.IsObjectType();
         public virtual bool IsRestrictedType() => TypeSymbol.IsRestrictedType();
         public bool IsPointerType() => TypeSymbol.IsPointerType();
+        public bool IsErrorType() => TypeSymbol.IsErrorType();
         public bool IsUnsafe() => TypeSymbol.IsUnsafe();
         public virtual bool IsStatic => TypeSymbol.IsStatic;
         public bool IsNullableTypeOrTypeParameter() => TypeSymbol.IsNullableTypeOrTypeParameter();
@@ -323,6 +336,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return true;
+        }
+
+        internal sealed class EqualsComparer : EqualityComparer<TypeSymbolWithAnnotations>
+        {
+            internal static readonly EqualsComparer Instance = new EqualsComparer();
+
+            private EqualsComparer()
+            {
+            }
+
+            public override int GetHashCode(TypeSymbolWithAnnotations obj)
+            {
+                if ((object)obj == null)
+                {
+                    return 0;
+                }
+                return obj.TypeSymbol.GetHashCode();
+            }
+
+            public override bool Equals(TypeSymbolWithAnnotations x, TypeSymbolWithAnnotations y)
+            {
+                if ((object)x == null)
+                {
+                    return (object)y == null;
+                }
+                return x.Equals(y, TypeCompareKind.CompareNullableModifiersForReferenceTypes);
+            }
         }
 
         protected virtual bool TypeSymbolEquals(TypeSymbolWithAnnotations other, TypeCompareKind comparison)
@@ -606,6 +646,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return this;
             }
+
+            internal override string GetDebuggerDisplay()
+            {
+                var str = _typeSymbol.ToString();
+                if (IsNullable == false)
+                {
+                    str += "!";
+                }
+                return str;
+            }
         }
 
         private class NullableReferenceTypeWithoutCustomModifiers : TypeSymbolWithAnnotations
@@ -659,6 +709,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
                 return new WithoutCustomModifiers(_typeSymbol);
+            }
+
+            internal override string GetDebuggerDisplay()
+            {
+                return _typeSymbol.ToString() + "?";
             }
         }
 
@@ -714,6 +769,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return new WithoutCustomModifiers(_typeSymbol);
             }
+
+            internal override string GetDebuggerDisplay()
+            {
+                return _typeSymbol.ToString();
+            }
         }
 
         private sealed class LazyNullableType : TypeSymbolWithAnnotations
@@ -744,7 +804,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if ((object)_resolved == null)
                     {
-                        if (_underlying.IsReferenceType && ((CSharpParseOptions)_nullableTypeSyntax.SyntaxTree.Options).IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking))
+                        if (!_underlying.IsValueType && ((CSharpParseOptions)_nullableTypeSyntax.SyntaxTree.Options).IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking))
                         {
                             _resolved = _underlying.TypeSymbol;
                         }
@@ -759,6 +819,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     return _resolved;
                 }
+            }
+
+            internal override string GetDebuggerDisplay()
+            {
+                return _underlying.TypeSymbol.ToString() + "?";
             }
 
             public override TypeSymbol NullableUnderlyingTypeOrSelf => _underlying.TypeSymbol;
@@ -828,11 +893,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override TypeSymbolWithAnnotations AsNotNullableReferenceType()
             {
-                if (_underlying.TypeSymbol.IsReferenceType)
+                if (!_underlying.TypeSymbol.IsValueType)
                 {
+                    Debug.Assert(_underlying.IsNullable == false);
                     return _underlying;
                 }
 
+                Debug.Assert(!this.IsNullable == false);
                 return this;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class TupleErrorFieldSymbol : SynthesizedFieldSymbolBase
     {
-        private readonly TypeSymbol _type;
+        private readonly TypeSymbolWithAnnotations _type;
 
         /// <summary>
         /// If this field represents a tuple element with index X
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             string name, 
             int tupleElementIndex, 
             Location location, 
-            TypeSymbol type, 
+            TypeSymbolWithAnnotations type, 
             DiagnosticInfo useSiteDiagnosticInfo, 
             bool isImplicitlyDeclared,
             TupleErrorFieldSymbol correspondingDefaultFieldOpt)
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override TypeSymbolWithAnnotations GetFieldType(ConsList<FieldSymbol> fieldsBeingBound)
         {
-            return TypeSymbolWithAnnotations.Create(_type);
+            return _type;
         }
 
         internal override DiagnosticInfo GetUseSiteDiagnostic()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -623,7 +623,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// If this symbol represents a tuple type, get the types of the tuple's elements.
         /// </summary>
-        public virtual ImmutableArray<TypeSymbol> TupleElementTypes => default(ImmutableArray<TypeSymbol>);
+        public virtual ImmutableArray<TypeSymbolWithAnnotations> TupleElementTypes => default(ImmutableArray<TypeSymbolWithAnnotations>);
 
         /// <summary>
         /// If this symbol represents a tuple type, get the names of the tuple's elements.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return invokeMethod.Parameters;
         }
 
-        public static bool TryGetElementTypesIfTupleOrCompatible(this TypeSymbol type, out ImmutableArray<TypeSymbol> elementTypes)
+        public static bool TryGetElementTypesIfTupleOrCompatible(this TypeSymbol type, out ImmutableArray<TypeSymbolWithAnnotations> elementTypes)
         {
             if (type.IsTupleType)
             {
@@ -389,11 +389,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!type.IsTupleCompatible(out cardinality))
             {
                 // source not a tuple or compatible
-                elementTypes = default(ImmutableArray<TypeSymbol>);
+                elementTypes = default(ImmutableArray<TypeSymbolWithAnnotations>);
                 return false;
             }
 
-            var elementTypesBuilder = ArrayBuilder<TypeSymbol>.GetInstance(cardinality);
+            var elementTypesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance(cardinality);
             TupleTypeSymbol.AddElementTypes((NamedTypeSymbol)type, elementTypesBuilder);
 
             Debug.Assert(elementTypesBuilder.Count == cardinality);
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-       public static ImmutableArray<TypeSymbol> GetElementTypesOfTupleOrCompatible(this TypeSymbol type)
+       public static ImmutableArray<TypeSymbolWithAnnotations> GetElementTypesOfTupleOrCompatible(this TypeSymbol type)
         {
             if (type.IsTupleType)
             {
@@ -418,7 +418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // PERF: if allocations here become nuisance, consider caching the results
             //       in the type symbols that can actually be tuple compatible
-            var elementTypesBuilder = ArrayBuilder<TypeSymbol>.GetInstance();
+            var elementTypesBuilder = ArrayBuilder<TypeSymbolWithAnnotations>.GetInstance();
             TupleTypeSymbol.AddElementTypes((NamedTypeSymbol)type, elementTypesBuilder);
 
             return elementTypesBuilder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -289,9 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         NamedTypeSymbol namedType = (NamedTypeSymbol)type;
                         while ((object)namedType != null)
                         {
-                            var typeParts = namedType.IsTupleType ?
-                                namedType.TupleElementTypes.SelectAsArray(TypeMap.AsTypeSymbolWithAnnotations) :
-                                namedType.TypeArgumentsNoUseSiteDiagnostics;
+                            var typeParts = namedType.IsTupleType ? namedType.TupleElementTypes : namedType.TypeArgumentsNoUseSiteDiagnostics;
                             foreach (TypeSymbolWithAnnotations typePart in typeParts)
                             {
                                 if (Contains(typePart.TypeSymbol, typeParam))

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -260,7 +260,10 @@ class C
                 case SymbolKind.Method:
                     var methodSymbol = (MethodSymbol)symbol;
                     typeSymbols.Add(methodSymbol.ReturnType.TypeSymbol);
-                    typeSymbols.AddRange(methodSymbol.ParameterTypes);
+                    foreach (var parameterType in methodSymbol.ParameterTypes)
+                    {
+                        typeSymbols.Add(parameterType.TypeSymbol);
+                    }
                     break;
                 case SymbolKind.NamedType:
                     var namedType = (NamedTypeSymbol)symbol;
@@ -471,7 +474,7 @@ class C
                 Assert.True(firstTuple.IsTupleType);
                 Assert.True(firstTuple.TupleElementNames.IsDefault);
                 Assert.Equal(2, firstTuple.TupleElementTypes.Length);
-                var secondTuple = firstTuple.TupleElementTypes[1];
+                var secondTuple = firstTuple.TupleElementTypes[1].TypeSymbol;
                 Assert.True(secondTuple.IsTupleType);
                 Assert.True(secondTuple.TupleElementNames.IsDefault);
                 Assert.Equal(2, secondTuple.TupleElementTypes.Length);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -882,7 +882,7 @@ references: s_valueTupleRefs);
             Assert.Equal(1, first.TupleElementTypes.Length);
             Assert.True(first.TupleElementNames.IsDefault);
 
-            var second = first.TupleElementTypes[0];
+            var second = first.TupleElementTypes[0].TypeSymbol;
             Assert.True(second.IsTupleType);
             Assert.True(second.TupleElementNames.IsDefault);
             Assert.Equal(2, second.TupleElementTypes.Length);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -4735,7 +4735,7 @@ class Program
             comp.VerifyDiagnostics();
 
             var expectedOperator = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S1").GetMembers(WellKnownMemberNames.EqualityOperatorName).
-                OfType<MethodSymbol>().Single(m => m.ParameterTypes[0].TypeSymbol == m.ParameterTypes[1].TypeSymbol);
+                OfType<MethodSymbol>().Single(m => m.ParameterTypes[0].Equals(m.ParameterTypes[1], TypeCompareKind.AllAspects));
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -4735,7 +4735,7 @@ class Program
             comp.VerifyDiagnostics();
 
             var expectedOperator = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("S1").GetMembers(WellKnownMemberNames.EqualityOperatorName).
-                OfType<MethodSymbol>().Single(m => m.ParameterTypes[0] == m.ParameterTypes[1]);
+                OfType<MethodSymbol>().Single(m => m.ParameterTypes[0].TypeSymbol == m.ParameterTypes[1].TypeSymbol);
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -15565,7 +15565,7 @@ class C
         b = c ? x! : y!;
     }
 }";
-            var comp = CreateCompilationWithMscorlib45(
+            var comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -521,6 +521,7 @@ class B : A
             Assert.False(m2.OverriddenMethod.ReturnType.IsNullableType());
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Override matches other M3<T>.
         [Fact(Skip = "TODO")]
         public void Overriding_04()
         {
@@ -609,7 +610,8 @@ class B : A
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular8);
 
-            // TODO: The overriding is ambiguous. We simply matched the first candidate. Should this be an error?
+            // PROTOTYPE(NullableReferenceTypes): The overriding is ambiguous.
+            // We simply matched the first candidate. Should this be an error?
             compilation.VerifyDiagnostics();
 
             var b = compilation.GetTypeByMetadataName("B");
@@ -11781,7 +11783,8 @@ public class F : C<F?>, I1<C<B?>>, I2<C<B>?>
                                     var f = ((PEModuleSymbol)m).GlobalNamespace.GetTypeMember("F");
                                     Assert.Equal("C<F?>", f.BaseType.ToTestDisplayString());
 
-                                    // TODO: Should we round-trip nullable modifiers for implemented interfaces too. 
+                                    // PROTOTYPE(NullableReferenceTypes): Should we round-trip
+                                    // nullable modifiers for implemented interfaces too?
                                     Assert.Equal("I1<C<B>>", f.Interfaces[0].ToTestDisplayString());
                                     Assert.Equal("I2<C<B>>", f.Interfaces[1].ToTestDisplayString());
                                 });

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -3,6 +3,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -16101,7 +16102,7 @@ class B
 
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
-            var declarator = tree.GetRoot().DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax>().First();
+            var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
             var symbol = (LocalSymbol)model.GetDeclaredSymbol(declarator);
             Assert.Equal("System.String", symbol.Type.ToTestDisplayString());
             Assert.Equal(true, symbol.Type.IsNullable);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -320,12 +320,9 @@ class C
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         F(x, new List<C?>() { y }).ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, new List<C?>() { y })").WithLocation(7, 9),
-                // (8,14): warning CS8620: Nullability of reference types in argument of type 'List<C>' doesn't match target type 'List<C?>' for parameter 'y' in 'C? C.F<C?>(C? x, List<C?> y)'.
+                // (8,11): warning CS8604: Possible null reference argument for parameter 'x' in 'C C.F<C>(C x, List<C> y)'.
                 //         F(y, new List<C>() { x }).ToString();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "new List<C>() { x }").WithArguments("System.Collections.Generic.List<C>", "System.Collections.Generic.List<C?>", "y", "C? C.F<C?>(C? x, List<C?> y)").WithLocation(8, 14),
-                // (8,9): warning CS8602: Possible dereference of a null reference.
-                //         F(y, new List<C>() { x }).ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, new List<C>() { x })").WithLocation(8, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "y").WithArguments("x", "C C.F<C>(C x, List<C> y)").WithLocation(8, 11));
         }
 
         [Fact]
@@ -939,8 +936,7 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y").WithLocation(11, 13));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Type inference incorrect.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void TypeInference_TupleNameDifferences_01()
         {
             var source =
@@ -979,8 +975,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "x").WithArguments("(object, int)", "x").WithLocation(13, 22));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Type inference incorrect.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void TypeInference_TupleNameDifferences_02()
         {
             var source =
@@ -1004,16 +999,12 @@ class C
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (13,9): warning CS8602: Possible dereference of a null reference.
-                //         c.F((o, -1)).x.ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c.F((o, -1)).x").WithLocation(13, 9),
                 // (13,22): error CS1061: '(object, int)' does not contain a definition for 'x' and no extension method 'x' accepting a first argument of type '(object, int)' could be found (are you missing a using directive or an assembly reference?)
                 //         c.F((o, -1)).x.ToString();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "x").WithArguments("(object, int)", "x").WithLocation(13, 22));
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Type inference incorrect.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void TypeInference_DynamicDifferences_01()
         {
             var source =
@@ -1046,8 +1037,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        // PROTOTYPE(NullableReferenceTypes): Type inference incorrect.
-        [Fact(Skip = "TODO")]
+        [Fact]
         public void TypeInference_DynamicDifferences_02()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -1,0 +1,898 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public partial class StaticNullChecking : CSharpTestBase
+    {
+        [Fact]
+        public void TypeInference_01()
+        {
+            var source =
+@"class A { }
+class B { }
+class C
+{
+    static void F<T>(T? t) where T : A { }
+    static void G(B? b)
+    {
+        F(b);
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,9): error CS0311: The type 'B' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(T?)'. There is no implicit reference conversion from 'B' to 'A'.
+                //         F(b);
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "F").WithArguments("C.F<T>(T?)", "A", "T", "B").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void TypeInference_02()
+        {
+            var source =
+@"interface I<T> { }
+class C
+{
+    static T F<T>(I<T> t)
+    {
+        throw new System.Exception();
+    }
+    static void G(I<string> x, I<string?> y)
+    {
+        F(x).ToString();
+        F(y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void TypeInference_03()
+        {
+            var source =
+@"interface I<T> { }
+class C
+{
+    static T F<T>(I<T?> t)
+    {
+        throw new System.Exception();
+    }
+    static void G(I<string> x, I<string?> y)
+    {
+        F(x).ToString();
+        F(y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (10,11): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 't' in 'string C.F<string>(I<string?> t)'.
+                //         F(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<string>", "I<string?>", "t", "string C.F<string>(I<string?> t)").WithLocation(10, 11));
+        }
+
+        [Fact]
+        public void TypeInference_04()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T x, T y) => x;
+    static void G(C? x, C y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, x)").WithLocation(6, 9),
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(7, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, x)").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void TypeInference_05()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T x, T? y) => x;
+    static void G(C? x, C y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, x)").WithLocation(6, 9),
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void TypeInference_06()
+        {
+            var source =
+@"class C
+{
+    static T F<T, U>(T t, U u) where U : T => t;
+    static void G(C? x, C y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, x)").WithLocation(6, 9),
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void TypeInference_07()
+        {
+            var source =
+@"using System.Collections.Generic;
+class C
+{
+    static T F<T>(T x, List<T> y) => x;
+    static void G(C x, C? y)
+    {
+        F(x, new List<C?>() { y }).ToString();
+        F(y, new List<C>() { x }).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, new List<C?>() { y }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, new List<C?>() { y })").WithLocation(7, 9),
+                // (8,14): warning CS8620: Nullability of reference types in argument of type 'List<C>' doesn't match target type 'List<C?>' for parameter 'y' in 'C? C.F<C?>(C? x, List<C?> y)'.
+                //         F(y, new List<C>() { x }).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "new List<C>() { x }").WithArguments("System.Collections.Generic.List<C>", "System.Collections.Generic.List<C?>", "y", "C? C.F<C?>(C? x, List<C?> y)").WithLocation(8, 14),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, new List<C>() { x }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, new List<C>() { x })").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void TypeInference_08()
+        {
+            var source =
+@"class A { }
+class B { }
+class C<T, U> { }
+class C
+{
+    static void F<T>(T x, T y) { }
+    static void G(C<A, B?> x, C<A?, B> y, C<A, B> z, C<A?, B?> w)
+    {
+        F(x, y);
+        F(y, x);
+        F(z, w);
+        F(w, z);
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,14): warning CS8620: Nullability of reference types in argument of type 'C<A?, B>' doesn't match target type 'C<A, B?>' for parameter 'y' in 'void C.F<C<A, B?>>(C<A, B?> x, C<A, B?> y)'.
+                //         F(x, y);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("C<A?, B>", "C<A, B?>", "y", "void C.F<C<A, B?>>(C<A, B?> x, C<A, B?> y)").WithLocation(9, 14),
+                // (10,14): warning CS8620: Nullability of reference types in argument of type 'C<A, B?>' doesn't match target type 'C<A?, B>' for parameter 'y' in 'void C.F<C<A?, B>>(C<A?, B> x, C<A?, B> y)'.
+                //         F(y, x);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("C<A, B?>", "C<A?, B>", "y", "void C.F<C<A?, B>>(C<A?, B> x, C<A?, B> y)").WithLocation(10, 14),
+                // (11,14): warning CS8620: Nullability of reference types in argument of type 'C<A?, B?>' doesn't match target type 'C<A, B>' for parameter 'y' in 'void C.F<C<A, B>>(C<A, B> x, C<A, B> y)'.
+                //         F(z, w);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "w").WithArguments("C<A?, B?>", "C<A, B>", "y", "void C.F<C<A, B>>(C<A, B> x, C<A, B> y)").WithLocation(11, 14),
+                // (12,14): warning CS8620: Nullability of reference types in argument of type 'C<A, B>' doesn't match target type 'C<A?, B?>' for parameter 'y' in 'void C.F<C<A?, B?>>(C<A?, B?> x, C<A?, B?> y)'.
+                //         F(w, z);
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("C<A, B>", "C<A?, B?>", "y", "void C.F<C<A?, B?>>(C<A?, B?> x, C<A?, B?> y)").WithLocation(12, 14));
+        }
+
+        [Fact]
+        public void TypeInference_09()
+        {
+            var source =
+@"interface I<T> { }
+interface IIn<in T> { }
+interface IOut<out T> { }
+class C
+{
+    static T F<T>(I<T> x, I<T> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(I<string> x, I<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+    static T F<T>(IIn<T> x, IIn<T> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(IIn<string> x, IIn<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+    static T F<T>(IOut<T> x, IOut<T> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(IOut<string> x, IOut<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (13,11): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 'x' in 'string? C.F<string?>(I<string?> x, I<string?> y)'.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<string>", "I<string?>", "x", "string? C.F<string?>(I<string?> x, I<string?> y)").WithLocation(13, 11),
+                // (13,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(13, 9),
+                // (14,14): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 'y' in 'string? C.F<string?>(I<string?> x, I<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<string>", "I<string?>", "y", "string? C.F<string?>(I<string?> x, I<string?> y)").WithLocation(14, 14),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, x)").WithLocation(14, 9),
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(15, 9),
+                // (24,14): warning CS8620: Nullability of reference types in argument of type 'IIn<string?>' doesn't match target type 'IIn<string>' for parameter 'y' in 'string C.F<string>(IIn<string> x, IIn<string> y)'.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("IIn<string?>", "IIn<string>", "y", "string C.F<string>(IIn<string> x, IIn<string> y)").WithLocation(24, 14),
+                // (25,11): warning CS8620: Nullability of reference types in argument of type 'IIn<string?>' doesn't match target type 'IIn<string>' for parameter 'x' in 'string C.F<string>(IIn<string> x, IIn<string> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("IIn<string?>", "IIn<string>", "x", "string C.F<string>(IIn<string> x, IIn<string> y)").WithLocation(25, 11),
+                // (26,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(26, 9),
+                // (35,11): warning CS8620: Nullability of reference types in argument of type 'IOut<string>' doesn't match target type 'IOut<string?>' for parameter 'x' in 'string? C.F<string?>(IOut<string?> x, IOut<string?> y)'.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IOut<string>", "IOut<string?>", "x", "string? C.F<string?>(IOut<string?> x, IOut<string?> y)").WithLocation(35, 11),
+                // (35,9): warning CS8602: Possible dereference of a null reference.
+                //         F(x, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(x, y)").WithLocation(35, 9),
+                // (36,14): warning CS8620: Nullability of reference types in argument of type 'IOut<string>' doesn't match target type 'IOut<string?>' for parameter 'y' in 'string? C.F<string?>(IOut<string?> x, IOut<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IOut<string>", "IOut<string?>", "y", "string? C.F<string?>(IOut<string?> x, IOut<string?> y)").WithLocation(36, 14),
+                // (36,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, x)").WithLocation(36, 9),
+                // (37,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(37, 9));
+        }
+
+        [Fact]
+        public void TypeInference_10()
+        {
+            var source =
+@"interface I<T> { }
+interface IIn<in T> { }
+interface IOut<out T> { }
+class C
+{
+    static T F<T>(I<T> x, I<T?> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(I<string> x, I<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+    static T F<T>(IIn<T> x, IIn<T?> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(IIn<string> x, IIn<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+    static T F<T>(IOut<T> x, IOut<T?> y)
+    {
+        throw new System.Exception();
+    }
+    static void G(IOut<string> x, IOut<string?> y)
+    {
+        F(x, x).ToString();
+        F(x, y).ToString();
+        F(y, x).ToString();
+        F(y, y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (12,14): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 'y' in 'string C.F<string>(I<string> x, I<string?> y)'.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<string>", "I<string?>", "y", "string C.F<string>(I<string> x, I<string?> y)").WithLocation(12, 14),
+                // (14,14): warning CS8620: Nullability of reference types in argument of type 'I<string>' doesn't match target type 'I<string?>' for parameter 'y' in 'string? C.F<string?>(I<string?> x, I<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<string>", "I<string?>", "y", "string? C.F<string?>(I<string?> x, I<string?> y)").WithLocation(14, 14),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, x)").WithLocation(14, 9),
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(15, 9),
+                // (23,14): warning CS8620: Nullability of reference types in argument of type 'IIn<string>' doesn't match target type 'IIn<string?>' for parameter 'y' in 'string C.F<string>(IIn<string> x, IIn<string?> y)'.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IIn<string>", "IIn<string?>", "y", "string C.F<string>(IIn<string> x, IIn<string?> y)").WithLocation(23, 14),
+                // (25,11): warning CS8620: Nullability of reference types in argument of type 'IIn<string?>' doesn't match target type 'IIn<string>' for parameter 'x' in 'string C.F<string>(IIn<string> x, IIn<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("IIn<string?>", "IIn<string>", "x", "string C.F<string>(IIn<string> x, IIn<string?> y)").WithLocation(25, 11),
+                // (25,14): warning CS8620: Nullability of reference types in argument of type 'IIn<string>' doesn't match target type 'IIn<string?>' for parameter 'y' in 'string C.F<string>(IIn<string> x, IIn<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IIn<string>", "IIn<string?>", "y", "string C.F<string>(IIn<string> x, IIn<string?> y)").WithLocation(25, 14),
+                // (26,11): warning CS8620: Nullability of reference types in argument of type 'IIn<string?>' doesn't match target type 'IIn<string>' for parameter 'x' in 'string C.F<string>(IIn<string> x, IIn<string?> y)'.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "y").WithArguments("IIn<string?>", "IIn<string>", "x", "string C.F<string>(IIn<string> x, IIn<string?> y)").WithLocation(26, 11),
+                // (34,14): warning CS8620: Nullability of reference types in argument of type 'IOut<string>' doesn't match target type 'IOut<string?>' for parameter 'y' in 'string C.F<string>(IOut<string> x, IOut<string?> y)'.
+                //         F(x, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IOut<string>", "IOut<string?>", "y", "string C.F<string>(IOut<string> x, IOut<string?> y)").WithLocation(34, 14),
+                // (36,14): warning CS8620: Nullability of reference types in argument of type 'IOut<string>' doesn't match target type 'IOut<string?>' for parameter 'y' in 'string? C.F<string?>(IOut<string?> x, IOut<string?> y)'.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IOut<string>", "IOut<string?>", "y", "string? C.F<string?>(IOut<string?> x, IOut<string?> y)").WithLocation(36, 14),
+                // (36,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, x)").WithLocation(36, 9),
+                // (37,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y, y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(37, 9));
+        }
+
+        [Fact]
+        public void TupleTypeInference_01()
+        {
+            var source =
+@"class C
+{
+    static (T, T) F<T>((T, T) t) => t;
+    static void G(string x, string? y)
+    {
+        F((x, x)).Item2.ToString();
+        F((x, y)).Item2.ToString();
+        F((y, x)).Item2.ToString();
+        F((y, y)).Item2.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,9): warning CS8602: Possible dereference of a null reference.
+                //         F((x, y)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((x, y)).Item2").WithLocation(7, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F((y, x)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F((y, y)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, y)).Item2").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TupleTypeInference_02()
+        {
+            var source =
+@"class C
+{
+    static (T, T) F<T>((T, T?) t) => (t.Item1, t.Item1);
+    static void G(string x, string? y)
+    {
+        F((x, x)).Item2.ToString();
+        F((x, y)).Item2.ToString();
+        F((y, x)).Item2.ToString();
+        F((y, y)).Item2.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F((y, x)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F((y, y)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, y)).Item2").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TupleTypeInference_03()
+        {
+            var source =
+@"class C
+{
+    static T F<T>((T, T?) t) => t.Item1;
+    static void G((string, string) x, (string, string?) y, (string?, string) z, (string?, string?) w)
+    {
+        F(x).ToString();
+        F(y).ToString();
+        F(z).ToString();
+        F(w).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,11): warning CS8620: Nullability of reference types in argument of type '(string, string)' doesn't match target type '(string, string)' for parameter 't' in 'string C.F<string>((string, string) t)'.
+                //         F(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("(string, string)", "(string, string)", "t", "string C.F<string>((string, string) t)").WithLocation(6, 11),
+                // (8,11): warning CS8620: Nullability of reference types in argument of type '(string, string)' doesn't match target type '(string, string)' for parameter 't' in 'string? C.F<string?>((string, string) t)'.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("(string, string)", "(string, string)", "t", "string? C.F<string?>((string, string) t)").WithLocation(8, 11),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(z)").WithLocation(8, 9),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(w).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(w)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TupleTypeInference_04()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(out (T, T?) t) => throw new System.Exception();
+    static void G()
+    {
+        F(out (string, string) t1).ToString();
+        F(out (string, string?) t2).ToString();
+        F(out (string?, string) t3).ToString();
+        F(out (string?, string?) t4).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,15): warning CS8619: Nullability of reference types in value of type '(string, string)' doesn't match target type '(string, string)'.
+                //         F(out (string, string) t1).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(string, string) t1").WithArguments("(string, string)", "(string, string)").WithLocation(6, 15),
+                // (8,15): warning CS8619: Nullability of reference types in value of type '(string, string)' doesn't match target type '(string, string)'.
+                //         F(out (string?, string) t3).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "(string?, string) t3").WithArguments("(string, string)", "(string, string)").WithLocation(8, 15),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(out (string?, string) t3).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(out (string?, string) t3)").WithLocation(8, 9),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(out (string?, string?) t4).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(out (string?, string?) t4)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TupleTypeInference_05()
+        {
+            var source =
+@"interface I<T> { }
+interface IIn<in T> { }
+interface IOut<out T> { }
+class C
+{
+    static T F<T>(I<(T, T?)> t) => throw new System.Exception();
+    static void G(I<(string, string)> x, I<(string, string?)> y, I<(string?, string)> z, I<(string?, string?)> w)
+    {
+        F(x).ToString();
+        F(y).ToString();
+        F(z).ToString();
+        F(w).ToString();
+    }
+    static T F<T>(IIn<(T, T?)> t) => throw new System.Exception();
+    static void G(IIn<(string, string)> x, IIn<(string, string?)> y, IIn<(string?, string)> z, IIn<(string?, string?)> w)
+    {
+        F(x).ToString();
+        F(y).ToString();
+        F(z).ToString();
+        F(w).ToString();
+    }
+    static T F<T>(IOut<(T, T?)> t) => throw new System.Exception();
+    static void G(IOut<(string, string)> x, IOut<(string, string?)> y, IOut<(string?, string)> z, IOut<(string?, string?)> w)
+    {
+        F(x).ToString();
+        F(y).ToString();
+        F(z).ToString();
+        F(w).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,11): warning CS8620: Nullability of reference types in argument of type 'I<(string, string)>' doesn't match target type 'I<(string, string)>' for parameter 't' in 'string C.F<string>(I<(string, string)> t)'.
+                //         F(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("I<(string, string)>", "I<(string, string)>", "t", "string C.F<string>(I<(string, string)> t)").WithLocation(9, 11),
+                // (11,11): warning CS8620: Nullability of reference types in argument of type 'I<(string, string)>' doesn't match target type 'I<(string, string)>' for parameter 't' in 'string? C.F<string?>(I<(string, string)> t)'.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("I<(string, string)>", "I<(string, string)>", "t", "string? C.F<string?>(I<(string, string)> t)").WithLocation(11, 11),
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(z)").WithLocation(11, 9),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         F(w).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(w)").WithLocation(12, 9),
+                // (17,11): warning CS8620: Nullability of reference types in argument of type 'IIn<(string, string)>' doesn't match target type 'IIn<(string, string)>' for parameter 't' in 'string C.F<string>(IIn<(string, string)> t)'.
+                //         F(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IIn<(string, string)>", "IIn<(string, string)>", "t", "string C.F<string>(IIn<(string, string)> t)").WithLocation(17, 11),
+                // (19,11): warning CS8620: Nullability of reference types in argument of type 'IIn<(string, string)>' doesn't match target type 'IIn<(string, string)>' for parameter 't' in 'string? C.F<string?>(IIn<(string, string)> t)'.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("IIn<(string, string)>", "IIn<(string, string)>", "t", "string? C.F<string?>(IIn<(string, string)> t)").WithLocation(19, 11),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(z)").WithLocation(19, 9),
+                // (20,9): warning CS8602: Possible dereference of a null reference.
+                //         F(w).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(w)").WithLocation(20, 9),
+                // (25,11): warning CS8620: Nullability of reference types in argument of type 'IOut<(string, string)>' doesn't match target type 'IOut<(string, string)>' for parameter 't' in 'string C.F<string>(IOut<(string, string)> t)'.
+                //         F(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "x").WithArguments("IOut<(string, string)>", "IOut<(string, string)>", "t", "string C.F<string>(IOut<(string, string)> t)").WithLocation(25, 11),
+                // (27,11): warning CS8620: Nullability of reference types in argument of type 'IOut<(string, string)>' doesn't match target type 'IOut<(string, string)>' for parameter 't' in 'string? C.F<string?>(IOut<(string, string)> t)'.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "z").WithArguments("IOut<(string, string)>", "IOut<(string, string)>", "t", "string? C.F<string?>(IOut<(string, string)> t)").WithLocation(27, 11),
+                // (27,9): warning CS8602: Possible dereference of a null reference.
+                //         F(z).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(z)").WithLocation(27, 9),
+                // (28,9): warning CS8602: Possible dereference of a null reference.
+                //         F(w).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(w)").WithLocation(28, 9));
+        }
+
+        [Fact]
+        public void ReturnTypeInference_01()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(System.Func<T> f)
+    {
+        return f();
+    }
+    static void G(string x, string? y)
+    {
+        F(() => x).ToString();
+        F(() => y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         F(() => y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => y)").WithLocation(10, 9));
+        }
+
+        // Multiple returns, one of which is null.
+        [Fact]
+        public void ReturnTypeInference_02()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(System.Func<T> f)
+    {
+        return f();
+    }
+    static void G(string x)
+    {
+        F(() => { if (x.Length > 0) return x; return null; }).ToString();
+        F(() => { if (x.Length == 0) return null; return x; }).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(() => { if (x.Length > 0) return x; return null; }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (x.Length > 0) return x; return null; })").WithLocation(9, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         F(() => { if (x.Length == 0) return null; return x; }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (x.Length == 0) return null; return x; })").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void ReturnTypeInference_CSharp7()
+        {
+            var source =
+@"using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        args.F(arg => arg.Length);
+    }
+}
+static class E
+{
+    internal static U[] F<T, U>(this T[] a, Func<T, U> f) => throw new Exception();
+}";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(
+                source,
+                parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TypeInference_Local()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G()
+    {
+        object x = new object();
+        object? y = x;
+        F(x).ToString();
+        F(y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TypeInference_Call()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static object F1() => new object();
+    static object? F2() => null;
+    static void G()
+    {
+        F(F1()).ToString();
+        F(F2()).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(F2()).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(F2())").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TypeInference_Property()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static object P => new object();
+    static object? Q => null;
+    static void G()
+    {
+        F(P).ToString();
+        F(Q).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(Q).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(Q)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TypeInference_FieldAccess()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static object F1 = new object();
+    static object? F2 = null;
+    static void G()
+    {
+        F(F1).ToString();
+        F(F2).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(F2).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(F2)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void TypeInference_Literal()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G()
+    {
+        F(0).ToString();
+        F('A').ToString();
+        F(""B"").ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TypeInference_Default()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G()
+    {
+        F(default(object)).ToString();
+        F(default(int)).ToString();
+        F(default(string)).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         F(default(object)).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(object))").WithLocation(6, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(default(string)).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(default(string))").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void TypeInference_ObjectCreation()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G()
+    {
+        F(new C { }).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TypeInference_BinaryOperator()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G(string x, string? y)
+    {
+        F(x + x).ToString();
+        F(x + y).ToString();
+        F(y + x).ToString();
+        F(y + y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TypeInference_NullCoalescingOperator()
+        {
+            var source =
+@"class C
+{
+    static T F<T>(T t) => t;
+    static void G(object x, object? y)
+    {
+        F(x ?? x).ToString();
+        F(x ?? y).ToString();
+        F(y ?? x).ToString();
+        F(y ?? y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,11): hidden CS8607: Expression is probably never null.
+                //         F(x ?? x).ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x").WithLocation(6, 11),
+                // (7,11): hidden CS8607: Expression is probably never null.
+                //         F(x ?? y).ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "x").WithLocation(7, 11),
+                // (9,9): warning CS8602: Possible dereference of a null reference.
+                //         F(y ?? y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y ?? y)").WithLocation(9, 9));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -827,6 +827,30 @@ static class E
         }
 
         [Fact]
+        public void TypeInference_Tuple()
+        {
+            var source =
+@"class C
+{
+    static (T, U) F<T, U>((T, U) t) => t;
+    static void G(string x, string? y)
+    {
+        var t = (x, y);
+        F(t).Item1.ToString();
+        F(t).Item2.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         F(t).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(t).Item2").WithLocation(8, 9));
+        }
+
+        [Fact]
         public void TypeInference_ObjectCreation()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -3312,7 +3312,7 @@ class Z
 
             var gType = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("G");
             var mngMethod = (MethodSymbol)comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Z").GetMembers("MNG").First();
-            var gNullableType = mngMethod.ParameterTypes[0];
+            var gNullableType = mngMethod.ParameterTypes[0].TypeSymbol;
             Assert.True(gNullableType.IsNullableType(), "MNG parameter is not a nullable type?");
             Assert.Equal(gType, gNullableType.StrippedType());
 
@@ -3377,7 +3377,7 @@ class Z
 
             var gType = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("G");
             var mngMethod = (MethodSymbol)comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Z").GetMembers("MNG").First();
-            var gNullableType = mngMethod.ParameterTypes[0];
+            var gNullableType = mngMethod.ParameterTypes[0].TypeSymbol;
             Assert.True(gNullableType.IsNullableType(), "MNG parameter is not a nullable type?");
             Assert.Equal(gType, gNullableType.StrippedType());
 
@@ -4660,9 +4660,9 @@ class C : A
             var classC = global.GetMember<NamedTypeSymbol>("C");
             var methodBar = classC.GetMember<MethodSymbol>("Bar");
 
-            var paramType0 = methodBar.ParameterTypes[0];
+            var paramType0 = methodBar.ParameterTypes[0].TypeSymbol;
             Assert.Equal(TypeKind.TypeParameter, paramType0.TypeKind);
-            var paramType1 = methodBar.ParameterTypes[1];
+            var paramType1 = methodBar.ParameterTypes[1].TypeSymbol;
             Assert.Equal(TypeKind.Class, paramType1.TypeKind);
 
             int position = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First().SpanStart;
@@ -4705,9 +4705,9 @@ class C : A
             var classC = global.GetMember<NamedTypeSymbol>("C");
             var methodBar = classC.GetMember<MethodSymbol>("Bar");
 
-            var paramType0 = methodBar.ParameterTypes[0];
+            var paramType0 = methodBar.ParameterTypes[0].TypeSymbol;
             Assert.Equal(TypeKind.TypeParameter, paramType0.TypeKind);
-            var paramType1 = methodBar.ParameterTypes[1];
+            var paramType1 = methodBar.ParameterTypes[1].TypeSymbol;
             Assert.Equal(TypeKind.Class, paramType1.TypeKind);
 
             int position = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First().SpanStart;

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -3486,7 +3486,7 @@ class Derived : Test
             var expr = identifier.FirstAncestorOrSelf<ArgumentSyntax>().Parent.Parent;
 
             var exprInfo = model.GetSymbolInfo(expr);
-            var firstParamType = ((Symbol)exprInfo.CandidateSymbols.Single()).GetParameterTypes().First();
+            var firstParamType = ((Symbol)exprInfo.CandidateSymbols.Single()).GetParameterTypes().First().TypeSymbol;
             Assert.Equal(actionType, firstParamType);
 
             var identifierInfo = model.GetTypeInfo(identifier);

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -5874,7 +5874,7 @@ enum E { }
             compilation.VerifyDiagnostics();
 
             var expectedSymbol = compilation.GetSpecialType(SpecialType.System_String).
-                InstanceConstructors.Single(ctor => ctor.ParameterCount == 1 && ctor.ParameterTypes[0].IsArray());
+                InstanceConstructors.Single(ctor => ctor.ParameterCount == 1 && ctor.ParameterTypes[0].TypeSymbol.IsArray());
 
             var cref = GetCrefSyntaxes(compilation).Single();
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
@@ -263,19 +263,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             //public static dynamic F1(dynamic x) { return x; }
             var f1 = _derivedClass.GetMember<MethodSymbol>("F1");
             Assert.Equal(s_dynamicType, f1.ReturnType.TypeSymbol);
-            Assert.Equal(s_dynamicType, f1.ParameterTypes[0]);
+            Assert.Equal(s_dynamicType, f1.ParameterTypes[0].TypeSymbol);
 
             //public static dynamic F2(ref dynamic x) { return x; }
             var f2 = _derivedClass.GetMember<MethodSymbol>("F2");
             Assert.Equal(s_dynamicType, f2.ReturnType.TypeSymbol);
-            Assert.Equal(s_dynamicType, f2.ParameterTypes[0]);
+            Assert.Equal(s_dynamicType, f2.ParameterTypes[0].TypeSymbol);
             Assert.Equal(RefKind.Ref, f2.Parameters[0].RefKind);
 
             //public static dynamic[] F3(dynamic[] x) { return x; }
             var f3 = _derivedClass.GetMember<MethodSymbol>("F3");
             var arrayOfDynamic = ArrayTypeSymbol.CreateCSharpArray(_assembly, TypeSymbolWithAnnotations.Create(s_dynamicType));
             Assert.Equal(arrayOfDynamic, f3.ReturnType.TypeSymbol);
-            Assert.Equal(arrayOfDynamic, f3.ParameterTypes[0]);
+            Assert.Equal(arrayOfDynamic, f3.ParameterTypes[0].TypeSymbol);
             Assert.Equal(RefKind.None, f3.Parameters[0].RefKind);
 
             var derivedTypeParam = _derivedClass.TypeParameters[0];
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             //public static Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] F4(Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] x) { return x; }
             var f4 = _derivedClass.GetMember<MethodSymbol>("F4");
             Assert.Equal(complicatedInnerInnerArrayOfArray, f4.ReturnType.TypeSymbol);
-            Assert.Equal(complicatedInnerInnerArrayOfArray, f4.ParameterTypes[0]);
+            Assert.Equal(complicatedInnerInnerArrayOfArray, f4.ParameterTypes[0].TypeSymbol);
             Assert.Equal(RefKind.None, f4.Parameters[0].RefKind);
 
             //public static dynamic Prop1 { get { return field1; } }
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(complicatedInnerInnerArrayOfArray, prop2.Type.TypeSymbol);
             Assert.Equal(complicatedInnerInnerArrayOfArray, prop2.GetMethod.ReturnType.TypeSymbol);
             Assert.Equal(SpecialType.System_Void, prop2.SetMethod.ReturnType.SpecialType);
-            Assert.Equal(complicatedInnerInnerArrayOfArray, prop2.SetMethod.ParameterTypes[0]);
+            Assert.Equal(complicatedInnerInnerArrayOfArray, prop2.SetMethod.ParameterTypes[0].TypeSymbol);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetCustomAttributes.cs
@@ -85,10 +85,10 @@ class TestClass
                 Assert.NotSame(oldMsCorLib_debuggerTypeProxyAttributeType, newMsCorLib_debuggerTypeProxyAttributeType);
 
                 oldMsCorLib_debuggerTypeProxyAttributeCtor = (MethodSymbol)oldMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").Single(
-                    m => ((MethodSymbol)m).ParameterCount == 1 && ((MethodSymbol)m).ParameterTypes[0] == oldMsCorLib_systemType);
+                    m => ((MethodSymbol)m).ParameterCount == 1 && ((MethodSymbol)m).ParameterTypes[0].TypeSymbol == oldMsCorLib_systemType);
 
                 newMsCorLib_debuggerTypeProxyAttributeCtor = (MethodSymbol)newMsCorLib_debuggerTypeProxyAttributeType.GetMembers(".ctor").Single(
-                    m => ((MethodSymbol)m).ParameterCount == 1 && ((MethodSymbol)m).ParameterTypes[0] == newMsCorLib_systemType);
+                    m => ((MethodSymbol)m).ParameterCount == 1 && ((MethodSymbol)m).ParameterTypes[0].TypeSymbol == newMsCorLib_systemType);
 
                 Assert.NotSame(oldMsCorLib_debuggerTypeProxyAttributeCtor, newMsCorLib_debuggerTypeProxyAttributeCtor);
             }
@@ -141,7 +141,7 @@ class TestClass
 
                 Assert.Same(newMsCorLib_debuggerTypeProxyAttributeType, attribute.AttributeClass);
                 Assert.Same(newMsCorLib_debuggerTypeProxyAttributeCtor, attribute.AttributeConstructor);
-                Assert.Same(newMsCorLib_systemType, attribute.AttributeConstructor.ParameterTypes[0]);
+                Assert.Same(newMsCorLib_systemType, attribute.AttributeConstructor.ParameterTypes[0].TypeSymbol);
 
                 Assert.Equal(1, attribute.CommonConstructorArguments.Length);
                 attribute.VerifyValue(0, TypedConstantKind.Type, newMsCorLib_systemType);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -861,13 +861,13 @@ class C : I
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     interfaceMethod1.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    interfaceMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    interfaceMethod1.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             Assert.Equal("(System.Object a, System.Object b) C.I.M((System.Object c, System.Object d) x)", classMethod1.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod1.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    classMethod1.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var source2 = @"
 class C : I
@@ -889,7 +889,7 @@ class C : I
                 classMethod2.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                classMethod2.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var source3 = @"
 class C : I
@@ -910,7 +910,7 @@ class C : I
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod3.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod3.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    classMethod3.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var source4 = @"
 class C : I
@@ -925,7 +925,7 @@ class C : I
 
             Assert.Equal("(System.Object a, System.Object b) C.M((System.Object c, System.Object d) x)", classMethod4.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod4.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString()); // modopts not copied
-            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod4.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString()); // modopts not copied
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod4.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString()); // modopts not copied
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]
@@ -1123,7 +1123,7 @@ class C : Base
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     baseMethod1.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    baseMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    baseMethod1.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var baseProperty1 = comp1.GlobalNamespace.GetMember<PropertySymbol>("Base.P");
 
@@ -1142,7 +1142,7 @@ class C : Base
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod1.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    classMethod1.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var source2 = @"
 class C : Base
@@ -1169,7 +1169,7 @@ class C : Base
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod2.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    classMethod2.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
 
             var source3 = @"
 class C : Base
@@ -1191,7 +1191,7 @@ class C : Base
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod3.ReturnType.TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod3.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+                    classMethod3.ParameterTypes[0].TypeSymbol.TupleUnderlyingType.ToTestDisplayString());
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
@@ -2215,15 +2215,15 @@ class Derived2 : Base
             var event1 = derived1.GetMember<EventSymbol>("E");
             Assert.Equal(baseEventType, event1.Type.TypeSymbol);
             Assert.Equal(baseEventType, event1.AssociatedField.Type.TypeSymbol);
-            Assert.Equal(baseEventType, event1.AddMethod.ParameterTypes.Single());
-            Assert.Equal(baseEventType, event1.RemoveMethod.ParameterTypes.Single());
+            Assert.Equal(baseEventType, event1.AddMethod.ParameterTypes.Single().TypeSymbol);
+            Assert.Equal(baseEventType, event1.RemoveMethod.ParameterTypes.Single().TypeSymbol);
 
             var derived2 = global.GetMember<NamedTypeSymbol>("Derived2");
             var event2 = derived2.GetMember<EventSymbol>("E");
             Assert.Equal(baseEventType, event2.Type.TypeSymbol);
             Assert.Null(event2.AssociatedField);
-            Assert.Equal(baseEventType, event2.AddMethod.ParameterTypes.Single());
-            Assert.Equal(baseEventType, event2.RemoveMethod.ParameterTypes.Single());
+            Assert.Equal(baseEventType, event2.AddMethod.ParameterTypes.Single().TypeSymbol);
+            Assert.Equal(baseEventType, event2.RemoveMethod.ParameterTypes.Single().TypeSymbol);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -3491,13 +3491,13 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Assert.Equal(tokenType, addMethod.ReturnType.TypeSymbol);
             Assert.False(addMethod.ReturnsVoid);
             Assert.Equal(1, addMethod.ParameterCount);
-            Assert.Equal(eventType.TypeSymbol, addMethod.ParameterTypes.Single());
+            Assert.Equal(eventType.TypeSymbol, addMethod.ParameterTypes.Single().TypeSymbol);
 
             var removeMethod = @event.RemoveMethod;
             Assert.Equal(voidType, removeMethod.ReturnType.TypeSymbol);
             Assert.True(removeMethod.ReturnsVoid);
             Assert.Equal(1, removeMethod.ParameterCount);
-            Assert.Equal(tokenType, removeMethod.ParameterTypes.Single());
+            Assert.Equal(tokenType, removeMethod.ParameterTypes.Single().TypeSymbol);
 
             if (@event.HasAssociatedField)
             {
@@ -3522,13 +3522,13 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Assert.Equal(voidType, addMethod.ReturnType.TypeSymbol);
             Assert.True(addMethod.ReturnsVoid);
             Assert.Equal(1, addMethod.ParameterCount);
-            Assert.Equal(eventType, addMethod.ParameterTypes.Single());
+            Assert.Equal(eventType, addMethod.ParameterTypes.Single().TypeSymbol);
 
             var removeMethod = @event.RemoveMethod;
             Assert.Equal(voidType, removeMethod.ReturnType.TypeSymbol);
             Assert.True(removeMethod.ReturnsVoid);
             Assert.Equal(1, removeMethod.ParameterCount);
-            Assert.Equal(eventType, removeMethod.ParameterTypes.Single());
+            Assert.Equal(eventType, removeMethod.ParameterTypes.Single().TypeSymbol);
 
             if (@event.HasAssociatedField)
             {

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -522,7 +522,7 @@ class Program
             var expectedOrderedItems = new List<SignatureHelpTestItem>
             {
                 new SignatureHelpTestItem(
-$@"void List<'a>.Add('a item)
+$@"void List<'a?>.Add('a? item)
 
 {FeaturesResources.Anonymous_Types_colon}
     'a {FeaturesResources.is_} new {{ string Name, int Age }}",


### PR DESCRIPTION
Include nullability in type inference. `MethodTypeInferrer` now includes nullability when calculating exact matches and lower and upper bounds. From those bounds, the inferrer now _fixes_ the type variables in two passes: first, considering nullability, and second, ignoring nullability. If the first pass succeeds, the second pass should succeed as well, although perhaps with different nullability. If the first pass succeeds, that result is returned, otherwise the result from the second pass is returned.

`F<T>(T x, T? y)`
Infer `T=string` for `F(string, string)` and `F(string, string?)`, and infer `T=string?` for `F(string?, string)` and `F(string?, string?`)`.

`interface IIn<in T> { }`
`F<T>(IIn<T> x, IIn<T> y)`
Infer `T=string` for `F(IIn<string>, IIn<string?>)`.

`interface IOut<out T> { }`
`F<T>(IOut<T> x, IOut<T> y)`
Infer `T=string?` for `F(IOut<string>, IOut<string?>)`.
