### PR TITLE
Added support for scripting environment #5979

### DIFF
--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -990,5 +990,35 @@ Type ""#help"" for more information.
 1
 > ", runner.Console.Out.ToString());
         }
+
+        [Fact]
+        public void ScriptEnv_Script()
+        {
+            var script = Temp.CreateFile(extension: ".csx").WriteAllText("Print(ScriptEnv.FilePath)");
+            var runner = CreateRunner(new[] {script.Path});
+
+            var result = runner.RunInteractive();
+
+            Assert.Equal(0, result);
+           
+            var printedPath = runner.Console.Out.ToString()
+                .Replace("\\\\", "\\")
+                .Replace(Environment.NewLine, string.Empty)
+                .Replace("\"",string.Empty);
+
+            Assert.Equal(script.Path, printedPath);
+        }
+
+        [Fact]
+        public void ScriptEnv_Interactive()
+        {
+            var runner = CreateRunner(
+                args: new[] { "-i" },
+                input: "Print(ScriptEnv.FilePath)");
+
+            var printedPath = runner.Console.Out.ToString();
+
+            Assert.Equal(string.Empty, printedPath);
+        }
     }
 }

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -178,8 +178,8 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         }
 
         private int RunScript(ScriptOptions options, SourceText code, ErrorLogger errorLogger, CancellationToken cancellationToken)
-        {
-            var globals = new CommandLineScriptGlobals(_console.Out, _objectFormatter);
+        {            
+            var globals = new CommandLineScriptGlobals(_console.Out, _objectFormatter, new ScriptEnv(options.FilePath));
             globals.Args.AddRange(_compiler.Arguments.ScriptArguments);
 
             var script = Script.CreateInitialScript<int>(_scriptCompiler, code, options, globals.GetType(), assemblyLoaderOpt: null);

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineScriptGlobals.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineScriptGlobals.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         public PrintOptions PrintOptions { get; }
 
         /// <summary>
+        /// The scripting environment.
+        /// </summary>
+        public ScriptEnv ScriptEnv { get; }
+
+        /// <summary>
         /// Pretty-prints an object.
         /// </summary>
         public void Print(object value)
@@ -35,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             _outputWriter.WriteLine(_objectFormatter.FormatObject(value, PrintOptions));
         }
 
-        public CommandLineScriptGlobals(TextWriter outputWriter, ObjectFormatter objectFormatter)
+        public CommandLineScriptGlobals(TextWriter outputWriter, ObjectFormatter objectFormatter, ScriptEnv scriptEnv = null)
         {
             if (outputWriter == null)
             {
@@ -46,6 +51,8 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             {
                 throw new ArgumentNullException(nameof(objectFormatter));
             }
+
+            ScriptEnv = scriptEnv ?? new ScriptEnv(string.Empty);
 
             PrintOptions = new PrintOptions();
 

--- a/src/Scripting/Core/Hosting/CommandLine/ScriptEnv.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/ScriptEnv.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.CodeAnalysis.Scripting.Hosting
+{
+    /// <summary>
+    /// Provides access to the scripting environment.
+    /// </summary>
+    public class ScriptEnv
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptEnv"/> class.
+        /// </summary>
+        ///<param name="filePath">The path to the script being executed.</param>
+        public ScriptEnv(string filePath)
+        {
+            FilePath = filePath;
+        }
+
+        /// <summary>
+        /// The path to the script source if it originated from a file, empty otherwise.
+        /// </summary>
+        public string FilePath { get; }
+    }
+}

--- a/src/Scripting/Core/PublicAPI.Shipped.txt
+++ b/src/Scripting/Core/PublicAPI.Shipped.txt
@@ -6,7 +6,6 @@ Microsoft.CodeAnalysis.Scripting.CompilationErrorException.CompilationErrorExcep
 Microsoft.CodeAnalysis.Scripting.CompilationErrorException.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
 Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals
 Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.Args.get -> System.Collections.Generic.IList<string>
-Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.CommandLineScriptGlobals(System.IO.TextWriter outputWriter, Microsoft.CodeAnalysis.Scripting.Hosting.ObjectFormatter objectFormatter) -> void
 Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.Print(object value) -> void
 Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.PrintOptions.get -> Microsoft.CodeAnalysis.Scripting.Hosting.PrintOptions
 Microsoft.CodeAnalysis.Scripting.Hosting.FileShadowCopy

--- a/src/Scripting/Core/PublicAPI.Unshipped.txt
+++ b/src/Scripting/Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
-
+Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.CommandLineScriptGlobals(System.IO.TextWriter outputWriter, Microsoft.CodeAnalysis.Scripting.Hosting.ObjectFormatter objectFormatter, Microsoft.CodeAnalysis.Scripting.Hosting.ScriptEnv scriptEnv = null) -> void
+Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineScriptGlobals.ScriptEnv.get -> Microsoft.CodeAnalysis.Scripting.Hosting.ScriptEnv
+Microsoft.CodeAnalysis.Scripting.Hosting.ScriptEnv
+Microsoft.CodeAnalysis.Scripting.Hosting.ScriptEnv.FilePath.get -> string
+Microsoft.CodeAnalysis.Scripting.Hosting.ScriptEnv.ScriptEnv(string filePath) -> void


### PR DESCRIPTION
**Scripting**
When running scripts it would be very useful to get access to the path of the executed script.

Usage (from within a script file)
```
var pathToScript = ScriptEnv.FilePath;
``` 

The `CommandLineRunner` has been updated to pass the path of the script. 

This also represents a unified way for other script runner to provide the path of the executed script.  

OmniSharp.Script also provides metadata for `CommandScriptGlobals` so we get intellisense for this new property as well. 

**Bugs this fixes:**
If not fixes, let's say addresses :)

https://github.com/dotnet/roslyn/issues/5979

