### PR TITLE
Fix completion crash in tuple in alias

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7672,5 +7672,20 @@ End Namespace
             End Using
 
         End Function
+
+        <WorkItem(22002, "https://github.com/dotnet/roslyn/issues/22002")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function DoNotCrashInTupleAlias() As Task
+            Dim text =
+<code><![CDATA[
+Imports Boom = System.Collections.Generic.List(Of ($$) '<---put caret between brackets.
+
+Public Module Module1
+  Public Sub Main()
+  End Sub
+End Module
+]]></code>.Value
+            Await VerifyItemExistsAsync(text, "System")
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
@@ -88,10 +88,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             For importDirective = 0 To 1
                 For preselect = 0 To 1
                     For tuple = 0 To 1
-                        If importDirective = 1 AndAlso tuple = 1 Then
-                            Continue For
-                        End If
-
                         Dim context = ValueTuple.Create(importDirective = 1, preselect = 1, tuple = 1)
                         result(context) = MakeRule(importDirective, preselect, tuple)
                     Next


### PR DESCRIPTION
We were not generating a cached completion item rule for a non-preselected item in a tuple context that was also an alias context
Fixes https://github.com/dotnet/roslyn/issues/22002


