### PR TITLE
NormalizeWhitespace introduces a space between in nullable type

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -425,6 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 if (!next.IsKind(SyntaxKind.ColonToken) &&
                     !next.IsKind(SyntaxKind.DotToken) &&
+                    !next.IsKind(SyntaxKind.QuestionToken) &&
                     !next.IsKind(SyntaxKind.SemicolonToken) &&
                     !next.IsKind(SyntaxKind.OpenBracketToken) &&
                     !next.IsKind(SyntaxKind.CloseParenToken) &&

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -503,5 +503,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // no space between DateTime and ?
             Assert.Equal("class C\r\n{\r\n    DateTime? P\r\n    {\r\n    }\r\n}", syntaxNode.ToFullString());
         }
+
+        [Fact]
+        [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
+        public void TestSpacingOnTernary()
+        {
+            var syntaxNode = SyntaxFactory.ParseExpression("x is int? y: z").NormalizeWhitespace();
+
+            // space between int and ?
+            Assert.Equal("x is int ? y : z", syntaxNode.ToFullString());
+
+            var syntaxNode2 = SyntaxFactory.ParseExpression("x is DateTime? y: z").NormalizeWhitespace();
+
+            // space between DateTime and ?
+            Assert.Equal("x is DateTime ? y : z", syntaxNode2.ToFullString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -456,5 +456,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(Location.None, token.GetLocation());
             token.GetDiagnostics().Verify();
         }
+
+        [Fact]
+        [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
+        public void TestSpacingOnNullableType()
+        {
+            var syntaxNode = 
+                SyntaxFactory.CompilationUnit()
+                .WithMembers(
+                    SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
+                        SyntaxFactory.ClassDeclaration("C")
+                        .WithMembers(
+                            SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
+                                SyntaxFactory.PropertyDeclaration(
+                                    SyntaxFactory.NullableType(
+                                        SyntaxFactory.PredefinedType(
+                                            SyntaxFactory.Token(SyntaxKind.IntKeyword))),
+                                    SyntaxFactory.Identifier("P"))
+                                    .WithAccessorList(
+                                        SyntaxFactory.AccessorList())))))
+                .NormalizeWhitespace();
+
+            Assert.Equal(
+@"class C
+{
+    int ? P
+    {
+    }
+}", syntaxNode.ToFullString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -459,9 +459,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
-        public void TestSpacingOnNullableType()
+        public void TestSpacingOnNullableIntType()
         {
-            var syntaxNode = 
+            var syntaxNode =
                 SyntaxFactory.CompilationUnit()
                 .WithMembers(
                     SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
@@ -477,10 +477,40 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                         SyntaxFactory.AccessorList())))))
                 .NormalizeWhitespace();
 
