### PR TITLE
Package descriptions for CSharp and VB should include summary blurb

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -2,12 +2,13 @@
 <package>
  <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Build.Tasks</id>
-    <summary>The build Tasks for running the C# and VB compilers in MSBuild.</summary>
     <description>
-        Contains the build task and targets used by MSBuild to run the C# and VB compilers.
-        Supports using VBCSCompiler on Windows.
+      The build task and targets used by MSBuild to run the C# and VB compilers.
+      Supports using VBCSCompiler on Windows.
 
-        $commitPathMessage$
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -2,6 +2,9 @@
 <package>
  <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Build.Tasks</id>
+    <summary>
+      The build task and targets used by MSBuild to run the C# and VB compilers.
+    </summary>
     <description>
       The build task and targets used by MSBuild to run the C# and VB compilers.
       Supports using VBCSCompiler on Windows.

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.CodeStyle</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") code style analyzers for C#.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") code style analyzers for C#.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.CodeStyle</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") code style analyzers for C#.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
     </dependencies>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Features</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for creating C# editing experiences.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Features" version="$version$" />
       <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="$version$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Features</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for creating C# editing experiences.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for creating C# editing experiences.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
@@ -2,8 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.CSharp.Scripting</id>
-    <summary>Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.</summary>
-    <description>$commitPathMessage$</description>
+    <description>
+      Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.CSharp.Scripting</id>
+    <summary>
+      Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.
+    </summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Workspaces</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for analyzing C# projects and solutions.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for analyzing C# projects and solutions.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Workspaces</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for analyzing C# projects and solutions.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
 
       More details at https://aka.ms/roslyn-packages
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -3,10 +3,11 @@
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Common</id>
     <summary>
-      A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").
     </summary>
     <description>
-      A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       More details at https://aka.ms/roslyn-packages
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Common</id>
-    <summary>A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").</summary>
     <description>
       A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Common</id>
+    <summary>
+      A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
     <description>
       A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Compilers</id>
-    <summary>.NET Compiler Platform ("Roslyn")</summary>
     <description>
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Compilers</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -3,12 +3,12 @@
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Compilers</id>
     <summary>
-      .NET Compiler Platform ("Roslyn").
+      Compiler layer of the .NET Compiler Platform ("Roslyn").
     </summary>
     <description>
-      .NET Compiler Platform ("Roslyn").
+      Compiler layer of the .NET Compiler Platform ("Roslyn").
       Install this package to get both C# and Visual Basic support.
-      Install either of the dependencies directly to get one of the languages separately.
+      If you want just support for one language, install Microsoft.CodeAnalysis.CSharp or Microsoft.CodeAnalysis.VisualBasic.
 
       More details at https://aka.ms/roslyn-packages
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -3,10 +3,11 @@
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Compilers</id>
     <summary>
-      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support
+      .NET Compiler Platform ("Roslyn").
     </summary>
     <description>
-      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support.
+      .NET Compiler Platform ("Roslyn").
+      Install this package to get both C# and Visual Basic support.
       Install either of the dependencies directly to get one of the languages separately.
 
       More details at https://aka.ms/roslyn-packages

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -3,10 +3,11 @@
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Compilers</id>
     <summary>
-      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
+      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support
     </summary>
     <description>
-      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
+      .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support.
+      Install either of the dependencies directly to get one of the languages separately.
 
       More details at https://aka.ms/roslyn-packages
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
@@ -2,9 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Debugging</id>
-    <summary>Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders</summary>
     <description>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders.
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Debugging</id>
+    <summary>
+      Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders.
+    </summary>
     <description>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures.Text</id>
-    <summary>
-      .NET Compiler Platform ("Roslyn") support for working with Visual Studio text buffers.
-    </summary>
     <description>
+      .NET Compiler Platform ("Roslyn") support for working with Visual Studio text buffers.
+
       Supported Platforms:
       - .NET Framework 4.6
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures.Text</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for working with Visual Studio text buffers.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for working with Visual Studio text buffers.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures</id>
     <summary>
-      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
+      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor.
     </summary>
     <description>
-      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
+      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor.
 
       Supported Platforms:
       - .NET Framework 4.6

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures</id>
-    <summary>
-      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
-    </summary>
     <description>
+      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
+
       Supported Platforms:
       - .NET Framework 4.6
       
