### PR TITLE
Fix up .gitattributes to clone .sh files with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,8 +10,7 @@
 #
 # However, right now the toolset packages must be built on Windows, and so the
 # files must be hard-coded to be cloned with LF
-src/Compilers/CSharp/CscCore/csc text eol=lf
-src/Compilers/VisualBasic/VbcCore/vbc text eol=lf
+*.sh text eol=lf
 build/NuGetAdditionalFiles/RunCsc text eol=lf
 build/NuGetAdditionalFiles/RunVbc text eol=lf
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,16 +3,16 @@
 ###############################################################################
 * text=auto encoding=UTF-8
 
-# csc/vbc are shell scripts and should always have unix line endings
+# RunCsc/RunVbc are shell scripts and should always have unix line endings
 # These shell scripts are included in the toolset packages. Normally, the shell
 # scripts in our repo are only run by cloning onto a Linux/Mac machine, and git
 # automatically chooses LF as the line ending.
 #
 # However, right now the toolset packages must be built on Windows, and so the
 # files must be hard-coded to be cloned with LF
-*.sh text eol=lf
 build/NuGetAdditionalFiles/RunCsc text eol=lf
 build/NuGetAdditionalFiles/RunVbc text eol=lf
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
Also, `src/Compilers/CSharp/CscCore/csc` (and vbc) no longer exist.

This is particularly annoying when using WSL with `git config core.eol crlf`, as that fixes a lot of issues with native windows git interacting with WSL git, but we should still check out all of our helper scripts with LF, so they can still be ran in WSL. (If they have CRLF line endings, everything gets really upset)