### PR TITLE
Escape rules for deconstruction and foreach variables

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2536,7 +2536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (argument.Kind == BoundKind.OutDeconstructVarPendingInference)
                 {
                     TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
-                    arguments[arg] = ((OutDeconstructVarPendingInference)argument).SetInferredType(parameterType, success: true);
+                    arguments[arg] = ((OutDeconstructVarPendingInference)argument).SetInferredType(parameterType, this, success: true);
                 }
                 else if (argument.Kind == BoundKind.DiscardExpression && !argument.HasExpressionType())
                 {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -168,8 +168,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = !GetEnumeratorInfoAndInferCollectionElementType(ref builder, ref collectionExpr, diagnostics, out inferredType);
 
             ExpressionSyntax variables = ((ForEachVariableStatementSyntax)_syntax).Variable;
-            uint collectionEscape = GetValEscape(collectionExpr, this.LocalScopeDepth);
-            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, collectionEscape, inferredType ?? CreateErrorType("var"));
+
+            // Tracking narrowest safe-to-escape scope by default, the proper val escape will be set when doing full binding of the foreach statement
+            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, this.LocalScopeDepth, inferredType ?? CreateErrorType("var"));
+
             DeclarationExpressionSyntax declaration = null;
             ExpressionSyntax expression = null;
             BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -87,6 +87,7 @@
   It is used to perform intermediate binding, and will not survive the local rewriting.
   -->
   <Node Name="BoundDeconstructValuePlaceholder" Base="BoundValuePlaceholderBase">
+    <Field Name="ValEscape" Type="uint" Null="NotApplicable"/>
   </Node>
 
   <!-- only used by codegen -->

--- a/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
@@ -9,17 +9,17 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public BoundDeconstructValuePlaceholder Placeholder;
 
