### PR TITLE
Multitarget VBCSCompiler.csproj

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -172,6 +172,7 @@
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
     <SystemIOFileSystemWatcherVersion>4.3.0</SystemIOFileSystemWatcherVersion>
     <SystemIOPipesVersion>4.3.0</SystemIOPipesVersion>
+    <SystemIOPipesAccessControlVersion>4.3.0</SystemIOPipesAccessControlVersion>
     <SystemLinqVersion>4.3.0</SystemLinqVersion>
     <SystemLinqExpressionsVersion>4.3.0</SystemLinqExpressionsVersion>
     <SystemLinqParallelVersion>4.3.0</SystemLinqParallelVersion>

--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -50,7 +50,7 @@
         "Dlls\\Workspaces\\Microsoft.CodeAnalysis.Workspaces.dll",
         "Dlls\\XamlVisualStudio\\Microsoft.VisualStudio.LanguageServices.Xaml.dll",
         "Exes\\InteractiveHost\\InteractiveHost.exe",
-        "Exes\\VBCSCompiler\\VBCSCompiler.exe",
+        "Exes\\VBCSCompiler\\net46\\VBCSCompiler.exe",
         "Exes\\csc\\csc.exe",
         "Exes\\csccore\\csc.dll",
         "Exes\\csi\\csi.exe",

--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -102,6 +102,7 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+      <!-- Workaround for https://github.com/dotnet/sdk/issues/433#issuecomment-320024771 . Remove once resolved. -->
       <AdditionalProperties>TargetFramework=net46</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\csc\csc.csproj">

--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -102,6 +102,7 @@
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+      <AdditionalProperties>TargetFramework=net46</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\csc\csc.csproj">
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems</IncludeOutputGroupsInVSIX>

--- a/src/Compilers/Server/VBCSCompiler/CoreClrCompilerServerHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/CoreClrCompilerServerHost.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#if NETCOREAPP2_0
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CompilerServer
+{
+    internal sealed class CoreClrCompilerServerHost : CompilerServerHost
+    {
+        private static readonly IAnalyzerAssemblyLoader s_analyzerLoader = new CoreClrAnalyzerAssemblyLoader();
+
+        // Caches are used by C# and VB compilers, and shared here.
+        public static readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> SharedAssemblyReferenceProvider = (path, properties) => new CachingMetadataReference(path, properties);
+
+        public override IAnalyzerAssemblyLoader AnalyzerAssemblyLoader => s_analyzerLoader;
+
+        public override Func<string, MetadataReferenceProperties, PortableExecutableReference> AssemblyReferenceProvider => SharedAssemblyReferenceProvider;
+
+        internal CoreClrCompilerServerHost(string clientDirectory, string sdkDirectory)
+            : base(clientDirectory, sdkDirectory)
+        {
+        }
+
+        public override bool CheckAnalyzers(string baseDirectory, ImmutableArray<CommandLineAnalyzerReference> analyzers)
+        {
+            return AnalyzerConsistencyChecker.Check(baseDirectory, analyzers, s_analyzerLoader);
+        }
+    }
+}
+
+#endif

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
@@ -34,38 +28,35 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // VBCSCompiler is installed in the same directory as csc.exe and vbc.exe which is also the 
             // location of the response files.
             var clientDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#if NET46
             var sdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
             var compilerServerHost = new DesktopCompilerServerHost(clientDirectory, sdkDirectory);
