### PR TITLE
Fix EnC and EE for ref features

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -152,6 +152,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     methodCompiler.CompileSynthesizedMethods(additionalTypes, diagnostics);
                 }
 
+                var embeddedTypes = moduleBeingBuiltOpt.GetEmbeddedTypes(diagnostics);
+                if (!embeddedTypes.IsEmpty)
+                {
+                    methodCompiler.CompileSynthesizedMethods(embeddedTypes, diagnostics);
+                }
+
                 // By this time we have processed all types reachable from module's global namespace
                 compilation.AnonymousTypeManager.AssignTemplatesNamesAndCompile(methodCompiler, moduleBeingBuiltOpt, diagnostics);
                 methodCompiler.WaitForWorkers();

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -147,16 +147,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (moduleBeingBuiltOpt != null)
             {
                 var additionalTypes = moduleBeingBuiltOpt.GetAdditionalTopLevelTypes(diagnostics);
-                if (!additionalTypes.IsEmpty)
-                {
-                    methodCompiler.CompileSynthesizedMethods(additionalTypes, diagnostics);
-                }
+                methodCompiler.CompileSynthesizedMethods(additionalTypes, diagnostics);
 
                 var embeddedTypes = moduleBeingBuiltOpt.GetEmbeddedTypes(diagnostics);
-                if (!embeddedTypes.IsEmpty)
-                {
-                    methodCompiler.CompileSynthesizedMethods(embeddedTypes, diagnostics);
-                }
+                methodCompiler.CompileSynthesizedMethods(embeddedTypes, diagnostics);
 
                 // By this time we have processed all types reachable from module's global namespace
                 compilation.AnonymousTypeManager.AssignTemplatesNamesAndCompile(methodCompiler, moduleBeingBuiltOpt, diagnostics);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -66,8 +66,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         internal override ImmutableArray<NamedTypeSymbol> GetAdditionalTopLevelTypes(DiagnosticBag diagnostics)
         {
+            return _additionalTypes;
+        }
+
+        internal override ImmutableArray<NamedTypeSymbol> GetEmbeddedTypes(DiagnosticBag diagnostics)
+        {
             var builder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-            builder.AddRange(_additionalTypes);
 
             CreateEmbeddedAttributesIfNeeded(diagnostics);
             if ((object)_lazyEmbeddedAttribute != null)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -414,6 +414,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 yield return type;
             }
 
+            foreach (var type in GetEmbeddedTypes(context.Diagnostics))
+            {
+                yield return type;
+            }
+
             var namespacesToProcess = new Stack<NamespaceSymbol>();
             namespacesToProcess.Push(SourceModule.GlobalNamespace);
 
@@ -437,6 +442,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         }
 
         internal virtual ImmutableArray<NamedTypeSymbol> GetAdditionalTopLevelTypes(DiagnosticBag diagnostics)
+        {
+            return ImmutableArray<NamedTypeSymbol>.Empty;
+        }
+
+        internal virtual ImmutableArray<NamedTypeSymbol> GetEmbeddedTypes(DiagnosticBag diagnostics)
         {
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -127,7 +127,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (parameter.RefKind == RefKind.RefReadOnly)
                 {
-                    parameter.DeclaringCompilation.EnsureIsReadOnlyAttributeExists(diagnostics, parameter.GetNonNullSyntaxNode().Location, modifyCompilationForRefReadOnly);
+                    // These parameters might not come from a compilation (example: lambdas evaluated in EE).
+                    // During rewriting, lowering will take care of flagging the appropriate PEModuleBuilder instead.
+                    parameter.DeclaringCompilation?.EnsureIsReadOnlyAttributeExists(diagnostics, parameter.GetNonNullSyntaxNode().Location, modifyCompilationForRefReadOnly);
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -6659,6 +6659,81 @@ class Program
                 Diagnostic(RudeEditKind.Renamed, "int X", "parameter"));
         }
 
