### PR TITLE
Quote variable/array expansions in shell scripts

### DIFF
--- a/build/linux/setup-pcl.sh
+++ b/build/linux/setup-pcl.sh
@@ -6,7 +6,7 @@ usage()
 	echo "setup-pcl.sh <path-to-mono-install>" 
 }
 
-XBUILD_FRAMEWORKS=$1/lib/mono/xbuild-frameworks
+XBUILD_FRAMEWORKS="$1"/lib/mono/xbuild-frameworks
 if [ ! -d "$XBUILD_FRAMEWORKS" ]; then
 	echo "$XBUILD_FRAMEWORKS does not exist"
 	usage
@@ -14,7 +14,7 @@ if [ ! -d "$XBUILD_FRAMEWORKS" ]; then
 fi
 
 PCL_NAME=PortableReferenceAssemblies-2014-04-14
-PCL_TARGET=$XBUILD_FRAMEWORKS/.NETPortable
+PCL_TARGET="$XBUILD_FRAMEWORKS"/.NETPortable
 
 # Now to install the PCL on the snapshot 
 pushd /tmp 
@@ -28,9 +28,9 @@ if [ ! -d "/tmp/$PCL_NAME" ]; then
 fi
 
 echo "Installing to $PCL_TARGET"
-mkdir $PCL_TARGET
-cp -r /tmp/$PCL_NAME/* $PCL_TARGET
+mkdir "$PCL_TARGET"
+cp -r /tmp/"$PCL_NAME"/* "$PCL_TARGET"
 
-rm -rf /tmp/$PCL_NAME
+rm -rf /tmp/"$PCL_NAME"
 rm /tmp/pcl.zip
 

--- a/build/linux/setup-snapshot.sh
+++ b/build/linux/setup-snapshot.sh
@@ -19,4 +19,4 @@ if [ ! -d "$MONO_PREFIX" ]; then
 fi
 
 # Now install the PCL assemblies on the snapshot
-source setup-pcl $MONO_PREFIX
+source setup-pcl "$MONO_PREFIX"

--- a/build/scripts/build-utils.sh
+++ b/build/scripts/build-utils.sh
@@ -14,10 +14,10 @@ get_repo_dir()
 # specified version file.
 get_version_core()
 {
-    local name=${1/./}
-    local name=${name/-/}
-    local version=$(awk -F'[<>]' "/<${name}Version>/{print \$3}" $2)
-    echo $version
+    local name="${1/./}"
+    local name="${name/-/}"
+    local version="$(awk -F'[<>]' "/<${name}Version>/{print \$3}" "$2")"
+    echo "$version"
 }
 
 # This function will give you the current version number for a given nuget package
@@ -28,16 +28,16 @@ get_version_core()
 #   get_package_version System.Console
 get_package_version() 
 {
-    local repoDir=$(get_repo_dir)
-    local version=$(get_version_core $1 ${repoDir}/build/Targets/Packages.props)
-    echo $version
+    local repoDir="$(get_repo_dir)"
+    local version="$(get_version_core "$1" "${repoDir}"/build/Targets/Packages.props)"
+    echo "$version"
 }
 
 get_tool_version() 
 {
-    local repoDir=$(get_repo_dir)
-    local version=$(get_version_core $1 ${repoDir}/build/Targets/Tools.props)
-    echo $version
+    local repoDir="$(get_repo_dir)"
+    local version="$(get_version_core "$1" "${repoDir}"/build/Targets/Tools.props)"
+    echo "$version"
 }
 
 

--- a/build/scripts/crossgen.sh
+++ b/build/scripts/crossgen.sh
@@ -8,10 +8,10 @@
 
 set -e
 
-BIN_DIR="$( cd $1 && pwd )"
+BIN_DIR="$( cd "$1" && pwd )"
 CONTAINING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-UNAME=`uname`
+UNAME="$(uname)"
 
 if [ -z "$RID" ]; then
     if [ "$UNAME" == "Darwin" ]; then
@@ -24,29 +24,29 @@ if [ -z "$RID" ]; then
     fi
 fi
 
-DEPENDENCIES=$CONTAINING_DIR/../Targets/Dependencies.props
-CORECLR_VERSION="$(grep -o '<MicrosoftNETCoreRuntimeCoreCLRVersion>.*</MicrosoftNETCoreRuntimeCoreCLRVersion>' $DEPENDENCIES | sed 's/ *<\/*MicrosoftNETCoreRuntimeCoreCLRVersion> *//g')"
+DEPENDENCIES="$CONTAINING_DIR"/../Targets/Dependencies.props
+CORECLR_VERSION="$(grep -o '<MicrosoftNETCoreRuntimeCoreCLRVersion>.*</MicrosoftNETCoreRuntimeCoreCLRVersion>' "$DEPENDENCIES" | sed 's/ *<\/*MicrosoftNETCoreRuntimeCoreCLRVersion> *//g')"
 
