### PR TITLE
Fix ref and out keyword completion to appear in local functions

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
@@ -405,5 +405,13 @@ $$");
 
             await VerifyKeywordAsync(text);
         }
+
+        [WorkItem(22253, "https://github.com/dotnet/roslyn/issues/22253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInLocalFunction()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"void F(int x, $$"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
@@ -806,5 +806,13 @@ $$");
             await VerifyKeywordWithRefsAsync(AddInsideMethod(
 @" D1 lambda = () => $$"));
         }
+
+        [WorkItem(22253, "https://github.com/dotnet/roslyn/issues/22253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInLocalMethod()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(
+@" void Goo(int test, $$) "));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxNodeExtensions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return
                 node.IsParentKind(SyntaxKind.MethodDeclaration) ||
                 node.IsParentKind(SyntaxKind.ConstructorDeclaration) ||
-                node.IsParentKind(SyntaxKind.DelegateDeclaration);
+                node.IsParentKind(SyntaxKind.DelegateDeclaration) ||
+                node.IsParentKind(SyntaxKind.LocalFunctionStatement);
         }
     }
 }


### PR DESCRIPTION
Fixes #22253

**Customer scenario**
If customer is in a local function, `out` and `ref` will not appear in the completion list when adding a parameter

**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/22253

**Workarounds, if any**
customer can type `out` or `ref` instead of choosing it from the completion list

**Risk**
Low, should only impact keyword completion feature

**Performance impact**
Low, minor code fix

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Local functions were not included as a possible place for `out` and `ref` keywords to be offered in completion

How did we miss it?  What tests are we adding to guard against it in the future?
Did not consider local functions.  New tests have been added for `ref` and `out`

**How was the bug found?**
Issue filed by team member

**Test documentation updated?**
N/A
