### PR TITLE
Add experimental support for running build.ps1 on linux

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -107,6 +107,11 @@ function Exec-Script([string]$script, [string]$scriptArgs = "") {
     Exec-Command "powershell" "-noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs"
 }
 
+# True if we are running on Linux or MacOS
+function Is-Unix() {
+    return $PSVersionTable.PSEdition -eq "Core" -and $PSVersionTable.Platform -eq "Unix"
+}
+
 # Ensure that NuGet is installed and return the path to the 
 # executable to use.
 function Ensure-NuGet() {
@@ -137,8 +142,7 @@ function Ensure-NuGet() {
 # SDK.
 function Ensure-SdkInPathAndData() { 
     $sdkVersion = Get-ToolVersion "dotnetSdk"
-
-    if ($PSVersionTable.Platform -eq "Unix") {
+    if (Is-Unix) {
         $dotnetName = "dotnet"
     }
     else {
@@ -180,7 +184,7 @@ function Ensure-SdkInPathAndData() {
         Create-Directory $cliDir
         Create-Directory $toolsDir
         $webClient = New-Object -TypeName "System.Net.WebClient"
-        if ($PSVersionTable.Platform -eq "Unix") {
+        if (Is-Unix) {
             $destFile = Join-Path $toolsDir "dotnet-install.sh"
             $webClient.DownloadFile("https://dot.net/v1/dotnet-install.sh", $destFile)
             # AppImage mucks with LD_LIBRARY_PATH and causes the install to fail
@@ -202,8 +206,8 @@ function Ensure-SdkInPathAndData() {
 
     ${env:PATH} = "$cliDir$pathSep${env:PATH}"
     $sdkPath = Join-Path $cliDir "sdk\$sdkVersion"
-    Write-Host $dotnetExe
-    Write-Host $sdkPath
+    Write-Output $dotnetExe
+    Write-Output $sdkPath
     return
 }
 
@@ -494,7 +498,7 @@ function Restore-Packages-Dotnet([string]$dotnet = "", [string]$project = "") {
 
 # Restore all of the projects that the repo consumes
 function Restore-All([string]$msbuildDir = "", [string]$dotnet = "") {
-    if ($PSVersionTable.Platform -eq "Unix") {
+    if (Is-Unix) {
         Restore-Packages-Dotnet -dotnet $dotnet
     }
     else {

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -138,11 +138,19 @@ function Ensure-NuGet() {
 function Ensure-SdkInPathAndData() { 
     $sdkVersion = Get-ToolVersion "dotnetSdk"
 
+    if ($PSVersionTable.Platform -eq "Unix") {
+        $dotnetName = "dotnet"
+    }
+    else {
+        $dotnetName = "dotnet.exe"
+    }
+    $pathSep = [IO.Path]::PathSeparator
+
     # Get the path to dotnet.exe. This is the first path on %PATH% that contains the 
     # dotnet.exe instance. Many SDK tools use this to locate items like the SDK.
     function Get-DotnetDir() { 
-        foreach ($part in ${env:PATH}.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)) {
-            $dotnetExe = Join-Path $part "dotnet.exe"
+        foreach ($part in ${env:PATH}.Split($pathSep, [System.StringSplitOptions]::RemoveEmptyEntries)) {
+            $dotnetExe = Join-Path $part $dotnetName
             if (Test-Path $dotnetExe) {
                 return $part
             }
@@ -156,7 +164,7 @@ function Ensure-SdkInPathAndData() {
     if ($dotnetDir -ne $null) { 
         $sdkPath = Join-Path $dotnetDir "sdk\$sdkVersion"
         if (Test-Path $sdkPath) {
-            Write-Output (Join-Path $dotnetDir "dotnet.exe")
+            Write-Output (Join-Path $dotnetDir $dotnetName)
             Write-Output $sdkPath
             return        
         }
@@ -166,18 +174,33 @@ function Ensure-SdkInPathAndData() {
     # Binaries\Tools directory
     $toolsDir = Join-Path $binariesDir "Tools"
     $cliDir = Join-Path $toolsDir "dotnet"
-    $dotnetExe = Join-Path $cliDir "dotnet.exe"
+    $dotnetExe = Join-Path $cliDir $dotnetName
     if (-not (Test-Path $dotnetExe)) { 
         Write-Host "Downloading CLI $sdkVersion"
         Create-Directory $cliDir
         Create-Directory $toolsDir
-        $destFile = Join-Path $toolsDir "dotnet-install.ps1"
         $webClient = New-Object -TypeName "System.Net.WebClient"
-        $webClient.DownloadFile("https://dot.net/v1/dotnet-install.ps1", $destFile)
-        Exec-Block { & $destFile -Version $sdkVersion -InstallDir $cliDir } | Out-Null
+        if ($PSVersionTable.Platform -eq "Unix") {
+            $destFile = Join-Path $toolsDir "dotnet-install.sh"
+            $webClient.DownloadFile("https://dot.net/v1/dotnet-install.sh", $destFile)
+            # AppImage mucks with LD_LIBRARY_PATH and causes the install to fail
+            $old_ld_path = $env:LD_LIBRARY_PATH
+            try {
+                $env:LD_LIBRARY_PATH = ""
+                Exec-Block { & bash $destFile -Version $sdkVersion -InstallDir $cliDir } | Out-Null
+            }
+            finally {
+                $env:LD_LIBRARY_PATH = $old_ld_path
+            }
+        }
+        else {
+            $destFile = Join-Path $toolsDir "dotnet-install.ps1"
+            $webClient.DownloadFile("https://dot.net/v1/dotnet-install.ps1", $destFile)
+            Exec-Block { & $destFile -Version $sdkVersion -InstallDir $cliDir } | Out-Null
+        }
     }
 
-    ${env:PATH} = "$cliDir;${env:PATH}"
+    ${env:PATH} = "$cliDir$pathSep${env:PATH}"
     $sdkPath = Join-Path $cliDir "sdk\$sdkVersion"
     Write-Host $dotnetExe
     Write-Host $sdkPath
@@ -280,7 +303,7 @@ function Get-PackagesDir() {
         $d = $env:NUGET_PACKAGES
     }
     else {
-        $d = Join-Path $env:UserProfile ".nuget\packages\"
+        $d = Join-Path $home ".nuget\packages\"
     }
 
     Create-Directory $d
@@ -443,7 +466,39 @@ function Restore-Packages([string]$msbuildDir = "", [string]$project = "") {
 }
 
 # Restore all of the projects that the repo consumes
-function Restore-All([string]$msbuildDir = "") {
-    Restore-Packages -msbuildDir $msbuildDir
+function Restore-Packages-Dotnet([string]$dotnet = "", [string]$project = "") {
+    if ($dotnet -eq "") {
+        $dotnet, $sdkDir = Ensure-SdkInPathAndData
+    }
+
+    Write-Host "Restore using dotnet at $dotnet"
+
+    if ($project -ne "") {
+        Write-Host "Restoring project $project"
+
+        Exec-Block { & $dotnet restore $project } | Write-Host
+    }
+    else {
+        $all = @(
+            "Base Toolset:build\ToolsetPackages\BaseToolset.csproj",
+            "CoreClr Toolset:build\ToolsetPackages\CoreToolset.csproj",
+            "CrossPlatform:CrossPlatform.sln")
+
+        foreach ($cur in $all) {
+            $both = $cur.Split(':')
+            Write-Host "Restoring $($both[0])"
+            Exec-Block { & $dotnet restore $both[1] } | Write-Host
+        }
+    }
+}
+
+# Restore all of the projects that the repo consumes
+function Restore-All([string]$msbuildDir = "", [string]$dotnet = "") {
+    if ($PSVersionTable.Platform -eq "Unix") {
+        Restore-Packages-Dotnet -dotnet $dotnet
+    }
+    else {
+        Restore-Packages -msbuildDir $msbuildDir
+    }
 }
 

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -327,6 +327,11 @@ function Get-PackageDir([string]$name, [string]$version = "") {
     return $p
 }
 
+# Return the RID of the provided dotnet executable
+function Get-DotnetRID([string]$dotnet) {
+    return (Exec-Block { & $dotnet "--info" } | Where-Object {$_.Contains("RID:")} | Foreach-Object {$_.Split(":")[1].Trim()} | Select-Object -Index 0)
+}
+
 # The intent of this script is to locate and return the path to the MSBuild directory that
 # we should use for bulid operations.  The preference order for MSBuild to use is as 
 # follows:

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -115,10 +115,6 @@ function Process-Arguments() {
 }
 
 function Run-MSBuild([string]$buildArgs = "", [string]$logFile = "", [switch]$parallel = $true) {
-    if (!$dotnet) {
-        $dotnet, $sdkDir = Ensure-SdkInPathAndData
-    }
-
     # MSBuildAdditionalCommandLineArgs=
     $args = "/p:TreatWarningsAsErrors=true /warnaserror /nologo /consoleloggerparameters:Verbosity=minimal;summary /p:Configuration=$buildConfiguration";
 
@@ -143,7 +139,7 @@ function Run-MSBuild([string]$buildArgs = "", [string]$logFile = "", [switch]$pa
     }
 
     $args += " $buildArgs"
-    if ($PSVersionTable.Platform -eq "Unix") {
+    if (Is-Unix) {
         $args = "--no-restore $args"
         $argsNoPublish = $args -replace "/t:Publish",""
         if ($args -eq $argsNoPublish) {
@@ -184,7 +180,7 @@ function Make-BootstrapBuild() {
 }
 
 function Build-Artifacts() { 
-    if ($PSVersionTable.Platform -eq "Unix") {
+    if (Is-Unix) {
         Run-MSBuild "CrossPlatform.sln"
     }
     else {
@@ -309,12 +305,8 @@ function Test-PerfRun() {
 }
 
 function Test-XUnitCoreClr() { 
-    if (!$dotnet) {
-        $dotnet, $sdkDir = Ensure-SdkInPathAndData
-    }
-
     $unitDir = Join-Path $configDir "UnitTests"
-    if ($PSVersionTable.Platform -eq "Unix") {
+    if (Is-Unix) {
         $runtimeIdentifier = "ubuntu.14.04-x64"
     }
     else {
@@ -575,7 +567,7 @@ try {
 
     Process-Arguments
 
-    if ($PSVersionTable.Platform -ne "Unix") {
+    if (!(Is-Unix)) {
         $msbuild, $msbuildDir = Ensure-MSBuildAndDir -msbuildDir $msbuildDir
     }
     $dotnet, $sdkDir = Ensure-SdkInPathAndData

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -307,7 +307,7 @@ function Test-PerfRun() {
 function Test-XUnitCoreClr() { 
     $unitDir = Join-Path $configDir "UnitTests"
     if (Is-Unix) {
-        $runtimeIdentifier = "ubuntu.14.04-x64"
+        $runtimeIdentifier = Get-DotnetRID $dotnet
     }
     else {
         $runtimeIdentifier = "win7-x64"

--- a/build/scripts/experimental_build.sh
+++ b/build/scripts/experimental_build.sh
@@ -6,15 +6,31 @@ set -e
 set -u
 
 ROOT_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-POWERSHELL_EXE=${ROOT_DIR}/Binaries/Tools/powershell.AppImage
-POWERSHELL_URL=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
+POWERSHELL_VERSION=6.0.0-beta.7
+POWERSHELL_APPIMAGE=${ROOT_DIR}/Binaries/Tools/PowerShell-${POWERSHELL_VERSION}-x86_64.AppImage
+POWERSHELL_EXE=${ROOT_DIR}/Binaries/Tools/powershell/squashfs-root/AppRun
+POWERSHELL_URL=https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/PowerShell-${POWERSHELL_VERSION}-x86_64.AppImage
 
 if [[ ! -x "${POWERSHELL_EXE}" ]]
 then
-    echo "Downloading ${POWERSHELL_URL} -> ${POWERSHELL_EXE}"
-    mkdir -p $(dirname "${POWERSHELL_EXE}")
-    curl -L "${POWERSHELL_URL}" -o "${POWERSHELL_EXE}"
-    chmod +x "${POWERSHELL_EXE}"
+    if [[ ! -x "${POWERSHELL_APPIMAGE}" ]]
+    then
+        echo "Downloading ${POWERSHELL_URL} -> ${POWERSHELL_APPIMAGE}"
+        mkdir -p $(dirname "${POWERSHELL_APPIMAGE}")
+        curl -L "${POWERSHELL_URL}" -o "${POWERSHELL_APPIMAGE}"
+        chmod +x "${POWERSHELL_APPIMAGE}"
+    fi
+
+    # The AppImage needs to be extracted (instead of directly run) because, on
+    # WSL, directly running it results in "kernel module 'fuse' not found".
+    EXTRACT_DIR=$(dirname $(dirname "${POWERSHELL_EXE}"))
+    EXTRACT_LOGFILE="${EXTRACT_DIR}/appimage_extract.log"
+    mkdir -p "${EXTRACT_DIR}"
+    echo "Extracting ${POWERSHELL_APPIMAGE} -> ${EXTRACT_DIR}"
+    # The powershell AppImage 6.0.0-beta.7 is broken - usr/bin fails to be
+    # created with "TODO: Implement inode.base.inode_type 8"
+    mkdir -p "${EXTRACT_DIR}/squashfs-root/usr/bin"
+    cd "${EXTRACT_DIR}" && "${POWERSHELL_APPIMAGE}" --appimage-extract > "${EXTRACT_LOGFILE}"
 fi
 
 if [[ $# -eq 0 ]]

--- a/build/scripts/experimental_build.sh
+++ b/build/scripts/experimental_build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set -e
+set -u
+
+ROOT_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+POWERSHELL_EXE=${ROOT_DIR}/Binaries/Tools/powershell.AppImage
+POWERSHELL_URL=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
+
+if [[ ! -x "${POWERSHELL_EXE}" ]]
+then
+    echo "Downloading ${POWERSHELL_URL} -> ${POWERSHELL_EXE}"
+    mkdir -p $(dirname "${POWERSHELL_EXE}")
+    curl -L "${POWERSHELL_URL}" -o "${POWERSHELL_EXE}"
+    chmod +x "${POWERSHELL_EXE}"
+fi
+
+if [[ $# -eq 0 ]]
+then
+    ${POWERSHELL_EXE} -noprofile -executionPolicy RemoteSigned -file "${ROOT_DIR}/build/scripts/build.ps1" -build
+else
+    ${POWERSHELL_EXE} -noprofile -executionPolicy RemoteSigned -file "${ROOT_DIR}/build/scripts/build.ps1" "$@"
+fi


### PR DESCRIPTION
Powershell is xplat and works on linux. Let's use it!

The reasoning here is that our Linux build story has diverged quite significantly from the Windows builds, and the tooling / how you interact with the repo is almost like working on an entirely different codebase. If we share all of the tooling code, then that problem will go away! 😊

Scenarios supported right now are `./build.sh -restore -build -testCoreClr` and subsets of those three flags.

(I have Mac planned as well, but there's no super easy appimage equivalent)

---

This is still very experimental, and shouldn't be used in CI yet. Once stable, the entry point, `build/scripts/experimental_build.sh` will just be in the root `./build.sh` (next to `build.cmd`). I would like to wait for @jaredpar to get back from vacation to merge this, as he touches this powershell code quite frequently

The changes needed to the ps1 scripts should be a no-op change for the Windows build, but that'll hopefully be validated in CI.