### PR TITLE
Remove InitialTargets=MakeCompilerScriptsExecutable

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" InitialTargets="MakeCompilerScriptsExecutable" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Always use the local build task, even if we just shell out to an exe in case there are
        new properties in the local build task. -->
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"


### PR DESCRIPTION
This should have been removed in an earlier commit (https://github.com/dotnet/roslyn/pull/21673), but was forgotten.

Fixes https://github.com/dotnet/roslyn/issues/21970