### PR TITLE
Remove Debugger.Break call from two unittests

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -357,7 +357,6 @@ $$
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task PrivateProtectedModifier()
         {
-            System.Diagnostics.Debugger.Break();
             var text = @"
 class C
 {
@@ -370,7 +369,6 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task ProtectedPrivateModifier()
         {
-            System.Diagnostics.Debugger.Break();
             var text = @"
 class C
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/22156

I accidentally left those calls in unittests in https://github.com/dotnet/roslyn/pull/21239

@dotnet/roslyn-ide for review.