### PR TITLE
Ref ternary should be shielded form optimization in the containing expression that may expose it to mutations

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -575,6 +575,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.FieldAccess:
                     return true;
 
+                case BoundKind.ConditionalOperator:
+                    return ((BoundConditionalOperator)receiver).IsByRef;
+
                 case BoundKind.Call:
                     return ((BoundCall)receiver).Method.RefKind == RefKind.Ref;
             }


### PR DESCRIPTION
Since it can be writeable, ref ternary should be shielded form optimization in the containing expression that may expose it to mutations.

Just need to add it to the list of other possible writeable lvalues checked by WouldBeAssignableIfUsedAsMethodReceiver helper.

Fixes:#18220

=== user impact
Without the fix folding optimizations may unexpectedly expose variables to mutations, which otherwie would be performed on copies.

