### PR TITLE
Modify CharacterInfo.BeginsBaseLiteral.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -257,7 +257,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function BeginsBaseLiteral(c As Char) As Boolean
             Return (c = "H"c Or c = "O"c Or c = "B"c Or c = "h"c Or c = "o"c Or c = "b"c) OrElse
-                    (IsFullWidth(c) AndAlso (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_O Or c = FULLWIDTH_LATIN_CAPITAL_LETTER_B))
+                    (IsFullWidth(c) AndAlso (BeginsBaseLiteral_Hex(c) OrElse BeginsBaseLiteral_Oct(c) OrElse BeginsBaseLiteral_Bin(c)))
+        End Function
+
+        Private Shared Function BeginsBaseLiteral_Hex(c As Char) As Boolean
+            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H
+        End Function
+
+        Private Shared Function BeginsBaseLiteral_Oct(c As Char) As Boolean
+            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O
+        End Function
+
+        Private Shared Function BeginsBaseLiteral_Bin(c As Char) As Boolean
+            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B
         End Function
 
         Private Shared ReadOnly s_isIDChar As Boolean() =

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -257,18 +257,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function BeginsBaseLiteral(c As Char) As Boolean
             Return (c = "H"c Or c = "O"c Or c = "B"c Or c = "h"c Or c = "o"c Or c = "b"c) OrElse
-                    (IsFullWidth(c) AndAlso (BeginsBaseLiteral_Hex(c) OrElse BeginsBaseLiteral_Oct(c) OrElse BeginsBaseLiteral_Bin(c)))
+                    (IsFullWidth(c) AndAlso FullwidthCharacter_BeginsBaseLiteral(c))
         End Function
 
-        Private Shared Function BeginsBaseLiteral_Hex(c As Char) As Boolean
+        Private Shared Function FullwidthCharacter_BeginsBaseLiteral(c As Char) As Boolean
+            Debug.Assert(IsFullWidth(c), NameOf(FullwidthCharacter_BeginsBaseLiteral) & " should only be called with Fullwidth Characters.")
+            Return FullwidthCharacter_BeginsBaseLiteral_Hex(c) OrElse
+                   FullwidthCharacter_BeginsBaseLiteral_Oct(c) OrElse
+                   FullwidthCharacter_BeginsBaseLiteral_Bin(c)
+        End Function
+
+        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Hex(c As Char) As Boolean
             Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H
         End Function
 
-        Private Shared Function BeginsBaseLiteral_Oct(c As Char) As Boolean
+        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Oct(c As Char) As Boolean
             Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O
         End Function
 
-        Private Shared Function BeginsBaseLiteral_Bin(c As Char) As Boolean
+        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Bin(c As Char) As Boolean
             Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -257,14 +257,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function BeginsBaseLiteral(c As Char) As Boolean
             Return (c = "H"c Or c = "O"c Or c = "B"c Or c = "h"c Or c = "o"c Or c = "b"c) OrElse
-                    (IsFullWidth(c) AndAlso FullwidthCharacter_BeginsBaseLiteral(c))
+                    (IsFullWidth(c) AndAlso (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H) Or
+                                            (c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O) Or
+                                            (c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B))
         End Function
 
