### PR TITLE
AddParameterCodeFixProvider: Add support for method invocations.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -584,5 +584,91 @@ class D
     }
 }");
         }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationInstanceMethod1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    void M1()
+    {
+    }
+    void M2()
+    {
+        int i=0;
+        [|M1|](i);
+    }
+}
+",
+@"
+class C
+{
+    void M1(int i)
+    {
+    }
+    void M2()
+    {
+        int i=0;
+        M1(i);
+    }
+}
+");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationInheritedMethodGetFixed()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class Base
+{
+    protected void M1()
+    {
+    }
+}
+class C1 : Base
+{
+    void M2()
+    {
+        int i = 0;
+        [|M1|](i);
+    }
+}",
+@"
+class Base
+{
+    protected void M1(int i)
+    {
+    }
+}
+class C1 : Base
+{
+    void M2()
+    {
+        int i = 0;
+        M1(i);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationInheritedMethodInMetadatGetsNotFixed()
+        {
+            await TestMissingAsync(
+    @"
+class C1
+{
+    void M2()
+    {
+        int i = 0;
+        [|GetHashCode|](i);
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -1003,7 +1003,7 @@ class C1
         M1(1, 2);
     }
 }";
-                using (var workspace = CreateWorkspaceFromOptions(code, default))
+            using (var workspace = CreateWorkspaceFromOptions(code, default))
             {
                 var actions = await GetCodeActionsAsync(workspace, default);
                 Assert.True(actions.Length == 1);

--- a/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddParameter/AddParameterTests.cs
@@ -670,5 +670,345 @@ class C1
     }
 }");
         }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationLocalFunction()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C1
+{
+    void M1()
+    {
+        int Local() => 1;
+        [|Local|](2);
+    }
+}",
+@"
+class C1
+{
+    void M1()
+    {
+        int Local(int v) => 1;
+        Local(2);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationLambda1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+class C1
+{
+    void M1()
+    {
+        Action a = () => { };
+        [|a|](2);
+    }
+}",
+@"
+using System;
+class C1
+{
+    void M1()
+    {
+        Action a = (int v) => { };
+        a(2);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationStaticMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C1
+{
+    static void M1()
+    {
+    }
+    void M2()
+    {
+        [|M1|](1);
+    }
+}",
+@"
+class C1
+{
+    static void M1(int v)
+    {
+    }
+    void M2()
+    {
+        M1(1);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationExtensionMethod()
+        {
+            await TestAsync(
+@"
+static class Extensions
+{
+    public static void ExtensionM1(this object o)
+    {
+    }
+}
+class C1
+{
+    void M1()
+    {
+        new object().[|ExtensionM1|](1);
+    }
+}",
+@"
+static class Extensions
+{
+    public static void ExtensionM1(this object o, int v)
+    {
+    }
+}
+class C1
+{
+    void M1()
+    {
+        new object().ExtensionM1(1);
+    }
+}", null);
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationOverride()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class Base
+{
+    protected virtual void M1() { }
+}
+class C1 : Base
+{
+    protected override void M1() { }
+    void M2()
+    {
+        [|M1|](1);
+    }
+}",
+@"
+class Base
+{
+    protected virtual void M1() { }
+}
+class C1 : Base
+{
+    protected override void M1(int v) { }
+    void M2()
+    {
+        M1(1);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationExplicitInterface()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+interface I1
+{
+    void M1();
+}
+class C1 : I1
+{
+    void I1.M1() { }
+    void M2()
+    {
+        ((I1)this).[|M1|](1);
+    }
+}",
+@"
+interface I1
+{
+    void M1(int v);
+}
+class C1 : I1
+{
+    void I1.M1() { }
+    void M2()
+    {
+        ((I1)this).M1(1);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationImplicitInterface()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+interface I1
+{
+    void M1();
+}
+class C1 : I1
+{
+    public void M1() { }
+    void M2()
+    {
+        [|M1|](1);
+    }
+}",
+@"
+interface I1
+{
+    void M1();
+}
+class C1 : I1
+{
+    public void M1(int v) { }
+    void M2()
+    {
+        M1(1);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationGenericMethod()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C1
+{
+    void M1<T>(T arg) { }
+    void M2()
+    {
+        [|M1|](1, 2);
+    }
+}",
+@"
+class C1
+{
+    void M1<T>(int v, T arg) { }
+    void M2()
+    {
+        M1(1, 2);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationRecursion()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C1
+{
+    void M1()
+    {
+        [|M1|](1);
+    }
+}",
+@"
+class C1
+{
+    void M1(int v)
+    {
+        M1(1);
+    }
+}");
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationOverloads1()
+        {
+            var code =
+@"
+class C1
+{
+    void M1(string s) { }
+    void M1(int i) { }
+    void M2()
+    {
+        [|M1|](1, 2);
+    }
+}";
+            var fix0 =
+@"
+class C1
+{
+    void M1(string s) { }
+    void M1(int i, int v) { }
+    void M2()
+    {
+        M1(1, 2);
+    }
+}";
+            var fix1 =
+@"
+class C1
+{
+    void M1(int v, string s) { }
+    void M1(int i) { }
+    void M2()
+    {
+        M1(1, 2);
+    }
+}";
+            await TestInRegularAndScriptAsync(code, fix0, 0);
+            await TestInRegularAndScriptAsync(code, fix1, 1);
+        }
+
+        [WorkItem(21446, "https://github.com/dotnet/roslyn/issues/21446")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)]
+        public async Task TestInvocationOverloads2()
+        {
+            var code =
+@"
+class C1
+{
+    void M1(string s1, string s2) { }
+    void M1(string s) { }
+    void M1(int i) { }
+    void M2()
+    {
+        M1(1, [|2|]);
+    }
+}";
+            var fix0 =
+@"
+class C1
+{
+    void M1(string s1, string s2) { }
+    void M1(string s) { }
+    void M1(int i, int v) { }
+    void M2()
+    {
+        M1(1, 2);
+    }
+}";
+                using (var workspace = CreateWorkspaceFromOptions(code, default))
+            {
+                var actions = await GetCodeActionsAsync(workspace, default);
+                Assert.True(actions.Length == 1);
+            }
+            await TestInRegularAndScriptAsync(code, fix0, 0);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -3,8 +3,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using Microsoft.CodeAnalysis.AddParameter;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod;
 using Microsoft.CodeAnalysis.CSharp.GenerateConstructor;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -20,8 +22,11 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
         InvocationExpressionSyntax,
         ObjectCreationExpressionSyntax>
     {
-        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            GenerateConstructorDiagnosticIds.AllDiagnosticIds;
+        private static readonly ImmutableArray<string> AddParameterFixableDiagnosticIds =
+            GenerateConstructorDiagnosticIds.AllDiagnosticIds.Union(
+            GenerateMethodDiagnosticIds.FixableDiagnosticIds).ToImmutableArray();
+
+        public override ImmutableArray<string> FixableDiagnosticIds => AddParameterFixableDiagnosticIds;
 
         protected override ImmutableArray<string> TooManyArgumentsDiagnosticIds { get; } =
             GenerateConstructorDiagnosticIds.TooManyArgumentsDiagnosticIds;

--- a/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddParameter/CSharpAddParameterCodeFixProvider.cs
@@ -24,7 +24,9 @@ namespace Microsoft.CodeAnalysis.CSharp.AddParameter
     {
         private static readonly ImmutableArray<string> AddParameterFixableDiagnosticIds =
             GenerateConstructorDiagnosticIds.AllDiagnosticIds.Union(
-            GenerateMethodDiagnosticIds.FixableDiagnosticIds).ToImmutableArray();
+            GenerateMethodDiagnosticIds.FixableDiagnosticIds).Union(
+            Enumerable.Repeat("CS1593", 1)). // C# Delegate 'Action' does not take 1 arguments
+            ToImmutableArray();
 
         public override ImmutableArray<string> FixableDiagnosticIds => AddParameterFixableDiagnosticIds;
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2666,6 +2666,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return ((DestructorDeclarationSyntax)declaration).WithParameterList(list);
                 case SyntaxKind.IndexerDeclaration:
                     return ((IndexerDeclarationSyntax)declaration).WithParameterList(list);
+                case SyntaxKind.LocalFunctionStatement:
+                    return ((LocalFunctionStatementSyntax)declaration).WithParameterList((ParameterListSyntax)list);
                 case SyntaxKind.ParenthesizedLambdaExpression:
                     return ((ParenthesizedLambdaExpressionSyntax)declaration).WithParameterList((ParameterListSyntax)list);
                 case SyntaxKind.SimpleLambdaExpression:
@@ -3158,9 +3160,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-#endregion
+        #endregion
 
-#region Remove, Replace, Insert
+        #region Remove, Replace, Insert
 
         public override SyntaxNode ReplaceNode(SyntaxNode root, SyntaxNode declaration, SyntaxNode newDeclaration)
         {
@@ -3497,9 +3499,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override bool IsRegularOrDocComment(SyntaxTrivia trivia)
             => trivia.IsRegularOrDocComment();
 
-#endregion
+        #endregion
 
-#region Statements and Expressions
+        #region Statements and Expressions
 
         public override SyntaxNode AddEventHandler(SyntaxNode @event, SyntaxNode handler)
         {
@@ -4187,6 +4189,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         public override SyntaxNode TupleExpression(IEnumerable<SyntaxNode> arguments)
             => SyntaxFactory.TupleExpression(SyntaxFactory.SeparatedList(arguments.Select(AsArgument)));
 
-#endregion
+        #endregion
     }
 }


### PR DESCRIPTION
**Customer scenario**

Fixes #21446.
Follow up to #17082.

This PR is an initial attempt to expand the `AddPrarameterCodefixProvider` to also support method invocations.
This PR is for review only as there are many open questions for the different invocation kinds. I tried to come up with as few code changes as possible (The github diff looks bigger than what actually changed. Most code parts are just moved to new methods to be reusable.) and unit tests for lots of those invocation kinds to see what is already working and what needs to be fixed.

**Bugs this fixes:**

Fixes #21446.
Follow up to #17082.

**Workarounds, if any**

None.

**Risk**

Code refactoring might break user code.

**Performance impact**

Low. The analyzer is already shipped and this only increases the number of supported diagnostics.

**Is this a regression from a previous update?**

#17082 intentionally left method invocation out, because of the lots of complicated cases.

**Root cause analysis:**

Was intended for future improvement.

**How was the bug found?**

Customer reported. #21446

**Test documentation updated?**

No.