### PR TITLE
DO NOT MERGE: test to see if a missing ConfigureAwait is caught by CI

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var timeout = TimeSpan.FromMilliseconds(workspace.Options.GetOption(RemoteHostOptions.RequestServiceTimeoutInMS));
                 var remoteHostStream = await RequestServiceAsync(primary, WellKnownRemoteHostServices.RemoteHostService, hostGroup, timeout, cancellationToken).ConfigureAwait(false);
 
-                var remotableDataRpc = new RemotableDataJsonRpc(workspace, primary.Logger, await RequestServiceAsync(primary, WellKnownServiceHubServices.SnapshotService, hostGroup, timeout, cancellationToken).ConfigureAwait(false));
+                var remotableDataRpc = new RemotableDataJsonRpc(workspace, primary.Logger, await RequestServiceAsync(primary, WellKnownServiceHubServices.SnapshotService, hostGroup, timeout, cancellationToken));
                 var instance = new ServiceHubRemoteHostClient(workspace, primary, hostGroup, new ReferenceCountedDisposable<RemotableDataJsonRpc>(remotableDataRpc), remoteHostStream);
 
                 // make sure connection is done right


### PR DESCRIPTION
We noticed a case where a missing ConfigureAwait might have not been caught by CI. I see analyzers running locally, so want to see if CI is broken somehow.