### PR TITLE
Disabled cross function inlining if used the same type parameter name.

### DIFF
--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2070,5 +2070,71 @@ class Program
   public static void Out<T>(out T t) => t = default;
 }");
         }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestMissingOnCrossFunction3()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Method<string>();
+    }
+
+    public static void Method<T>()
+    { 
+        [|T t|];
+        void Local<T>()
+        {
+            { // <-- note this set of added braces
+                Out(out t);
+                Console.WriteLine(t);
+            }
+        }
+        Local<int>();
+    }
+
+    public static void Out<T>(out T t) => t = default;
+}");
+        }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestMissingOnCrossFunction4()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Method<string>();
+    }
+
+    public static void Method<T>()
+    {
+        { // <-- note this set of added braces
+            [|T t|];
+            void Local<T>()
+            {
+                { // <-- and my axe
+                    Out(out t);
+                    Console.WriteLine(t);
+                }
+            }
+            Local<int>();
+        }
+    }
+
+    public static void Out<T>(out T t) => t = default;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2007,5 +2007,68 @@ class C
     }
 }");
         }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestMissingOnCrossFunction1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+  static void Main(string[] args)
+  {
+    Method<string>();
+  }
+
+  public static void Method<T>()
+  { 
+    [|T t|];
+    void Local<T>()
+    {
+      Out(out t);
+      Console.WriteLine(t);
+    }
+    Local<int>();
+  }
+
+  public static void Out<T>(out T t) => t = default;
+}");
+        }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestMissingOnCrossFunction2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+  static void Main(string[] args)
+  {
+    Method<string>();
+  }
+
+  public static void Method<T>()
+  { 
+    void Local<T>()
+    {
+        [|T t|];
+        void InnerLocal<T>()
+        {
+          Out(out t);
+          Console.WriteLine(t);
+        }
+    }
+    Local<int>();
+  }
+
+  public static void Out<T>(out T t) => t = default;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -1219,5 +1219,134 @@ ignoreTrivia: false);
 }",
 ignoreTrivia: false);
         }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingOnCrossFunction1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+  static void Main(string[] args)
