### PR TITLE
Added tests for `out` and `ref` completion in local function

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
@@ -405,5 +405,13 @@ $$");
 
             await VerifyKeywordAsync(text);
         }
+
+        [WorkItem(22253, "https://github.com/dotnet/roslyn/issues/22253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInLocalFunction()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"void F(int x, $$"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
@@ -822,6 +822,15 @@ ref int x = ref true ? $$"));
             await VerifyKeywordWithRefsAsync(AddInsideMethod(@"
 int x = 0;
 ref int y = ref true ? ref x : $$"));
+	}
+
+        [WorkItem(22253, "https://github.com/dotnet/roslyn/issues/22253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInLocalMethod()
+        {
+            await VerifyKeywordWithRefsAsync(AddInsideMethod(
+@" void Goo(int test, $$) "));
+
         }
     }
 }


### PR DESCRIPTION
Tests added in response to issue #22253.  
The issue was fixed by a previous PR by #17447 which was merged into master with #22050.
This PR is for additional tests only.

**Customer scenario**
If customer is in a local function, out and ref will not appear in the completion list when adding a parameter

**Bugs this fixes:**
#22253

**Risk**
Low, tests only

**Performance impact**
Low, only 2 tests added

**How was the bug found?**
Team member filed issue

**Test documentation updated?**
N/A

