### PR TITLE
Fix serialization of attribute data to account for named params argument

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -836,7 +836,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return namedValue;
                     }
 
-                    // A named argument for a params parameter must be trailing, so expanded params must have a single value
+                    // A named argument for a params parameter is necessarily the only one for that parameter
                     return new TypedConstant(parameter.Type, ImmutableArray.Create(constructorArgsArray[argIndex] ));
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -183,6 +183,38 @@ static class Program
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
+        public void TestNamedArgumentOnObjectParamsArgument4()
+        {
+            var source = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Reflection;
+
+sealed class MarkAttribute : Attribute
+{
+    public MarkAttribute(bool a, params object[] b)
+    {
+        B = b;
+    }
+    public object[] B { get; }
+}
+
+[Mark(a: true, new object[] { ""Hello"" }, new object[] { ""World"" })]
+static class Program
+{
+    public static void Main()
+    {
+        var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
+        var worldArray = (object[])attr.B[1];
+        Console.Write(worldArray[0]);
+    }
+}", options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_2);
+            source.VerifyDiagnostics();
+
+            CompileAndVerify(source, expectedOutput: @"World");
+        }
+
+        [Fact]
+        [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnNonParamsArgument()
         {
             var source = CreateCompilationWithMscorlib46(@"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -65,7 +65,7 @@ class C
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnStringParamsArgument()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 
 class MarkAttribute : Attribute
@@ -76,21 +76,60 @@ class MarkAttribute : Attribute
 }
 
 [Mark(b: new string[] { ""Hello"", ""World"" }, a: true)]
+[Mark(b: ""Hello"", true)]
 static class Program
 {
-}");
-            source.VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
                 // (11,2): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
                 // [Mark(b: new string[] { "Hello", "World" }, a: true)]
-                Diagnostic(ErrorCode.ERR_BadAttributeArgument, @"Mark(b: new string[] { ""Hello"", ""World"" }, a: true)").WithLocation(11, 2)
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, @"Mark(b: new string[] { ""Hello"", ""World"" }, a: true)").WithLocation(11, 2),
+                // (12,7): error CS8323: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+                // [Mark(b: "Hello", true)]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "b").WithArguments("b").WithLocation(12, 7)
                 );
+        }
+
+        [Fact]
+        [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
+        public void TestNamedArgumentOnOrderedObjectParamsArgument()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Reflection;
+
+sealed class MarkAttribute : Attribute
+{
+    public MarkAttribute(bool a, params object[] b)
+    {
+        B = b;
+    }
+    public object[] B { get; }
+}
+
+[Mark(a: true, b: new object[] { ""Hello"", ""World"" })]
+static class Program
+{
+    public static void Main()
+    {
+        var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
+        Console.Write($""B.Length={attr.B.Length}, B[0]={attr.B[0]}, B[1]={attr.B[1]}"");
+    }
+}", options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: @"B.Length=2, B[0]=Hello, B[1]=World");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 0, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -112,16 +151,20 @@ static class Program
         Console.Write($""B.Length={attr.B.Length}, B[0]={attr.B[0]}, B[1]={attr.B[1]}"");
     }
 }", options: TestOptions.DebugExe);
-            source.VerifyDiagnostics();
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: @"B.Length=2, B[0]=Hello, B[1]=World");
+            CompileAndVerify(comp, expectedOutput: @"B.Length=2, B[0]=Hello, B[1]=World");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 1, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument2()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -144,17 +187,21 @@ static class Program
         var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
         Console.Write($""A={attr.A}, B.Length={attr.B.Length}, B[0]={attr.B[0]}"");
     }
-}", options: TestOptions.DebugExe);
-            source.VerifyDiagnostics();
+}", options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: @"A=True, B.Length=1, B[0]=Hello");
+            CompileAndVerify(comp, expectedOutput: @"A=True, B.Length=1, B[0]=Hello");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 1, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument3()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -177,16 +224,20 @@ static class Program
         Console.Write(worldArray[0]);
     }
 }", options: TestOptions.DebugExe);
-            source.VerifyDiagnostics();
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: @"World");
+            CompileAndVerify(comp, expectedOutput: @"World");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 0, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument4()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -209,16 +260,20 @@ static class Program
         Console.Write(worldArray[0]);
     }
 }", options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_2);
-            source.VerifyDiagnostics();
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: @"World");
+            CompileAndVerify(comp, expectedOutput: @"World");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 0, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument5()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -240,16 +295,20 @@ static class Program
         Console.Write(attr.B == null);
     }
 }", options: TestOptions.DebugExe);
-            source.VerifyDiagnostics();
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: @"True");
+            CompileAndVerify(comp, expectedOutput: @"True");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 1, -1 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnNonParamsArgument()
         {
-            var source = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilationWithMscorlib46(@"
 using System;
 using System.Reflection;
 
@@ -273,9 +332,13 @@ static class Program
         Console.Write($""A={attr.A}, B={attr.B}"");
     }
 }", options: TestOptions.DebugExe);
