### PR TITLE
back ported only portion that is causing perf issues in dev15.4.x fro…

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -150,9 +150,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             // We can reuse the index for any given reference as long as it hasn't changed.
             // So our checksum is just the checksum for the PEReference itself.
-            var serializer = new Serializer(solution.Workspace);
-            var checksum = serializer.CreateChecksum(reference, cancellationToken);
-            return checksum;
+            return ChecksumCache.GetOrCreate(reference, _ =>
+            {
+                var serializer = new Serializer(solution.Workspace);
+                var checksum = serializer.CreateChecksum(reference, cancellationToken);
+                return checksum;
+            });
         }
 
         private static Task<SymbolTreeInfo> TryLoadOrCreateMetadataSymbolTreeInfoAsync(


### PR DESCRIPTION
…m master.

this basically prevent symbol info indexer from creating/calculating same checksum again and again for every documents in the solution.

this should make it to do it only once per project rather than document, and only update it when there is a change in the project.

**Customer scenario**

Customer opens a big solution in VS and start to use it for a while and VS crashes due to OOM.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=497689&_a=edit

**Workarounds, if any**

currently, there is no workaround.

**Risk**

Low, we cache 20 bytes per project. so. 500 projects solution consumes 10K bytes more memory.

**Performance impact**

It should get rid of OOM caused by this issue. and prevent us from re-doing same work multiple times (for every documents) to 1 per project. and only once for a project that is actually changed, rather than all projects that depends on the project that changed.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

code didn't check the case where same work is asked multiple times and re-did the same work multiple times. previously, when versions are used, this was fine, since checking versions are cheap, but now we use checksum, and calculating checksums are expansive compared to getting versions, so it caused this issue.

**How was the bug found?**

dogfooding, watson and feedbacks.

