### PR TITLE
Fix ngen priority for command line compilers...

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -7,10 +7,10 @@ vs.dependencies
   vs.dependency id=Microsoft.Net.PackageGroup.4.6.1.Redist
 
 folder InstallDir:\MSBuild\15.0\Bin\Roslyn
-    file source=$(OutputPath)\Exes\VBCSCompiler\net46\VBCSCompiler.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\csc\csc.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\csi\csi.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\vbc\vbc.exe vs.file.ngenArchitecture=all
+    file source=$(OutputPath)\Exes\VBCSCompiler\net46\VBCSCompiler.exe vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+    file source=$(OutputPath)\Exes\csc\csc.exe vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+    file source=$(OutputPath)\Exes\csi\csi.exe vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+    file source=$(OutputPath)\Exes\vbc\vbc.exe vs.file.ngenArchitecture=all vs.file.ngenPriority=1
 
     file source=$(OutputPath)\Exes\csc\csc.exe.config
     file source=$(OutputPath)\Exes\csi\csi.exe.config


### PR DESCRIPTION
**Customer scenario**

Install update...command line compilers are slow for some period of time...then they return to normal.

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Wait patiently (up to 24 hours) for ngen queue to execute fully.

**Risk**

zip...zero...zilch...nada...

**Performance impact**

Better experience compiling immediately after installing VS update (at the expense of minor additional install time).

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

This was missed when setup projects were ported to Willow.

**How did we miss it?  What tests are we adding to guard against it in the future?**

🤔 

**How was the bug found?**

customer reported

**Test documentation updated?**

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.