+        [Fact]
+        public void LocalFunction_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = @"class Test { void M() { } }";
+            var src2 = @"class Test { void M() { void local(ref readonly int b) { throw null; } } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [void M() { }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void LocalFunction_ReadOnlyRef_Parameter_InsertParameter()
+        {
+            var src1 = @"class Test { void M() { void local() { throw null; } } }";
+            var src2 = @"class Test { void M() { void local(ref readonly int b) { throw null; } } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [void M() { void local() { throw null; } }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void LocalFunction_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = @"class Test { void M() { void local(int b) { throw null; } } }";
+            var src2 = @"class Test { void M() { void local(ref readonly int b) { throw null; } } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [void M() { void local(int b) { throw null; } }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void LocalFunction_ReadOnlyRef_ReturnType_Insert()
+        {
+            var src1 = @"class Test { void M() { } }";
+            var src2 = @"class Test { void M() { ref readonly int local() { throw null; } } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [void M() { }]@13 -> [void M() { ref readonly int local() { throw null; } }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", "local function"));
+        }
+
+        [Fact]
+        public void LocalFunction_ReadOnlyRef_ReturnType_Update()
+        {
+            var src1 = @"class Test { void M() { int local() { throw null; } } }";
+            var src2 = @"class Test { void M() { ref readonly int local() { throw null; } } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [void M() { int local() { throw null; } }]@13 -> [void M() { ref readonly int local() { throw null; } }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", "local function"));
+        }
+
         #endregion
 
         #region Queries

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -6671,7 +6671,7 @@ class Program
                 "Update [void M() { }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -6686,7 +6686,7 @@ class Program
                 "Update [void M() { void local() { throw null; } }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -6701,7 +6701,7 @@ class Program
                 "Update [void M() { void local(int b) { throw null; } }]@13 -> [void M() { void local(ref readonly int b) { throw null; } }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -6716,7 +6716,7 @@ class Program
                 "Update [void M() { }]@13 -> [void M() { ref readonly int local() { throw null; } }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", "local function"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", FeaturesResources.local_function));
         }
 
         [Fact]
@@ -6731,7 +6731,7 @@ class Program
                 "Update [void M() { int local() { throw null; } }]@13 -> [void M() { ref readonly int local() { throw null; } }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", "local function"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "local", FeaturesResources.local_function));
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -676,6 +676,66 @@ public interface I
             edits.VerifyRudeDiagnostics();
         }
 
+        [Fact]
+        public void RefStructInsert()
+        {
+            string src1 = "";
+            string src2 = "ref struct X { }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref struct X { }]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.RefStruct, "ref struct X", "struct"));
+        }
+
+        [Fact]
+        public void ReadOnlyStructInsert()
+        {
+            string src1 = "";
+            string src2 = "readonly struct X { }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [readonly struct X { }]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyStruct, "readonly struct X", "struct"));
+        }
+
+        [Fact]
+        public void RefStructUpdate()
+        {
+            string src1 = "struct X { }";
+            string src2 = "ref struct X { }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [struct X { }]@0 -> [ref struct X { }]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref struct X", "struct"));
+        }
+
+        [Fact]
+        public void ReadOnlyStructUpdate()
+        {
+            string src1 = "struct X { }";
+            string src2 = "readonly struct X { }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [struct X { }]@0 -> [readonly struct X { }]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "readonly struct X", "struct"));
+        }
+
         #endregion
 
         #region Enums
@@ -1418,6 +1478,84 @@ public interface I
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Insert, "[return:A]", FeaturesResources.attribute));
+        }
+
+        [Fact]
+        public void Delegates_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = "";
+            var src2 = "public delegate int D(ref readonly int b);";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [public delegate int D(ref readonly int b);]@0",
+                "Insert [(ref readonly int b)]@21",
+                "Insert [ref readonly int b]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Delegates_ReadOnlyRef_Parameter_InsertParameter()
+        {
+            var src1 = "public delegate int D();";
+            var src2 = "public delegate int D(ref readonly int b);";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int b]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Delegates_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = "public delegate int D(int b);";
+            var src2 = "public delegate int D(ref readonly int b);";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int b]@22 -> [ref readonly int b]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Delegates_ReadOnlyRef_ReturnType_Insert()
+        {
+            var src1 = "";
+            var src2 = "public delegate ref readonly int D();";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [public delegate ref readonly int D();]@0",
+                "Insert [()]@34");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "public delegate ref readonly int D()", "delegate"));
+        }
+
+        [Fact]
+        public void Delegates_ReadOnlyRef_ReturnType_Update()
+        {
+            var src1 = "public delegate int D();";
+            var src2 = "public delegate ref readonly int D();";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [public delegate int D();]@0 -> [public delegate ref readonly int D();]@0");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "public delegate ref readonly int D()", "delegate"));
         }
 
         #endregion