+#else
+            var sdkDirectory = (string)null;
+            var compilerServerHost = new CoreClrCompilerServerHost(clientDirectory, sdkDirectory);
+#endif
             return new NamedPipeClientConnectionHost(compilerServerHost, pipeName);
         }
 
         protected internal override TimeSpan? GetKeepAliveTimeout()
         {
-            try
+            int keepAliveValue;
+            string keepAliveStr = _appSettings[KeepAliveSettingName];
+            if (int.TryParse(keepAliveStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out keepAliveValue) &&
+                keepAliveValue >= 0)
             {
-                int keepAliveValue;
-                string keepAliveStr = _appSettings[KeepAliveSettingName];
-                if (int.TryParse(keepAliveStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out keepAliveValue) &&
-                    keepAliveValue >= 0)
+                if (keepAliveValue == 0)
                 {
-                    if (keepAliveValue == 0)
-                    {
-                        // This is a one time server entry.
-                        return null;
-                    }
-                    else
-                    {
-                        return TimeSpan.FromSeconds(keepAliveValue);
-                    }
+                    // This is a one time server entry.
+                    return null;
                 }
                 else
                 {
-                    return ServerDispatcher.DefaultServerKeepAlive;
+                    return TimeSpan.FromSeconds(keepAliveValue);
                 }
             }
-            catch (ConfigurationErrorsException e)
+            else
             {
-                CompilerServerLogger.LogException(e, "Could not read AppSettings");
                 return ServerDispatcher.DefaultServerKeepAlive;
             }
         }

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -40,23 +40,31 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         protected internal override TimeSpan? GetKeepAliveTimeout()
         {
-            int keepAliveValue;
-            string keepAliveStr = _appSettings[KeepAliveSettingName];
-            if (int.TryParse(keepAliveStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out keepAliveValue) &&
-                keepAliveValue >= 0)
+            try
             {
-                if (keepAliveValue == 0)
+                int keepAliveValue;
+                string keepAliveStr = _appSettings[KeepAliveSettingName];
+                if (int.TryParse(keepAliveStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out keepAliveValue) &&
+                    keepAliveValue >= 0)
                 {
-                    // This is a one time server entry.
-                    return null;
+                    if (keepAliveValue == 0)
+                    {
+                        // This is a one time server entry.
+                        return null;
+                    }
+                    else
+                    {
+                        return TimeSpan.FromSeconds(keepAliveValue);
+                    }
                 }
                 else
                 {
-                    return TimeSpan.FromSeconds(keepAliveValue);
+                    return ServerDispatcher.DefaultServerKeepAlive;
                 }
             }
-            else
+            catch (Exception e)
             {
+                CompilerServerLogger.LogException(e, "Could not read AppSettings");
                 return ServerDispatcher.DefaultServerKeepAlive;
             }
         }

--- a/src/Compilers/Server/VBCSCompiler/DesktopCompilerServerHost.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopCompilerServerHost.cs
@@ -1,18 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if NET46
+
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CommandLine;
-using System.IO.Pipes;
-using System.Threading;
-using System.Security.Principal;
-using System.Security.AccessControl;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {
@@ -27,11 +19,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         public override Func<string, MetadataReferenceProperties, PortableExecutableReference> AssemblyReferenceProvider => SharedAssemblyReferenceProvider;
 
-        internal DesktopCompilerServerHost()
-            : this(AppDomain.CurrentDomain.BaseDirectory, RuntimeEnvironment.GetRuntimeDirectory())
-        {
-        }
-
         internal DesktopCompilerServerHost(string clientDirectory, string sdkDirectory)
             : base(clientDirectory, sdkDirectory)
         {
@@ -43,3 +30,5 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         }
     }
 }
+
+#endif

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -148,9 +148,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 PipeTransmissionMode.Byte,
                 PipeOptions.Asynchronous | PipeOptions.WriteThrough,
                 PipeBufferSize, // Default input buffer
-                PipeBufferSize, // Default output buffer
-                security,
-                HandleInheritability.None);
+                PipeBufferSize // Default output buffer
+            );
+            pipeStream.SetAccessControl(security);
 
             CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", pipeName);
 

--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -136,6 +136,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
             PipeSecurity security = new PipeSecurity();
 
+#if NET46
             // Restrict access to just this account.  
             PipeAccessRule rule = new PipeAccessRule(identifier, PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow);
             security.AddAccessRule(rule);
@@ -148,9 +149,27 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 PipeTransmissionMode.Byte,
                 PipeOptions.Asynchronous | PipeOptions.WriteThrough,
                 PipeBufferSize, // Default input buffer
-                PipeBufferSize // Default output buffer
-            );
-            pipeStream.SetAccessControl(security);
+                PipeBufferSize, // Default output buffer
+                security,
+                HandleInheritability.None);
+#else
+            // The overload of NamedPipeServerStream with the PipeAccessRule
+            // parameter was removed in netstandard. However, the default
+            // constructor does not provide WRITE_DAC, so attempting to use
+            // SetAccessControl will always fail. So, completely ignore ACLs on
+            // netcore, and trust that our `ClientAndOurIdentitiesMatch`
+            // verification will catch any invalid connections.
+            // Issue to add WRITE_DAC support:
+            // https://github.com/dotnet/corefx/issues/24040
+            NamedPipeServerStream pipeStream = new NamedPipeServerStream(
+                pipeName,
+                PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances, // Maximum connections.
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous | PipeOptions.WriteThrough,
+                PipeBufferSize, // Default input buffer
+                PipeBufferSize);// Default output buffer
+#endif
 
             CompilerServerLogger.Log("Successfully constructed pipe '{0}'.", pipeName);
 

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -3,7 +3,6 @@
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
 using System.Collections.Specialized;
-using System.Configuration;
 using System.IO;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
