### PR TITLE
Do not emit PDB path in PE file if not generating PDB

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9597,6 +9597,31 @@ class C
             Assert.Equal("", result.Output.Trim());
         }
 
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void PdbPathNotEmittedWitoutPdb()
+        {
+            var dir = Temp.CreateDirectory();
+
+            var source = @"class Program { static void Main() { } }";
+            var src = dir.CreateFile("a.cs").WriteAllText(source);
+            var args = new[] { "/nologo", "a.cs", "/out:a.exe", "/debug-" };
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+
+            var csc = new MockCSharpCompiler(null, dir.Path, args);
+            int exitCode = csc.Run(outWriter);
+            Assert.Equal(0, exitCode);
+
+            var exePath = Path.Combine(dir.Path, "a.exe");
+            Assert.True(File.Exists(exePath));
+            using (var peStream = File.OpenRead(exePath))
+            using (var peReader = new PEReader(peStream))
+            {
+                var debugDirectory = peReader.PEHeaders.PEHeader.DebugTableDirectory;
+                Assert.Equal(0, debugDirectory.Size);
+                Assert.Equal(0, debugDirectory.RelativeVirtualAddress);
+            }
+        }
+
         public class QuotedArgumentTests
         {
             private void VerifyQuotedValid<T>(string name, string value, T expected, Func<CSharpCommandLineArguments, T> getValue)

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9598,6 +9598,7 @@ class C
         }
 
         [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(21935, "https://github.com/dotnet/roslyn/issues/21935")]
         public void PdbPathNotEmittedWitoutPdb()
         {
             var dir = Temp.CreateDirectory();

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2418,6 +2418,10 @@ namespace Microsoft.CodeAnalysis
             {
                 pePdbFilePath = pePdbFilePath ?? FileNameUtilities.ChangeExtension(SourceModule.Name, "pdb");
             }
+            else
+            {
+                pePdbFilePath = null;
+            }
 
             if (moduleBeingBuilt.DebugInformationFormat == DebugInformationFormat.Embedded && !string.IsNullOrEmpty(pePdbFilePath))
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21935

This regression was caused by this region of change: https://github.com/dotnet/roslyn/commit/b66f68c485fb1c6bbfa69c62490ff47d37d5dae5#diff-9ab09861519e8dfab2c0787cad46ab15L2412

In particular, before the change, if `pdbFilePath != null` and `pdbStreamProvider == null`, the resulting `pePdbPath == null`.

After the change, if `pePdbFilePath != null` and `pdbStreamProvider == null`, `pePdbFilePath == the_original_value`.

(conditions simplified a bit to make it more readable)

So, this PR fixes it up to keep the behavior before the change.

(Putting the PDB path in the PE file is keyed off that variable being null or not)

---

I don't know how to test this change. I have manually verified it works, but advice on how to unit-test this (and prevent further regressions) would be appreciated.