### PR TITLE
Clean up some prototype comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -459,7 +459,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Returns true if the conversion is a stackalloc conversion.
-        /// PROTOTYPE(span) review public API change
         /// </summary>
         public bool IsStackAlloc
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -319,9 +319,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!sourceExpression.Syntax.IsLegalSpanStackAllocPosition())
                     {
-                        // PROTOTYPE(span) short work around until we look into spilling stackalloc expressions
                         // Because the instruction cannot have any values on the stack before CLR execution.
                         // Limit it to assignments and conditional expressions for now.
+                        // https://github.com/dotnet/roslyn/issues/22046
 
                         HashSetExtensions.InitializeAndAdd(ref useSiteDiagnostics, new CSDiagnosticInfo(ErrorCode.ERR_InvalidExprTerm, SyntaxFacts.GetText(SyntaxKind.StackAllocKeyword)));
                     }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -122,10 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// PROTOTYPE(span):
-        /// short work around until we look into spilling stackalloc expressions
         /// Because the instruction cannot have any values on the stack before CLR execution.
         /// Limit it to assignments and conditional expressions for now.
+        /// https://github.com/dotnet/roslyn/issues/22046
         /// </summary>
         internal static bool IsLegalSpanStackAllocPosition(this SyntaxNode node)
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -1560,9 +1560,6 @@ public class Test
         [Fact]
         public void RefReadOnlyDefinitionsInsideUserDefinedIsReadOnlyAttribute_Class_NoParent()
         {
-            // PROTOTYPE(readonlyRefs) when the following bug is fixed that test should fail:
-            // https://github.com/dotnet/roslyn/issues/19395
-
             var code = @"
 namespace System.Runtime.CompilerServices
 {
@@ -1876,9 +1873,6 @@ namespace System.Runtime.CompilerServices
         [Fact]
         public void RefReadOnlyDefinitionsInsideUserDefinedIsReadOnlyAttribute_Class_WrongParent()
         {
-            // PROTOTYPE(readonlyRefs) when the following bug is fixed that test should fail:
-            // https://github.com/dotnet/roslyn/issues/19395
-
             var code = @"
 namespace System.Runtime.CompilerServices
 {
@@ -1918,25 +1912,6 @@ namespace System.Runtime.CompilerServices
                 AssertReferencedIsReadOnlyAttribute(Accessibility.Public, indexer.GetAttributes(), module.ContainingAssembly.Name);
                 AssertReferencedIsReadOnlyAttribute(Accessibility.Public, indexer.Parameters.Single().GetAttributes(), module.ContainingAssembly.Name);
             });
-        }
-
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19394")]
-        public void RefReadOnlyDefinitionsInsideUserDefinedIsReadOnlyAttribute_Struct()
-        {
-            // PROTOTYPE(readonlyRefs) verify bug is fixed and enable the test
-            // https://github.com/dotnet/roslyn/issues/19394
-
-            var code = @"
-namespace System.Runtime.CompilerServices
-{
-    public struct IsReadOnlyAttribute
-    {
-        public ref readonly int Method(ref readonly int x) => ref x;
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyEmitDiagnostics(/* there should be an error */);
-            Assert.False(true, "It must produce an error about not being able to find the correct signature");
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -217,7 +217,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         internal static PEAssemblyBuilder GetDefaultPEBuilder(CSharpCompilation compilation)
         {
-            // PROTOTYPE(readonlyRefs): Using a PEAssemblyBuilder here is a hack till https://github.com/dotnet/roslyn/issues/18799 is fixed.
             return new PEAssemblyBuilder(
                 (SourceAssemblySymbol)compilation.Assembly,
                 EmitOptions.Default,


### PR DESCRIPTION
* `Conversion.cs`: created #22045 for that.
* `Conversions.cs` and `SyntaxNodeExtensions.cs`: created #22046 for that.
* `AttributeTests_RefReadOnly.cs` and `CSharpTestBase.cs`: relevant bugs in master are tracking the issues. This is not specific to the prototype.