+      More details at https://aka.ms/roslyn-packages
+
       $commitPathMessage$
     </description>
     <dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Features</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for creating editing experiences.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for creating editing experiences.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Features</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for creating editing experiences.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.PooledObjects</id>
+    <summary>
+      Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects.
+    </summary>
     <description>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
@@ -2,9 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.PooledObjects</id>
-    <summary>Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects</summary>
     <description>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects.
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Razor.ServiceHub</id>
     <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
     </summary>
     <description>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       Supported Platforms:
       - .NET Framework 4.6

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Razor.ServiceHub</id>
+    <summary>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -2,16 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Razor.ServiceHub</id>
-    <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
-    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
-Supported Platforms:
-- .NET Framework 4.6
+      Supported Platforms:
+      - .NET Framework 4.6
 
-    $commitPathMessage$
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.ServiceHub</id>
     <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
     </summary>
     <description>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       Supported Platforms:
       - .NET Framework 4.6

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
@@ -2,7 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.ServiceHub</id>
-   <description>
+    <summary>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
+    <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       Supported Platforms:

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
@@ -2,16 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.ServiceHub</id>
-    <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
-    </summary>
-    <description>
+   <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
-Supported Platforms:
-- .NET Framework 4.6
+      Supported Platforms:
+      - .NET Framework 4.6
 
-    $commitPathMessage$
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Workspaces</id>
+    <summary>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Workspaces</id>
     <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
     </summary>
     <description>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       Supported Platforms:
       - .NET Framework 4.6

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -2,16 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Workspaces</id>
-    <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
-    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
-Supported Platforms:
-- .NET Framework 4.6
+      Supported Platforms:
+      - .NET Framework 4.6
 
-    $commitPathMessage$
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Scripting.Common</id>
-    <summary>Microsoft .NET Compiler Platform ("Roslyn") shared scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Scripting.Common</id>
+    <summary>
+      Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.Scripting.Common</id>
     <summary>
-      Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      Microsoft .NET Compiler Platform ("Roslyn") shared scripting package.
     </summary>
     <description>
-      Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      Microsoft .NET Compiler Platform ("Roslyn") shared scripting package.
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       More details at https://aka.ms/roslyn-packages
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Scripting</id>
-    <summary>Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.Scripting</id>
+    <summary>
+      Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.
+    </summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.CodeStyle</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") code style analyzers for Visual Basic.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
     </dependencies>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.CodeStyle</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") code style analyzers for Visual Basic.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") code style analyzers for Visual Basic.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Features</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for creating Visual Basic editing experiences.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for creating Visual Basic editing experiences.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Features</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for creating Visual Basic editing experiences.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Features" version="$version$" />
       <dependency id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$version$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
@@ -2,10 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.VisualBasic.Scripting</id>
-    <summary>Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.
       
+      More details at https://aka.ms/roslyn-packages
+
       $commitPathMessage$
     </description>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.VisualBasic.Scripting</id>
+    <summary>
+      Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.
+    </summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.
       

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Workspaces</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for analyzing Visual Basic projects and solutions.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for analyzing Visual Basic projects and solutions.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Workspaces</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for analyzing Visual Basic projects and solutions.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.VisualBasic" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
 
       More details at https://aka.ms/roslyn-packages
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="$version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Workspaces.Common</id>
+    <summary>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -3,10 +3,11 @@
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Workspaces.Common</id>
     <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions.
     </summary>
     <description>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions.
+      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
 
       More details at https://aka.ms/roslyn-packages
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -2,11 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Workspaces.Common</id>
-    <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions.
-    </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.CodeAnalysis.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn").
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn").
 

--- a/src/NuGet/Microsoft.CodeAnalysis.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.nuspec
@@ -2,7 +2,6 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis</id>
-    <summary>.NET Compiler Platform ("Roslyn").</summary>
     <description>
       .NET Compiler Platform ("Roslyn").
 
