### PR TITLE
[WIP] Validate tuple element names in OHI scenarios using an analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/TupleElementNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/TupleElementNamesTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.TupleElementNames;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics
+{
+    public partial class TupleElementNamesTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace) =>
+            (new CSharpTupleElementNameDiagnosticAnalyzer(), new TupleElementNamesCodeFixProvider());
+
+        [Fact]
+        public async Task ImplementTupleInterfaceWithValueTuple1()
+        {
+            string source = @"
+public interface I
+{
+    (int i1, int i2) M((string, string) a);
+}
+
+class C : I
+{
+    public System.ValueTuple<int, int> [|M|](System.ValueTuple<string, string> a)
+    {
+        return (1, 2);
+    }
+}
+" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+            string fixedSource = @"
+public interface I
+{
+    (int i1, int i2) M((string, string) a);
+}
+
+class C : I
+{
+    public (int i1, int i2) M(System.ValueTuple<string, string> a)
+    {
+        return (1, 2);
+    }
+}
+" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+
+            await TestInRegularAndScriptAsync(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task ImplementTupleInterfaceWithValueTuple2()
+        {
+            string source = @"
+public interface I
+{
+    (int i1, int i2) M((string, string) a);
+}
+
+class C : I
+{
+    public (int, int) [|M|]((string, string) a)
+    {
+        return (1, 2);
+    }
+}
+" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+            string fixedSource = @"
+public interface I
+{
+    (int i1, int i2) M((string, string) a);
+}
+
+class C : I
+{
+    public (int i1, int i2) M((string, string) a)
+    {
+        return (1, 2);
+    }
+}
+" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+
+            await TestInRegularAndScriptAsync(source, fixedSource);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/TupleElementNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/TupleElementNamesTests.cs
@@ -1,15 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.TupleElementNames;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -80,6 +80,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add tuple element names.
+        /// </summary>
+        internal static string Add_tuple_element_names {
+            get {
+                return ResourceManager.GetString("Add_tuple_element_names", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to anonymous method.
         /// </summary>
         internal static string anonymous_method {
@@ -356,6 +365,42 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string element_name {
             get {
                 return ResourceManager.GetString("element_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos;: cannot change tuple element names when overriding inherited member &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_CantChangeTupleNamesOnOverride {
+            get {
+                return ResourceManager.GetString("ERR_CantChangeTupleNamesOnOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot change tuple element names when overriding an inherited member.
+        /// </summary>
+        internal static string ERR_CantChangeTupleNamesOnOverride_Title {
+            get {
+                return ResourceManager.GetString("ERR_CantChangeTupleNamesOnOverride_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The tuple element names in the signature of method &apos;{0}&apos; must match the tuple element names of interface method &apos;{1}&apos; (including on the return type)..
+        /// </summary>
+        internal static string ERR_ImplBadTupleNames {
+            get {
+                return ResourceManager.GetString("ERR_ImplBadTupleNames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot change tuple element names when implementing an interface member.
+        /// </summary>
+        internal static string ERR_ImplBadTupleNames_Title {
+            get {
+                return ResourceManager.GetString("ERR_ImplBadTupleNames_Title", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -524,4 +524,19 @@
   <data name="Use_is_null_check" xml:space="preserve">
     <value>Use 'is null' check</value>
   </data>
+  <data name="ERR_CantChangeTupleNamesOnOverride" xml:space="preserve">
+    <value>'{0}': cannot change tuple element names when overriding inherited member '{1}'</value>
+  </data>
+  <data name="ERR_CantChangeTupleNamesOnOverride_Title" xml:space="preserve">
+    <value>Cannot change tuple element names when overriding an inherited member</value>
+  </data>
+  <data name="ERR_ImplBadTupleNames" xml:space="preserve">
+    <value>The tuple element names in the signature of method '{0}' must match the tuple element names of interface method '{1}' (including on the return type).</value>
+  </data>
+  <data name="ERR_ImplBadTupleNames_Title" xml:space="preserve">
+    <value>Cannot change tuple element names when implementing an interface member</value>
+  </data>
+  <data name="Add_tuple_element_names" xml:space="preserve">
+    <value>Add tuple element names</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CodeFixes/TupleElementNames/TupleElementNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/TupleElementNames/TupleElementNamesCodeFixProvider.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TupleElementNames
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.AddTupleElementNames), Shared]
+    [ExtensionOrder(After = PredefinedCodeFixProviderNames.ImplementInterface)]
+    internal partial class TupleElementNamesCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(IDEDiagnosticIds.TupleElementNamesMatchBaseDiagnosticId);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return null;
+        }
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(
+                new MyCodeAction(
+                    CSharpFeaturesResources.Add_tuple_element_names,
+                    cancellationToken => AddTupleElementNamesAsync(context.Document, context.Span, cancellationToken)),
+                context.Diagnostics);
+
+            return Task.CompletedTask;
+        }
+
+        private static async Task<Document> AddTupleElementNamesAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var declaration = root.FindNode(span, getInnermostNodeForTie: true);
+            var generator = SyntaxGenerator.GetGenerator(document);
+            var editor = new SyntaxEditor(root, generator);
+
+            ISymbol symbol;
+            TypeSyntax typeDeclaration;
+            BaseParameterListSyntax parameterList;
+            switch (declaration)
+            {
+                case MethodDeclarationSyntax methodDeclaration:
+                    symbol = semanticModel.GetDeclaredSymbol(methodDeclaration, cancellationToken);
+                    typeDeclaration = methodDeclaration.ReturnType;
+                    parameterList = methodDeclaration.ParameterList;
+                    break;
+
+                case IndexerDeclarationSyntax indexerDeclaration:
+                    symbol = semanticModel.GetDeclaredSymbol(indexerDeclaration, cancellationToken);
+                    typeDeclaration = indexerDeclaration.Type;
+                    parameterList = indexerDeclaration.ParameterList;
+                    break;
+
+                case BasePropertyDeclarationSyntax basePropertyDeclaration:
+                    symbol = semanticModel.GetDeclaredSymbol(basePropertyDeclaration, cancellationToken);
+                    typeDeclaration = basePropertyDeclaration.Type;
+                    parameterList = null;
+                    break;
+
+                case IdentifierNameSyntax identifierName:
+                    var variableDeclarator = identifierName.Parent as VariableDeclaratorSyntax;
+                    var variableDeclaration = variableDeclarator?.Parent as VariableDeclarationSyntax;
+                    if (variableDeclaration == null)
+                    {
+                        return null;
+                    }
+
+                    symbol = semanticModel.GetDeclaredSymbol(variableDeclarator, cancellationToken);
+                    typeDeclaration = variableDeclaration.Type;
+                    parameterList = null;
+                    break;
+
+                default:
+                    return null;
+            }
+
+            var originalSymbol = GetMismatchedDefinition(symbol);
+            GetSymbolInformation(originalSymbol, out var originalType, out var originalParameterTypes);
+
+            if (CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(originalType))
+            {
+                editor.ReplaceNode(typeDeclaration, generator.TypeExpression(originalType));
+            }
+
+            for (var i = 0; i < originalParameterTypes.Length; i++)
+            {
+                if (CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(originalParameterTypes[i]))
+                {
+                    editor.ReplaceNode(parameterList.Parameters[i].Type, generator.TypeExpression(originalParameterTypes[i]));
+                }
+            }
+
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+
+        private static ISymbol GetMismatchedDefinition(ISymbol symbol)
+        {
+            // For this code fix, the mismatched symbol is the first one with any named tuple element
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Method:
+                    var overriddenMethod = ((IMethodSymbol)symbol).OverriddenMethod;
+                    if (overriddenMethod != null && CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(overriddenMethod))
+                    {
+                        return overriddenMethod;
+                    }
+
+                    foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+                    {
+                        foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IMethodSymbol>())
+                        {
+                            if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                            {
+                                if (CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(member))
+                                {
+                                    return member;
+                                }
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case SymbolKind.Property:
+                    var overriddenProperty = ((IPropertySymbol)symbol).OverriddenProperty;
+                    if (overriddenProperty != null && CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(overriddenProperty))
+                    {
+                        return overriddenProperty;
+                    }
+
+                    foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+                    {
+                        foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IPropertySymbol>())
+                        {
+                            if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                            {
+                                if (CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(member))
+                                {
+                                    return member;
+                                }
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case SymbolKind.Event:
+                    var overriddenEvent = ((IEventSymbol)symbol).OverriddenEvent;
+                    if (overriddenEvent != null && CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(overriddenEvent))
+                    {
+                        return overriddenEvent;
+                    }
+
+                    foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+                    {
+                        foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IEventSymbol>())
+                        {
+                            if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                            {
+                                if (CSharpTupleElementNameDiagnosticAnalyzer.ContainsTupleTypeWithNames(member))
+                                {
+                                    return member;
+                                }
+                            }
+                        }
+                    }
+
+                    return null;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+            }
+        }
+
+        private static void GetSymbolInformation(ISymbol symbol, out ITypeSymbol type, out ImmutableArray<ITypeSymbol> parameterTypes)
+        {
+            switch (symbol)
+            {
+                case IMethodSymbol methodSymbol:
+                    type = methodSymbol.ReturnType;
+                    parameterTypes = methodSymbol.Parameters.SelectAsArray(parameter => parameter.Type);
+                    return;
+
+                case IPropertySymbol propertySymbol:
+                    type = propertySymbol.Type;
+                    parameterTypes = propertySymbol.Parameters.SelectAsArray(parameter => parameter.Type);
+                    return;
+
+                case IEventSymbol eventSymbol:
+                    type = eventSymbol.Type;
+                    parameterTypes = ImmutableArray<ITypeSymbol>.Empty;
+                    return;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+            }
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CodeFixes/TupleElementNames/TupleElementNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/TupleElementNames/TupleElementNamesCodeFixProvider.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTupleElementNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTupleElementNameDiagnosticAnalyzer.cs
@@ -1,0 +1,456 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpTupleElementNameDiagnosticAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
+    {
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(CSharpFeaturesResources.ERR_CantChangeTupleNamesOnOverride), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(CSharpFeaturesResources.ERR_CantChangeTupleNamesOnOverride_Title), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(
+            IDEDiagnosticIds.TupleElementNamesMatchBaseDiagnosticId,
+            s_localizableTitle,
+            s_localizableMessage,
+            DiagnosticCategory.Style,
+            DiagnosticSeverity.Hidden,
+            isEnabledByDefault: true);
+
+        private static readonly Func<ITypeSymbol, ITypeSymbol, object, bool> CompareTupleElements =
+            (left, right, _) =>
+            {
+                if (right.IsTupleType && !left.IsTupleType)
+                {
+                    return true;
+                }
+
+                if (!right.IsTupleType)
+                {
+                    return false;
+                }
+
+                var rightElements = ((INamedTypeSymbol)right).TupleElements;
+                return rightElements.Any(field => !field.IsImplicitlyDeclared && field.Name != null);
+            };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(s_descriptor);
+
+        public bool OpenFileOnly(Workspace workspace)
+        {
+            var preferTupleElementNamesMatchBase = workspace.Options.GetOption(
+                CodeStyleOptions.PreferTupleNamesMatchBase, LanguageNames.CSharp).Notification;
+
+            return !(preferTupleElementNamesMatchBase == NotificationOption.Warning || preferTupleElementNamesMatchBase == NotificationOption.Error);
+        }
+
+        public DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+            context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
+            context.RegisterSymbolAction(AnalyzeEvent, SymbolKind.Event);
+        }
+
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
+        {
+            var symbol = (IMethodSymbol)context.Symbol;
+            if (!ContainsTupleType(symbol))
+            {
+                // Stop immediately if no tuple types are involved
+                return;
+            }
+
+            if (ContainsTupleTypeWithNames(symbol))
+            {
+                // This is handled by the compiler
+                return;
+            }
+
+            var overriddenMethod = symbol.OverriddenMethod;
+            if (overriddenMethod != null && CompareMethods(symbol, overriddenMethod) != null)
+            {
+                var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                return;
+            }
+
+            foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+            {
+                foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IMethodSymbol>())
+                {
+                    if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                    {
+                        if (CompareMethods(symbol, member) != null)
+                        {
+                            var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                            context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                            return;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            // Local Functions
+            ITypeSymbol CompareMethods(IMethodSymbol left, IMethodSymbol right)
+            {
+                if (WalkTypes(left.ReturnType, right.ReturnType, CompareTupleElements, null).Item1 is ITypeSymbol type)
+                {
+                    return type;
+                }
+
+                for (int i = 0; i < left.Parameters.Length; i++)
+                {
+                    if (WalkTypes(left.Parameters[i].Type, right.Parameters[i].Type, CompareTupleElements, null).Item1 is ITypeSymbol parameterType)
+                    {
+                        return parameterType;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        private static void AnalyzeProperty(SymbolAnalysisContext context)
+        {
+            var symbol = (IPropertySymbol)context.Symbol;
+            if (!ContainsTupleType(symbol))
+            {
+                // Stop immediately if no tuple types are involved
+                return;
+            }
+
+            if (ContainsTupleTypeWithNames(symbol))
+            {
+                // This is handled by the compiler
+                return;
+            }
+
+            var overriddenProperty = symbol.OverriddenProperty;
+            if (overriddenProperty != null && WalkTypes(symbol.Type, overriddenProperty.Type, CompareTupleElements, null).Item1 != null)
+            {
+                var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                return;
+            }
+
+            foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+            {
+                foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IPropertySymbol>())
+                {
+                    if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                    {
+                        if (WalkTypes(symbol.Type, member.Type, CompareTupleElements, null).Item1 != null)
+                        {
+                            var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                            context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                            return;
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static void AnalyzeEvent(SymbolAnalysisContext context)
+        {
+            var symbol = (IEventSymbol)context.Symbol;
+            if (!ContainsTupleType(symbol))
+            {
+                // Stop immediately if no tuple types are involved
+                return;
+            }
+
+            if (ContainsTupleTypeWithNames(symbol))
+            {
+                // This is handled by the compiler
+                return;
+            }
+
+            var overriddenEvent = symbol.OverriddenEvent;
+            if (overriddenEvent != null && WalkTypes(symbol.Type, overriddenEvent.Type, CompareTupleElements, null).Item1 != null)
+            {
+                var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                return;
+            }
+
+            foreach (var implementedInterface in symbol.ContainingType.Interfaces)
+            {
+                foreach (var member in implementedInterface.GetMembers(symbol.Name).OfType<IEventSymbol>())
+                {
+                    if (symbol.ContainingType.FindImplementationForInterfaceMember(member) == symbol)
+                    {
+                        if (WalkTypes(symbol.Type, member.Type, CompareTupleElements, null).Item1 != null)
+                        {
+                            var optionSet = context.Options.GetDocumentOptionSetAsync(symbol.Locations[0].SourceTree, context.CancellationToken).GetAwaiter().GetResult();
+                            context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(optionSet), symbol.Locations[0]));
+                            return;
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static DiagnosticDescriptor GetDescriptor(OptionSet optionSet)
+        {
+            var optionValue = optionSet.GetOption(CodeStyleOptions.PreferTupleNamesMatchBase, LanguageNames.CSharp);
+            if (optionValue.Notification.Value != DiagnosticSeverity.Hidden)
+            {
+                return new DiagnosticDescriptor(
+                    IDEDiagnosticIds.TupleElementNamesMatchBaseDiagnosticId,
+                    s_localizableTitle,
+                    s_localizableMessage,
+                    DiagnosticCategory.Style,
+                    optionValue.Notification.Value,
+                    isEnabledByDefault: true);
+            }
+
+            return s_descriptor;
+        }
+
+        internal static bool ContainsTupleType(ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Method:
+                    var method = (IMethodSymbol)symbol;
+                    return ContainsTupleType(method.ReturnType) || method.Parameters.Any(parameter => ContainsTupleType(parameter.Type));
+
+                case SymbolKind.Property:
+                    return ContainsTupleType(((IPropertySymbol)symbol).Type);
+
+                case SymbolKind.Event:
+                    return ContainsTupleType(((IEventSymbol)symbol).Type);
+
+                case SymbolKind.ArrayType:
+                case SymbolKind.DynamicType:
+                case SymbolKind.ErrorType:
+                case SymbolKind.NamedType:
+                case SymbolKind.PointerType:
+                case SymbolKind.TypeParameter:
+                    return VisitType((ITypeSymbol)symbol, type => IsTupleType(type)) != null;
+
+                default:
+                    // We currently don't need to use this method for fields or locals
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+            }
+        }
+
+        private static bool IsTupleType(ITypeSymbol symbol)
+        {
+            if (symbol.IsTupleType)
+            {
+                return true;
+            }
+
+            if (symbol.TypeKind != TypeKind.Struct)
+            {
+                return false;
+            }
+
+            var namedTypeSymbol = (INamedTypeSymbol)symbol;
+            if (!namedTypeSymbol.IsGenericType)
+            {
+                return false;
+            }
+
+            return namedTypeSymbol.Name == nameof(ValueTuple)
+                && namedTypeSymbol.ContainingNamespace.Name == nameof(System)
+                && namedTypeSymbol.ContainingNamespace.ContainingNamespace.IsGlobalNamespace;
+        }
+
+        internal static bool ContainsTupleTypeWithNames(ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Method:
+                    var method = (IMethodSymbol)symbol;
+                    return ContainsTupleTypeWithNames(method.ReturnType) || method.Parameters.Any(parameter => ContainsTupleTypeWithNames(parameter.Type));
+
+                case SymbolKind.Property:
+                    return ContainsTupleTypeWithNames(((IPropertySymbol)symbol).Type);
+
+                case SymbolKind.Event:
+                    return ContainsTupleTypeWithNames(((IEventSymbol)symbol).Type);
+
+                case SymbolKind.ArrayType:
+                case SymbolKind.DynamicType:
+                case SymbolKind.ErrorType:
+                case SymbolKind.NamedType:
+                case SymbolKind.PointerType:
+                case SymbolKind.TypeParameter:
+                    return VisitType((ITypeSymbol)symbol, type => type.IsTupleType && ((INamedTypeSymbol)type).TupleElements.Any(field => !field.IsImplicitlyDeclared && field.Name != null)) != null;
+
+                default:
+                    // We currently don't need to use this method for fields or locals
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+            }
+        }
+
+        internal static ITypeSymbol VisitType(ITypeSymbol type, Func<ITypeSymbol, bool> predicate)
+        {
+            // In order to handle extremely "deep" types like "int[][][][][][][][][]...[]"
+            // or int*****************...* we implement manual tail recursion rather than 
+            // doing the natural recursion.
+
+            ITypeSymbol current = type;
+
+            while (true)
+            {
+                if (predicate(current))
+                {
+                    return current;
+                }
+
+                switch (current.TypeKind)
+                {
+                    case TypeKind.Error:
+                    case TypeKind.Dynamic:
+                    case TypeKind.TypeParameter:
+                    case TypeKind.Submission:
+                    case TypeKind.Enum:
+                        return null;
+
+                    case TypeKind.Class:
+                    case TypeKind.Struct:
+                    case TypeKind.Interface:
+                    case TypeKind.Delegate:
+                        if (current.IsTupleType)
+                        {
+                            // turn tuple type elements into parameters
+                            current = ((INamedTypeSymbol)current).TupleUnderlyingType;
+                        }
+
+                        foreach (var nestedType in ((INamedTypeSymbol)current).TypeArguments)
+                        {
+                            var result = VisitType(nestedType, predicate);
+                            if (result != null)
+                            {
+                                return result;
+                            }
+                        }
+                        return null;
+
+                    case TypeKind.Array:
+                        current = ((IArrayTypeSymbol)current).ElementType;
+                        continue;
+
+                    case TypeKind.Pointer:
+                        current = ((IPointerTypeSymbol)current).PointedAtType;
+                        continue;
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(current.TypeKind);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Visit the given type and, in the case of compound types, visit all "sub type"
+        /// (such as A in A[], or { A&lt;T&gt;, T, U } in A&lt;T&gt;.B&lt;U&gt;) invoking 'predicate'
+        /// with the type and 'arg' at each sub type. If the predicate returns true for any type,
+        /// traversal stops and that type is returned from this method. Otherwise if traversal
+        /// completes without the predicate returning true for any type, this method returns null.
+        /// </summary>
+        /// <remarks>
+        /// Taken from TypeSymbolExtensions.
+        /// </remarks>
+        internal static (ITypeSymbol, ITypeSymbol) WalkTypes<TArg>(ITypeSymbol left, ITypeSymbol right, Func<ITypeSymbol, ITypeSymbol, TArg, bool> predicate, TArg arg)
+        {
+            // In order to handle extremely "deep" types like "int[][][][][][][][][]...[]"
+            // or int*****************...* we implement manual tail recursion rather than 
+            // doing the natural recursion.
+
+            ITypeSymbol currentLeft = left;
+            ITypeSymbol currentRight = right;
+
+            while (true)
+            {
+                if (predicate(currentLeft, currentRight, arg))
+                {
+                    return (currentLeft, currentRight);
+                }
+
+                if (currentLeft.TypeKind != currentRight.TypeKind)
+                {
+                    return (null, null);
+                }
+
+                switch (currentLeft.TypeKind)
+                {
+                    case TypeKind.Error:
+                    case TypeKind.Dynamic:
+                    case TypeKind.TypeParameter:
+                    case TypeKind.Submission:
+                    case TypeKind.Enum:
+                        return (null, null);
+
+                    case TypeKind.Class:
+                    case TypeKind.Struct:
+                    case TypeKind.Interface:
+                    case TypeKind.Delegate:
+                        if (currentLeft.IsTupleType)
+                        {
+                            // turn tuple type elements into parameters
+                            currentLeft = ((INamedTypeSymbol)currentLeft).TupleUnderlyingType;
+                        }
+
+                        if (currentRight.IsTupleType)
+                        {
+                            // turn tuple type elements into parameters
+                            currentRight = ((INamedTypeSymbol)currentRight).TupleUnderlyingType;
+                        }
+
+                        if (!currentLeft.OriginalDefinition.Equals(currentRight.OriginalDefinition))
+                        {
+                            return (null, null);
+                        }
+
+                        var leftTypeArguments = ((INamedTypeSymbol)currentLeft).TypeArguments;
+                        var rightTypeArguments = ((INamedTypeSymbol)currentRight).TypeArguments;
+                        for (int i = 0; i < leftTypeArguments.Length; i++)
+                        {
+                            var result = WalkTypes(leftTypeArguments[i], rightTypeArguments[i], predicate, arg);
+                            if (result.Item1 != null || result.Item2 != null)
+                            {
+                                return result;
+                            }
+                        }
+
+                        return (null, null);
+
+                    case TypeKind.Array:
+                        currentLeft = ((IArrayTypeSymbol)currentLeft).ElementType;
+                        currentRight = ((IArrayTypeSymbol)currentRight).ElementType;
+                        continue;
+
+                    case TypeKind.Pointer:
+                        currentLeft = ((IPointerTypeSymbol)currentLeft).PointedAtType;
+                        currentRight = ((IPointerTypeSymbol)currentRight).PointedAtType;
+                        continue;
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(currentLeft.TypeKind);
+                }
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string AddParameter = nameof(AddParameter);
         public const string ApplyNamingStyle = nameof(ApplyNamingStyle);
         public const string AddBraces = nameof(AddBraces);
+        public const string AddTupleElementNames = nameof(AddTupleElementNames);
         public const string ChangeReturnType = nameof(ChangeReturnType);
         public const string ChangeToYield = nameof(ChangeToYield);
         public const string ConvertToAsync = nameof(ConvertToAsync);

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string UseIsNullCheckDiagnosticId = "IDE0041";
 
+        public const string TupleElementNamesMatchBaseDiagnosticId = "IDE0042";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -134,6 +134,14 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_explicit_tuple_names"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferExplicitTupleNames") });
 
+        internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferTupleNamesMatchBase = new PerLanguageOption<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions),
+            nameof(PreferTupleNamesMatchBase),
+            defaultValue: TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[] {
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_tuple_names_match_base"),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferTupleNamesMatchBase") });
+
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIsNullCheckOverReferenceEqualityMethod = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferIsNullCheckOverReferenceEqualityMethod),


### PR DESCRIPTION
Fixes #20850

Items remaining:

* Fix diagnostic message formatting to include symbol names
* Additional testing
* Update code fix to handle related compiler warnings, or file a bug to do so later
* If necessary¹, implement an option in Tools &rarr; Options for this

¹ I would prefer to only expose this feature via **.editorconfig** and rule set files.

<details><summary>Ask mode incomplete</summary><p>

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)

**Test documentation updated?**

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</p></details>