-        public BoundDeconstructValuePlaceholder SetInferredType(TypeSymbol type, bool success)
+        public BoundDeconstructValuePlaceholder SetInferredType(TypeSymbol type, Binder binder, bool success)
         {
-            Debug.Assert((object)Placeholder == null);
+            Debug.Assert(Placeholder is null);
 
-            Placeholder = new BoundDeconstructValuePlaceholder(this.Syntax, type, hasErrors: this.HasErrors || !success);
+            Placeholder = new BoundDeconstructValuePlaceholder(this.Syntax, binder.LocalScopeDepth, type, hasErrors: this.HasErrors || !success);
             return Placeholder;
         }
 
         public BoundDeconstructValuePlaceholder FailInference(Binder binder)
         {
-            return SetInferredType(binder.CreateErrorType(), success: false);
+            return SetInferredType(binder.CreateErrorType(), binder, success: false);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutDeconstructVarPendingInference.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(Placeholder is null);
 
+            // The val escape scope for this placeholder won't be used, so defaulting to narrowest scope
             Placeholder = new BoundDeconstructValuePlaceholder(this.Syntax, binder.LocalScopeDepth, type, hasErrors: this.HasErrors || !success);
             return Placeholder;
         }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -412,33 +412,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDeconstructValuePlaceholder : BoundValuePlaceholderBase
     {
-        public BoundDeconstructValuePlaceholder(SyntaxNode syntax, TypeSymbol type, bool hasErrors)
+        public BoundDeconstructValuePlaceholder(SyntaxNode syntax, uint valEscape, TypeSymbol type, bool hasErrors)
             : base(BoundKind.DeconstructValuePlaceholder, syntax, type, hasErrors)
         {
 
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            this.ValEscape = valEscape;
         }
 
-        public BoundDeconstructValuePlaceholder(SyntaxNode syntax, TypeSymbol type)
+        public BoundDeconstructValuePlaceholder(SyntaxNode syntax, uint valEscape, TypeSymbol type)
             : base(BoundKind.DeconstructValuePlaceholder, syntax, type)
         {
 
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            this.ValEscape = valEscape;
         }
 
+
+        public uint ValEscape { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitDeconstructValuePlaceholder(this);
         }
 
-        public BoundDeconstructValuePlaceholder Update(TypeSymbol type)
+        public BoundDeconstructValuePlaceholder Update(uint valEscape, TypeSymbol type)
         {
-            if (type != this.Type)
+            if (valEscape != this.ValEscape || type != this.Type)
             {
-                var result = new BoundDeconstructValuePlaceholder(this.Syntax, type, this.HasErrors);
+                var result = new BoundDeconstructValuePlaceholder(this.Syntax, valEscape, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8466,7 +8470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(type);
+            return node.Update(node.ValEscape, type);
         }
         public override BoundNode VisitDup(BoundDup node)
         {
@@ -9377,6 +9381,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new TreeDumperNode("deconstructValuePlaceholder", null, new TreeDumperNode[]
             {
+                new TreeDumperNode("valEscape", node.ValEscape, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal virtual void SetValEscape(uint value)
         {
-            throw ExceptionUtilities.Unreachable;
+            _valEscapeScope = value;
         }
 
         public override Symbol ContainingSymbol

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -4596,7 +4596,10 @@ class C
                 Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(5, 17),
                 // (5,31): error CS8210: A tuple may not contain a value of type 'void'.
                 //         (int x, void y) = (1, Main());
-                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31)
+                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31),
+                // (5,17): error CS0029: Cannot implicitly convert type 'void' to 'void'
+                //         (int x, void y) = (1, Main());
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "void y").WithArguments("void", "void").WithLocation(5, 17)
                 );
             var main = comp.GetMember<MethodSymbol>("C.Main");
             var tree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -4596,10 +4596,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(5, 17),
                 // (5,31): error CS8210: A tuple may not contain a value of type 'void'.
                 //         (int x, void y) = (1, Main());
-                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31),
-                // (5,17): error CS0029: Cannot implicitly convert type 'void' to 'void'
-                //         (int x, void y) = (1, Main());
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "void y").WithArguments("void", "void").WithLocation(5, 17)
+                Diagnostic(ErrorCode.ERR_VoidInTuple, "Main()").WithLocation(5, 31)
                 );
             var main = comp.GetMember<MethodSymbol>("C.Main");
             var tree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2583,10 +2583,21 @@ public class C
     {
         Span<int> local = stackalloc int[10];
         string s;
+        C c;
+
         (global, global) = (local, local); // error 1
+
         (global, s) = (local, """"); // error 2
+        (global, s) = (local, null); // error 3
+
+        (local, s) = (global, """"); // error 4
+        (local, s) = (global, null); // error 5
+
+        (c, s) = (local, """"); // error 6
+        (c, s) = (local, null);
     }
     public static void Main() => throw null;
+    public static implicit operator C(Span<int> s) => throw null;
 }
 namespace System
 {
@@ -2604,58 +2615,27 @@ namespace System
 }
 ";
             CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
-                // (10,29): error CS0306: The type 'Span<int>' may not be used as a type argument
+                // (12,29): error CS0306: The type 'Span<int>' may not be used as a type argument
                 //         (global, global) = (local, local); // error 1
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(10, 29),
-                // (10,36): error CS0306: The type 'Span<int>' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(12, 29),
+                // (12,36): error CS0306: The type 'Span<int>' may not be used as a type argument
                 //         (global, global) = (local, local); // error 1
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(10, 36),
-                // (11,24): error CS0306: The type 'Span<int>' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(12, 36),
+                // (14,24): error CS0306: The type 'Span<int>' may not be used as a type argument
                 //         (global, s) = (local, ""); // error 2
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(11, 24)
-            );
-        }
-
-        [Fact]
-        public void DeconstructionAssignmentOfTypelessTuple()
-        {
-            var text = @"
-using System;
-
-public class C
-{
-    public void M(ref Span<int> global)
-    {
-        Span<int> local = stackalloc int[10];
-        Span<int> local2 = stackalloc int[10];
-        string s;
-        (global, s) = (local, null); // error 1
-        (local2, s) = (local, null); // error 2
-    }
-    public static void Main() => throw null;
-}
-namespace System
-{
-    public struct ValueTuple<T1, T2>
-    {
-        public T1 Item1;
-        public T2 Item2;
-
-        public ValueTuple(T1 item1, T2 item2)
-        {
-            this.Item1 = item1;
-            this.Item2 = item2;
-        }
-    }
-}
-";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
-                // (11,24): error CS0306: The type 'Span<int>' may not be used as a type argument
-                //         (global, s) = (local, null); // error 1
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(11, 24),
-                // (12,24): error CS0306: The type 'Span<int>' may not be used as a type argument
-                //         (local2, s) = (local, null); // error 2
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(12, 24)
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(14, 24),
+                // (15,24): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, s) = (local, null); // error 3
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(15, 24),
+                // (17,23): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (local, s) = (global, ""); // error 4
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(17, 23),
+                // (18,23): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (local, s) = (global, null); // error 5
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(18, 23),
+                // (20,19): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (c, s) = (local, ""); // error 6
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(20, 19)
             );
         }
 
@@ -2670,9 +2650,22 @@ public class C
     public void M(ref Span<int> global)
     {
         Span<int> local = stackalloc int[10];
-        (global, global) = (local, local); // error
+        String s;
+        C c;
+
+        (global, global) = (local, local); // error 1
+
+        (global, s) = (local, """"); // error 2
+        (global, s) = (local, null); // error 3
+
+        (local, s) = (global, """"); // error 4
+        (local, s) = (global, null); // error 5
+
+        (c, s) = (local, """"); // error 6
+        (c, s) = (local, null);
     }
     public static void Main() => throw null;
+    public static implicit operator C(Span<int> s) => throw null;
 }
 namespace System
 {
@@ -2691,12 +2684,39 @@ namespace System
 }
 ";
             CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
-                // (9,29): error CS0306: The type 'Span<int>' may not be used as a type argument
-                //         (global, global) = (local, local); // error
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 29),
-                // (9,36): error CS0306: The type 'Span<int>' may not be used as a type argument
-                //         (global, global) = (local, local); // error
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 36)
+                // (12,29): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local); // error 1
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(12, 29),
+                // (12,36): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local); // error 1
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(12, 36),
+                // (12,29): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, global) = (local, local); // error 1
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(12, 29),
+                // (14,24): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, s) = (local, ""); // error 2
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(14, 24),
+                // (14,24): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, s) = (local, ""); // error 2
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(14, 24),
+                // (15,24): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, s) = (local, null); // error 3
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(15, 24),
+                // (15,24): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, s) = (local, null); // error 3
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(15, 24),
+                // (17,23): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (local, s) = (global, ""); // error 4
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(17, 23),
+                // (18,23): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (local, s) = (global, null); // error 5
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(18, 23),
+                // (20,19): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (c, s) = (local, ""); // error 6
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(20, 19),
+                // (20,19): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (c, s) = (local, ""); // error 6
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(20, 19)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2386,5 +2386,415 @@ class Program
 }
 ");
         }
