### PR TITLE
Fixed issue with converting auto properties in partial classes

### DIFF
--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -60,11 +60,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             CodeRefactoringProvider provider,
             TestWorkspace workspace)
         {
-            var document = GetDocument(workspace);
             var documentsWithSelections = workspace.Documents.Where(d => !d.IsLinkFile && d.SelectedSpans.Count == 1);
             Debug.Assert(documentsWithSelections.Count() == 1, "One document must have a single span annotation");
             var span = documentsWithSelections.Single().SelectedSpans.Single();
             var actions = ArrayBuilder<CodeAction>.GetInstance();
+            var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
             var context = new CodeRefactoringContext(document, span, actions.Add, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 

--- a/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
 {
@@ -97,14 +98,18 @@ namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
                 propertySymbol.Type, fieldName,
                 initializer: GetInitializerValue(property));
 
-            //var containingType = GetTypeBlock(
-            //    propertySymbol.ContainingType.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(cancellationToken));
-            var containingType = propertySymbol.ContainingType.DeclaringSyntaxReferences
-                    .Select(r => GetTypeBlock(r.GetSyntax(cancellationToken)))
-                    .Single(d => property.Ancestors().Contains(d));
-            editor.ReplaceNode(containingType, (currentTypeDecl, _)
-                => CodeGenerator.AddFieldDeclaration(currentTypeDecl, newField, workspace)
-                .WithAdditionalAnnotations(Formatter.Annotation));
+            var typeDeclaration = propertySymbol.ContainingType.DeclaringSyntaxReferences;
+            foreach (var td in typeDeclaration)
+            {
+                var block = GetTypeBlock(await td.GetSyntaxAsync(cancellationToken).ConfigureAwait(false));
+                if (property.Ancestors().Contains(block))
+                {
+                    editor.ReplaceNode(block, (currentTypeDecl, _)  
+                        => CodeGenerator.AddFieldDeclaration(currentTypeDecl, newField, workspace)
+                        .WithAdditionalAnnotations(Formatter.Annotation));
+                }
+            }
+
             var newRoot = editor.GetChangedRoot();
             return document.WithSyntaxRoot(newRoot);
         }

--- a/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertAutoPropertyToFullProperty/AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider.cs
@@ -96,8 +96,12 @@ namespace Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty
                 DeclarationModifiers.From(propertySymbol),
                 propertySymbol.Type, fieldName,
                 initializer: GetInitializerValue(property));
-            var containingType = GetTypeBlock(
-                propertySymbol.ContainingType.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(cancellationToken));
+
+            //var containingType = GetTypeBlock(
+            //    propertySymbol.ContainingType.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(cancellationToken));
+            var containingType = propertySymbol.ContainingType.DeclaringSyntaxReferences
+                    .Select(r => GetTypeBlock(r.GetSyntax(cancellationToken)))
+                    .Single(d => property.Ancestors().Contains(d));
             editor.ReplaceNode(containingType, (currentTypeDecl, _)
                 => CodeGenerator.AddFieldDeclaration(currentTypeDecl, newField, workspace)
                 .WithAdditionalAnnotations(Formatter.Annotation));


### PR DESCRIPTION
Fixes #22146

**Customer scenario**
If customer creates a partial class and does the auto property to full property refactoring while in the class that is 2nd in the list, it will throw an error in the info bar

**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/22146

**Workarounds, if any**
none

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Did not consider partial classes.  Will add partial class tests to new features to avoid this error in the future.

**How was the bug found?**
Found by IDE team member

**Test documentation updated?**
n/a
