### PR TITLE
Making default type of stackalloc expression to be Span<T> when not directly in an initializer

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1887,6 +1887,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Local:
                     return ((BoundLocal)expr).LocalSymbol.ValEscapeScope;
 
+                case BoundKind.StackAllocArrayCreation:
                 case BoundKind.ConvertedStackAllocExpression:
                     return Binder.TopLevelScope;
 
@@ -2054,6 +2055,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     return true;
 
+                case BoundKind.StackAllocArrayCreation:
                 case BoundKind.ConvertedStackAllocExpression:
                     if (escapeTo < Binder.TopLevelScope)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -75,20 +75,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         sourceTuple.HasErrors);
                 }
 
-                // identity stackalloc conversions result in a converted node
-                // to indicate that stackalloc conversions are no longer applicable.
-                // nothing else changes
-                if (source.Kind == BoundKind.StackAllocArrayCreation)
-                {
-                    var sourceStackAlloc = (BoundStackAllocArrayCreation)source;
-                    source = new BoundConvertedStackAllocExpression(
-                        sourceStackAlloc.Syntax,
-                        sourceStackAlloc.ElementType,
-                        sourceStackAlloc.Count,
-                        sourceStackAlloc.Type, 
-                        sourceStackAlloc.HasErrors);
-                }
-
                 // We need to preserve any conversion that changes the type (even identity conversions, like object->dynamic),
                 // or that was explicitly written in code (so that GetSemanticInfo can find the syntax in the bound tree).
                 if (!isCast && source.Type == destination)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3016,9 +3016,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             StackAllocArrayCreationExpressionSyntax node, DiagnosticBag diagnostics)
         {
             bool hasErrors = false;
+            var inLegalPosition = (IsInMethodBody || IsLocalFunctionsScopeBinder) && node.IsLegalSpanStackAllocPosition();
 
-            if (!IsInMethodBody && !IsLocalFunctionsScopeBinder ||
-                !node.IsLegalSpanStackAllocPosition())
+            if (!inLegalPosition)
             {
                 hasErrors = true;
                 diagnostics.Add(
@@ -3105,7 +3105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             TypeSymbol type = null;
-            if (!node.IsVariableDeclarationInitialization())
+            if (inLegalPosition && !node.IsVariableDeclarationInitialization())
             {
                 CheckFeatureAvailability(node, MessageID.IDS_FeatureRefStructs, diagnostics);
                 GetWellKnownTypeMember(Compilation, WellKnownMember.System_Span_T__ctor, diagnostics, syntax: node);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3017,7 +3017,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             bool hasErrors = false;
 
-            if (!IsInMethodBody && !IsLocalFunctionsScopeBinder)
+            if (!IsInMethodBody && !IsLocalFunctionsScopeBinder ||
+                !node.IsLegalSpanStackAllocPosition())
             {
                 hasErrors = true;
                 diagnostics.Add(
@@ -3103,7 +3104,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return new BoundStackAllocArrayCreation(node, elementType, count, type: null, hasErrors: hasErrors || typeHasErrors);
+            TypeSymbol type = null;
+            if (!node.IsVariableDeclarationInitialization())
+            {
+                CheckFeatureAvailability(node, MessageID.IDS_FeatureRefStructs, diagnostics);
+                GetWellKnownTypeMember(Compilation, WellKnownMember.System_Span_T__ctor, diagnostics, syntax: node);
+
+                var spanType = GetWellKnownType(WellKnownType.System_Span_T, diagnostics, node);
+                if (!spanType.IsErrorType())
+                {
+                    type = spanType.Construct(elementType);
+                }
+            }
+
+            return new BoundStackAllocArrayCreation(node, elementType, count, type, hasErrors: hasErrors || typeHasErrors);
         }
 
         private static int? GetIntegerConstantForArraySize(BoundExpression expression)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1435,13 +1435,9 @@
     <Field Name="Count" Type="BoundExpression"/>
   </Node>
 
-  <Node Name="BoundConvertedStackAllocExpression" Base="BoundExpression">
+  <Node Name="BoundConvertedStackAllocExpression" Base="BoundStackAllocArrayCreation">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
-    <Field Name="ElementType" Type="TypeSymbol" Null="disallow"/>
-    <Field Name="Count" Type="BoundExpression"/>
-    <Field Name="ConversionKind" Type="ConversionKind" Null="allow"/>
   </Node>
 
   <Node Name="BoundFieldAccess" Base="BoundExpression">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -1053,7 +1053,7 @@ class Test
         var span1 = condition ? stackalloc int[1] : new Span<int>(null, 2);
         Console.Write(span1.Length);
 
-        var span2 = condition ? new Span<int>(null, 3) : stackalloc int[4];
+        var span2 = condition ? stackalloc int[1] : stackalloc int[4];
         Console.Write(span2.Length);
     }
 }", TestOptions.UnsafeReleaseExe);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
@@ -236,10 +236,7 @@ class Test
     {
         var x = true ? stackalloc int [10] : stackalloc int [5];
     }
-}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (6,17): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'stackalloc int[10]' and 'stackalloc int[5]'
-                //         var x = true ? stackalloc int [10] : stackalloc int [5];
-                Diagnostic(ErrorCode.ERR_InvalidQM, "true ? stackalloc int [10] : stackalloc int [5]").WithArguments("stackalloc int[10]", "stackalloc int[5]").WithLocation(6, 17));
+}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]
@@ -317,9 +314,13 @@ class Test
         if(stackalloc int[10] == stackalloc int[10]) { }
     }
 }", TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (6,12): error CS0019: Operator '==' cannot be applied to operands of type 'stackalloc int[10]' and 'stackalloc int[10]'