@@ -3232,6 +3370,84 @@ class C
                 "Update [public void M(int a) { f((ref int b) => b = 1); }]@10 -> [public void M(int a) { f((out int b) => b = 1); }]@10");
         }
 
+        [Fact]
+        public void Method_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { int M(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [int M(ref readonly int b) => throw null;]@13",
+                "Insert [(ref readonly int b)]@18",
+                "Insert [ref readonly int b]@19");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Method_ReadOnlyRef_Parameter_InsertParameter()
+        {
+            var src1 = "class Test { int M() => throw null; }";
+            var src2 = "class Test { int M(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int b]@19");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Method_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = "class Test { int M(int b) => throw null; }";
+            var src2 = "class Test { int M(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int b]@19 -> [ref readonly int b]@19");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Method_ReadOnlyRef_ReturnType_Insert()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { ref readonly int M() => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int M() => throw null;]@13",
+                "Insert [()]@31");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", "method"));
+        }
+
+        [Fact]
+        public void Method_ReadOnlyRef_ReturnType_Update()
+        {
+            var src1 = "class Test { int M() => throw null; }";
+            var src2 = "class Test { ref readonly int M() => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int M() => throw null;]@13 -> [ref readonly int M() => throw null;]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", "method"));
+        }
+
         #endregion
 
         #region Operators
@@ -3434,6 +3650,38 @@ class C
                 "Reorder [public static C operator -(C c, C d) { return d; }]@74 -> @18");
 
             edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void Operator_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { public static bool operator !(ref readonly Test b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [public static bool operator !(ref readonly Test b) => throw null;]@13",
+                "Insert [(ref readonly Test b)]@42",
+                "Insert [ref readonly Test b]@43");
+
+            edits.VerifyRudeDiagnostics(
+                 Diagnostic(RudeEditKind.InsertOperator, "public static bool operator !(ref readonly Test b)", "operator"));
+        }
+
+        [Fact]
+        public void Operator_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = "class Test { public static bool operator !(Test b) => throw null; }";
+            var src2 = "class Test { public static bool operator !(ref readonly Test b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [Test b]@43 -> [ref readonly Test b]@43");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly Test b", "parameter"));
         }
 
         #endregion
@@ -4655,6 +4903,53 @@ public class C
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.Finalize"), preserveLocalVariables: false)
                 });
+        }
+
+        [Fact]
+        public void Constructor_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { Test(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [Test(ref readonly int b) => throw null;]@13",
+                "Insert [(ref readonly int b)]@17",
+                "Insert [ref readonly int b]@18");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Constructor_ReadOnlyRef_Parameter_InsertParameter()
+        {
+            var src1 = "class Test { Test() => throw null; }";
+            var src2 = "class Test { Test(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int b]@18");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+        }
+
+        [Fact]
+        public void Constructor_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = "class Test { Test(int b) => throw null; }";
+            var src2 = "class Test { Test(ref readonly int b) => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int b]@18 -> [ref readonly int b]@18");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
         }
 
         #endregion
@@ -7047,6 +7342,37 @@ class C
             edits.VerifyRudeDiagnostics();
         }
 
+        [Fact]
+        public void Property_ReadOnlyRef_Insert()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { ref readonly int M() { get; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int M() { get; }]@13",
+                "Insert [()]@31");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", "method"));
+        }
+
+        [Fact]
+        public void Property_ReadOnlyRef_Update()
+        {
+            var src1 = "class Test { int M() { get; } }";
+            var src2 = "class Test { ref readonly int M() { get; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int M() { get; }]@13 -> [ref readonly int M() { get; }]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", "method"));
+        }
+
         #endregion
 
         #region Indexers
