### PR TITLE
guard us from getting duplicated errors from the build.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -522,7 +522,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             private void AddError<T>(Dictionary<T, Dictionary<DiagnosticData, int>> map, T key, DiagnosticData diagnostic)
             {
                 var errors = GetErrorSet(map, key);
-                errors.Add(diagnostic, GetNextIncrement());
+                AddError(errors, diagnostic);
+            }
+
+            private void AddError(Dictionary<DiagnosticData, int> errors, DiagnosticData diagnostic)
+            {
+                // add only new errors
+                if (!errors.TryGetValue(diagnostic, out _))
+                {
+                    errors.Add(diagnostic, GetNextIncrement());
+                }
             }
 
             private int GetNextIncrement()

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -160,6 +160,30 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             End Using
         End Sub
 
+        <Fact>
+        Public Async Function TestExternalDiagnostics_AddDuplicatedErrors() As Task
+            Using workspace = TestWorkspace.CreateCSharp(String.Empty)
+                Dim waiter = New Waiter()
+
+                Dim project = workspace.CurrentSolution.Projects.First()
+                Dim diagnostic = GetDiagnosticData(workspace, project.Id)
+
+                Dim service = New TestDiagnosticAnalyzerService()
+                Dim source = New ExternalErrorDiagnosticUpdateSource(workspace, service, New MockDiagnosticUpdateSourceRegistrationService(), waiter)
+
+                ' we shouldn't crash here
+                source.AddNewErrors(project.Id, diagnostic)
+                source.AddNewErrors(project.Id, diagnostic)
+
+                source.OnSolutionBuild(Me, Shell.UIContextChangedEventArgs.From(False))
+
+                AddHandler source.DiagnosticsUpdated, Sub(o, a)
+                                                          Assert.Equal(1, a.Diagnostics.Length)
+                                                      End Sub
+                Await waiter.CreateWaitTask()
+            End Using
+        End Function
+
         Private Function GetDiagnosticData(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, Optional isBuildDiagnostic As Boolean = False) As DiagnosticData
             Dim properties = If(isBuildDiagnostic, DiagnosticData.PropertiesForBuildDiagnostic, ImmutableDictionary(Of String, String).Empty)
             Return New DiagnosticData(


### PR DESCRIPTION
**Customer scenario**

user builds a solution and solution has duplicated errors on same file and VS crash. 

this can be quite common on XAML projects. for example, "MahApps.Metro" which is quite popular github project will crash VS when built.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/500533

**Workarounds, if any**

There is no workaround.

**Risk**

There is no risk

**Performance impact**

there should be no visible perf impact

**Is this a regression from a previous update?**

Yes. it regressed when I made build error to preserve error ordering we got from build.

**Root cause analysis:**

we used to use hashset to store errors which doesn't care about duplicates, now it changed to dictionary for ordering and now we became duplicates sensitive.

test is added to prevent regression.

**How was the bug found?**

Testing.