+
+        [Fact]
+        public void DeconstructionAssignmentToGlobal()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        (global, global) = global;
+        (global, global) = local; // error 1
+        (global, local) = local; // error 2
+        (local, local) = local;
+        (global, _) = local; // error 3
+        (local, _) = local; // error 4
+        (global, _) = global;
+    }
+    public static void Main()
+    {
+    }
+}
+public static class Extensions
+{
+    public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y)
+    {
+        throw null;
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (10,28): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, global) = local; // error 1
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(10, 28),
+                // (11,27): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, local) = local; // error 2
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(11, 27),
+                // (13,23): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, _) = local; // error 3
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(13, 23),
+                // (14,22): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (local, _) = local; // error 4
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(14, 22),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentToRefMethods()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        (M(), M()) = local;
+    }
+    public static void Main() => throw null;
+    public ref Span<int> M() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (9,22): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (M(), M()) = local;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(9, 22),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentWithRefExtension()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        (global, global) = global;
+    }
+    public static void Main() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(ref this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (8,9): error CS1510: A ref or out value must be an assignable variable
+                //         (global, global) = global;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(global, global) = global").WithLocation(8, 9),
+                // (8,28): error CS8129: No suitable Deconstruct instance or extension method was found for type 'Span<int>', with 2 out parameters and a void return type.
+                //         (global, global) = global;
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "global").WithArguments("System.Span<int>", "2").WithLocation(8, 28),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentWithRefReadonlyExtension()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        (global, global) = global;
+        (global, global) = local;
+    }
+    public static void Main() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(ref readonly this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (10,28): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, global) = local;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(10, 28),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentWithReturnValue()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        var t = ((global, global) = global);
+    }
+    public static void Main() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (8,19): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         var t = ((global, global) = global);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(8, 19),
+                // (8,27): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         var t = ((global, global) = global);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "global").WithArguments("System.Span<int>").WithLocation(8, 27),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentOfTuple()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        (global, global) = (local, local);
+    }
+    public static void Main() => throw null;
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (9,29): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 29),
+                // (9,36): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 36)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentOfRefLikeTuple()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        (global, global) = (local, local);
+    }
+    public static void Main() => throw null;
+}
+namespace System
+{
+    // Note: there is no way to make a ValueTuple type that will hold Spans and still be recognized as well-known type for tuples
+    public ref struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (9,29): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 29),
+                // (9,36): error CS0306: The type 'Span<int>' may not be used as a type argument
+                //         (global, global) = (local, local);
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "local").WithArguments("System.Span<int>").WithLocation(9, 36)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionAssignmentToOuter()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        Span<int> outer = stackalloc int[10];
+
+        {
+            Span<int> local = stackalloc int[10]; // both stackallocs have the same escape scope
+            (outer, outer) = outer;
+            (outer, outer) = local;
+            (outer, local) = local;
+            (local, local) = local;
+        }
+    }
+    public static void Main() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+";
+
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+            );
+        }
+
+        [Fact]
+        public void DeconstructionDeclaration()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref Span<int> global)
+    {
+        Span<int> local = stackalloc int[10];
+        var (local1, local2) = local;
+        global = local1;
+        global = local2;
+
+        var (local3, local4) = global;
+        global = local3;
+        global = local4;
+    }
+    public static void Main() => throw null;
+}
+public static class Extensions
+{
+    public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (10,18): error CS8352: Cannot use local 'local1' in this context because it may expose referenced variables outside of their declaration scope
+                //         global = local1;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local1").WithArguments("local1").WithLocation(10, 18),
+                // (11,18): error CS8352: Cannot use local 'local2' in this context because it may expose referenced variables outside of their declaration scope
+                //         global = local2;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local2").WithArguments("local2").WithLocation(11, 18),
+                // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1)
+                );
+        }
+
+        [Fact]
+        public void RefLikeForeach()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref S global)
+    {
+        S localCollection = stackalloc int[10];
+        foreach (var local in localCollection)
+        {
+            global = local;
+        }
+    }
+    public static void Main() => throw null;
+}
+
+public ref struct S
+{
+    public S GetEnumerator() => throw null;
+    public bool MoveNext() => throw null;
+    public S Current => throw null;
+    public static implicit operator S(Span<int> s) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (11,22): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //             global = local;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(11, 22)
+                );
+        }
+
+        [Fact]
+        public void RefLikeDeconstructionForeach()
+        {
+            var text = @"
+using System;
+
+public class C
+{
+    public void M(ref S global)
+    {
+        S localCollection = stackalloc int[10];
+        foreach (var (local1, local2) in localCollection)
+        {
+            global = local1; // error 1
+            global = local2; // error 2
+        }
+    }
+    public static void Main() => throw null;
+}
+
+public ref struct S
+{
+    public S GetEnumerator() => throw null;
+    public bool MoveNext() => throw null;
+    public S Current => throw null;
+    public static implicit operator S(Span<int> s) => throw null;
+    public void Deconstruct(out S s1, out S s2) => throw null;
+}
+";
+            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (11,22): error CS8352: Cannot use local 'local1' in this context because it may expose referenced variables outside of their declaration scope
+                //             global = local1; // error 1
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local1").WithArguments("local1").WithLocation(11, 22),
+                // (12,22): error CS8352: Cannot use local 'local2' in this context because it may expose referenced variables outside of their declaration scope
+                //             global = local2; // error 2
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local2").WithArguments("local2").WithLocation(12, 22)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4953,24 +4953,68 @@ class C
         }
 
         [Fact]
