### PR TITLE
Don't show snippets in VB comments

### DIFF
--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -135,6 +135,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
             SendEscape(AddressOf SnippetCommandHandler.ExecuteCommand, Function() EditorOperations.InsertText("EscapePassedThrough!"))
         End Sub
 
+        Public Overloads Sub SendTypeChars(typeChars As String)
+            Dim handler = DirectCast(_completionCommandHandler, ICommandHandler(Of TypeCharCommandArgs))
+            MyBase.SendTypeChars(typeChars, AddressOf handler.ExecuteCommand)
+        End Sub
+
         Private Class MockOrderableContentTypeMetadata
             Inherits OrderableContentTypeMetadata
 

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
@@ -12,6 +12,8 @@ Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
@@ -51,6 +53,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
             Dim syntaxTree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)()
             Dim isPossibleTupleContext = syntaxFacts.IsPossibleTupleContext(syntaxTree, position, cancellationToken)
+
+            Dim trivia = syntaxTree.FindTriviaToLeft(position, cancellationToken)
+            If (trivia.IsKind(SyntaxKind.CommentTrivia, SyntaxKind.DocumentationCommentTrivia)) Then
+                Return
+            End If
 
             context.IsExclusive = ShouldBeExclusive(context.Options)
             context.AddItems(CreateCompletionItems(snippets, isPossibleTupleContext))

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
@@ -12,7 +12,6 @@ Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
-Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Text
@@ -54,8 +53,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)()
             Dim isPossibleTupleContext = syntaxFacts.IsPossibleTupleContext(syntaxTree, position, cancellationToken)
 
-            Dim trivia = syntaxTree.FindTriviaToLeft(position, cancellationToken)
-            If (trivia.IsKind(SyntaxKind.CommentTrivia, SyntaxKind.DocumentationCommentTrivia)) Then
+            If (IsInNonUserCode(syntaxTree, position, cancellationToken)) Then
                 Return
             End If
 


### PR DESCRIPTION
Fixes issue 21801

**Customer scenario**

Code snippets are displayed in VB comments, when snippet behavior is set to "Always include snippets".  

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/21801

**Workarounds, if any**

Turn off code snippets for VB

**Risk**

Low risk bug fix that only affects the display of snippets in VB Comments

**Performance impact**

None, no complexity changes

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Infrequently used option

**How was the bug found?**
Customer report