-CROSSGEN_UTIL=~/.nuget/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/$CORECLR_VERSION/tools/crossgen
+CROSSGEN_UTIL=~/.nuget/packages/runtime."$RID".Microsoft.NETCore.Runtime.CoreCLR/"$CORECLR_VERSION"/tools/crossgen
 
-cd $BIN_DIR
+cd "$BIN_DIR"
 
 # Crossgen currently requires itself to be next to mscorlib
-cp $CROSSGEN_UTIL $BIN_DIR
+cp "$CROSSGEN_UTIL" "$BIN_DIR"
 chmod +x crossgen
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR mscorlib.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" mscorlib.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Collections.Immutable.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" System.Collections.Immutable.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" System.Reflection.Metadata.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" Microsoft.CodeAnalysis.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" Microsoft.CodeAnalysis.CSharp.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" Microsoft.CodeAnalysis.VisualBasic.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR csc.exe
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" csc.exe
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR vbc.exe
+./crossgen -nologo -platform_assemblies_paths "$BIN_DIR" vbc.exe

--- a/build/scripts/obtain_dotnet.sh
+++ b/build/scripts/obtain_dotnet.sh
@@ -21,11 +21,11 @@ fi
 # This is a function to keep variable assignments out of the parent script (that is sourcing this file)
 install_dotnet () {
     # Download and install `dotnet` locally
-    local THIS_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-    source ${THIS_DIR}/build-utils.sh
+    local THIS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "${THIS_DIR}"/build-utils.sh
 
-    local DOTNET_VERSION=$(get_tool_version dotnetSdk)
-    local DOTNET_PATH=${THIS_DIR}/../../Binaries/dotnet-cli
+    local DOTNET_VERSION="$(get_tool_version dotnetSdk)"
+    local DOTNET_PATH="${THIS_DIR}"/../../Binaries/dotnet-cli
 
     if [[ ! -x "${DOTNET_PATH}/dotnet" ]]
     then
@@ -36,6 +36,6 @@ install_dotnet () {
         echo "Skipping download of .NET CLI: Already installed at ${DOTNET_PATH}"
     fi
 
-    export PATH=${DOTNET_PATH}:${PATH}
+    export PATH="${DOTNET_PATH}:${PATH}"
 }
 install_dotnet

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # Workaround, see https://github.com/dotnet/roslyn/issues/10210
-export HOME=$(cd ~ && pwd)
+export HOME="$(cd ~ && pwd)"
 
 echo "Restoring toolset packages"
 
-dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/BaseToolset.csproj
+dotnet restore -v Minimal --disable-parallel "$(pwd)"/build/ToolsetPackages/BaseToolset.csproj
 
 echo "Restore CrossPlatform.sln"
 
-dotnet restore $(pwd)/CrossPlatform.sln
+dotnet restore "$(pwd)"/CrossPlatform.sln

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -7,18 +7,18 @@ set -u
 
 build_configuration=${1:-Debug}
 
-this_dir=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-source ${this_dir}/build-utils.sh
+this_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${this_dir}"/build-utils.sh
 
-root_path=$(get_repo_dir)
-binaries_path=${root_path}/Binaries
-unittest_dir=${binaries_path}/${build_configuration}/UnitTests
-log_dir=${binaries_path}/${build_configuration}/xUnitResults
-nuget_dir=${HOME}/.nuget/packages
-runtime_id=$(dotnet --info | awk '/RID:/{print $2;}')
+root_path="$(get_repo_dir)"
+binaries_path="${root_path}"/Binaries
+unittest_dir="${binaries_path}"/"${build_configuration}"/UnitTests
+log_dir="${binaries_path}"/"${build_configuration}"/xUnitResults
+nuget_dir="${HOME}"/.nuget/packages
+runtime_id="$(dotnet --info | awk '/RID:/{print $2;}')"
 target_framework=netcoreapp2.0
-xunit_console_version=$(get_package_version dotnet-xunit)
-xunit_console=${nuget_dir}/dotnet-xunit/${xunit_console_version}/tools/${target_framework}/xunit.console.dll
+xunit_console_version="$(get_package_version dotnet-xunit)"
+xunit_console="${nuget_dir}"/dotnet-xunit/"${xunit_console_version}"/tools/"${target_framework}"/xunit.console.dll
 
 echo "Using ${xunit_console}"
 
@@ -27,29 +27,29 @@ need_publish=(
     'src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj'
 )
 
-for project in $need_publish
+for project in "${need_publish[@]}"
 do
     echo "Publishing ${project}"
-    dotnet publish --no-restore ${root_path}/${project} -r ${runtime_id} -f ${target_framework} -p:SelfContained=true
+    dotnet publish --no-restore "${root_path}"/"${project}" -r "${runtime_id}" -f "${target_framework}" -p:SelfContained=true
 done
 
 # Discover and run the tests
 mkdir -p "${log_dir}"
 
-for test_path in ${unittest_dir}/*/${target_framework}
+for test_path in "${unittest_dir}"/*/"${target_framework}"
 do
-    publish_test_path=${test_path}/${runtime_id}/publish
-    if [ -d ${publish_test_path} ]
+    publish_test_path="${test_path}"/"${runtime_id}"/publish
+    if [ -d "${publish_test_path}" ]
     then
-        test_path=${publish_test_path}
+        test_path="${publish_test_path}"
     fi
 
-    file_name=( ${test_path}/*.UnitTests.dll )
-    log_file="${log_dir}/$(basename "${file_name%.*}.xml")"
-    deps_json="${file_name%.*}.deps.json"
-    runtimeconfig_json="${file_name%.*}.runtimeconfig.json"
-    echo "Running ${file_name}"
-    dotnet exec --depsfile "${deps_json}" --runtimeconfig "${runtimeconfig_json}" ${xunit_console} "$file_name" -xml "${log_file}"
+    file_name=( "${test_path}"/*.UnitTests.dll )
+    log_file="${log_dir}"/"$(basename "${file_name%.*}.xml")"
+    deps_json="${file_name%.*}".deps.json
+    runtimeconfig_json="${file_name%.*}".runtimeconfig.json
+    echo Running "${file_name[@]}"
+    dotnet exec --depsfile "${deps_json}" --runtimeconfig "${runtimeconfig_json}" "${xunit_console}" "${file_name[@]}" -xml "${log_file}"
     if [[ $? -ne 0 ]]; then
         echo Unit test failed
         exit 1

--- a/build/scripts/unzip.sh
+++ b/build/scripts/unzip.sh
@@ -3,7 +3,7 @@
 # Unzip reports a warning that zip contains backslashes and returns exit code 1 
 # even though everything is good. Ignore exit code 1.
 
-unzip -nq $1 -d $2
+unzip -nq "$1" -d "$2"
 EC=$?
 if [ $EC -eq 1 ]
   then exit 0

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -114,9 +114,9 @@ BUILD_ARGS="--no-restore -c ${BUILD_CONFIGURATION} /nologo /consoleloggerparamet
 PUBLISH_ARGS="-f ${TARGET_FRAMEWORK} -r ${RUNTIME_ID} ${BUILD_ARGS}"
 
 echo "Building bootstrap csc"
-dotnet publish "${SRC_PATH}"/Compilers/CSharp/csc -o "${BOOTSTRAP_PATH}"/csc "${PUBLISH_ARGS}"
+dotnet publish "${SRC_PATH}"/Compilers/CSharp/csc -o "${BOOTSTRAP_PATH}"/csc ${PUBLISH_ARGS}
 echo "Building bootstrap vbc"
-dotnet publish "${SRC_PATH}"/Compilers/VisualBasic/vbc -o "${BOOTSTRAP_PATH}"/vbc "${PUBLISH_ARGS}"
+dotnet publish "${SRC_PATH}"/Compilers/VisualBasic/vbc -o "${BOOTSTRAP_PATH}"/vbc ${PUBLISH_ARGS}
 rm -rf "${BINARIES_PATH:?}"/"${BUILD_CONFIGURATION}"
 BUILD_ARGS+=" /p:CscToolPath=${BOOTSTRAP_PATH}/csc /p:CscToolExe=csc /p:VbcToolPath=${BOOTSTRAP_PATH}/vbc /p:VbcToolExe=vbc"
 

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -104,11 +104,11 @@ echo "Using Runtime Identifier: ${RUNTIME_ID}"
 
 RESTORE_ARGS="-r ${RUNTIME_ID} -v Minimal --disable-parallel"
 echo "Restoring BaseToolset.csproj"
-dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/build/ToolsetPackages/BaseToolset.csproj
+dotnet restore ${RESTORE_ARGS} "${ROOT_PATH}"/build/ToolsetPackages/BaseToolset.csproj
 echo "Restoring CoreToolset.csproj"
-dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/build/ToolsetPackages/CoreToolset.csproj
+dotnet restore ${RESTORE_ARGS} "${ROOT_PATH}"/build/ToolsetPackages/CoreToolset.csproj
 echo "Restoring CrossPlatform.sln"
-dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/CrossPlatform.sln
+dotnet restore ${RESTORE_ARGS} "${ROOT_PATH}"/CrossPlatform.sln
 
 BUILD_ARGS="--no-restore -c ${BUILD_CONFIGURATION} /nologo /consoleloggerparameters:Verbosity=minimal;summary /bl:${BUILD_LOG_PATH} /maxcpucount:1"
 PUBLISH_ARGS="-f ${TARGET_FRAMEWORK} -r ${RUNTIME_ID} ${BUILD_ARGS}"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -18,13 +18,13 @@ usage()
     echo "  --skipcommitprinting  Do not print commit information"
 }
 
-THIS_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-source ${THIS_DIR}/build/scripts/build-utils.sh
-ROOT_PATH=$(get_repo_dir)
-BINARIES_PATH=${ROOT_PATH}/Binaries
-BOOTSTRAP_PATH=${BINARIES_PATH}/Bootstrap
-SRC_PATH=${ROOT_PATH}/src
-BUILD_LOG_PATH=${BINARIES_PATH}/Build.binlog
+THIS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${THIS_DIR}"/build/scripts/build-utils.sh
+ROOT_PATH="$(get_repo_dir)"
+BINARIES_PATH="${ROOT_PATH}"/Binaries
+BOOTSTRAP_PATH="${BINARIES_PATH}"/Bootstrap
+SRC_PATH="${ROOT_PATH}"/src
+BUILD_LOG_PATH="${BINARIES_PATH}"/Build.binlog
 TARGET_FRAMEWORK=netcoreapp2.0
 
 BUILD_CONFIGURATION=Debug
@@ -33,17 +33,17 @@ SKIP_TESTS=false
 SKIP_COMMIT_PRINTING=false
 
 # $HOME is unset when running the mac unit tests.
-if [[ -z ${HOME+x} ]]
+if [[ -z "${HOME+x}" ]]
 then
     # Note that while ~ usually refers to $HOME, in the case where $HOME is unset,
     # it looks up the current user's home dir, which is what we want.
     # https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
-    export HOME=$(cd ~ && pwd)
+    export HOME="$(cd ~ && pwd)"
 fi
 
 # LTTNG is the logging infrastructure used by coreclr.  Need this variable set 
 # so it doesn't output warnings to the console.
-export LTTNG_HOME=$HOME
+export LTTNG_HOME="$HOME"
 
 # There's no reason to send telemetry or prime a local package cach when building
 # in CI.
@@ -52,8 +52,8 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 while [[ $# > 0 ]]
 do
-    opt="$(echo $1 | awk '{print tolower($0)}')"
-    case $opt in
+    opt="$(echo "$1" | awk '{print tolower($0)}')"
+    case "$opt" in
         -h|--help)
         usage
         exit 1
@@ -97,34 +97,34 @@ fi
 
 # obtain_dotnet.sh puts the right dotnet on the PATH
 FORCE_DOWNLOAD=true
-source ${ROOT_PATH}/build/scripts/obtain_dotnet.sh
+source "${ROOT_PATH}"/build/scripts/obtain_dotnet.sh
 
-RUNTIME_ID=$(dotnet --info | awk '/RID:/{print $2;}')
+RUNTIME_ID="$(dotnet --info | awk '/RID:/{print $2;}')"
 echo "Using Runtime Identifier: ${RUNTIME_ID}"
 
 RESTORE_ARGS="-r ${RUNTIME_ID} -v Minimal --disable-parallel"
 echo "Restoring BaseToolset.csproj"
-dotnet restore ${RESTORE_ARGS} ${ROOT_PATH}/build/ToolsetPackages/BaseToolset.csproj
+dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/build/ToolsetPackages/BaseToolset.csproj
 echo "Restoring CoreToolset.csproj"
-dotnet restore ${RESTORE_ARGS} ${ROOT_PATH}/build/ToolsetPackages/CoreToolset.csproj
+dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/build/ToolsetPackages/CoreToolset.csproj
 echo "Restoring CrossPlatform.sln"
-dotnet restore ${RESTORE_ARGS} ${ROOT_PATH}/CrossPlatform.sln
+dotnet restore "${RESTORE_ARGS}" "${ROOT_PATH}"/CrossPlatform.sln
 
 BUILD_ARGS="--no-restore -c ${BUILD_CONFIGURATION} /nologo /consoleloggerparameters:Verbosity=minimal;summary /bl:${BUILD_LOG_PATH} /maxcpucount:1"
 PUBLISH_ARGS="-f ${TARGET_FRAMEWORK} -r ${RUNTIME_ID} ${BUILD_ARGS}"
 
 echo "Building bootstrap csc"
-dotnet publish ${SRC_PATH}/Compilers/CSharp/csc -o ${BOOTSTRAP_PATH}/csc ${PUBLISH_ARGS}
+dotnet publish "${SRC_PATH}"/Compilers/CSharp/csc -o "${BOOTSTRAP_PATH}"/csc "${PUBLISH_ARGS}"
 echo "Building bootstrap vbc"
-dotnet publish ${SRC_PATH}/Compilers/VisualBasic/vbc -o ${BOOTSTRAP_PATH}/vbc ${PUBLISH_ARGS}
-rm -rf ${BINARIES_PATH}/${BUILD_CONFIGURATION}
+dotnet publish "${SRC_PATH}"/Compilers/VisualBasic/vbc -o "${BOOTSTRAP_PATH}"/vbc "${PUBLISH_ARGS}"
+rm -rf "${BINARIES_PATH:?}"/"${BUILD_CONFIGURATION}"
 BUILD_ARGS+=" /p:CscToolPath=${BOOTSTRAP_PATH}/csc /p:CscToolExe=csc /p:VbcToolPath=${BOOTSTRAP_PATH}/vbc /p:VbcToolExe=vbc"
 
 echo "Building CrossPlatform.sln"
-dotnet build ${ROOT_PATH}/CrossPlatform.sln ${BUILD_ARGS}
+dotnet build "${ROOT_PATH}"/CrossPlatform.sln ${BUILD_ARGS}
 
 if [[ "${SKIP_TESTS}" == false ]]
 then
     echo "Running tests"
-    ${ROOT_PATH}/build/scripts/tests.sh ${BUILD_CONFIGURATION}
+    "${ROOT_PATH}"/build/scripts/tests.sh "${BUILD_CONFIGURATION}"
 fi


### PR DESCRIPTION
Lack of quoting causes issues when files have spaces or are empty names.
Additionally, some arrays (though single elements) were treated like
simple variables.

The careful reader will note that I have left BUILD_ARGS

`dotnet build "${ROOT_PATH}"/CrossPlatform.sln ${BUILD_ARGS}`

untouched, because it contains spaces meant to separate arguments. Word
expansion is somewhat desired there (I believe) to ensure the arguments
are properly parsed. Unfortunately, BUILD_ARGS may contains paths with
spaces in them, causing this to still fail.

Fix #22259

**Customer scenario**

Try to build roslyn in a path with spaces and fail.

**Bugs this fixes:**

#22259 

**Workarounds, if any**

Don't use a path with spaces.

**Risk**

I'm very wary of this particular change, as it *likely* won't break anything currently (no paths with spaces) but is hard to guarantee for paths with spaces (we don't have test coverage).
As this is my first real contribution, I may have inadvertently quoted something I shouldn't have.

**Performance impact**

Low: these are shell scripts anyways, and the extra quotes should require negligible time compared to the scripts.

**Is this a regression from a previous update?**

I don't think so.

**Root cause analysis:**

We still don't have test coverage (although it appears there has been some discussion on getting some #20929), so I'm not sure we can 100% verify this yet. This is a known issue.

**How was the bug found?**

I tried to build roslyn in a directory whose full name contained spaces.