### PR TITLE
Prevent crash when no capitalization is specified (invalid naming style)

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -95,6 +95,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
         }
 
         [Fact]
+        public static void TestRuleWithoutCapitalization()
+        {
+            var dictionary = new Dictionary<string, object>()
+            {
+                ["dotnet_naming_rule.async_methods_must_end_with_async.symbols"] = "any_async_methods",
+                ["dotnet_naming_rule.async_methods_must_end_with_async.style"] = "end_in_async",
+                ["dotnet_naming_rule.async_methods_must_end_with_async.severity"] = "suggestion",
+                ["dotnet_naming_symbols.any_async_methods.applicable_kinds"] = "method",
+                ["dotnet_naming_symbols.any_async_methods.applicable_accessibilities"] = "*",
+                ["dotnet_naming_symbols.any_async_methods.required_modifiers"] = "async",
+                ["dotnet_naming_style.end_in_async.required_suffix"] = "Async",
+            };
+            var result = ParseDictionary(dictionary);
+            Assert.Empty(result.NamingStyles);
+        }
+
+        [Fact]
         public static void TestPublicMembersCapitalizedRule()
         {
             var dictionary = new Dictionary<string, object>()

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -46,18 +46,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
             foreach (var namingRuleTitle in GetRuleTitles(trimmedDictionary))
             {
-                if (TryGetSymbolSpec(namingRuleTitle, trimmedDictionary, out var symbolSpec))
+                if (TryGetSymbolSpec(namingRuleTitle, trimmedDictionary, out var symbolSpec) &&
+                    TryGetNamingStyleData(namingRuleTitle, trimmedDictionary, out var namingStyle) &&
+                    TryGetSerializableNamingRule(namingRuleTitle, symbolSpec, namingStyle, trimmedDictionary, out var serializableNamingRule))
                 {
                     symbolSpecifications.Add(symbolSpec);
-                }
-
-                if (TryGetNamingStyleData(namingRuleTitle, trimmedDictionary, out var namingStyle))
-                {
                     namingStyles.Add(namingStyle);
-                }
-
-                if (TryGetSerializableNamingRule(namingRuleTitle, symbolSpec, namingStyle, trimmedDictionary, out var serializableNamingRule))
-                {
                     namingRules.Add(serializableNamingRule);
                 }
             }


### PR DESCRIPTION
**Customer scenario**

An incorrectly specified .editorconfig file causes a Visual Studio crash when Intellisense tries to load. In my case, I was missing the capitalization on the naming style..

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/21893

**Workarounds, if any**

The workaround is fixing the naming rule, but there is no hint that this is the cause without looking at the stack trace of the exception in Event Viewer and taking some educated guesses.

**Risk**

I'm not entirely sure if the fix is as I've done it - don't load if any one thing didn't work. The existing code uses `Single` and the specification (https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference) states "you must specify symbols, style, and a severity" so it seems a valid assumption to me. Please let me know if my approach here is incorrect.

**Performance impact**

Low.

**Is this a regression from a previous update?**
I don't know.

**Root cause analysis:**

I added a test with an invalid definition that ensures no actual naming styles are loaded.

**How was the bug found?**

I found it when Visual Studio started crashing after I created a .editorconfig file.

**Test documentation updated?**

N/A
