### PR TITLE
Fix analyzer execution using bootstrap compiler on Jenkins

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -49,6 +49,7 @@
     <MicrosoftNETTestSdkVersion>15.3.0</MicrosoftNETTestSdkVersion>
     <MicrosoftNetCompilersVersion>2.3.1</MicrosoftNetCompilersVersion>
     <MicrosoftNetRoslynDiagnosticsVersion>2.3.0-beta2-62118-03</MicrosoftNetRoslynDiagnosticsVersion>
+    <MicrosoftNetRoslynDiagnosticsVersionForBootstrapCompiler>2.5.0-beta1-62011-01</MicrosoftNetRoslynDiagnosticsVersionForBootstrapCompiler>
     <MicrosoftNetCoreILAsmVersion>2.0.0</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCoreCompilersVersion>2.3.1-beta1-61919-13</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCoreVersion>5.0.0</MicrosoftNETCoreVersion>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -15,9 +15,11 @@
     <VSIXExpInstallerPackageName>RoslynTools.Microsoft.VSIXExpInstaller</VSIXExpInstallerPackageName>
     <VSIXExpInstallerPackageVersion>0.2.1-beta</VSIXExpInstallerPackageVersion>
     <RoslynDiagnosticsNugetPackageVersion>$(MicrosoftNetRoslynDiagnosticsVersion)</RoslynDiagnosticsNugetPackageVersion>
+    <RoslynDiagnosticsNugetPackageVersion Condition="'$(BootstrapBuildPath)' != ''">$(MicrosoftNetRoslynDiagnosticsVersionForBootstrapCompiler)</RoslynDiagnosticsNugetPackageVersion>
     <!-- Disable analyzers if NuGet deviated from the expected restore location (e.g. by changing case on a case-sensitive file system) -->
     <UseRoslynAnalyzers Condition="!Exists('$(NuGetPackageRoot)\Microsoft.CodeQuality.Analyzers\$(RoslynDiagnosticsNugetPackageVersion)\analyzers\dotnet\cs\Analyzer.Utilities.dll')">False</UseRoslynAnalyzers>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)/microsoft.net.roslyndiagnostics/$(RoslynDiagnosticsNugetPackageVersion)/roslyn/Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
+    <RoslynDiagnosticsPropsFilePath Condition="'$(BootstrapBuildPath)' != ''">$(NuGetPackageRoot)/microsoft.net.roslyndiagnostics/$(RoslynDiagnosticsNugetPackageVersion)/build/Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <RoslynPortableTargetFrameworks>net461;netcoreapp2.0</RoslynPortableTargetFrameworks>
     <RoslynPortableTargetFrameworks46>net46;netcoreapp2.0</RoslynPortableTargetFrameworks46>
     <RoslynPortableRuntimeIdentifiers>win7;win7-x64</RoslynPortableRuntimeIdentifiers>

--- a/build/ToolsetPackages/BootstrapToolset.csproj
+++ b/build/ToolsetPackages/BootstrapToolset.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(MSBuildThisFileDirectory)..\Targets\Packages.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\Targets\FixedPackages.props" />
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersionForBootstrapCompiler)" />
+  </ItemGroup>
+</Project>

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -413,7 +413,7 @@ function Restore-Project([string]$fileName, [string]$nuget, [string]$msbuildDir)
 }
 
 # Restore all of the projects that the repo consumes
-function Restore-Packages([string]$msbuildDir = "", [string]$project = "") {
+function Restore-Packages([string]$msbuildDir = "", [string]$project = "", [string]$bootstrap = $false) {
     $nuget = Ensure-NuGet
     if ($msbuildDir -eq "") {
         $msbuildDir = Get-MSBuildDir
@@ -434,6 +434,10 @@ function Restore-Packages([string]$msbuildDir = "", [string]$project = "") {
             "Templates:src\Setup\Templates\Templates.sln",
             "DevDivInsertionFiles:src\Setup\DevDivInsertionFiles\DevDivInsertionFiles.sln")
 
+        if ($bootstrap) {
+            $all += "Bootstrap Toolset:build\ToolsetPackages\BootstrapToolset.csproj"
+        }
+
         foreach ($cur in $all) {
             $both = $cur.Split(':')
             Write-Host "Restoring $($both[0])"
@@ -443,7 +447,7 @@ function Restore-Packages([string]$msbuildDir = "", [string]$project = "") {
 }
 
 # Restore all of the projects that the repo consumes
-function Restore-All([string]$msbuildDir = "") {
-    Restore-Packages -msbuildDir $msbuildDir
+function Restore-All([string]$msbuildDir = "", [string]$bootstrap = $false) {
+    Restore-Packages -msbuildDir $msbuildDir -bootstrap $bootstrap
 }
 

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -568,7 +568,7 @@ try {
 
     if ($restore) { 
         Write-Host "Running restore"
-        Restore-All -msbuildDir $msbuildDir 
+        Restore-All -msbuildDir $msbuildDir -bootstrap $bootstrap
     }
 
     if ($bootstrap) {


### PR DESCRIPTION
Due to the fact that master is currently on 2.3 compiler and analyzer toolset, but the bootstrap compiler has latest IOperation API changes, we need to use the latest analyzer package based on new IOperation APIs when building with boostrap compiler.

This commit can be reverted once we move master to 2.6 compiler toolset. I will file a separate issue for this revert once I get PR approval.