### PR TITLE
made timeout to 7 days so that sleep won't affect it. for master, we …

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         // normally response time is within 10s ms. at most 100ms. if priority is changed to "Normal", most of time 10s ms.
         [ExportOption]
         public static readonly Option<int> RequestServiceTimeoutInMS = new Option<int>(
-            nameof(InternalFeatureOnOffOptions), nameof(RequestServiceTimeoutInMS), defaultValue: 10 * 60 * 1000,
+            nameof(InternalFeatureOnOffOptions), nameof(RequestServiceTimeoutInMS), defaultValue: 7 * 24 * 60 * 60 * 1000 /* 7 day */,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(RequestServiceTimeoutInMS)));
 
         // This options allow users to restart OOP when it is killed by users

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -34,9 +34,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         // this is our timeout on how long we will try keep connecting. so far I saw over 2-3 seconds before connection made 
         // when there are many (over 10+ requests) at the same time. one of reasons of this is we put our service hub process as "Below Normal" priority.
         // normally response time is within 10s ms. at most 100ms. if priority is changed to "Normal", most of time 10s ms.
+        // 
+        // also another reason why timeout is so big is that, if user put this computer sleep, then timeout can happen. so for now, until we have
+        // sleep aware timer, we put very long timeout for request service (https://github.com/dotnet/roslyn/pull/22151)
         [ExportOption]
         public static readonly Option<int> RequestServiceTimeoutInMS = new Option<int>(
-            nameof(InternalFeatureOnOffOptions), nameof(RequestServiceTimeoutInMS), defaultValue: 7 * 24 * 60 * 60 * 1000 /* 7 day */,
+            nameof(InternalFeatureOnOffOptions), nameof(RequestServiceTimeoutInMS), defaultValue: 7 * 24 * 60 * 60 * 1000 /* 7 days */,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(RequestServiceTimeoutInMS)));
 
         // This options allow users to restart OOP when it is killed by users

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -205,14 +205,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             // operation timed out, more than we are willing to wait
             ShowInfoBar();
 
-            // create its own cancellation token and throw it
+            // user didn't ask for cancellation, but we can't fullfill this request. so we
+            // create our own cancellation token and then throw it. this doesn't guarantee
+            // 100% that we won't crash, but this is at least safest way we know until user
+            // restart VS (with info bar)
             using (var ownCancellationSource = new CancellationTokenSource())
             {
                 ownCancellationSource.Cancel();
                 ownCancellationSource.Token.ThrowIfCancellationRequested();
             }
 
-            // unreachable
             throw ExceptionUtilities.Unreachable;
         }
 

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Execution;
+using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.ServiceHub.Client;
@@ -192,10 +193,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 // wait for retry_delayInMS before next try
                 await Task.Delay(retry_delayInMS, cancellationToken).ConfigureAwait(false);
+
+                ReportTimeout(start);
             }
 
             // operation timed out, more than we are willing to wait
