### PR TITLE
IntroduceField code action should remove trivia as the other IntroduceVariable actions do.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -195,6 +195,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             await TestInRegularAndScriptAsync(code, expected, index: 1);
         }
 
+        [WorkItem(21747, "https://github.com/dotnet/roslyn/issues/21747")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestTriviaFieldFix2()
+        {
+            var code =
+@"class C
+{
+    int i = (/* CommentLeading */ [|1 + /*CommentEmbedded*/ 1|] /* CommentTrailing */) + (1 + 1);
+}";
+
+            var expected =
+@"class C
+{
+    private const int {|Rename:V|} = 1 + /*CommentEmbedded*/ 1;
+    int i = /* CommentLeading */ V /* CommentTrailing */ + V;
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 1);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestConstFieldFix1()
         {

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -175,6 +175,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             await TestInRegularAndScriptAsync(code, expected, index: 1);
         }
 
+        [WorkItem(21747, "https://github.com/dotnet/roslyn/issues/21747")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestTriviaFieldFix1()
+        {
+            var code =
+@"class C
+{
+    int i = (/* CommentLeading */ [|1 + 1|] /* CommentTrailing */) + (1 + 1);
+}";
+
+            var expected =
+@"class C
+{
+    private const int {|Rename:V|} = 1 + 1;
+    int i = /* CommentLeading */ V /* CommentTrailing */ + V;
+}";
+
+            await TestInRegularAndScriptAsync(code, expected, index: 1);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestConstFieldFix1()
         {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                         SyntaxFactory.VariableDeclarator(
                             newNameToken.WithAdditionalAnnotations(RenameAnnotation.Create()),
                             null,
-                            SyntaxFactory.EqualsValueClause(expression))))).WithAdditionalAnnotations(Formatter.Annotation);
+                            SyntaxFactory.EqualsValueClause(expression.WithoutTrailingTrivia().WithoutLeadingTrivia()))))).WithAdditionalAnnotations(Formatter.Annotation);
 
             if (oldTypeDeclaration != null)
             {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                         SyntaxFactory.VariableDeclarator(
                             newNameToken.WithAdditionalAnnotations(RenameAnnotation.Create()),
                             null,
-                            SyntaxFactory.EqualsValueClause(expression.WithoutTrailingTrivia().WithoutLeadingTrivia()))))).WithAdditionalAnnotations(Formatter.Annotation);
+                            SyntaxFactory.EqualsValueClause(expression.WithoutTrivia()))))).WithAdditionalAnnotations(Formatter.Annotation);
 
             if (oldTypeDeclaration != null)
             {

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                     SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(
                         newLocalNameToken.WithAdditionalAnnotations(RenameAnnotation.Create()),
                         null,
-                        SyntaxFactory.EqualsValueClause(expression.WithoutTrailingTrivia().WithoutLeadingTrivia())))));
+                        SyntaxFactory.EqualsValueClause(expression.WithoutTrivia())))));
 
             switch (containerToGenerateInto)
             {


### PR DESCRIPTION
**Customer scenario**

From #21747.

> CSharpIntroduceVariableService.IntroduceFieldAsync doesn't drop leading and trailing trivia the way IntroduceLocalAsync does (i.e. expression.WithoutTrailingTrivia().WithoutLeadingTrivia()). As a result, the trivia appear in both the initializer of the newly-created field and at its use-site.

> I didn't check VB.

I also looked at the VB implementation and there it should be fine and covered by tests:

* Code: [`VisualBasicIntroduceVariableService.CreateFieldDeclaration`](https://github.com/dotnet/roslyn/blob/6847f1e5a909395aae9456e8f366cbf4deb86b69/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceField.vb#L198)
* Test: [`IntroduceVariableTests.TestIntroduceFieldWithTrailingTrivia`](https://github.com/dotnet/roslyn/blob/b57c9b1ebc7ad6eaabe4b8ea8fb37f9898a86325/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb#L753)

**Bugs this fixes:**

#21747

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Wasn't covered by tests.

**How was the bug found?**

Reported by @amcasey 

**Test documentation updated?**

No.