### PR TITLE
Removed unnecesary InitialTargets in Microsoft.Net.Compilers.props

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="15.0" DefaultTargets="Build" InitialTargets="ValidateMSBuildToolsVersion" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- The UsingTask, UseSharedCompilation, and ToolPath/Exe variables all interact to
        choose which compiler path to use and whether or not to use the compiler server.
        If UsingTask and UseSharedCompilation are set then the compiler server next to the


### PR DESCRIPTION
Removed unnecesary InitialTargets in Microsoft.Net.Compilers.props

This unblocks compiler package on Core