@@ -7644,6 +7970,70 @@ class SampleCollection<T>
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.ModifiersUpdate, "const int x = 0", FeaturesResources.const_field));
+        }
+
+        [Fact]
+        public void Indexer_ReadOnlyRef_Parameter_InsertWhole()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { int this[ref readonly int i] => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [int this[ref readonly int i] => throw null;]@13",
+                "Insert [[ref readonly int i]]@21",
+                "Insert [ref readonly int i]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int i", "parameter"));
+        }
+        
+        [Fact]
+        public void Indexer_ReadOnlyRef_Parameter_Update()
+        {
+            var src1 = "class Test { int this[int i] => throw null; }";
+            var src2 = "class Test { int this[ref readonly int i] => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int i]@22 -> [ref readonly int i]@22");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int i", "parameter"));
+        }
+
+        [Fact]
+        public void Indexer_ReadOnlyRef_ReturnType_Insert()
+        {
+            var src1 = "class Test { }";
+            var src2 = "class Test { ref readonly int this[int i] => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Insert [ref readonly int this[int i] => throw null;]@13",
+                "Insert [[int i]]@34",
+                "Insert [int i]@35");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int this[int i]", "indexer"));
+        }
+
+        [Fact]
+        public void Indexer_ReadOnlyRef_ReturnType_Update()
+        {
+            var src1 = "class Test { int this[int i] => throw null; }";
+            var src2 = "class Test { ref readonly int this[int i] => throw null; }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            edits.VerifyEdits(
+                "Update [int this[int i] => throw null;]@13 -> [ref readonly int this[int i] => throw null;]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int this[int i]", "indexer"));
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -688,7 +688,7 @@ public interface I
                 "Insert [ref struct X { }]@0");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.RefStruct, "ref struct X", "struct"));
+                Diagnostic(RudeEditKind.RefStruct, "ref struct X", SyntaxFacts.GetText(SyntaxKind.StructKeyword)));
         }
 
         [Fact]
@@ -703,7 +703,7 @@ public interface I
                 "Insert [readonly struct X { }]@0");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyStruct, "readonly struct X", "struct"));
+                Diagnostic(RudeEditKind.ReadOnlyStruct, "readonly struct X", SyntaxFacts.GetText(SyntaxKind.StructKeyword)));
         }
 
         [Fact]
@@ -718,7 +718,7 @@ public interface I
                 "Update [struct X { }]@0 -> [ref struct X { }]@0");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref struct X", "struct"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref struct X", SyntaxFacts.GetText(SyntaxKind.StructKeyword)));
         }
 
         [Fact]
@@ -733,7 +733,7 @@ public interface I
                 "Update [struct X { }]@0 -> [readonly struct X { }]@0");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "readonly struct X", "struct"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "readonly struct X", SyntaxFacts.GetText(SyntaxKind.StructKeyword)));
         }
 
         #endregion
@@ -1494,7 +1494,7 @@ public interface I
                 "Insert [ref readonly int b]@22");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -1509,7 +1509,7 @@ public interface I
                 "Insert [ref readonly int b]@22");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -1524,7 +1524,7 @@ public interface I
                 "Update [int b]@22 -> [ref readonly int b]@22");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -1540,7 +1540,7 @@ public interface I
                 "Insert [()]@34");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "public delegate ref readonly int D()", "delegate"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "public delegate ref readonly int D()", FeaturesResources.delegate_));
         }
 
         [Fact]
@@ -1555,7 +1555,7 @@ public interface I
                 "Update [public delegate int D();]@0 -> [public delegate ref readonly int D();]@0");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "public delegate ref readonly int D()", "delegate"));
+                Diagnostic(RudeEditKind.TypeUpdate, "public delegate ref readonly int D()", FeaturesResources.delegate_));
         }
 
         #endregion
@@ -3384,7 +3384,7 @@ class C
                 "Insert [ref readonly int b]@19");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -3399,7 +3399,7 @@ class C
                 "Insert [ref readonly int b]@19");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -3414,7 +3414,7 @@ class C
                 "Update [int b]@19 -> [ref readonly int b]@19");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -3430,7 +3430,7 @@ class C
                 "Insert [()]@31");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", "method"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", FeaturesResources.method));
         }
 
         [Fact]
@@ -3445,7 +3445,7 @@ class C
                 "Update [int M() => throw null;]@13 -> [ref readonly int M() => throw null;]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", "method"));
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", FeaturesResources.method));
         }
 
         #endregion