+                // (6,12): error CS1525: Invalid expression term 'stackalloc'
                 //         if(stackalloc int[10] == stackalloc int[10]) { }
-                Diagnostic(ErrorCode.ERR_BadBinaryOps, "stackalloc int[10] == stackalloc int[10]").WithArguments("==", "stackalloc int[10]", "stackalloc int[10]").WithLocation(6, 12));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(6, 12),
+                // (6,34): error CS1525: Invalid expression term 'stackalloc'
+                //         if(stackalloc int[10] == stackalloc int[10]) { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(6, 34)
+            );
         }
 
         [Fact]
@@ -435,9 +436,10 @@ public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, options: TestOptions.ReleaseDll.WithAllowUnsafe(true)).VerifyDiagnostics(
-                // (7,31): error CS1510: A ref or out value must be an assignable variable
+                // (7,31): error CS1525: Invalid expression term 'stackalloc'
                 //         ref Span<int> p = ref stackalloc int[1];
-                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "stackalloc int[1]").WithLocation(7, 31));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(7, 31)
+            );
         }
 
         [Fact]
@@ -457,9 +459,10 @@ public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, options: TestOptions.ReleaseDll.WithAllowUnsafe(true)).VerifyDiagnostics(
-                // (7,9): error CS1525: Invalid expression term 'stackalloc'
+                // (7,11): error CS1525: Invalid expression term 'stackalloc'
                 //         N(stackalloc int[1]);
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "N").WithArguments("stackalloc").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(7, 11)
+            );
         }
 
         [Fact]
@@ -475,9 +478,10 @@ public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, TestOptions.ReleaseDll).VerifyDiagnostics(
-                // (6,22): error CS0023: Operator '.' cannot be applied to operand of type 'stackalloc int[10]'
+                // (6,23): error CS1525: Invalid expression term 'stackalloc'
                 //         int length = (stackalloc int [10]).Length;
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "(stackalloc int [10]).Length").WithArguments(".", "stackalloc int[10]").WithLocation(6, 22));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(6, 23)
+            );
         }
 
         [Fact]
@@ -499,9 +503,10 @@ unsafe public class Test
 }
 ";
             CreateCompilationWithMscorlibAndSpan(test, TestOptions.UnsafeReleaseExe).VerifyDiagnostics(
-                // (7,16): error CS1503: Argument 1: cannot convert from 'stackalloc int[10]' to 'Span<short>'
+                // (7,16): error CS1525: Invalid expression term 'stackalloc'
                 //         Invoke(stackalloc int [10]);
-                Diagnostic(ErrorCode.ERR_BadArgType, "stackalloc int [10]").WithArguments("1", "stackalloc int[10]", "System.Span<short>").WithLocation(7, 16));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(7, 16)
+            );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocSpanExpressionsTests.cs
@@ -227,7 +227,7 @@ namespace System
         }
 
         [Fact]
