### PR TITLE
Keep attribute on the same line as a member if they started on a single line

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -67,19 +67,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var tokens = memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
                 AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, tokens.Item2);
 
-                // Also, If the member is on single line with its attributes on it, then keep 
-                // it on a single line.  This is for code like the following:
-                //
-                //      [Import] public int Field1;
-                //      [Import] public int Field2;
-                var attributes = memberDeclNode.GetAttributes();
-                for (int i = 0; i < attributes.Count; ++i)
-                {
-                    AddSuppressWrappingIfOnSingleLineOperation(list,
-                        attributes[i].GetFirstToken(includeZeroWidth: true),
-                        node.GetLastToken(includeZeroWidth: true));
-                }
-
                 var propertyDeclNode = node as PropertyDeclarationSyntax;
                 if (propertyDeclNode?.Initializer != null && propertyDeclNode?.AccessorList != null)
                 {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 //      [Import] public int Field1;
                 //      [Import] public int Field2;
                 var attributes = memberDeclNode.GetAttributes();
-                for (int i = 0; i < attributes.Count - 1; ++i)
+                for (int i = 0; i < attributes.Count; ++i)
                 {
                     AddSuppressWrappingIfOnSingleLineOperation(list,
                         attributes[i].GetFirstToken(includeZeroWidth: true),

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -67,6 +67,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 var tokens = memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
                 AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, tokens.Item2);
 
+                // Also, If the member is on single line with its attributes on it, then keep 
+                // it on a single line.  This is for code like the following:
+                //
+                //      [Import] public int Field1;
+                //      [Import] public int Field2;
+                var attributes = memberDeclNode.GetAttributes();
+                for (int i = 0; i < attributes.Count; ++i)
+                {
+                    AddSuppressWrappingIfOnSingleLineOperation(list,
+                        attributes[i].GetFirstToken(includeZeroWidth: true),
+                        node.GetLastToken(includeZeroWidth: true));
+                }
+
                 var propertyDeclNode = node as PropertyDeclarationSyntax;
                 if (propertyDeclNode?.Initializer != null && propertyDeclNode?.AccessorList != null)
                 {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -73,11 +73,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 //      [Import] public int Field1;
                 //      [Import] public int Field2;
                 var attributes = memberDeclNode.GetAttributes();
-                for (int i = 0; i < attributes.Count; ++i)
+                var endToken = node.GetLastToken(includeZeroWidth: true);
+                for (var i = 0; i < attributes.Count; ++i)
                 {
                     AddSuppressWrappingIfOnSingleLineOperation(list,
                         attributes[i].GetFirstToken(includeZeroWidth: true),
-                        node.GetLastToken(includeZeroWidth: true));
+                        endToken);
                 }
 
                 var propertyDeclNode = node as PropertyDeclarationSyntax;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -62,21 +62,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             if (node is MemberDeclarationSyntax memberDeclNode)
             {
-                // Attempt to keep the part of a member that follows hte attributes on a single
+                // Attempt to keep the part of a member that follows the attributes on a single
                 // line if that's how it's currently written.
                 var tokens = memberDeclNode.GetFirstAndLastMemberDeclarationTokensAfterAttributes();
                 AddSuppressWrappingIfOnSingleLineOperation(list, tokens.Item1, tokens.Item2);
 
+                // Also, If the member is on single line with its attributes on it, then keep 
+                // it on a single line.  This is for code like the following:
+                //
+                //      [Import] public int Field1;
+                //      [Import] public int Field2;
                 var attributes = memberDeclNode.GetAttributes();
-                if (attributes.Count > 0)
+                for (int i = 0; i < attributes.Count - 1; ++i)
                 {
-                    // Also, If the member is on single line with its attributes on it, then keep 
-                    // it on a single line.  This is for code like the following:
-                    //
-                    //      [Import] public int Field1;
-                    //      [Import] public int Field2;
                     AddSuppressWrappingIfOnSingleLineOperation(list,
-                        node.GetFirstToken(includeZeroWidth: true),
+                        attributes[i].GetFirstToken(includeZeroWidth: true),
                         node.GetLastToken(includeZeroWidth: true));
                 }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     attributeOwner is MemberDeclarationSyntax ||
                     attributeOwner is AccessorDeclarationSyntax)
                 {
-                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+                    return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
                 }
 
                 return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     attributeOwner is MemberDeclarationSyntax ||
                     attributeOwner is AccessorDeclarationSyntax)
                 {
-                    return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }
 
                 return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7948,7 +7948,7 @@ class C {
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
-        public async Task FormatMultipleAttributeOnSameLineAsField()
+        public async Task FormatMultipleAttributeOnSameLineAsField1()
         {
             await AssertFormatAsync(
 @"
@@ -7962,6 +7962,25 @@ class C
 class C {
     [Attr1]
     [Attr2]
+    [Attr3][Attr4]   int   i;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
+        public async Task FormatMultipleAttributesOnSameLineAsField2()
+        {
+            await AssertFormatAsync(
+@"
+class C
+{
+    [Attr1]
+    [Attr2]
+    [Attr3] [Attr4] int i;
+}",
+@"
+class C {
+    [Attr1][Attr2]
     [Attr3][Attr4]   int   i;
 }");
         }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7948,7 +7948,7 @@ class C {
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
-        public async Task FormatMultipleAttributeOnSameLineAsField()
+        public async Task FormatMultipleAttributesOnSameLineAsField1()
         {
             await AssertFormatAsync(
 @"
@@ -7968,14 +7968,31 @@ class C {
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
+        public async Task FormatMultipleAttributesOnSameLineAsField2()
+        {
+            await AssertFormatAsync(
+@"
+class C
+{
+    [Attr1] [Attr2]
+    [Attr3] [Attr4] int i;
+}",
+@"
+class C {
+    [Attr1][Attr2]
+    [Attr3][Attr4]   int   i;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
         public async Task FormatMultipleAttributeOnSameLineAndFieldOnNewLine()
         {
             await AssertFormatAsync(
 @"
 class C
 {
-    [Attr1]
-    [Attr2]
+    [Attr1] [Attr2]
     int i;
 }",
 @"

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7947,6 +7947,45 @@ class C {
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
+        public async Task FormatMultipleAttributeOnSameLineAsField()
+        {
+            await AssertFormatAsync(
+@"
+class C
+{
+    [Attr1]
+    [Attr2]
+    [Attr3] [Attr4] int i;
+}",
+@"
+class C {
+    [Attr1]
+    [Attr2]
+    [Attr3][Attr4]   int   i;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
+        public async Task FormatMultipleAttributeOnSameLineAndFieldOnNewLine()
+        {
+            await AssertFormatAsync(
+@"
+class C
+{
+    [Attr1]
+    [Attr2]
+    int i;
+}",
+@"
+class C {
+    [Attr1][Attr2]
+    int   i;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(6628, "https://github.com/dotnet/roslyn/issues/6628")]
         public async Task FormatOnElseBlockBracesOnSameLineRemainsInSameLine_2()
         {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7948,7 +7948,7 @@ class C {
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
-        public async Task FormatMultipleAttributesOnSameLineAsField1()
+        public async Task FormatMultipleAttributeOnSameLineAsField()
         {
             await AssertFormatAsync(
 @"
@@ -7962,24 +7962,6 @@ class C
 class C {
     [Attr1]
     [Attr2]
-    [Attr3][Attr4]   int   i;
-}");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        [WorkItem(21789, "https://github.com/dotnet/roslyn/issues/21789")]
-        public async Task FormatMultipleAttributesOnSameLineAsField2()
-        {
-            await AssertFormatAsync(
-@"
-class C
-{
-    [Attr1] [Attr2]
-    [Attr3] [Attr4] int i;
-}",
-@"
-class C {
-    [Attr1][Attr2]
     [Attr3][Attr4]   int   i;
 }");
         }
@@ -7992,7 +7974,8 @@ class C {
 @"
 class C
 {
-    [Attr1] [Attr2]
+    [Attr1]
+    [Attr2]
     int i;
 }",
 @"


### PR DESCRIPTION
**Customer scenario**

Fix for #21789. Formatting of fields with multiple attributes wraps attributes that should stay on the same line. Example from #21789:

**Code to format**
```CSharp
    [Tooltip("Should probably start at 0,1 and end at 1,0\n to make attraction near the suctionOrigin highest")]
    [SerializeField] [CurveRange] AnimationCurve _suctionForceDistanceCurve = null;
```
**Expected**
```CSharp
    [Tooltip("Should probably start at 0,1 and end at 1,0\n to make attraction near the suctionOrigin highest")]
    [SerializeField] [CurveRange] AnimationCurve _suctionForceDistanceCurve = null;
```
**Actual**
```CSharp
    [Tooltip("Should probably start at 0,1 and end at 1,0\n to make attraction near the suctionOrigin highest")]
    [SerializeField]
    [CurveRange]
    AnimationCurve _suctionForceDistanceCurve = null;
```

The fix suppresses wrapping for all attributes that are on the same line as the field.
I find the current solution a little bit odd because:

This will be kept:
```CSharp
    [Attr3][Attr4] int i;
```
while this 
```CSharp
    [Attr3][Attr4]
    int i;
```
will be wrapped like this
```CSharp
    [Attr3]
    [Attr4]
    int i;
```

See also the new test method `FormatMultipleAttributeOnSameLineAndFieldOnNewLine`.
It should be considered to generally keep attributes on the same line no matter what they are attributed to.

**Bugs this fixes:**

#21789 

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

#11685 missed this case.

**Root cause analysis:**

Edge case. Requires multiple attributes in multiple lines.

**How was the bug found?**

customer reported

**Test documentation updated?**

No.