@@ -15,7 +14,12 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             NameValueCollection appSettings;
             try
             {
-                appSettings = ConfigurationManager.AppSettings;
+#if NET46
+                appSettings = System.Configuration.ConfigurationManager.AppSettings;
+#else
+                // Do not use AppSettings on non-desktop platforms
+                appSettings = new NameValueCollection();
+#endif
             }
             catch (Exception ex)
             {

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -10,9 +10,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CompilerServer</RootNamespace>
     <LargeAddressAware>true</LargeAddressAware>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>win7;ubuntu.14.04;osx.10.10</RuntimeIdentifiers>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\CSharp\Portable\CSharpCodeAnalysis.csproj" />
@@ -22,9 +23,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\BuildClient.cs">
@@ -32,6 +32,9 @@
     </Compile>
     <Compile Include="..\..\Shared\BuildServerConnection.cs">
       <Link>BuildServerConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
+      <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs">
       <Link>DesktopAnalyzerAssemblyLoader.cs</Link>

--- a/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if NETCOREAPP1_1 || NETCOREAPP2_0
+
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -39,3 +41,5 @@ namespace Microsoft.CodeAnalysis
         }
     }
 }
+
+#endif

--- a/src/Compilers/Shared/DesktopAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/DesktopAnalyzerAssemblyLoader.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if NET46
+
 using System;
 using System.Reflection;
 using System.Threading;
@@ -46,3 +48,5 @@ namespace Microsoft.CodeAnalysis
         }
     }
 }
+
+#endif

--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if NET46
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -193,3 +195,5 @@ namespace Microsoft.CodeAnalysis
         }
     }
 }
+
+#endif

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -40,8 +40,8 @@
     <file src="Exes\vbc\vbc.exe"  target="tools" />
     <file src="Exes\vbc\vbc.exe.config"  target="tools" />
     <file src="Exes\vbc\vbc.rsp"  target="tools" />
-    <file src="Exes\VBCSCompiler\VBCSCompiler.exe" target="tools" />
-    <file src="Exes\VBCSCompiler\VBCSCompiler.exe.config" target="tools" />
+    <file src="Exes\VBCSCompiler\net46\VBCSCompiler.exe" target="tools" />
+    <file src="Exes\VBCSCompiler\net46\VBCSCompiler.exe.config" target="tools" />
     <file src="Dlls\MSBuildTask\Microsoft.Build.Tasks.CodeAnalysis.dll" target="tools" />
     <file src="Dlls\MSbuildTask\Microsoft.CSharp.Core.targets" target="tools" />
     <file src="Dlls\MSbuildTask\Microsoft.VisualBasic.Core.targets" target="tools" />

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -833,7 +833,7 @@ Public Class BuildDevDivInsertionFiles
         add("Exes\csc\csc.rsp")
         add("Exes\vbc\vbc.exe.config")
         add("Exes\vbc\vbc.rsp")
-        add("Exes\VBCSCompiler\VBCSCompiler.exe.config")
+        add("Exes\VBCSCompiler\net46\VBCSCompiler.exe.config")
         add("Exes\InteractiveHost\InteractiveHost.exe.config")
         add("Exes\csi\csi.rsp")
         add("Vsix\Roslyn.Deployment.Full.Next\remoteSymbolSearchUpdateEngine.servicehub.service.json")

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -7,7 +7,7 @@ vs.dependencies
   vs.dependency id=Microsoft.Net.PackageGroup.4.6.1.Redist
 
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn
-    file source=$(OutputPath)\Exes\VBCSCompiler\VBCSCompiler.exe vs.file.ngenArchitecture=all
+    file source=$(OutputPath)\Exes\VBCSCompiler\net46\VBCSCompiler.exe vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\csc\csc.exe vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\csi\csi.exe vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\vbc\vbc.exe vs.file.ngenArchitecture=all
@@ -15,7 +15,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Exes\csc\csc.exe.config
     file source=$(OutputPath)\Exes\csi\csi.exe.config
     file source=$(OutputPath)\Exes\vbc\vbc.exe.config
-    file source=$(OutputPath)\Exes\VBCSCompiler\VBCSCompiler.exe.config
+    file source=$(OutputPath)\Exes\VBCSCompiler\net46\VBCSCompiler.exe.config
 
     file source=$(OutputPath)\Exes\csc\csc.rsp
     file source=$(OutputPath)\Exes\csi\csi.rsp


### PR DESCRIPTION
This is part of work to make the compiler server xplat.

Currently, this change is only targeted at getting VBCSCompiler on desktop/coreclr, but both on Windows (not coreclr+mac/linux).

There will be a follow-up PR to make VBCSCompilerTests multitargeted (but that requires a larger set of changes - I'm currently working on nuking CscCore and making csc multitargeted, which is required (or at least makes it significantly easier))

cc @jaredpar