### PR TITLE
removed unused GetOperationOptions

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -469,13 +469,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.GetOperationWorker(csnode, cancellationToken);
         }
 
-        internal enum GetOperationOptions
-        {
-            Highest,
-            Lowest,
-            Parent
-        }
-
         internal virtual IOperation GetOperationWorker(CSharpSyntaxNode node, CancellationToken cancellationToken)
         {
             return null;

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -132,12 +132,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                  TypeOf (node) Is OrderingSyntax)
         End Function
 
-        Friend Enum GetOperationOptions
-            Lowest
-            Highest
-            Parent
-        End Enum
-
         Protected Overrides Function GetOperationCore(node As SyntaxNode, cancellationToken As CancellationToken) As IOperation
             Dim vbnode = DirectCast(node, VisualBasicSyntaxNode)
             CheckSyntaxNode(vbnode)


### PR DESCRIPTION
we used to use this option to specific whether we want highest or lowest bound node from the map. but we no longer use those.