@@ -12,6 +11,8 @@
         - "Microsoft.CodeAnalysis.Compilers" (both compilers)       
         - "Microsoft.CodeAnalysis.CSharp" (only the C# compiler)      
         - "Microsoft.CodeAnalysis.VisualBasic (only the VB compiler)
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.NETCore.Compilers</id>
-    <summary>
+    <description>
       CoreCLR-compatible versions of the C# and VB compilers for use in MSBuild.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.NETCore.Compilers</id>
+    <summary>
+      CoreCLR-compatible versions of the C# and VB compilers for use in MSBuild.
+    </summary>
     <description>
       CoreCLR-compatible versions of the C# and VB compilers for use in MSBuild.
 

--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.CSharp.Interactive.netcore</id>
+    <summary>
+      CoreCLR-compatible version of csi.exe.
+    </summary>
     <description>
       CoreCLR-compatible version of csi.exe.
 

--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -2,13 +2,16 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.CSharp.Interactive.netcore</id>
-    <summary>
+    <description>
       CoreCLR-compatible version of csi.exe.
 
       Supported Platforms:
       - .NET Core (NETCoreApp1.0)
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -2,10 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers.netcore</id>
-    <summary>
+    <description>
       CoreCLR-compatible versions of the C# and VB compilers.
-    </summary>
-    <description>$commitPathMessage$</description>
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers.netcore</id>
+    <summary>
+      CoreCLR-compatible versions of the C# and VB compilers.
+    </summary>
     <description>
       CoreCLR-compatible versions of the C# and VB compilers.
 

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers</id>
+    <summary>
+      .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
+    </summary>
     <description>
       .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -2,12 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers</id>
-    <summary>
-    .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
+    <description>
+      .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 
-    This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.
-    </summary>
-    <description>$commitPathMessage$</description>
+      This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>Microsoft.Net.Compilers</id>
     <summary>
-      .Net Compilers package.
+      .NET Compilers package.
     </summary>
     <description>
-      .Net Compilers package.
+      .NET Compilers package.
       Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 
       This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -3,10 +3,11 @@
   <metadata>
     <id>Microsoft.Net.Compilers</id>
     <summary>
-      .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
+      .Net Compilers package.
     </summary>
     <description>
-      .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
+      .Net Compilers package.
+      Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 
       This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.
 

--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -2,8 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.IntegrationTest.Utilities</id>
-    <summary>Utility methods used to run Visual Studio integration tests.</summary>
-    <description>$commitPathMessage$</description>
+    <description>
+      Utility methods used to run Visual Studio integration tests.
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.IntegrationTest.Utilities</id>
+    <summary>
+      Utility methods used to run Visual Studio integration tests.
+    </summary>
     <description>
       Utility methods used to run Visual Studio integration tests.
 

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
 

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient</id>
-    <summary>
-      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
-    </summary>
     <description>
+      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+
       Supported Platforms:
         - .NET Framework 4.6
+
+      More details at https://aka.ms/roslyn-packages
 
       $commitPathMessage$
     </description>

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
@@ -2,13 +2,16 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices</id>
-    <summary>
+    <description>
       .NET Compiler Platform ("Roslyn") support for Visual Studio.
       
-Supported Platforms:
-- .NET Framework 4.6
-    </summary>
-    <description>$commitPathMessage$</description>
+      Supported Platforms:
+      - .NET Framework 4.6
+
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis" version="[$version$]" />
     </dependencies>

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
@@ -2,6 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for Visual Studio.
+    </summary>
     <description>
       .NET Compiler Platform ("Roslyn") support for Visual Studio.
       


### PR DESCRIPTION
**Customer scenario**

Find the compiler packages to add to your project on nuget.org or myget.org (for example [CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp/2.3.2)). The package `description` should give you a summary and a link to our package documentation (including versioning).
But currently, many packages only show a commit link.

Also, I'm removing the `summary` section since it does not seem to appear anywhere.

Correct:
![image](https://user-images.githubusercontent.com/12466233/30550241-b3bfe27e-9c4b-11e7-9ea7-8765f2af701e.png)

Incorrect:
![image](https://user-images.githubusercontent.com/12466233/30550259-c0fc860e-9c4b-11e7-9cc2-d524488b9b73.png)

**Workarounds, if any**

This does not block usage of the packages, but makes it very difficult to figure out what changes are included in a specific version.

**Risk**
Low (doc-only).

**Is this a regression from a previous update?**

**Root cause analysis:**

Yes, this [change](https://github.com/dotnet/roslyn/commit/45ca8bd2099c03e037311a67b859afd4d7c3f06c#diff-77a94aa20547b79d30aa77934e89adb8) split the description of nuget packages into "summary" and "description", but it looks like nuget.org only displays the description in such case.

**How was the bug found?**

I did a manual check while investigating another package documentation issue (https://github.com/dotnet/roslyn/issues/21574).

@jaredpar @dotnet/roslyn-infrastructure for review. Thanks