@@ -3666,7 +3666,7 @@ class C
                 "Insert [ref readonly Test b]@43");
 
             edits.VerifyRudeDiagnostics(
-                 Diagnostic(RudeEditKind.InsertOperator, "public static bool operator !(ref readonly Test b)", "operator"));
+                 Diagnostic(RudeEditKind.InsertOperator, "public static bool operator !(ref readonly Test b)", FeaturesResources.operator_));
         }
 
         [Fact]
@@ -3681,7 +3681,7 @@ class C
                 "Update [Test b]@43 -> [ref readonly Test b]@43");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly Test b", "parameter"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly Test b", FeaturesResources.parameter));
         }
 
         #endregion
@@ -4919,7 +4919,7 @@ public class C
                 "Insert [ref readonly int b]@18");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -4934,7 +4934,7 @@ public class C
                 "Insert [ref readonly int b]@18");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.Insert, "ref readonly int b", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -4949,7 +4949,7 @@ public class C
                 "Update [int b]@18 -> [ref readonly int b]@18");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", "parameter"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int b", FeaturesResources.parameter));
         }
 
         #endregion
@@ -7355,7 +7355,7 @@ class C
                 "Insert [()]@31");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", "method"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int M()", FeaturesResources.method));
         }
 
         [Fact]
@@ -7370,7 +7370,7 @@ class C
                 "Update [int M() { get; }]@13 -> [ref readonly int M() { get; }]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", "method"));
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int M()", FeaturesResources.method));
         }
 
         #endregion
@@ -7986,7 +7986,7 @@ class SampleCollection<T>
                 "Insert [ref readonly int i]@22");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int i", "parameter"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int i", FeaturesResources.parameter));
         }
         
         [Fact]
@@ -8001,7 +8001,7 @@ class SampleCollection<T>
                 "Update [int i]@22 -> [ref readonly int i]@22");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int i", "parameter"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "ref readonly int i", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -8018,7 +8018,7 @@ class SampleCollection<T>
                 "Insert [int i]@35");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int this[int i]", "indexer"));
+                Diagnostic(RudeEditKind.ReadOnlyReferences, "ref readonly int this[int i]", FeaturesResources.indexer_));
         }
 
         [Fact]
@@ -8033,7 +8033,7 @@ class SampleCollection<T>
                 "Update [int this[int i] => throw null;]@13 -> [ref readonly int this[int i] => throw null;]@13");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int this[int i]", "indexer"));
+                Diagnostic(RudeEditKind.TypeUpdate, "ref readonly int this[int i]", FeaturesResources.indexer_));
         }
 
         #endregion

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -46,7 +46,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.InsertFile,
                 RudeEditKind.InsertConstructorToTypeWithInitializersWithLambdas,
                 RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement,
-                RudeEditKind.SwitchBetweenLambdaAndLocalFunction
+                RudeEditKind.SwitchBetweenLambdaAndLocalFunction,
+                RudeEditKind.RefStruct,
+                RudeEditKind.ReadOnlyStruct,
+                RudeEditKind.ReadOnlyReferences,
             };
 
             var arg2 = new HashSet<RudeEditKind>()
@@ -67,7 +70,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.DeleteLambdaWithMultiScopeCapture,
             };
 
-            List<RudeEditKind> errors = new List<RudeEditKind>();
             foreach (RudeEditKind value in Enum.GetValues(typeof(RudeEditKind)))
             {
                 if (value == RudeEditKind.None)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -191,9 +191,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             int atLineNumber = -1,
             bool includeSymbols = true)
         {
-            ResultProperties resultProperties;
-            string error;
-            var result = Evaluate(source, outputKind, methodName, expr, out resultProperties, out error, atLineNumber, includeSymbols);
+            var result = Evaluate(source, outputKind, methodName, expr, out _, out string error, atLineNumber, includeSymbols);
+            Assert.Null(error);
+            return result;
+        }
+
+        internal CompilationTestData Evaluate(
+            CSharpCompilation compilation,
+            string methodName,
+            string expr,
+            int atLineNumber = -1,
+            bool includeSymbols = true)
+        {
+            var result = Evaluate(compilation, methodName, expr, out _, out string error, atLineNumber, includeSymbols);
             Assert.Null(error);
             return result;
         }