-            throw new TimeoutException("RequestServiceAsync timed out");
+            ShowInfoBar();
+
+            // create its own cancellation token and throw it
+            using (var ownCancellationSource = new CancellationTokenSource())
+            {
+                ownCancellationSource.Cancel();
+                ownCancellationSource.Token.ThrowIfCancellationRequested();
+            }
+
+            // unreachable
+            throw ExceptionUtilities.Unreachable;
         }
 
         private static async Task<Stream> RequestServiceAsync(
@@ -264,6 +277,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             try
             {
+                // add service hub process.
+                // we will record dumps for all service hub processes
+                foreach (var p in Process.GetProcessesByName("ServiceHub.RoslynCodeAnalysisService32"))
+                {
+                    // include all remote host processes
+                    faultUtility.AddProcessDump(p.Id);
+                }
+
                 var logPath = Path.Combine(Path.GetTempPath(), "servicehub", "logs");
                 if (!Directory.Exists(logPath))
                 {
@@ -302,6 +323,37 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             // catch all exception. not worth crashing VS.
             return true;
+        }
+
+        private static readonly TimeSpan s_reportTimeout = TimeSpan.FromMinutes(10);
+        private static bool s_timeoutReported = false;
+
+        private static void ReportTimeout(DateTime start)
+        {
+            // if we tried for 10 min and still couldn't connect. NFW some data
+            if (!s_timeoutReported && (DateTime.UtcNow - start) > s_reportTimeout)
+            {
+                s_timeoutReported = true;
+
+                // report service hug logs along with dump
+                WatsonReporter.Report("RequestServiceAsync Timeout", new Exception("RequestServiceAsync Timeout"), ReportDetailInfo);
+            }
+        }
+
+        private static bool s_infoBarReported = false;
+
+        private static void ShowInfoBar()
+        {
+            // use info bar to show warning to users
+            if (CodeAnalysis.PrimaryWorkspace.Workspace != null && !s_infoBarReported)
+            {
+                // do not report it multiple times
+                s_infoBarReported = true;
+
+                // use info bar to show warning to users
+                CodeAnalysis.PrimaryWorkspace.Workspace.Services.GetService<IErrorReportingService>()?.ShowGlobalErrorInfo(
+                    ServicesVSResources.Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/ObjectPools/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ObjectPools/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace Roslyn.Utilities
@@ -12,6 +13,11 @@ namespace Roslyn.Utilities
         public static PooledObject<StringBuilder> GetPooledObject(this ObjectPool<StringBuilder> pool)
         {
             return PooledObject<StringBuilder>.Create(pool);
+        }
+
+        public static PooledObject<Stopwatch> GetPooledObject(this ObjectPool<Stopwatch> pool)
+        {
+            return PooledObject<Stopwatch>.Create(pool);
         }
 
         public static PooledObject<Stack<TItem>> GetPooledObject<TItem>(this ObjectPool<Stack<TItem>> pool)
@@ -50,6 +56,14 @@ namespace Roslyn.Utilities
             sb.Clear();
 
             return sb;
+        }
+
+        public static Stopwatch AllocateAndClear(this ObjectPool<Stopwatch> pool)
+        {
+            var watch = pool.Allocate();
+            watch.Reset();
+
+            return watch;
         }
 
         public static Stack<T> AllocateAndClear<T>(this ObjectPool<Stack<T>> pool)
@@ -107,6 +121,17 @@ namespace Roslyn.Utilities
             }
 
             pool.Free(sb);
+        }
+
+        public static void ClearAndFree(this ObjectPool<Stopwatch> pool, Stopwatch watch)
+        {
+            if (watch == null)
+            {
+                return;
+            }
+
+            watch.Reset();
+            pool.Free(watch);
         }
 
         public static void ClearAndFree<T>(this ObjectPool<HashSet<T>> pool, HashSet<T> set)

--- a/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace Roslyn.Utilities
@@ -37,6 +38,14 @@ namespace Roslyn.Utilities
         public static PooledObject<StringBuilder> Create(ObjectPool<StringBuilder> pool)
         {
             return new PooledObject<StringBuilder>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
+        } 
+
+        public static PooledObject<Stopwatch> Create(ObjectPool<Stopwatch> pool)
+        {
+            return new PooledObject<Stopwatch>(
                 pool,
                 p => Allocator(p),
                 (p, sb) => Releaser(p, sb));
@@ -90,6 +99,16 @@ namespace Roslyn.Utilities
         }
 
         private static void Releaser(ObjectPool<StringBuilder> pool, StringBuilder sb)
+        {
+            pool.ClearAndFree(sb);
+        }
+
+        private static Stopwatch Allocator(ObjectPool<Stopwatch> pool)
+        {
+            return pool.AllocateAndClear();
+        }
+
+        private static void Releaser(ObjectPool<Stopwatch> pool, Stopwatch sb)
         {
             pool.ClearAndFree(sb);
         }


### PR DESCRIPTION
…should create sleep aware timer to check timeout. for now just 7 days.

also made crash to NFW and info bar.

**Customer scenario**

VS crashes sometimes if user makes machine to go to sleep for long time and resume the machine since ongoing connection got timed out.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=494903&src=WorkItemMention&src-action=artifact_link&fullScreen=true&_a=edit

**Workarounds, if any**

Currently, there is no workaround.

**Risk**

longer timeout could hide a bug in hang in service hub service. but until we have sleep aware timer, I don't have better solution.

**Performance impact**

we can potentially have more connections pending but all those are async IO so, I dont think it will have user observable performance changes.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

Timeout was not aware of system changes such as machine going sleep.

**How was the bug found?**

Watson, feedback and etc
