### PR TITLE
ReplaceNode loses parse options

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -486,47 +486,47 @@ namespace Microsoft.CodeAnalysis.CSharp
             IEnumerable<SyntaxTrivia> trivia = null,
             Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
         {
-            return SyntaxReplacer.Replace(this, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.Replace(this, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceNodeInListCore(SyntaxNode originalNode, IEnumerable<SyntaxNode> replacementNodes)
         {
-            return SyntaxReplacer.ReplaceNodeInList(this, originalNode, replacementNodes).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.ReplaceNodeInList(this, originalNode, replacementNodes).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertNodesInListCore(SyntaxNode nodeInList, IEnumerable<SyntaxNode> nodesToInsert, bool insertBefore)
         {
-            return SyntaxReplacer.InsertNodeInList(this, nodeInList, nodesToInsert, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.InsertNodeInList(this, nodeInList, nodesToInsert, insertBefore).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceTokenInListCore(SyntaxToken originalToken, IEnumerable<SyntaxToken> newTokens)
         {
-            return SyntaxReplacer.ReplaceTokenInList(this, originalToken, newTokens).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.ReplaceTokenInList(this, originalToken, newTokens).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertTokensInListCore(SyntaxToken originalToken, IEnumerable<SyntaxToken> newTokens, bool insertBefore)
         {
-            return SyntaxReplacer.InsertTokenInList(this, originalToken, newTokens, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.InsertTokenInList(this, originalToken, newTokens, insertBefore).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceTriviaInListCore(SyntaxTrivia originalTrivia, IEnumerable<SyntaxTrivia> newTrivia)
         {
-            return SyntaxReplacer.ReplaceTriviaInList(this, originalTrivia, newTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.ReplaceTriviaInList(this, originalTrivia, newTrivia).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertTriviaInListCore(SyntaxTrivia originalTrivia, IEnumerable<SyntaxTrivia> newTrivia, bool insertBefore)
         {
-            return SyntaxReplacer.InsertTriviaInList(this, originalTrivia, newTrivia, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxReplacer.InsertTriviaInList(this, originalTrivia, newTrivia, insertBefore).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode RemoveNodesCore(IEnumerable<SyntaxNode> nodes, SyntaxRemoveOptions options)
         {
-            return SyntaxNodeRemover.RemoveNodes(this, nodes.Cast<CSharpSyntaxNode>(), options).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxNodeRemover.RemoveNodes(this, nodes.Cast<CSharpSyntaxNode>(), options).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode NormalizeWhitespaceCore(string indentation, string eol, bool elasticTrivia)
         {
-            return SyntaxNormalizer.Normalize(this, indentation, eol, elasticTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
+            return SyntaxNormalizer.Normalize(this, indentation, eol, elasticTrivia).AsRootOfNewTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected override bool IsEquivalentToCore(SyntaxNode node, bool topLevel = false)

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -38,19 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
-        //TODO: move to common
-        /// <summary>
-        /// Creates a clone of a red node that can be used as a root of given syntaxTree.
-        /// New node has no parents, position == 0, and syntaxTree as specified.
-        /// </summary>
-        internal static T CloneNodeAsRoot<T>(T node, SyntaxTree syntaxTree) where T : SyntaxNode
-        {
-            var clone = (T)node.Green.CreateRed(null, 0);
-            clone._syntaxTree = syntaxTree;
-
-            return clone;
-        }
-
         /// <summary>
         /// Returns a non-null <see cref="SyntaxTree"/> that owns this node.
         /// If this node was created with an explicit non-null <see cref="SyntaxTree"/>, returns that tree.
@@ -499,47 +486,47 @@ namespace Microsoft.CodeAnalysis.CSharp
             IEnumerable<SyntaxTrivia> trivia = null,
             Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
         {
-            return SyntaxReplacer.Replace(this, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia);
+            return SyntaxReplacer.Replace(this, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceNodeInListCore(SyntaxNode originalNode, IEnumerable<SyntaxNode> replacementNodes)
         {
-            return SyntaxReplacer.ReplaceNodeInList(this, originalNode, replacementNodes);
+            return SyntaxReplacer.ReplaceNodeInList(this, originalNode, replacementNodes).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertNodesInListCore(SyntaxNode nodeInList, IEnumerable<SyntaxNode> nodesToInsert, bool insertBefore)
         {
-            return SyntaxReplacer.InsertNodeInList(this, nodeInList, nodesToInsert, insertBefore);
+            return SyntaxReplacer.InsertNodeInList(this, nodeInList, nodesToInsert, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceTokenInListCore(SyntaxToken originalToken, IEnumerable<SyntaxToken> newTokens)
         {
-            return SyntaxReplacer.ReplaceTokenInList(this, originalToken, newTokens);
+            return SyntaxReplacer.ReplaceTokenInList(this, originalToken, newTokens).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertTokensInListCore(SyntaxToken originalToken, IEnumerable<SyntaxToken> newTokens, bool insertBefore)
         {
-            return SyntaxReplacer.InsertTokenInList(this, originalToken, newTokens, insertBefore);
+            return SyntaxReplacer.InsertTokenInList(this, originalToken, newTokens, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode ReplaceTriviaInListCore(SyntaxTrivia originalTrivia, IEnumerable<SyntaxTrivia> newTrivia)
         {
-            return SyntaxReplacer.ReplaceTriviaInList(this, originalTrivia, newTrivia);
+            return SyntaxReplacer.ReplaceTriviaInList(this, originalTrivia, newTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode InsertTriviaInListCore(SyntaxTrivia originalTrivia, IEnumerable<SyntaxTrivia> newTrivia, bool insertBefore)
         {
-            return SyntaxReplacer.InsertTriviaInList(this, originalTrivia, newTrivia, insertBefore);
+            return SyntaxReplacer.InsertTriviaInList(this, originalTrivia, newTrivia, insertBefore).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode RemoveNodesCore(IEnumerable<SyntaxNode> nodes, SyntaxRemoveOptions options)
         {
-            return SyntaxNodeRemover.RemoveNodes(this, nodes.Cast<CSharpSyntaxNode>(), options);
+            return SyntaxNodeRemover.RemoveNodes(this, nodes.Cast<CSharpSyntaxNode>(), options).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected internal override SyntaxNode NormalizeWhitespaceCore(string indentation, string eol, bool elasticTrivia)
         {
-            return SyntaxNormalizer.Normalize(this, indentation, eol, elasticTrivia);
+            return SyntaxNormalizer.Normalize(this, indentation, eol, elasticTrivia).InTreeWithOptionsFrom(this.SyntaxTree);
         }
 
         protected override bool IsEquivalentToCore(SyntaxNode node, bool topLevel = false)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxReplacer.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1482,5 +1482,17 @@ namespace Microsoft.CodeAnalysis
             return new Syntax.InternalSyntax.SyntaxDiagnosticInfoList(this.Green).Any(
                 info => info.Severity == DiagnosticSeverity.Error);
         }
+
+        /// <summary>
+        /// Creates a clone of a red node that can be used as a root of given syntaxTree.
+        /// New node has no parents, position == 0, and syntaxTree as specified.
+        /// </summary>
+        internal static T CloneNodeAsRoot<T>(T node, SyntaxTree syntaxTree) where T : SyntaxNode
+        {
+            var clone = (T)node.Green.CreateRed(null, 0);
+            clone._syntaxTree = syntaxTree;
+
+            return clone;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -423,5 +423,13 @@ namespace Microsoft.CodeAnalysis
         {
             return node.WithTrailingTrivia((IEnumerable<SyntaxTrivia>)trivia);
         }
+
+        /// <summary>
+        /// Attaches the node to a SyntaxTree that the same options as <paramref name="oldTree"/>
+        /// </summary>
+        internal static SyntaxNode InTreeWithOptionsFrom(this SyntaxNode node, SyntaxTree oldTree)
+        {
+            return oldTree.WithRootAndOptions(node, oldTree.Options).GetRoot();
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Attaches the node to a SyntaxTree that the same options as <paramref name="oldTree"/>
         /// </summary>
-        internal static SyntaxNode InTreeWithOptionsFrom(this SyntaxNode node, SyntaxTree oldTree)
+        internal static SyntaxNode AsRootOfNewTreeWithOptionsFrom(this SyntaxNode node, SyntaxTree oldTree)
         {
             return oldTree.WithRootAndOptions(node, oldTree.Options).GetRoot();
         }

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -40,17 +40,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         ''' <summary>
-        ''' Creates a clone of a red node that can be used as a root of given syntaxTree.
-        ''' New node has no parents, position == 0, and syntaxTree as specified.
-        ''' </summary>
-        Friend Shared Function CloneNodeAsRoot(Of T As VisualBasicSyntaxNode)(node As T, syntaxTree As SyntaxTree) As T
-            Dim clone = DirectCast(node.Green.CreateRed(Nothing, 0), T)
-            clone._syntaxTree = syntaxTree
-
-            Return clone
-        End Function
-
-        ''' <summary>
         ''' Returns a non-null SyntaxTree that owns this node.
         ''' If this node was created with an explicit non-null SyntaxTree, returns that tree.
         ''' Otherwise, if this node has a non-null parent, then returns the parent's SyntaxTree.
@@ -416,39 +405,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional computeReplacementToken As Func(Of SyntaxToken, SyntaxToken, SyntaxToken) = Nothing,
             Optional trivia As IEnumerable(Of SyntaxTrivia) = Nothing,
             Optional computeReplacementTrivia As Func(Of SyntaxTrivia, SyntaxTrivia, SyntaxTrivia) = Nothing) As SyntaxNode
-            Return SyntaxReplacer.Replace(Me, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia)
+
+            Return SyntaxReplacer.Replace(Me, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function RemoveNodesCore(nodes As IEnumerable(Of SyntaxNode), options As SyntaxRemoveOptions) As SyntaxNode
-            Return SyntaxNodeRemover.RemoveNodes(Me, nodes, options)
+            Return SyntaxNodeRemover.RemoveNodes(Me, nodes, options).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceNodeInListCore(originalNode As SyntaxNode, replacementNodes As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceNodeInList(Me, originalNode, replacementNodes)
+            Return SyntaxReplacer.ReplaceNodeInList(Me, originalNode, replacementNodes).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertNodesInListCore(nodeInList As SyntaxNode, nodesToInsert As IEnumerable(Of SyntaxNode), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertNodeInList(Me, nodeInList, nodesToInsert, insertBefore)
+            Return SyntaxReplacer.InsertNodeInList(Me, nodeInList, nodesToInsert, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceTokenInListCore(originalToken As SyntaxToken, newTokens As IEnumerable(Of SyntaxToken)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceTokenInList(Me, originalToken, newTokens)
+            Return SyntaxReplacer.ReplaceTokenInList(Me, originalToken, newTokens).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertTokensInListCore(originalToken As SyntaxToken, newTokens As IEnumerable(Of SyntaxToken), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertTokenInList(Me, originalToken, newTokens, insertBefore)
+            Return SyntaxReplacer.InsertTokenInList(Me, originalToken, newTokens, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceTriviaInListCore(originalTrivia As SyntaxTrivia, newTrivia As IEnumerable(Of SyntaxTrivia)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceTriviaInList(Me, originalTrivia, newTrivia)
+            Return SyntaxReplacer.ReplaceTriviaInList(Me, originalTrivia, newTrivia).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertTriviaInListCore(originalTrivia As SyntaxTrivia, newTrivia As IEnumerable(Of SyntaxTrivia), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertTriviaInList(Me, originalTrivia, newTrivia, insertBefore)
+            Return SyntaxReplacer.InsertTriviaInList(Me, originalTrivia, newTrivia, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function NormalizeWhitespaceCore(indentation As String, eol As String, elasticTrivia As Boolean) As SyntaxNode
-            Return SyntaxNormalizer.Normalize(Me, indentation, eol, elasticTrivia, useDefaultCasing:=False)
+            Return SyntaxNormalizer.Normalize(Me, indentation, eol, elasticTrivia, useDefaultCasing:=False).InTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 #End Region
 

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -406,39 +406,39 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional trivia As IEnumerable(Of SyntaxTrivia) = Nothing,
             Optional computeReplacementTrivia As Func(Of SyntaxTrivia, SyntaxTrivia, SyntaxTrivia) = Nothing) As SyntaxNode
 
-            Return SyntaxReplacer.Replace(Me, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.Replace(Me, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function RemoveNodesCore(nodes As IEnumerable(Of SyntaxNode), options As SyntaxRemoveOptions) As SyntaxNode
-            Return SyntaxNodeRemover.RemoveNodes(Me, nodes, options).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxNodeRemover.RemoveNodes(Me, nodes, options).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceNodeInListCore(originalNode As SyntaxNode, replacementNodes As IEnumerable(Of SyntaxNode)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceNodeInList(Me, originalNode, replacementNodes).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.ReplaceNodeInList(Me, originalNode, replacementNodes).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertNodesInListCore(nodeInList As SyntaxNode, nodesToInsert As IEnumerable(Of SyntaxNode), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertNodeInList(Me, nodeInList, nodesToInsert, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.InsertNodeInList(Me, nodeInList, nodesToInsert, insertBefore).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceTokenInListCore(originalToken As SyntaxToken, newTokens As IEnumerable(Of SyntaxToken)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceTokenInList(Me, originalToken, newTokens).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.ReplaceTokenInList(Me, originalToken, newTokens).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertTokensInListCore(originalToken As SyntaxToken, newTokens As IEnumerable(Of SyntaxToken), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertTokenInList(Me, originalToken, newTokens, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.InsertTokenInList(Me, originalToken, newTokens, insertBefore).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function ReplaceTriviaInListCore(originalTrivia As SyntaxTrivia, newTrivia As IEnumerable(Of SyntaxTrivia)) As SyntaxNode
-            Return SyntaxReplacer.ReplaceTriviaInList(Me, originalTrivia, newTrivia).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.ReplaceTriviaInList(Me, originalTrivia, newTrivia).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function InsertTriviaInListCore(originalTrivia As SyntaxTrivia, newTrivia As IEnumerable(Of SyntaxTrivia), insertBefore As Boolean) As SyntaxNode
-            Return SyntaxReplacer.InsertTriviaInList(Me, originalTrivia, newTrivia, insertBefore).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxReplacer.InsertTriviaInList(Me, originalTrivia, newTrivia, insertBefore).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 
         Protected Overrides Function NormalizeWhitespaceCore(indentation As String, eol As String, elasticTrivia As Boolean) As SyntaxNode
-            Return SyntaxNormalizer.Normalize(Me, indentation, eol, elasticTrivia, useDefaultCasing:=False).InTreeWithOptionsFrom(Me.SyntaxTree)
+            Return SyntaxNormalizer.Normalize(Me, indentation, eol, elasticTrivia, useDefaultCasing:=False).AsRootOfNewTreeWithOptionsFrom(Me.SyntaxTree)
         End Function
 #End Region
 

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.RecoverableSyntaxTree.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxTreeFactoryService.RecoverableSyntaxTree.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Return Me
                     End If
 
-                    Return Create(DirectCast(root, CompilationUnitSyntax), Me.Options, _info.FilePath)
+                    Return Create(DirectCast(root, VisualBasicSyntaxNode), Me.Options, _info.FilePath)
                 End Function
 
                 Public Overrides Function WithFilePath(path As String) As SyntaxTree


### PR DESCRIPTION
**Customer scenario**

Call `ReplaceNode` on a syntax node, then get the `SyntaxTree` property on the resulting new node. You get back a brand new syntax tree, which does not have the parse options of the tree the original node belonged to.
I'm adding a test to capture this scenario.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/19741


From discussion with Neal, there are other public APIs with a similar problem (`RemoveNode`, `RemoveNodes`, another overload of `ReplaceNode`, ` InsertNodesBefore`, ` InsertNodesAfter` and possibly others). They should all be fixed, but we're concerned whether that could have an impact on the IDE experience, so we'd rather not chance it for 15.5.