### PR TITLE
Add an option to disable name suggestions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -207,9 +207,9 @@ public class C
     void Goo(StringBuilder $$) {}
 }
 ";
-            await VerifyItemExistsAsync(markup, "stringBuilder", glyph: (int) Glyph.Parameter);
-            await VerifyItemExistsAsync(markup, "@string", glyph: (int) Glyph.Parameter);
-            await VerifyItemExistsAsync(markup, "builder", glyph: (int) Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "stringBuilder", glyph: (int)Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "@string", glyph: (int)Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "builder", glyph: (int)Glyph.Parameter);
         }
 
         [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
@@ -223,7 +223,7 @@ public class C
     void Goo(For $$) {}
 }
 ";
-            await VerifyItemExistsAsync(markup, "@for", glyph: (int) Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "@for", glyph: (int)Glyph.Parameter);
         }
 
         [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
@@ -625,6 +625,31 @@ class Test
 }
 ";
             await VerifyItemExistsAsync(markup, "test");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void DisabledByOption()
+        {
+            var workspace = WorkspaceFixture.GetWorkspace();
+            var originalOptions = WorkspaceFixture.GetWorkspace().Options;
+            try
+            {
+                workspace.Options = originalOptions.
+                    WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false);
+
+                var markup = @"
+class Test
+{
+    Test $$
+}
+";
+                await VerifyNoItemsExistAsync(markup);
+            }
+            finally
+            {
+                workspace.Options = originalOptions;
+            }
+
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var cancellationToken = completionContext.CancellationToken;
             var semanticModel = await document.GetSemanticModelForSpanAsync(new Text.TextSpan(position, 0), cancellationToken).ConfigureAwait(false);
 
+            if (!completionContext.Options.GetOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp))
+            {
+                return;
+            }
+
             var context = CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken);
             if (context.IsInNonUserCode)
             {

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -37,6 +37,10 @@ namespace Microsoft.CodeAnalysis.Completion
             nameof(CompletionOptions), nameof(BlockForCompletionItems), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{BlockForCompletionItems}"));
 
+        public static readonly PerLanguageOption<bool> ShowNameSuggestions =
+            new PerLanguageOption<bool>(nameof(CompletionOptions), nameof(ShowNameSuggestions), defaultValue: true,
+            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions"));
+
         public static IEnumerable<PerLanguageOption<bool>> GetDev15CompletionOptions()
         {
             yield return ShowCompletionItemFilters;

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -1150,6 +1150,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show name s_uggestions.
+        /// </summary>
+        internal static string Show_name_suggestions {
+            get {
+                return ResourceManager.GetString("Show_name_suggestions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show preview for rename _tracking.
         /// </summary>
         internal static string Show_preview_for_rename_tracking {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -528,4 +528,7 @@
   <data name="Separate_using_directive_groups" xml:space="preserve">
     <value>Separate using directive groups</value>
   </data>
+  <data name="Show_name_suggestions" xml:space="preserve">
+    <value>Show name s_uggestions</value>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -60,6 +60,10 @@
                                           x:Name="Always_add_new_line_on_enter"
                                           Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Always_add_new_line_on_enter}"/>
                     </StackPanel>
+
+                    <CheckBox x:Uid="Show_name_suggestions"
+                                  x:Name="Show_name_suggestions"
+                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_name_suggestions}" />
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -29,6 +29,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Never_add_new_line_on_enter, CompletionOptions.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.CSharp);
             BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptions.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.CSharp);
             BindToOption(Always_add_new_line_on_enter, CompletionOptions.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
+
+            BindToOption(Show_name_suggestions, CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp);
         }
 
         private void Show_completion_list_after_a_character_is_typed_Checked(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
@@ -59,5 +59,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public static string Option_Include_snippets_when_question_Tab_is_typed_after_an_identifier =>
             CSharpVSResources.Include_snippets_when_Tab_is_typed_after_an_identifier;
+
+        public static string Option_Show_name_suggestions => 
+            CSharpVSResources.Show_name_suggestions;
     }
 }


### PR DESCRIPTION
Addresses the option request part of https://github.com/dotnet/roslyn/issues/22294. Does not prevent issues when snippets are active.