### PR TITLE
Add MonoDevelopGtk synchronization context as consumption of Roslyn i…

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.Utilities
         StaUnitTest,
         JoinableTask,
         ForcedByPackageInitialize,
+        MonoDevelopGtk,
         Unknown
     }
 
@@ -42,6 +43,10 @@ namespace Microsoft.CodeAnalysis.Utilities
                 case "System.Windows.Forms.WindowsFormsSynchronizationContext":
 
                     return WinForms;
+
+                case "MonoDevelop.Ide.DispatchService+GtkSynchronizationContext":
+
+                    return MonoDevelopGtk;
 
                 default:
 


### PR DESCRIPTION
…n VS for Mac uses this context.

**Customer scenario**

In VS for Mac, the foreground thread kind will be unknown, which causes issues at least in debug code.

**Bugs this fixes:**

N/A

**Workarounds, if any**

N/A

**Risk**

Low, as this only changes the VS for Mac behavior to not fall under the Unknown synchronization context path.

**Performance impact**

None, the change is trivial.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Consumption of Roslyn in VS for Mac is being used in new ways.

**How was the bug found?**

Tried running chk Roslyn bits in VS for Mac

**Test documentation updated?**

N/A
