### PR TITLE
Avoid scheduling an unnecessary dispose task for EmptyAsyncToken

### DIFF
--- a/src/Features/Core/Portable/Shared/TestHooks/IAsyncToken.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/IAsyncToken.cs
@@ -18,6 +18,8 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
 
         public void Dispose()
         {
+            // Empty by design requirement: operations which use IAsyncToken are free to optimize code sequences by
+            // eliding calls to EmptyAsyncToken.Dispose() with the understanding that it doesn't do anything.
         }
     }
 }

--- a/src/Features/Core/Portable/Shared/TestHooks/TaskExtensions.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/TaskExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
 
         public static Task CompletesTrackingOperation(this Task task, IDisposable token)
         {
-            if (token == null)
+            if (token == null || token == EmptyAsyncToken.Instance)
             {
                 return task;
             }


### PR DESCRIPTION
Fixes #22272

**Customer scenario**

Long sequences of asynchronous operations can be scheduled (#22274), which is a problematic condition further exacerbated by the scheduling of a separate call to an empty `Dispose` method.

**Bugs this fixes:**

#22272

**Workarounds, if any**

None

**Risk**

Very low. Avoids scheduling an asynchronous call to an empty non-virtual method.

**Performance impact**

Improves performance by eliminating an asynchronous operation.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Found during manual analysis of heaps provided by "low memory" events.

**How was the bug found?**

Manual inspection of heap dumps.

**Test documentation updated?**

N/A