+        public void TupleLiteralElement004_WithoutValueTuple()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (short X, string Y) = (Alice: 1, Bob: null);
+    }
+}
+";
+
+            var compilation = CreateStandardCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (6,31): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported, or is declared in multiple referenced assemblies
+                //         (short X, string Y) = (Alice: 1, Bob: null);
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(Alice: 1, Bob: null)").WithArguments("System.ValueTuple`2").WithLocation(6, 31)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
+            var model = compilation.GetSemanticModel(tree);
+            Assert.Null(model.GetDeclaredSymbol(decl));
+        }
+
+        [Fact]
         public void TupleLiteralElement004()
         {
             var source =
 @"
-
-using System;
-
 class C
 {
-    static void Main() 
-    { 
+    static void Main()
+    {
         (short X, string Y) = (Alice: 1, Bob: null);
     }
 }
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
 
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
 ";
 
             var compilation = CreateStandardCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (6,32): warning CS8123: The tuple element name 'Alice' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short X, string Y) = (Alice: 1, Bob: null);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "Alice: 1").WithArguments("Alice", "(short, string)").WithLocation(6, 32),
+                // (6,42): warning CS8123: The tuple element name 'Bob' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short X, string Y) = (Alice: 1, Bob: null);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "Bob: null").WithArguments("Bob", "(short, string)").WithLocation(6, 42)
+                );
             var tree = compilation.SyntaxTrees[0];
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4970,12 +4970,21 @@ class C
             compilation.VerifyDiagnostics(
                 // (6,31): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported, or is declared in multiple referenced assemblies
                 //         (short X, string Y) = (Alice: 1, Bob: null);
-                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(Alice: 1, Bob: null)").WithArguments("System.ValueTuple`2").WithLocation(6, 31)
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(Alice: 1, Bob: null)").WithArguments("System.ValueTuple`2").WithLocation(6, 31),
+                // (6,32): warning CS8123: The tuple element name 'Alice' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short X, string Y) = (Alice: 1, Bob: null);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "Alice: 1").WithArguments("Alice", "(short, string)").WithLocation(6, 32),
+                // (6,42): warning CS8123: The tuple element name 'Bob' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short X, string Y) = (Alice: 1, Bob: null);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "Bob: null").WithArguments("Bob", "(short, string)").WithLocation(6, 42)
                 );
             var tree = compilation.SyntaxTrees[0];
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
-            Assert.Null(model.GetDeclaredSymbol(decl));
+            var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
+            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob).Bob");
+            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
+            Assert.Equal(element.Locations.Single().IsInSource, true);
         }
 
         [Fact]


### PR DESCRIPTION
**Customer scenario**
Use ref-like types (such as `Span`) in a deconstruction or foreach loop. The assignments implicit in those operations need to be tracked to avoid holding on to references past their scope.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/22338

**Details of the fix**
1. Variables introduced by deconstructions and foreach (regular or deconstruction form) need to track their safe-to-escape scope, as dictated by the right-hand-side of a deconstruction and the foreach collection, respectively.
2. Expressions in the left-hand-side of a deconstruction need to abide by safe-to-escape rules for assignment: their safe-to-escape scopes should be narrower than the value they will receive from the right-hand-side.

**Workarounds, if any**
No workaround. This is a safety rule the compiler should enforce.

**Risk**
**Performance impact**
Low. This is mostly adding a check to binding deconstructions and foreach.

**Is this a regression from a previous update?**
No. This is part of a C# 7.2 feature (part of 15.5 release).