### PR TITLE
Report binding error for LINQ query on a type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -759,14 +759,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
             }
-            else if (receiver.Type.SpecialType == SpecialType.System_Void)
+            else
             {
-                if (!receiver.HasAnyErrors && !node.HasErrors)
+                if (receiver.Type.SpecialType == SpecialType.System_Void)
                 {
-                    diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, "void", methodName);
-                }
+                    if (!receiver.HasAnyErrors && !node.HasErrors)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, "void", methodName);
+                    }
 
-                receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
+                    receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
+                }
+                else if (ultimateReceiver.Kind == BoundKind.TypeExpression)
+                {
+                    diagnostics.Add(ErrorCode.ERR_BadSKunknown, ultimateReceiver.Syntax.Location, ultimateReceiver.Syntax, MessageID.IDS_SK_TYPE.Localize());
+                    receiver = new BoundBadExpression(receiver.Syntax, LookupResultKind.NotAValue, ImmutableArray<Symbol>.Empty, ImmutableArray.Create(receiver), CreateErrorType());
+                }
             }
 
             return (BoundCall)MakeInvocationExpression(


### PR DESCRIPTION
**Customer scenario**
Use a type as the collection in a LINQ query with a typed variable (`from object a in IEnumerable ...`). The compiler should produce an error, but instead it fails when emitting.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/21484

**Workarounds, if any**
Fix your code. But the compiler doesn't provide diagnostics pointing to the source of the error.

**Risk**
**Performance impact**
Low. Adding one more check during binding of queries (which already checks for a number of invalid query inputs).

**Is this a regression from a previous update?**
No.

**How was the bug found?**
Reported by customer.