### PR TITLE
Disable useUserOverride in CultureContext

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1417,7 +1417,7 @@ d.cs
         public void LanguageVersion_TryParseTurkishDisplayString()
         {
             var originalCulture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR", useUserOverride: false);
             Assert.True("ISO-1".TryParse(out var version));
             Assert.Equal(LanguageVersion.CSharp1, version);
             Thread.CurrentThread.CurrentCulture = originalCulture;

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -476,7 +476,7 @@ class C
     }
 }
 ";
-            using (new CultureContext(new CultureInfo("en-US", false)))
+            using (new CultureContext(new CultureInfo("en-US", useUserOverride: false)))
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>
@@ -769,7 +769,7 @@ class C
     }
 }
 ";
-            using (new CultureContext(new CultureInfo("en-US", false)))
+            using (new CultureContext(new CultureInfo("en-US", useUserOverride: false)))
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -476,7 +476,7 @@ class C
     }
 }
 ";
-            using (new CultureContext("en-US"))
+            using (new CultureContext(new CultureInfo("en-US", false)))
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>
@@ -769,7 +769,7 @@ class C
     }
 }
 ";
-            using (new CultureContext("en-US"))
+            using (new CultureContext(new CultureInfo("en-US", false)))
             {
                 CompileAndVerify(text, options: TestOptions.DebugDll).VerifyPdb("C.M", @"
 <symbols>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -397,7 +397,7 @@ class C
     }
 }
 ";
-            using (new CultureContext(new CultureInfo("en-US", false)))
+            using (new CultureContext(new CultureInfo("en-US", useUserOverride: false)))
             {
                 var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.ReleaseExe);
                 c.VerifyPdb(@"

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -396,7 +397,7 @@ class C
     }
 }
 ";
