### PR TITLE
Not poisoning restricted types known to be stack only.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1131,7 +1131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //     we will not emit Obsolete even if Deprecated or Experimental was used.
                 //     we do not want to get into a scenario where different kinds of deprecation are combined together.
                 //
-                if (obsoleteData == null)
+                if (obsoleteData == null && !this.IsRestrictedType(ignoreSpanLikeTypes:true))
                 {
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
                         ImmutableArray.Create(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -374,7 +374,7 @@ public class C1
         }
 
         [Fact()]
-        public void NoTypedRefBox2()
+        public void NoTypedRefBox_RefStruct()
         {
             var source1 =
 @"namespace System
@@ -392,6 +392,7 @@ public class C1
         public ObsoleteAttribute(string message, bool error){}
     }
 
+    // Make the type ref struct. Should work just fine.
     public ref struct TypedReference { }
 }";
             var compilation1 = CreateCompilation(source1, assemblyName: GetUniqueName());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -373,6 +373,56 @@ public class C1
 );
         }
 
+        [Fact()]
+        public void NoTypedRefBox2()
+        {
+            var source1 =
+@"namespace System
+{
+    public class Object { }
+    public class String { }
+    public struct Void { }
+    public class ValueType { }
+    public struct Int32 { }
+    public struct Boolean { }
+    public struct Decimal { }
+    public class Attribute{ }
+    public class ObsoleteAttribute: Attribute
+    {
+        public ObsoleteAttribute(string message, bool error){}
+    }
+
+    public ref struct TypedReference { }
+}";
+            var compilation1 = CreateCompilation(source1, assemblyName: GetUniqueName());
+            var reference1 = MetadataReference.CreateFromStream(compilation1.EmitToStream());
+            var source2 =
+@"    
+public class C1
+{
+    public static object rrr;
+
+    public static T Read<T>() where T : new()
+    {
+        T result = new T();
+        var refresult = __makeref(result);
+        rrr = refresult;
+        rrr = (object)__makeref(result);
+        return result;
+    }
+}
+";
+            var compilation2 = CreateCompilation(source2, new[] { reference1 });
+            compilation2.VerifyDiagnostics(
+    // (10,15): error CS0029: Cannot implicitly convert type 'System.TypedReference' to 'object'
+    //         rrr = refresult;
+    Diagnostic(ErrorCode.ERR_NoImplicitConv, "refresult").WithArguments("System.TypedReference", "object").WithLocation(10, 15),
+    // (11,15): error CS0030: Cannot convert type 'System.TypedReference' to 'object'
+    //         rrr = (object)__makeref(result);
+    Diagnostic(ErrorCode.ERR_NoExplicitConv, "(object)__makeref(result)").WithArguments("System.TypedReference", "object").WithLocation(11, 15)
+);
+        }
+
         [WorkItem(530861, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530861")]
         [Fact]
         public void MissingStringLengthForEach()


### PR DESCRIPTION
Not poisoning restricted types known to be stack only. (as per ECMA 335)

- TypedReference
- ArgIterator
- RuntimeArgumentHandle

Fixes:#22198

===
There are technical reasons for which making RestrictedTypes ref structs is advantageous. In fact it is already done in some cases - see example: https://github.com/dotnet/corert/blob/f23fb52ce14fa680bcebc07eab9a20fa8780e47f/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/Platform.cs#L71

We do not need to poison these types with Obsolete attribute when `ref struct` syntax is used. The stack-only semantics of these types is widely known and poisoning can only lead to compat troubles.
