### PR TITLE
Enable 64bit RemoteHost

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         // use 64bit OOP
         public static readonly Option<bool> OOP64Bit = new Option<bool>(
-            nameof(InternalFeatureOnOffOptions), nameof(OOP64Bit), defaultValue: false,
+            nameof(InternalFeatureOnOffOptions), nameof(OOP64Bit), defaultValue: true,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(OOP64Bit)));
 
         public static readonly Option<bool> RemoteHostTest = new Option<bool>(nameof(InternalFeatureOnOffOptions), nameof(RemoteHostTest), defaultValue: false);


### PR DESCRIPTION
Enable 64bit OOP.

before 15.5, this will be changed to A/B testing.