-            source.VerifyDiagnostics();
+            comp.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput: "A=1, B=42");
+            CompileAndVerify(comp, expectedOutput: "A=1, B=42");
+
+            var program = (NamedTypeSymbol)comp.GetMember("Program");
+            var attributeData = (SourceAttributeData)program.GetAttributes()[0];
+            Assert.Equal(new[] { 1, 0 }, attributeData.ConstructorArgumentsSourceIndices);
         }
 
         [WorkItem(984896, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984896")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -99,39 +99,86 @@ sealed class MarkAttribute : Attribute
 {
     public MarkAttribute(bool a, params object[] b)
     {
-        A = a;
         B = b;
     }
-    public bool A { get; }
-    public object[] B { get;  }
+    public object[] B { get; }
 }
 
 [Mark(b: new object[] { ""Hello"", ""World"" }, a: true)]
 static class Program
 {
-    private static void Test(bool a, params object[] b)
-        => PrintOutArgsInfo(b);
-
     public static void Main()
     {
-        Console.Write(""Method call: "");
-        Test(b: new object[] { ""Hello"", ""World"" }, a: true);
-
         var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
-        Console.Write(""Attribute constructor call: "");
-        PrintOutArgsInfo(attr.B);
-    }
-
-    private static void PrintOutArgsInfo(object[] args)
-    {
-        Console.WriteLine($""{args[0]}"");
+        Console.Write(attr.B[0]);
     }
 }", options: TestOptions.DebugExe);
             source.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput:
-@"Method call: Hello
-Attribute constructor call: Hello");
+            CompileAndVerify(source, expectedOutput: @"Hello");
+        }
+
+        [Fact]
+        [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
+        public void TestNamedArgumentOnObjectParamsArgument2()
+        {
+            var source = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Reflection;
+
+sealed class MarkAttribute : Attribute
+{
+    public MarkAttribute(bool a, params object[] b)
+    {
+        B = b;
+    }
+    public object[] B { get; }
+}
+
+[Mark(b: ""Hello"", a: true)]
+static class Program
+{
+    public static void Main()
+    {
+        var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
+        Console.Write(attr.B[0]);
+    }
+}", options: TestOptions.DebugExe);
+            source.VerifyDiagnostics();
+
+            CompileAndVerify(source, expectedOutput: @"Hello");
+        }
+
+        [Fact]
+        [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
+        public void TestNamedArgumentOnObjectParamsArgument3()
+        {
+            var source = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Reflection;
+
+sealed class MarkAttribute : Attribute
+{
+    public MarkAttribute(bool a, params object[] b)
+    {
+        B = b;
+    }
+    public object[] B { get; }
+}
+
+[Mark(true, new object[] { ""Hello"" }, new object[] { ""World"" })]
+static class Program
+{
+    public static void Main()
+    {
+        var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
+        var worldArray = (object[])attr.B[1];
+        Console.Write(worldArray[0]);
+    }
+}", options: TestOptions.DebugExe);
+            source.VerifyDiagnostics();
+
+            CompileAndVerify(source, expectedOutput: @"World");
         }
 
         [Fact]
@@ -146,39 +193,23 @@ sealed class MarkAttribute : Attribute
 {
     public MarkAttribute(int a, int b)
     {
-        A = a;
         B = b;
     }
-    public int A { get; }
     public int B { get;  }
 }
 
 [Mark(b: 42, a: 1)]
 static class Program
 {
-    private static void Test(int a, int b)
-        => PrintOutArgsInfo(b);
-
     public static void Main()
     {
-        Console.Write(""Method call: "");
-        Test(b: 42, a: 1);
-
         var attr = typeof(Program).GetCustomAttribute<MarkAttribute>();
-        Console.Write(""Attribute constructor call: "");
-        PrintOutArgsInfo(attr.B);
-    }
-
-    private static void PrintOutArgsInfo(int value)
-    {
-        Console.WriteLine($""Value={value}"");
+        Console.Write(attr.B);
     }
 }", options: TestOptions.DebugExe);
             source.VerifyDiagnostics();
 
-            CompileAndVerify(source, expectedOutput:
-@"Method call: Value=42
-Attribute constructor call: Value=42");
+            CompileAndVerify(source, expectedOutput: "42");
         }
 
         [WorkItem(984896, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984896")]


### PR DESCRIPTION
**Customer scenario**

Define attribute with `MarkAttribute(bool a, params object[] b)` and use it with `[Mark(b: new object[] { "Hello", "World" }, a: true)]`.
It will be incorrectly emitted as `[Mark(true, new object[] { true })]`.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/20741

**Workarounds, if any**
Use attribute without naming arguments.

**Risk**
**Performance impact**
Low. This only affects the serialization of attribute data for attributes that have a `params` parameter.

**Is this a regression from a previous update?**
No. This code was largely unchanged during the whole git history.

**Root cause analysis:**
The matching of arguments to parameters during overload resolution is fine. But when it comes time to prepare attribute data, we have logic to put arguments in the proper order (`GetRewrittenAttributeConstructorArguments`). It's implementation didn't handle named params arguments properly.

**How was the bug found?**
Reported by customer

**Test documentation updated?**
Not applicable