@@ -208,11 +218,23 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             int atLineNumber = -1,
             bool includeSymbols = true)
         {
-            var compilation0 = CreateStandardCompilation(
+            var compilation = CreateStandardCompilation(
                 source,
                 options: (outputKind == OutputKind.DynamicallyLinkedLibrary) ? TestOptions.DebugDll : TestOptions.DebugExe);
 
-            var runtime = CreateRuntimeInstance(compilation0, debugFormat: includeSymbols ? DebugInformationFormat.Pdb : 0);
+            return Evaluate(compilation, methodName, expr, out resultProperties, out error, atLineNumber, includeSymbols);
+        }
+
+        internal CompilationTestData Evaluate(
+            CSharpCompilation compilation,
+            string methodName,
+            string expr,
+            out ResultProperties resultProperties,
+            out string error,
+            int atLineNumber = -1,
+            bool includeSymbols = true)
+        {
+            var runtime = CreateRuntimeInstance(compilation, debugFormat: includeSymbols ? DebugInformationFormat.Pdb : 0);
             var context = CreateMethodContext(runtime, methodName, atLineNumber);
             var testData = new CompilationTestData();
             ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -80,6 +80,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, FeaturesResources.Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, FeaturesResources.Attribute_0_is_missing_Updating_an_async_method_or_an_iterator_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.SwitchBetweenLambdaAndLocalFunction, FeaturesResources.Switching_between_lambda_and_local_function_will_prevent_the_debug_session_from_continuing ) },
+            { GetDescriptorPair(RudeEditKind.RefStruct, FeaturesResources.Using_ref_structs_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.ReadOnlyStruct, FeaturesResources.Using_readonly_structs_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.ReadOnlyReferences, FeaturesResources.Using_readonly_references_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing) },
 
             // VB specific,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -93,6 +93,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         UpdatingStateMachineMethodMissingAttribute = 75,
 
         SwitchBetweenLambdaAndLocalFunction = 76,
+        RefStruct = 77,
+        ReadOnlyStruct = 78,
+        ReadOnlyReferences = 79,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1657,6 +1657,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to indexer.
+        /// </summary>
+        internal static string indexer_ {
+            get {
+                return ResourceManager.GetString("indexer_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Initialize field &apos;{0}&apos;.
         /// </summary>
         internal static string Initialize_field_0 {

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1900,6 +1900,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to local function.
+        /// </summary>
+        internal static string local_function {
+            get {
+                return ResourceManager.GetString("local_function", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to local variable.
         /// </summary>
         internal static string local_variable {
@@ -3587,6 +3596,33 @@ namespace Microsoft.CodeAnalysis {
         internal static string User_Diagnostic_Analyzer_Failure {
             get {
                 return ResourceManager.GetString("User_Diagnostic_Analyzer_Failure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using readonly references will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Using_readonly_references_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Using_readonly_references_will_prevent_the_debug_session_from_continuing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using readonly structs will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Using_readonly_structs_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Using_readonly_structs_will_prevent_the_debug_session_from_continuing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using ref structs will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Using_ref_structs_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Using_ref_structs_will_prevent_the_debug_session_from_continuing", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1307,7 +1307,16 @@ This version used in: {2}</value>
   <data name="Switching_between_lambda_and_local_function_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Switching between a lambda and a local function will prevent the debug session from continuing.</value>
   </data>
-  <data name="Switching_between_lambda_and_local_function_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Switching between a lambda and a local function will prevent the debug session from continuing.</value>
+  <data name="Using_readonly_structs_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Using readonly structs will prevent the debug session from continuing.</value>
+  </data>
+  <data name="Using_ref_structs_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Using ref structs will prevent the debug session from continuing.</value>
+  </data>
+  <data name="Using_readonly_references_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Using readonly references will prevent the debug session from continuing.</value>
+  </data>
+  <data name="local_function" xml:space="preserve">
+    <value>local function</value>
   </data>
 </root>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1319,4 +1319,7 @@ This version used in: {2}</value>
   <data name="local_function" xml:space="preserve">
     <value>local function</value>
   </data>
+  <data name="indexer_" xml:space="preserve">
+    <value>indexer</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR Fixes #19274, and does the following:

* Disables EnC for ref structs.
* Disables EnC for readonly structs.
* Disables EnC for ref readonly parameters and return types.
* Enables Expression Evaluation for lambdas containing ref readonly signatures.

cc @ivanbasov @VSadov @cston @dotnet/roslyn-compiler 