-            using (new CultureContext("en-US"))
+            using (new CultureContext(new CultureInfo("en-US", false)))
             {
                 var c = CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.ReleaseExe);
                 c.VerifyPdb(@"

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact, WorkItem(529850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529850")]
         public void CultureInvariance()
         {
-            using (new CultureContext(new CultureInfo("de-DE", false)))
+            using (new CultureContext(new CultureInfo("de-DE", useUserOverride: false)))
             {
                 var decimalValue = new Decimal(12.5);
                 Assert.Equal("12,5", decimalValue.ToString());

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/ObjectDisplayTests.cs
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact, WorkItem(529850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529850")]
         public void CultureInvariance()
         {
-            using (new CultureContext("de-DE"))
+            using (new CultureContext(new CultureInfo("de-DE", false)))
             {
                 var decimalValue = new Decimal(12.5);
                 Assert.Equal("12,5", decimalValue.ToString());

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestLiteralToStringDifferentCulture()
         {
             var culture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE", useUserOverride: false);
 
             // If we are using the current culture to format the string then
             // decimal values should render as , instead of .

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void AdditionalLocationsAsRelatedLocations()
         {
             var stream = new MemoryStream();
-            using (var logger = new StreamErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("fr-CA")))
+            using (var logger = new StreamErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("fr-CA", useUserOverride: false)))
             {
                 var span = new TextSpan(0, 0);
                 var position = new LinePositionSpan(LinePosition.Zero, LinePosition.Zero);
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             };
 
             var stream = new MemoryStream();
-            using (var logger = new StreamErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("en-US")))
+            using (var logger = new StreamErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("en-US", useUserOverride: false)))
             {
                 for (int i = 0; i < 2; i++)
                 {

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var name = new AssemblyName("goo");
             name.Flags = AssemblyNameFlags.Retargetable | AssemblyNameFlags.PublicKey | AssemblyNameFlags.EnableJITcompileOptimizer | AssemblyNameFlags.EnableJITcompileTracking;
-            name.CultureInfo = new CultureInfo("en-US");
+            name.CultureInfo = new CultureInfo("en-US", useUserOverride: false);
             name.ContentType = AssemblyContentType.Default;
             name.Version = new Version(1, 2, 3, 4);
             name.ProcessorArchitecture = ProcessorArchitecture.X86;

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -95,7 +95,7 @@ Public Class VisualBasicParseOptionsTests
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture
             Dim invariantCultureVersion = PredefinedPreprocessorSymbols.CurrentVersionNumber
             ' cs-CZ uses decimal comma, which can cause issues
-            CultureInfo.CurrentCulture = New CultureInfo("cs-CZ")
+            CultureInfo.CurrentCulture = New CultureInfo("cs-CZ", useUserOverride:=False)
             Dim czechCultureVersion = PredefinedPreprocessorSymbols.CurrentVersionNumber
             Assert.Equal(invariantCultureVersion, czechCultureVersion)
         Finally

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1106,7 +1106,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishDottedI()
         {
-            using (new CultureContext(new CultureInfo("tr-TR", false)))
+            using (new CultureContext(new CultureInfo("tr-TR", useUserOverride: false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1137,7 +1137,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishUndottedI()
         {
-            using (new CultureContext(new CultureInfo("tr-TR", false)))
+            using (new CultureContext(new CultureInfo("tr-TR", useUserOverride: false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1168,7 +1168,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Arabic()
         {
-            using (new CultureContext(new CultureInfo("ar-EG", false)))
+            using (new CultureContext(new CultureInfo("ar-EG", useUserOverride: false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1199,7 +1199,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Spanish()
         {
-            using (new CultureContext(new CultureInfo("es-ES", false)))
+            using (new CultureContext(new CultureInfo("es-ES", useUserOverride: false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1230,7 +1230,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Greek()
         {
-            using (new CultureContext(new CultureInfo("el-GR", false)))
+            using (new CultureContext(new CultureInfo("el-GR", useUserOverride: false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -1105,7 +1106,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishDottedI()
         {
-            using (new CultureContext("tr-TR"))
+            using (new CultureContext(new CultureInfo("tr-TR", false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1136,7 +1137,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_TurkishUndottedI()
         {
-            using (new CultureContext("tr-TR"))
+            using (new CultureContext(new CultureInfo("tr-TR", false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1167,7 +1168,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Arabic()
         {
-            using (new CultureContext("ar-EG"))
+            using (new CultureContext(new CultureInfo("ar-EG", false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1198,7 +1199,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Spanish()
         {
-            using (new CultureContext("es-ES"))
+            using (new CultureContext(new CultureInfo("es-ES", false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C
@@ -1229,7 +1230,7 @@ namespace ConsoleApplication1
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task AlwaysUseEnglishUSCultureWhenFixingVariableNames_Greek()
         {
-            using (new CultureContext("el-GR"))
+            using (new CultureContext(new CultureInfo("el-GR", false)))
             {
                 await TestAllOptionsOffAsync(
 @"class C

--- a/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ValidateFormatString/ValidateFormatStringTests.cs
@@ -156,7 +156,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR""), ""The current price is {0[||]:C2} per ounce"", 2.45);
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0[||]:C2} per ounce"", 2.45);
     }     
 }");
         }
@@ -169,7 +169,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR""), ""The current price is {0[||]:C2} per {1} "", 2.45, ""ounce"");
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0[||]:C2} per {1} "", 2.45, ""ounce"");
     }     
 }");
         }
@@ -182,7 +182,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR""), ""The current price is {0} {[||]1} {2} "", 
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {[||]1} {2} "", 
             2.45, ""per"", ""ounce"");
     }     
 }");
@@ -196,7 +196,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        testStr = string.Format(new CultureInfo(""pt-BR""), ""The current price is {0} {1[||]} {2} {3} "", 
+        testStr = string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""The current price is {0} {1[||]} {2} {3} "", 
             2.45, ""per"", ""ounce"", ""today only"");
     }     
 }");
@@ -211,7 +211,7 @@ class Program
     static void Main(string[] args)
     {
         object[] objectArray = { 1.25, ""2"", ""teststring""};
-        string.Format(new CultureInfo(""pt-BR""), ""This {0} {1} {[||]2} works"", objectArray); 
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This {0} {1} {[||]2} works"", objectArray); 
     }     
 }");
         }
@@ -344,7 +344,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(arg0: ""test"", provider: new CultureInfo(""pt-BR""), format: ""This {0[||]} works""); 
+        string.Format(arg0: ""test"", provider: new CultureInfo(""pt-BR"", useUserOverride: false), format: ""This {0[||]} works""); 
     }     
 }");
         }
@@ -643,7 +643,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(new CultureInfo(""pt-BR""), ""This [|{1}|] is my test"", ""teststring1"");
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This [|{1}|] is my test"", ""teststring1"");
     }     
 }",
                 options: null,
@@ -660,7 +660,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(new CultureInfo(""pt-BR""), ""This [|{2}|] is my test"", ""teststring1"", ""teststring2"");
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This [|{2}|] is my test"", ""teststring1"", ""teststring2"");
     }     
 }",
                 options: null,
@@ -677,7 +677,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(new CultureInfo(""pt-BR""), ""This{0}{1}{2}[|{3}|] is my test"", ""teststring1"", 
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This{0}{1}{2}[|{3}|] is my test"", ""teststring1"", 
             ""teststring2"", ""teststring3"");
     }     
 }",
@@ -695,7 +695,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(new CultureInfo(""pt-BR""), ""This{0}{1}{2}{3}[|{4}|] is my test"", ""teststring1"", 
+        string.Format(new CultureInfo(""pt-BR"", useUserOverride: false), ""This{0}{1}{2}{3}[|{4}|] is my test"", ""teststring1"", 
             ""teststring2"", ""teststring3"", ""teststring4"");
     }     
 }",
@@ -794,7 +794,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        string.Format(arg0: ""test"", arg1: ""also"", format: ""This {0} [|{2}|] works"", provider: new CultureInfo(""pt-BR""))
+        string.Format(arg0: ""test"", arg1: ""also"", format: ""This {0} [|{2}|] works"", provider: new CultureInfo(""pt-BR"", useUserOverride: false))
     }     
 }",
                 options: null,

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Globalization
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
@@ -2479,7 +2480,7 @@ class C
         <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMatchWithTurkishIWorkaround1() As Task
-            Using New CultureContext("tr-TR")
+            Using New CultureContext(New CultureInfo("tr-TR", False))
                 Using state = TestState.CreateCSharpTestState(
                                <Document><![CDATA[
         class C
@@ -2498,7 +2499,7 @@ class C
         <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMatchWithTurkishIWorkaround2() As Task
-            Using New CultureContext("tr-TR")
+            Using New CultureContext(New CultureInfo("tr-TR", False))
                 Using state = TestState.CreateCSharpTestState(
                                <Document><![CDATA[
         class C

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -2480,7 +2480,7 @@ class C
         <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMatchWithTurkishIWorkaround1() As Task
-            Using New CultureContext(New CultureInfo("tr-TR", False))
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestState.CreateCSharpTestState(
                                <Document><![CDATA[
         class C
@@ -2499,7 +2499,7 @@ class C
         <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMatchWithTurkishIWorkaround2() As Task
-            Using New CultureContext(New CultureInfo("tr-TR", False))
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestState.CreateCSharpTestState(
                                <Document><![CDATA[
         class C

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             Verify(FormatResult("new Decimal()", CreateDkmClrValue(new Decimal())), EvalResult("new Decimal()", "0", "decimal", "new Decimal()", editableValue: "0M"));
             // System.DateTime
             // Set currentCulture to en-US for the test to pass in all locales
-            using (new CultureContext("en-US"))
+            using (new CultureContext(new CultureInfo("en-US", false)))
             {
                 Verify(FormatResult("new DateTime()", CreateDkmClrValue(new DateTime())), EvalResult("new DateTime()", "{1/1/0001 12:00:00 AM}", "System.DateTime", "new DateTime()", DkmEvaluationResultFlags.Expandable));
             }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             Verify(FormatResult("new Decimal()", CreateDkmClrValue(new Decimal())), EvalResult("new Decimal()", "0", "decimal", "new Decimal()", editableValue: "0M"));
             // System.DateTime
             // Set currentCulture to en-US for the test to pass in all locales
-            using (new CultureContext(new CultureInfo("en-US", false)))
+            using (new CultureContext(new CultureInfo("en-US", useUserOverride: false)))
             {
                 Verify(FormatResult("new DateTime()", CreateDkmClrValue(new DateTime())), EvalResult("new DateTime()", "{1/1/0001 12:00:00 AM}", "System.DateTime", "new DateTime()", DkmEvaluationResultFlags.Expandable));
             }

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -142,9 +142,9 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         {
             var runner = CreateRunner(input:
 @"using System.Globalization;
-CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"", useUserOverride: false)
 Math.PI
-CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"")
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"", useUserOverride: false)
 Math.PI
 ");
             runner.RunInteractive();
@@ -155,11 +155,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
 > using System.Globalization;
-> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"", useUserOverride: false)
 [en-GB]
 > Math.PI
 3.1415926535897931
-> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"")
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"", useUserOverride: false)
 [de-DE]
 > Math.PI
 3,1415926535897931
@@ -168,10 +168,10 @@ Type ""#help"" for more information.
             // Tests that DefaultThreadCurrentUICulture is respected and not DefaultThreadCurrentCulture.
             runner = CreateRunner(input:
 @"using System.Globalization;
-CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
-CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"")
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"", useUserOverride: false)
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"", useUserOverride: false)
 Math.PI
-CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"")
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"", useUserOverride: false)
 Math.PI
 ");
             runner.RunInteractive();
@@ -182,13 +182,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
 > using System.Globalization;
-> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"", useUserOverride: false)
 [en-GB]
-> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"")
+> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"", useUserOverride: false)
 [en-GB]
 > Math.PI
 3.1415926535897931
-> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"")
+> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"", useUserOverride: false)
 [de-DE]
 > Math.PI
 3.1415926535897931

--- a/src/Test/Utilities/Portable/CultureContext.cs
+++ b/src/Test/Utilities/Portable/CultureContext.cs
@@ -16,10 +16,6 @@ namespace Roslyn.Test.Utilities
             CultureInfo.CurrentCulture = cultureInfo;
         }
 
-        public CultureContext(string testCulture)
-            : this(new CultureInfo(testCulture, false))
-        { }
-
         public void Dispose()
         {
             CultureInfo.CurrentCulture = _threadCulture;

--- a/src/Test/Utilities/Portable/CultureContext.cs
+++ b/src/Test/Utilities/Portable/CultureContext.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Test.Utilities
         }
 
         public CultureContext(string testCulture)
-            : this(new CultureInfo(testCulture))
+            : this(new CultureInfo(testCulture, false))
         { }
 
         public void Dispose()

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -5,6 +5,7 @@ Imports Roslyn.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
 Imports System.Threading.Tasks
+Imports System.Globalization
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.CSharp
     Public Class ObjectBrowserTests
@@ -545,7 +546,7 @@ class C
 </Code>
 
             Using state = CreateLibraryManager(GetWorkspaceDefinition(code)),
-                    testCulture As New CultureContext("en-US")
+                    testCulture As New CultureContext(New CultureInfo("en-US", False))
                 Dim library = state.GetLibrary()
                 Dim list = library.GetProjectList()
                 list = list.GetTypeList(0)

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -546,7 +546,7 @@ class C
 </Code>
 
             Using state = CreateLibraryManager(GetWorkspaceDefinition(code)),
-                    testCulture As New CultureContext(New CultureInfo("en-US", False))
+                    testCulture As New CultureContext(New CultureInfo("en-US", useUserOverride:=False))
                 Dim library = state.GetLibrary()
                 Dim list = library.GetProjectList()
                 list = list.GetTypeList(0)

--- a/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Globalization
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
@@ -754,7 +755,7 @@ End Namespace
 </Code>
 
             Using state = CreateLibraryManager(GetWorkspaceDefinition(code)),
-                    testCulture As New CultureContext("en-US")
+                    testCulture As New CultureContext(New CultureInfo("en-US", False))
                 Dim library = state.GetLibrary()
                 Dim list = library.GetProjectList()
                 list = list.GetNamespaceList(0)

--- a/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/VisualBasic/ObjectBrowerTests.vb
@@ -755,7 +755,7 @@ End Namespace
 </Code>
 
             Using state = CreateLibraryManager(GetWorkspaceDefinition(code)),
-                    testCulture As New CultureContext(New CultureInfo("en-US", False))
+                    testCulture As New CultureContext(New CultureInfo("en-US", useUserOverride:=False))
                 Dim library = state.GetLibrary()
                 Dim list = library.GetProjectList()
                 list = list.GetNamespaceList(0)


### PR DESCRIPTION
This is a test-only change.

[CultureInfo has this documentation](https://msdn.microsoft.com/en-us/library/ky2chs3h(v=vs.110).aspx): The user might choose to override some of the values associated with the current culture of Windows through the regional and language options portion of Control Panel. For example, the user might choose to display the date in a different format or to use a currency other than the default for the culture. **If the culture identifier associated with name matches the culture identifier of the current Windows culture, this constructor creates a CultureInfo object that uses those overrides**, including user settings for the properties of the DateTimeFormatInfo instance returned by the DateTimeFormat property, and the properties of the NumberFormatInfo instance returned by the NumberFormat property.

This was causing one test on my machine to fail:

```
Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests.ExpansionTests.Primitives

Assert.Equal() Failure\r\n           ↓ (pos 1)\r\nExpected: {1/1/0001 12:00:00 AM}\r\nActual:   {0001-01-01 00:00:00}\r\n           ↑ (pos 1)

   at Microsoft.CodeAnalysis.ExpressionEvaluator.ResultProviderTestBase.Verify(DkmEvaluationResult actual, DkmEvaluationResult expected)
   at Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests.ExpansionTests.Primitives() in C:\c\roslyn\src\ExpressionEvaluator\CSharp\Test\ResultProvider\ExpansionTests.cs:line 62
```

The fix is to explicitly override this behavior, by passing `useUserOverride = false` in a different constructor.

Behavior testing in a console app:

```
Console.WriteLine(new DateTime());
CultureInfo.CurrentCulture = new CultureInfo("en-US");
Console.WriteLine(new DateTime());
CultureInfo.CurrentCulture = new CultureInfo("en-US", false);
Console.WriteLine(new DateTime());
```

produces

```
0001-01-01 00:00:00
0001-01-01 00:00:00
1/1/0001 12:00:00 AM
```

---

I don't know what team should review this, so I've just added roslyn-compiler. Feel free to add a `area-*` and the correct reviewer if there is a more appropriate team.