### PR TITLE
Fix build parallelism issue with documentation file generation

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -48,11 +48,16 @@
 
   <!-- 
     DocumentationFile needs to be set before importing common targets. 
-    C# common targets (unlike VB) prefix DocumentationFile path with IntermediateOutputPath.
+
+    C# common targets (unlike VB) prefix DocumentationFile path with IntermediateOutputPath. However, using that here does not work with multi-targeting as
+    the IntermediateOutputPath will not yet have the TargetFramework appended, which will lead to a race where parallel builds for different TargetFrameworks
+    attempt to write the doc xml to the same xml location. Instead, we can simply set GenerateDocumentationFile=true and let the SDK pick the correct path.
+
+    Ideally, we'd just use the same construct for VB here, but that is currently blocked by https://github.com/dotnet/sdk/issues/1598.
   -->
-  <PropertyGroup Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(AssemblyName)' != ''">
+  <PropertyGroup Condition="'$(GenerateDocumentationFile)' == '' AND '$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(AssemblyName)' != ''">
     <DocumentationFile Condition="'$(ProjectLanguage)' == 'VB'">$(AssemblyName).xml</DocumentationFile>
-    <DocumentationFile Condition="'$(ProjectLanguage)' == 'CSharp'">$(IntermediateOutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile Condition="'$(ProjectLanguage)' == 'CSharp'">true</GenerateDocumentationFile>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Use GenerateDocumentationFile=true instead of DocumentationFile=$(IntermediateOutputPath)$(AssemblyName).xml. This lets the SDK pick the appropriate path.

At the point where the explicit DocumentationFile was being evaluated, the intermediate output path had not yet gotten the TargetFramework appended. As such, parallel builds of the different TargetFrameworks of a multi-targeted project were trying to write the documentation xml to the same intermediate location.