+  {
+    Method<string>();
+  }
+
+  public static void Method<T>()
+  { 
+    [|T t|];
+    void Local<T>()
+    {
+      Out(out t);
+      Console.WriteLine(t);
+    }
+    Local<int>();
+  }
+
+  public static void Out<T>(out T t) => t = default;
+}");
+        }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingOnCrossFunction2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+  static void Main(string[] args)
+  {
+    Method<string>();
+  }
+
+  public static void Method<T>()
+  { 
+    void Local<T>()
+    {
+        [|T t|];
+        void InnerLocal<T>()
+        {
+          Out(out t);
+          Console.WriteLine(t);
+        }
+    }
+    Local<int>();
+  }
+
+  public static void Out<T>(out T t) => t = default;
+}");
+        }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingOnCrossFunction3()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Method<string>();
+    }
+
+    public static void Method<T>()
+    { 
+        [|T t|];
+        void Local<T>()
+        {
+            { // <-- note this set of added braces
+                Out(out t);
+                Console.WriteLine(t);
+            }
+        }
+        Local<int>();
+    }
+
+    public static void Out<T>(out T t) => t = default;
+}");
+        }
+
+        [WorkItem(21907, "https://github.com/dotnet/roslyn/issues/21907")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TestMissingOnCrossFunction4()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Method<string>();
+    }
+
+    public static void Method<T>()
+    {
+        { // <-- note this set of added braces
+            [|T t|];
+            void Local<T>()
+            {
+                { // <-- and my axe
+                    Out(out t);
+                    Console.WriteLine(t);
+                }
+            }
+            Local<int>();
+        }
+    }
+
+    public static void Out<T>(out T t) => t = default;
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -196,8 +196,9 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
 
             if (enclosingBlockOfLocalStatement != outArgumentScope)
             {
-                var localFunctionOrMethodDeclaration = enclosingBlockOfLocalStatement.AncestorsAndSelf().FirstOrDefault(node => node.IsKind(SyntaxKind.LocalFunctionStatement, SyntaxKind.MethodDeclaration));
-                var localFunctionStatement = outArgumentScope.AncestorsAndSelf().FirstOrDefault(node => node.IsKind(SyntaxKind.LocalFunctionStatement));
+                var localFunctionOrMethodDeclaration = enclosingBlockOfLocalStatement.AncestorsAndSelf()
+                    .FirstOrDefault(node => node.IsKind(SyntaxKind.LocalFunctionStatement, SyntaxKind.MethodDeclaration));
+                var localFunctionStatement = outArgumentScope.FirstAncestorOrSelf<LocalFunctionStatementSyntax>();
 
                 if (localFunctionOrMethodDeclaration != localFunctionStatement &&
                     HasTypeParameterWithName(localFunctionOrMethodDeclaration, outLocalSymbol.Type.Name) &&

--- a/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/MoveDeclarationNearReference/CSharpMoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
@@ -53,6 +54,43 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveDeclarationNearReference
             }
 
             return true;
+        }
+
+        protected override bool CanMoveToBlock(ILocalSymbol localSymbol, SyntaxNode currentBlock, SyntaxNode destinationBlock)
+        {
+            if (currentBlock != destinationBlock)
+            {
+                var localFunctionOrMethodDeclaration = currentBlock.AncestorsAndSelf()
+                    .FirstOrDefault(node => node.IsKind(SyntaxKind.LocalFunctionStatement) || node.IsKind(SyntaxKind.MethodDeclaration));
+                var localFunctionStatement = destinationBlock.FirstAncestorOrSelf<LocalFunctionStatementSyntax>();
+
+                if (localFunctionOrMethodDeclaration != localFunctionStatement &&
+                    HasTypeParameterWithName(localFunctionOrMethodDeclaration, localSymbol.Type.Name) &&
+                    HasTypeParameterWithName(localFunctionStatement, localSymbol.Type.Name))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+
+            bool HasTypeParameterWithName(SyntaxNode node, string name)
+            {
+                SeparatedSyntaxList<TypeParameterSyntax>? typeParameters;
+                switch (node)
+                {
+                    case MethodDeclarationSyntax methodDeclaration:
+                        typeParameters = methodDeclaration.TypeParameterList?.Parameters;
+                        break;
+                    case LocalFunctionStatementSyntax localFunctionStatement:
+                        typeParameters = localFunctionStatement.TypeParameterList?.Parameters;
+                        break;
+                    default:
+                        return false;
+                }
+
+                return typeParameters.HasValue && typeParameters.Value.Any(typeParameter => typeParameter.Identifier.ValueText == name);
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveDeclarationNearReference/AbstractMoveDeclarationNearReferenceCodeRefactoringProvider.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
         where TVariableDeclaratorSyntax : SyntaxNode
     {
         protected abstract bool IsMeaningfulBlock(SyntaxNode node);
+        protected abstract bool CanMoveToBlock(ILocalSymbol localSymbol, SyntaxNode currentBlock, SyntaxNode destinationBlock);
         protected abstract SyntaxNode GetVariableDeclaratorSymbolNode(TVariableDeclaratorSyntax variableDeclarator);
         protected abstract bool IsValidVariableDeclarator(TVariableDeclaratorSyntax variableDeclarator);
         protected abstract SyntaxToken GetIdentifierOfVariableDeclarator(TVariableDeclaratorSyntax variableDeclarator);
@@ -54,6 +55,11 @@ namespace Microsoft.CodeAnalysis.MoveDeclarationNearReference
 
             var state = await State.GenerateAsync((TService)this, document, statement, cancellationToken).ConfigureAwait(false);
             if (state == null)
+            {
+                return;
+            }
+
+            if (!CanMoveToBlock(state.LocalSymbol, state.OutermostBlock, state.InnermostBlock))
             {
                 return;
             }

--- a/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/MoveDeclarationNearReference/VisualBasicMoveDeclarationNearReferenceCodeRefactoringProvider.vb
@@ -39,5 +39,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MoveDeclarationNearReference
         Protected Overrides Function TypesAreCompatibleAsync(document As Document, localSymbol As ILocalSymbol, declarationStatement As LocalDeclarationStatementSyntax, right As SyntaxNode, cancellationToken As CancellationToken) As Task(Of Boolean)
             Return SpecializedTasks.True
         End Function
+
+        Protected Overrides Function CanMoveToBlock(localSymbol As ILocalSymbol, currentBlock As SyntaxNode, destinationBlock As SyntaxNode) As Boolean
+            Return True
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.Extensions
+{
+    internal static class ILocalSymbolExtensions
+    {
+        public static bool CanSafelyMoveLocalToBlock(this ILocalSymbol localSymbol, SyntaxNode currentBlock, SyntaxNode destinationBlock)
+        {
+            if (currentBlock != destinationBlock)
+            {
+                var localFunctionOrMethodDeclaration = currentBlock.AncestorsAndSelf()
+                    .FirstOrDefault(node => node.IsKind(SyntaxKind.LocalFunctionStatement) || node.IsKind(SyntaxKind.MethodDeclaration));
+                var localFunctionStatement = destinationBlock.FirstAncestorOrSelf<LocalFunctionStatementSyntax>();
+
+                if (localFunctionOrMethodDeclaration != localFunctionStatement &&
+                    HasTypeParameterWithName(localFunctionOrMethodDeclaration, localSymbol.Type.Name) &&
+                    HasTypeParameterWithName(localFunctionStatement, localSymbol.Type.Name))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+
+            bool HasTypeParameterWithName(SyntaxNode node, string name)
+            {
+                SeparatedSyntaxList<TypeParameterSyntax>? typeParameters;
+                switch (node)
+                {
+                    case MethodDeclarationSyntax methodDeclaration:
+                        typeParameters = methodDeclaration.TypeParameterList?.Parameters;
+                        break;
+                    case LocalFunctionStatementSyntax localFunctionStatement:
+                        typeParameters = localFunctionStatement.TypeParameterList?.Parameters;
+                        break;
+                    default:
+                        return false;
+                }
+
+                return typeParameters.HasValue && typeParameters.Value.Any(typeParameter => typeParameter.Identifier.ValueText == name);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**
Cross function inlining in case of generic functions with the same type parameter name may breaks code logic

**Bugs this fixes:**
Fixes #21907 

**Risk**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Not covered case

**How was the bug found?**
customer reported