-        Private Shared Function FullwidthCharacter_BeginsBaseLiteral(c As Char) As Boolean
-            Return (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H) Or
-                   (c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O) Or
-                   (c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B)
-        End Function
 
         Private Shared ReadOnly s_isIDChar As Boolean() =
         {

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -262,21 +262,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared Function FullwidthCharacter_BeginsBaseLiteral(c As Char) As Boolean
             Debug.Assert(IsFullWidth(c), NameOf(FullwidthCharacter_BeginsBaseLiteral) & " should only be called with Fullwidth Characters.")
-            Return FullwidthCharacter_BeginsBaseLiteral_Hex(c) OrElse
-                   FullwidthCharacter_BeginsBaseLiteral_Oct(c) OrElse
-                   FullwidthCharacter_BeginsBaseLiteral_Bin(c)
-        End Function
-
-        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Hex(c As Char) As Boolean
-            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H
-        End Function
-
-        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Oct(c As Char) As Boolean
-            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O
-        End Function
-
-        Private Shared Function FullwidthCharacter_BeginsBaseLiteral_Bin(c As Char) As Boolean
-            Return c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B
+            Return (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H) Or
+                   (c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O) Or
+                   (c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B)
         End Function
 
         Private Shared ReadOnly s_isIDChar As Boolean() =

--- a/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb
@@ -261,7 +261,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function FullwidthCharacter_BeginsBaseLiteral(c As Char) As Boolean
-            Debug.Assert(IsFullWidth(c), NameOf(FullwidthCharacter_BeginsBaseLiteral) & " should only be called with Fullwidth Characters.")
             Return (c = FULLWIDTH_LATIN_CAPITAL_LETTER_H Or c = FULLWIDTH_LATIN_SMALL_LETTER_H) Or
                    (c = FULLWIDTH_LATIN_CAPITAL_LETTER_O Or c = FULLWIDTH_LATIN_SMALL_LETTER_O) Or
                    (c = FULLWIDTH_LATIN_CAPITAL_LETTER_B Or c = FULLWIDTH_LATIN_SMALL_LETTER_B)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -94,11 +94,28 @@ Public Class ParseExpressionTest
 
 #Region "Literal Test"
 
-
-    <Fact>
-    Public Sub ParseIntegerLiteralTest()
+    <Fact, Trait("IntegerLiteral_Prefix", "Hex")>
+    Private Sub ParseIntegerLiteralTest_HexPrefix()
         ParseExpression("&H1")
+        ParseExpression("&h1")
+        ParseExpression("&Ｈ1")
+        ParseExpression("&ｈ1")
+    End Sub
+
+    <Fact, Trait("IntegerLiteral_Prefix", "Oct")>
+    Private Sub ParseIntegerLiteralTest_OctPrefix()
         ParseExpression("&O1")
+        ParseExpression("&o1")
+        ParseExpression("&Ｏ1")
+        ParseExpression("&ｏ1")
+    End Sub
+
+    <Fact, Trait("IntegerLiteral_Prefix", "Bin")>
+    Private Sub ParseIntegerLiteralTest_BinPrefix()
+        ParseExpression("&B1")
+        ParseExpression("&b1")
+        ParseExpression("&Ｂ1")
+        ParseExpression("&ｂ1")
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -95,7 +95,7 @@ Public Class ParseExpressionTest
 #Region "Literal Test"
 
     <Fact, Trait("IntegerLiteral_Prefix", "Hex")>
-    Private Sub ParseIntegerLiteralTest_HexPrefix()
+    Public Sub ParseIntegerLiteralTest_HexPrefix()
         ParseExpression("&H1")
         ParseExpression("&h1")
         ParseExpression("&Ｈ1")
@@ -103,7 +103,7 @@ Public Class ParseExpressionTest
     End Sub
 
     <Fact, Trait("IntegerLiteral_Prefix", "Oct")>
-    Private Sub ParseIntegerLiteralTest_OctPrefix()
+    Public Sub ParseIntegerLiteralTest_OctPrefix()
         ParseExpression("&O1")
         ParseExpression("&o1")
         ParseExpression("&Ｏ1")
@@ -111,7 +111,7 @@ Public Class ParseExpressionTest
     End Sub
 
     <Fact, Trait("IntegerLiteral_Prefix", "Bin")>
-    Private Sub ParseIntegerLiteralTest_BinPrefix()
+    Public Sub ParseIntegerLiteralTest_BinPrefix()
         ParseExpression("&B1")
         ParseExpression("&b1")
         ParseExpression("&Ｂ1")


### PR DESCRIPTION
Correcting a possible copy and paste error, should be `FULLWIDTH_LATIN_SMALL_LETTER_B`.
Small refactoring to give better chance of Jit in-lining in the common case especially, but both methods now have the chance.

**Customer scenario**
The customer type a boolean literal base integer value. 
eg
```vbnet
 &b1 ' where the B is Fullwidth_Latin_Small_B
```
This would fail to compile.

**Bugs this fixes:**
In `CharacterInfo.BeginsBaseLiteral` the expression checks against `FULLWIDTH_LATIN_CAPITAL_B` twice.
[Link to Source](https://github.com/dotnet/roslyn/blob/master/src/Compilers/VisualBasic/Portable/Scanner/CharacterInfo.vb#L260)

**Workarounds, if any**
Using the Capital or the HalfWidth instance

**Risk**

`Low` change of constant used in comparision.

**Performance impact**
'NoiseLevel - Tiny`  change of constant. Refactored out the comparision into separate methods.
Those methods are tiny so highly likely to be jit-inlined. Rare parsng path.

**Is this a regression from a previous update?**

**Root cause analysis:**
External Contributor happened to be viewing that section of the codebase in their branch.

> How did we miss it?  What tests are we adding to guard against it in the future?
Likely copy paste mistake. I've extended the unit tests to cover the full range of allowed characters.

**How was the bug found?** `ad hoc testing`

**Test documentation updated?** - Yes
