### PR TITLE
Check for null before registering incremental analyzer

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -111,7 +111,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
 
                     var analyzer = lazyProvider.Value.CreateIncrementalAnalyzer(workspace);
-                    coordinator.AddAnalyzer(analyzer, metadata.HighPriorityForActiveFile);
+                    if (analyzer != null)
+                    {
+                        coordinator.AddAnalyzer(analyzer, metadata.HighPriorityForActiveFile);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This should enable the case where an analyzer provider needs to check whether a setting / feature flag is turned on before returning a valid analyzer. Currently, in such cases analyzer provider has to instead return an analyzer that ignores all changes that it is told about... After the change in this PR, analyzer provider can simply return null in such cases.