+            // no space between int and ?
             Assert.Equal(
 @"class C
 {
-    int ? P
+    int? P
+    {
+    }
+}", syntaxNode.ToFullString());
+        }
+
+        [Fact]
+        [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
+        public void TestSpacingOnNullableDatetimeType()
+        {
+            var syntaxNode =
+                SyntaxFactory.CompilationUnit()
+                .WithMembers(
+                    SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
+                        SyntaxFactory.ClassDeclaration("C")
+                        .WithMembers(
+                            SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
+                                SyntaxFactory.PropertyDeclaration(
+                                    SyntaxFactory.NullableType(
+                                        SyntaxFactory.ParseTypeName("DateTime")),
+                                    SyntaxFactory.Identifier("P"))
+                                    .WithAccessorList(
+                                        SyntaxFactory.AccessorList())))))
+                .NormalizeWhitespace();
+
+            // no space between DateTime and ?
+            Assert.Equal(
+@"class C
+{
+    DateTime? P
     {
     }
 }", syntaxNode.ToFullString());

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -478,13 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 .NormalizeWhitespace();
 
             // no space between int and ?
-            Assert.Equal(
-@"class C
-{
-    int? P
-    {
-    }
-}", syntaxNode.ToFullString());
+            Assert.Equal("class C\r\n{\r\n    int? P\r\n    {\r\n    }\r\n}", syntaxNode.ToFullString());
         }
 
         [Fact]
@@ -507,13 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 .NormalizeWhitespace();
 
             // no space between DateTime and ?
-            Assert.Equal(
-@"class C
-{
-    DateTime? P
-    {
-    }
-}", syntaxNode.ToFullString());
+            Assert.Equal("class C\r\n{\r\n    DateTime? P\r\n    {\r\n    }\r\n}", syntaxNode.ToFullString());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -518,5 +518,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // space between DateTime and ?
             Assert.Equal("x is DateTime ? y : z", syntaxNode2.ToFullString());
         }
+
+        [Fact]
+        [WorkItem(21231, "https://github.com/dotnet/roslyn/issues/21231")]
+        public void TestSpacingOnCoalescing()
+        {
+            var syntaxNode = SyntaxFactory.ParseExpression("x is int??y").NormalizeWhitespace();
+            Assert.Equal("x is int ?? y", syntaxNode.ToFullString());
+
+            var syntaxNode2 = SyntaxFactory.ParseExpression("x is DateTime??y").NormalizeWhitespace();
+            Assert.Equal("x is DateTime ?? y", syntaxNode2.ToFullString());
+
+            var syntaxNode3 = SyntaxFactory.ParseExpression("x is object??y").NormalizeWhitespace();
+            Assert.Equal("x is object ?? y", syntaxNode3.ToFullString());
+        }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/SyntaxTreeExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -52,6 +53,54 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public static SyntaxTree WithRemoveFirst(this SyntaxTree syntaxTree, string oldText)
         {
             return WithReplaceFirst(syntaxTree, oldText, string.Empty);
+        }
+
+        internal static string Dump(this SyntaxNode node)
+        {
+            var visitor = new CSharpSyntaxPrinter();
+            visitor.Visit(node);
+            return visitor.Dump();
+        }
+
+        internal static string Dump(this SyntaxTree tree)
+        {
+            return tree.GetRoot().Dump();
+        }
+
+        private class CSharpSyntaxPrinter : CSharpSyntaxWalker
+        {
+            PooledStringBuilder builder;
+            int indent = 0;
+
+            internal CSharpSyntaxPrinter()
+            {
+                builder = PooledStringBuilder.GetInstance();
+            }
+
+            internal string Dump()
+            {
+                return builder.ToStringAndFree();
+            }
+
+            public override void DefaultVisit(SyntaxNode node)
+            {
+                builder.Builder.Append(' ', repeatCount: indent);
+                builder.Builder.Append(node.Kind().ToString());
+                if (node.IsMissing)
+                {
+                    builder.Builder.Append(" (missing)");
+                }
+                else if (node is IdentifierNameSyntax name)
+                {
+                    builder.Builder.Append(" ");
+                    builder.Builder.Append(name.ToString());
+                }
+                builder.Builder.AppendLine();
+
+                indent += 2;
+                base.DefaultVisit(node);
+                indent -= 2;
+            }
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -22,6 +22,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         End Sub
 
         <Fact>
+        Public Sub TestSpacingOnNullableDatetimeType()
+            Dim node =
+                SyntaxFactory.CompilationUnit().WithMembers(
+                    SyntaxFactory.List(Of Syntax.StatementSyntax)(
+                    {
+                        SyntaxFactory.ClassBlock(SyntaxFactory.ClassStatement("C")).WithMembers(
+                            SyntaxFactory.List(Of Syntax.StatementSyntax)(
+                            {
+                                SyntaxFactory.PropertyStatement("P").WithAsClause(
+                                    SyntaxFactory.SimpleAsClause(
+                                        SyntaxFactory.NullableType(
+                                            SyntaxFactory.PredefinedType(
+                                                SyntaxFactory.Token(SyntaxKind.IntegerKeyword)))))
+                            }))
+                    })).NormalizeWhitespace()
+
+            Dim expected = "Class C" & vbCrLf & vbCrLf & "    Property P As Integer?" & vbCrLf & "End Class" & vbCrLf
+            Assert.Equal(expected, node.ToFullString())
+        End Sub
+
+        <Fact>
         <WorkItem(720708, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/720708")>
         Public Sub TestLiteralDefaultStringValues()
 


### PR DESCRIPTION
**Customer scenario**

Write an analyzer that modifies syntax and makes a nullable type, and calls `NormalizeWhitespace` API. For `int?`, it introduces a space (`int ?`).

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/21231

**Risk**
**Performance impact**
Low. The method that determines whether a separator is needed between two tokens now has an extra check (among many)

**Is this a regression from a previous update?**
No.

**How was the bug found?**
Customer.

**Test documentation updated?**
Not applicable.