### PR TITLE
Updating some nuspec to list the correct framework requirements and dependencies.

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -93,8 +93,7 @@
     <MicrosoftVisualStudioProjectSystemVersion>15.3.178-pre-g209fb07c2e</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>10.0.0.0-alpha</MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>
     <MicrosoftVisualStudioRemoteControlVersion>14.0.249-master2E2DC10C</MicrosoftVisualStudioRemoteControlVersion>
-    <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.3.269-rc</MicrosoftVisualStudioSetupConfigurationInteropVersion>
-    <MicrosoftVisualStudioSetupConfigurationNativex86Version>1.3.269-rc</MicrosoftVisualStudioSetupConfigurationNativex86Version>
+    <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.11.2290</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftVisualStudioSettings140Version>14.3.25407</MicrosoftVisualStudioSettings140Version>
     <MicrosoftVisualStudioShell140Version>14.3.25407</MicrosoftVisualStudioShell140Version>
     <MicrosoftVisualStudioShell150Version>15.0.26606</MicrosoftVisualStudioShell150Version>

--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -17,7 +17,7 @@
     <projectUrl>$projectUrl$</projectUrl>
     <tags>$tags$</tags>
     <dependencies>
-      <group targetFramework="NETCoreApp1.0">
+      <group targetFramework="netcoreapp1.1">
         <dependency id="Microsoft.CodeAnalysis.Compilers" version="$version$" />
         <dependency id="Microsoft.CodeAnalysis.Scripting" version="$version$" />
         <dependency id="NETStandard.Library" version="1.6.0" />

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -15,7 +15,7 @@
     <tags>$tags$</tags>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="netcoreapp1.0">
+      <group targetFramework="netcoreapp2.0">
         <dependency id="Microsoft.CodeAnalysis.Compilers" version="[$version$]" />
         <dependency id="System.AppContext" version="$SystemAppContextVersion$" />
         <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessVersion$" />
@@ -29,7 +29,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$emptyDirPath$/_._" target="ref/netcoreapp1.0" />
+    <file src="$emptyDirPath$/_._" target="ref/netcoreapp2.0" />
     <file src="Exes/CscCore/csc.dll" target="runtimes/any/native" />
     <file src="Exes/VbcCore/vbc.dll" target="runtimes/any/native" />
   </files>

--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -14,13 +14,13 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="Microsoft.VisualStudio.LanguageServices" version="$version$" />
-      <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.3.269-rc" />
-      <dependency id="Microsoft.VisualStudio.Setup.Configuration.Native.x86" version="1.3.269-rc" />
+      <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="$MicrosoftVisualStudioSetupConfigurationInteropVersion$" />
+      <dependency id="System.Diagnostics.Process" version="$SystemDiagnosticsProcessVersion$" />
     </dependencies>
   </metadata>
   <files>
-    <file src="Dlls\TestUtilities\net461\Roslyn.Test.Utilities.dll" target="lib\net46" />
-    <file src="Dlls\VisualStudioIntegrationTestUtilities\Microsoft.VisualStudio.IntegrationTest.Utilities.dll" target="lib\net46" />
-    <file src="Dlls\ServicesTestUtilities\Roslyn.Services.Test.Utilities.dll" target="lib\net46" />
+    <file src="Dlls\TestUtilities\net461\Roslyn.Test.Utilities.dll" target="lib\net461" />
+    <file src="Dlls\VisualStudioIntegrationTestUtilities\Microsoft.VisualStudio.IntegrationTest.Utilities.dll" target="lib\net461" />
+    <file src="Dlls\ServicesTestUtilities\Roslyn.Services.Test.Utilities.dll" target="lib\net461" />
   </files>
 </package>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -14,19 +14,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         private const string Kernel32 = "kernel32.dll";
         private const string Ole32 = "ole32.dll";
         private const string User32 = "User32.dll";
-        private const string SetupConfigurationNative = "x86\\Microsoft.VisualStudio.Setup.Configuration.Native.dll";
-
-        #region Microsoft.VisualStudio.Setup.Configuration.Native.dll
-
-        public const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
-
-        [DllImport(SetupConfigurationNative, BestFitMapping = false, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "GetSetupConfiguration", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
-        public static extern int GetSetupConfiguration(
-            [Out, MarshalAs(UnmanagedType.Interface)] out ISetupConfiguration setupConfiguration,
-            [In] IntPtr pReserved
-        );
-
-        #endregion
 
         #region kernel32.dll
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -197,29 +197,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             _currentlyRunningInstance = new VisualStudioInstance(hostProcess, dte, supportedPackageIds, installationPath);
         }
 
-        private static ISetupConfiguration GetSetupConfiguration()
-        {
-            try
-            {
-                return new SetupConfiguration();
-            }
-            catch (COMException comException) when (comException.HResult == NativeMethods.REGDB_E_CLASSNOTREG)
-            {
-                // Fallback to P/Invoke if the COM registration is missing
-                var hresult = NativeMethods.GetSetupConfiguration(out var setupConfiguration, pReserved: IntPtr.Zero);
-
-                if (hresult < 0)
-                {
-                    throw Marshal.GetExceptionForHR(hresult);
-                }
-
-                return setupConfiguration;
-            }
-        }
-
         private static IEnumerable<ISetupInstance> EnumerateVisualStudioInstances()
         {
-            var setupConfiguration = GetSetupConfiguration() as ISetupConfiguration2;
+            var setupConfiguration = new SetupConfiguration();
 
             var instanceEnumerator = setupConfiguration.EnumAllInstances();
             var instances = new ISetupInstance[3];

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Native.x86" Version="$(MicrosoftVisualStudioSetupConfigurationNativex86Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80Version)" />


### PR DESCRIPTION
This fixes up `Microsoft.Net.CSharp.Interactive.netcore.nuspec ` and `Microsoft.Net.Compilers.netcore.nuspec` to list the actual target framework: nc1.1 and nc2.0, respectively. These are the target frameworks of tools they include (csicore targets nc1.1 and csccore targets nc2.0).

This also updates `Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec` to list a missing dependency (`System.Diagnostics.Process`) and to move to the new version of `Microsoft.VisualStudio.Setup.Configuration.Interop`. Additionally, the `Microsoft.VisualStudio.Setup.Configuration.Native.x86` dependency was dropped as they are no longer producing a native DLL.