-        public void ConditionalExpressionOnSpan_NonConvertible()
+        public void ConditionalExpressionOnSpan_BothStackallocSpans()
         {
             CreateCompilationWithMscorlibAndSpan(@"
 class Test

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -7560,13 +7560,7 @@ unsafe class C
             CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (4,21): error CS1525: Invalid expression term 'stackalloc'
                 //     void M(int* p = stackalloc int[1])
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 21),
-                // (4,21): error CS0656: Missing compiler required member 'System.Span`1..ctor'
-                //     void M(int* p = stackalloc int[1])
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "stackalloc int[1]").WithArguments("System.Span`1", ".ctor").WithLocation(4, 21),
-                // (4,21): error CS0518: Predefined type 'System.Span`1' is not defined or imported
-                //     void M(int* p = stackalloc int[1])
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "stackalloc int[1]").WithArguments("System.Span`1").WithLocation(4, 21)
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 21)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -7560,7 +7560,14 @@ unsafe class C
             CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (4,21): error CS1525: Invalid expression term 'stackalloc'
                 //     void M(int* p = stackalloc int[1])
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 21));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 21),
+                // (4,21): error CS0656: Missing compiler required member 'System.Span`1..ctor'
+                //     void M(int* p = stackalloc int[1])
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "stackalloc int[1]").WithArguments("System.Span`1", ".ctor").WithLocation(4, 21),
+                // (4,21): error CS0518: Predefined type 'System.Span`1' is not defined or imported
+                //     void M(int* p = stackalloc int[1])
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "stackalloc int[1]").WithArguments("System.Span`1").WithLocation(4, 21)
+            );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -2876,7 +2876,14 @@ unsafe class Test
             CreateStandardCompilation(text, options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)).VerifyDiagnostics(
                 // (4,30): error CS1525: Invalid expression term 'stackalloc'
                 //     int* property { get; } = stackalloc int[256];
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 30));
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 30),
+                // (4,30): error CS0656: Missing compiler required member 'System.Span`1..ctor'
+                //     int* property { get; } = stackalloc int[256];
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "stackalloc int[256]").WithArguments("System.Span`1", ".ctor").WithLocation(4, 30),
+                // (4,30): error CS0518: Predefined type 'System.Span`1' is not defined or imported
+                //     int* property { get; } = stackalloc int[256];
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "stackalloc int[256]").WithArguments("System.Span`1").WithLocation(4, 30)
+                );
         }
         [Fact]
         public void RefPropertyWithoutGetter()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -2876,13 +2876,7 @@ unsafe class Test
             CreateStandardCompilation(text, options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)).VerifyDiagnostics(
                 // (4,30): error CS1525: Invalid expression term 'stackalloc'
                 //     int* property { get; } = stackalloc int[256];
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 30),
-                // (4,30): error CS0656: Missing compiler required member 'System.Span`1..ctor'
-                //     int* property { get; } = stackalloc int[256];
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "stackalloc int[256]").WithArguments("System.Span`1", ".ctor").WithLocation(4, 30),
-                // (4,30): error CS0518: Predefined type 'System.Span`1' is not defined or imported
-                //     int* property { get; } = stackalloc int[256];
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "stackalloc int[256]").WithArguments("System.Span`1").WithLocation(4, 30)
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(4, 30)
                 );
         }
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -4837,6 +4837,9 @@ public class Test
                 // (7,34): error CS1002: ; expected
                 //         int *pp = stackalloc int 30; 
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "30").WithLocation(7, 34),
+                // (6,18): error CS1525: Invalid expression term 'stackalloc'
+                //         int *p = stackalloc int (30); 
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "stackalloc").WithArguments("stackalloc").WithLocation(6, 18),
                 // (6,29): error CS1575: A stackalloc expression requires [] after type
                 //         int *p = stackalloc int (30); 
                 Diagnostic(ErrorCode.ERR_BadStackAllocExpr, "int").WithLocation(6, 29),
@@ -4845,7 +4848,8 @@ public class Test
                 Diagnostic(ErrorCode.ERR_BadStackAllocExpr, "int").WithLocation(7, 30),
                 // (7,34): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
                 //         int *pp = stackalloc int 30; 
-                Diagnostic(ErrorCode.ERR_IllegalStatement, "30").WithLocation(7, 34));
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "30").WithLocation(7, 34)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
Making default type of stackalloc expression to be Span<T> when not directly in an initializer

This makes it unnecessary to cast in many situations where the type could be inferred to be Span<T>.