### PR TITLE
Create NameLiteralArgument code fixer (C#)

### DIFF
--- a/src/EditorFeatures/CSharpTest/NameLiteralArgument/NameLiteralArgumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/NameLiteralArgument/NameLiteralArgumentTests.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.NameLiteralArgument;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NameLiteralArgument
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsNameLiteralArgument)]
+    public class NameLiteralArgumentTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpNameLiteralArgumentDiagnosticAnalyzer(), new CSharpNameLiteralArgumentCodeFixProvider());
+
+        private static readonly CSharpParseOptions s_parseOptions =
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        [Fact]
+        public async Task TestLiteralInInvocation()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M(int a, int b)
+    {
+        M(a, [||]2);
+    }
+}",
+@"
+class C
+{
+    void M(int a, int b)
+    {
+        M(a, b: 2);
+    }
+}", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        public async Task TestLiteralInCreation()
+        {
+            await TestAsync(
+@"
+class C
+{
+    C(int a, int b)
+    {
+        new C(a, [||]2);
+    }
+}",
+@"
+class C
+{
+    C(int a, int b)
+    {
+        new C(a, b: 2);
+    }
+}", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        public async Task TestSecondLiteralArgumentWithCSharp7()
+        {
+            await TestActionCountAsync(
+@"
+class C
+{
+    void M(int a, int b)
+    {
+        M(a, [||]2);
+    }
+}", count: 0, parameters: new TestParameters(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7)));
+        }
+
+        [Fact]
+        public async Task TestLiteralInParams()
+        {
+            await TestActionCountAsync(
+@"
+class C
+{
+    void M(int a, params int[] b)
+    {
+        M(a, [||]2);
+    }
+}", count: 0);
+        }
+
+        [Fact]
+        public async Task TestLiteralOnMissingOverload()
+        {
+            await TestActionCountAsync(
+@"
+class C
+{
+    void M(int a, int b, int c)
+    {
+        M(a, [||]2, 3);
+    }
+}", count: 0);
+        }
+
+        [Fact]
+        public async Task TestFixAllWithTrivia()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M(int a, int b, int c)
+    {
+        M(a, /*before*/ {|FixAllInDocument:2|} /*after*/, /*before*/ 3 /*after*/);
+    }
+}",
+@"
+class C
+{
+    void M(int a, int b, int c)
+    {
+        M(a, /*before*/ b: 2 /*after*/, /*before*/ c: 3 /*after*/);
+    }
+}", parseOptions: s_parseOptions);
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -104,6 +104,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsUseCollectionInitializer = "CodeActions.UseCollectionInitializer";
             public const string CodeActionsUseDefaultLiteral = "CodeActions.UseDefaultLiteral";
             public const string CodeActionsUseInferredMemberName = "CodeActions.UseInferredMemberName";
+            public const string CodeActionsNameLiteralArgument = "CodeActions.UseNamedArgument";
             public const string CodeActionsUseExpressionBody = "CodeActions.UseExpressionBody";
             public const string CodeActionsUseImplicitType = "CodeActions.UseImplicitType";
             public const string CodeActionsUseExplicitType = "CodeActions.UseExplicitType";

--- a/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentCodeFixProvider.cs
@@ -40,8 +40,12 @@ namespace Microsoft.CodeAnalysis.CSharp.NameLiteralArgument
             {
                 var argument = (ArgumentSyntax)root.FindNode(diagnostic.Location.SourceSpan);
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var invocation = (InvocationExpressionSyntax)argument.Parent.Parent;
+                switch(argument.Parent.Parent)
+                {
+                    case InvocationExpressionSyntax invocation:
                 var index = invocation.ArgumentList.Arguments.IndexOf(argument);
+
+                }
 
                 var methodSymbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invocation).Symbol;
                 var parameterName = methodSymbol.Parameters[index].Name;

--- a/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentCodeFixProvider.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.NameLiteralArgument
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal sealed class CSharpNameLiteralArgumentCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(IDEDiagnosticIds.NameLiteralArgumentDiagnosticId);
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(new MyCodeAction(
+                c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics);
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        protected override async Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var root = editor.OriginalRoot;
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var argument = (ArgumentSyntax)root.FindNode(diagnostic.Location.SourceSpan);
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var invocation = (InvocationExpressionSyntax)argument.Parent.Parent;
+                var index = invocation.ArgumentList.Arguments.IndexOf(argument);
+
+                var methodSymbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invocation).Symbol;
+                var parameterName = methodSymbol.Parameters[index].Name;
+
+                var newArgument = SyntaxFactory.Argument(SyntaxFactory.NameColon(parameterName), default, argument.Expression);
+                editor.ReplaceNode(argument, newArgument);
+            }
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Name_literal_argument, createChangedDocument, FeaturesResources.Name_literal_argument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/NameLiteralArgument/CSharpNameLiteralArgumentDiagnosticAnalyzer.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.CSharp.NameLiteralArgument
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpNameLiteralArgumentDiagnosticAnalyzer : AbstractCodeStyleDiagnosticAnalyzer
+    {
+        public CSharpNameLiteralArgumentDiagnosticAnalyzer()
+            : base(IDEDiagnosticIds.NameLiteralArgumentDiagnosticId,
+                   new LocalizableResourceString(nameof(FeaturesResources.Name_literal_argument), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
+        {
+        }
+
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        public override bool OpenFileOnly(Workspace workspace)
+            => false;
+
+        protected override void InitializeWorker(AnalysisContext context)
+            => context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
+
+        private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            var cancellationToken = context.CancellationToken;
+
+            var syntaxTree = context.Node.SyntaxTree;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var parseOptions = (CSharpParseOptions)syntaxTree.Options;
+            ReportDiagnosticsIfNeeded((InvocationExpressionSyntax)context.Node, context, optionSet, syntaxTree);
+        }
+
+        private void ReportDiagnosticsIfNeeded(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext context, OptionSet optionSet, SyntaxTree syntaxTree)
+        {
+            if (!optionSet.GetOption(CSharpCodeStyleOptions.PreferNamingLiteralArguments).Value)
+            {
+                return;
+            }
+
+            var parseOptions = (CSharpParseOptions)syntaxTree.Options;
+            if (parseOptions.LanguageVersion < LanguageVersion.CSharp7_2)
+            {
+                return;
+            }
+
+            var method = context.SemanticModel.GetSymbolInfo(invocation);
+            if (method.Symbol is null)
+            {
+                return;
+            }
+
+            var symbol = method.Symbol;
+            if (symbol.Kind != SymbolKind.Method)
+            {
+                return;
+            }
+
+            var methodSymbol = (IMethodSymbol)symbol;
+            var arguments = invocation.ArgumentList.Arguments;
+            var parameters = methodSymbol.Parameters;
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                var argument = arguments[i];
+                if (argument.NameColon != null)
+                {
+                    continue;
+                }
+
+                if (!argument.Expression.IsAnyLiteralExpression())
+                {
+                    continue;
+                }
+
+                if (parameters[i].IsParams)
+                {
+                    continue;
+                }
+
+                // Create a normal diagnostic
+                context.ReportDiagnostic(
+                Diagnostic.Create(GetDescriptorWithSeverity(
+                    optionSet.GetOption(CSharpCodeStyleOptions.PreferNamingLiteralArguments).Notification.Value),
+                    argument.GetLocation()));
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string UseIsNullCheckDiagnosticId = "IDE0041";
 
+        public const string NameLiteralArgumentDiagnosticId = "IDE0042";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -2183,6 +2183,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name literal argument.
+        /// </summary>
+        internal static string Name_literal_argument {
+            get {
+                return ResourceManager.GetString("Name_literal_argument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to namespace.
         /// </summary>
         internal static string namespace_ {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1253,6 +1253,9 @@ This version used in: {2}</value>
   <data name="Use_inferred_member_name" xml:space="preserve">
     <value>Use inferred member name</value>
   </data>
+  <data name="Name_literal_argument" xml:space="preserve">
+    <value>Name literal argument</value>
+  </data>
   <data name="Member_name_can_be_simplified" xml:space="preserve">
     <value>Member name can be simplified</value>
   </data>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -442,6 +442,23 @@ class Customer
 }}
 ";
 
+        private static readonly string s_preferNamingLiteralArgument = $@"
+class Customer
+{{
+    public Update(bool isActive)
+    {{
+//[
+        // {ServicesVSResources.Prefer_colon}
+        Update(isActive: true) {{ }}
+
+        // {ServicesVSResources.Over_colon}
+        Update(true) {{ }}
+//]
+    }}
+}}
+";
+
+
         private static readonly string s_preferInferredTupleName = $@"
 using System.Threading;
 
@@ -793,6 +810,7 @@ class List<T>
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferInferredTupleNames, ServicesVSResources.Prefer_inferred_tuple_names, s_preferInferredTupleName, s_preferInferredTupleName, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferInferredAnonymousTypeMemberNames, ServicesVSResources.Prefer_inferred_anonymous_type_member_names, s_preferInferredAnonymousTypeMemberName, s_preferInferredAnonymousTypeMemberName, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction, ServicesVSResources.Prefer_local_function_over_anonymous_function, s_preferLocalFunctionOverAnonymousFunction, s_preferLocalFunctionOverAnonymousFunction, this, optionSet, expressionPreferencesGroupTitle));
+            CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferNamingLiteralArguments, ServicesVSResources.Prefer_naming_literal_arguments, s_preferNamingLiteralArgument, s_preferNamingLiteralArgument, this, optionSet, expressionPreferencesGroupTitle));
 
             AddExpressionBodyOptions(optionSet, expressionPreferencesGroupTitle);
 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1640,11 +1640,20 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prefere local function over anonymous function.
+        ///   Looks up a localized string similar to Prefer local function over anonymous function.
         /// </summary>
         internal static string Prefer_local_function_over_anonymous_function {
             get {
                 return ResourceManager.GetString("Prefer_local_function_over_anonymous_function", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer naming literal arguments.
+        /// </summary>
+        internal static string Prefer_naming_literal_arguments {
+            get {
+                return ResourceManager.GetString("Prefer_naming_literal_arguments", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -960,6 +960,9 @@ Additional information: {1}</value>
     <value>Changes are not allowed while code is running.</value>
   </data>
   <data name="Prefer_local_function_over_anonymous_function" xml:space="preserve">
-    <value>Prefere local function over anonymous function</value>
+    <value>Prefer local function over anonymous function</value>
+  </data>
+  <data name="Prefer_naming_literal_arguments" xml:space="preserve">
+    <value>Prefer naming literal arguments</value>
   </data>
 </root>

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -154,6 +154,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
                 EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_inferred_anonymous_type_member_names"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferInferredAnonymousTypeMemberNames)}")});
 
+        public static readonly Option<CodeStyleOption<bool>> PreferNamingLiteralArguments = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(PreferNamingLiteralArguments), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[] {
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_naming_literal_arguments"),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferNamingLiteralArguments)}")});
+
         private static readonly SyntaxKind[] s_preferredModifierOrderDefault =
             {
                 SyntaxKind.PublicKeyword, SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword,
@@ -193,6 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             yield return PreferInferredTupleNames;
             yield return PreferInferredAnonymousTypeMemberNames;
             yield return PreferLocalOverAnonymousFunction;
+            yield return PreferNamingLiteralArguments;
         }
 
         public static IEnumerable<Option<CodeStyleOption<ExpressionBodyPreference>>> GetExpressionBodyOptions()


### PR DESCRIPTION
Adds a code style (Prefer_naming_literal_arguments`), an analyzer to complain about un-named literal arguments that could be named, and a fixer to rectify the situation.

@cyrusnajmabadi FYI
I plan to add support for attributes (they use different syntax) and VB, as the "AddNamedArgument" refactoring does. But I don't expect I'll be able to share much code, although I'm open to the possibility.
