### PR TITLE
Allow taking unmanaged/pinned addresses of readonly lvalues.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -395,7 +395,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Note: RValueOnly is checked at the beginning of this method. Since we are here we need more than readable.
                     //"this" is readonly in members of readonly structs, unless we are in a constructor.
                     if (!thisref.Type.IsValueType ||
-                        (thisref.Type.IsReadOnly && (this.ContainingMemberOrLambda as MethodSymbol)?.MethodKind != MethodKind.Constructor))
+                            (RequiresAssignableVariable(valueKind) &&
+                             thisref.Type.IsReadOnly && 
+                             (this.ContainingMemberOrLambda as MethodSymbol)?.MethodKind != MethodKind.Constructor))
                     {
                         // CONSIDER: the Dev10 name has angle brackets (i.e. "<this>")
                         Error(diagnostics, GetThisLvalueError(valueKind), node, ThisParameterSymbol.SymbolName);
@@ -1369,12 +1371,6 @@ moreArguments:
                 return;
             }
 
-            if (kind == BindValueKind.AddressOf)
-            {
-                Error(diagnostics, ErrorCode.ERR_AddrOnReadOnlyLocal, node);
-                return;
-            }
-
             ErrorCode[] ReadOnlyLocalErrors =
             {
                 ErrorCode.ERR_RefReadonlyLocalCause,
@@ -1401,7 +1397,7 @@ moreArguments:
                     return ErrorCode.ERR_RefReadonlyLocal;
 
                 case BindValueKind.AddressOf:
-                    return ErrorCode.ERR_AddrOnReadOnlyLocal;
+                    return ErrorCode.ERR_InvalidAddrOp;
 
                 case BindValueKind.IncrementDecrement:
                     return ErrorCode.ERR_IncrementLvalueExpected;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -99,27 +99,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             ReadonlyRef = RefersToLocation | RValue,
 
             /// <summary>
+            /// Expression can be the operand of an address-of operation (&amp;).
+            /// Same as ReadonlyRef. The difference is just for error reporting.
+            /// </summary>
+            AddressOf = ReadonlyRef + 1,
+
+            /// <summary>
+            /// Expression is the receiver of a fixed buffer field access
+            /// Same as ReadonlyRef. The difference is just for error reporting.
+            /// </summary>
+            FixedReceiver = ReadonlyRef + 2,
+
+            /// <summary>
             /// Expression is passed as a ref or out parameter or assigned to a byref variable.
             /// </summary>
             RefOrOut = RefersToLocation | RValue | Assignable,
 
             /// <summary>
-            /// Expression can be the operand of an address-of operation (&amp;).
-            /// Same as RefOrOut. The difference is just for error reporting.
-            /// </summary>
-            AddressOf = RefOrOut + 1,
-
-            /// <summary>
-            /// Expression is the receiver of a fixed buffer field access
-            /// Same as RefOrOut. The difference is just for error reporting.
-            /// </summary>
-            FixedReceiver = RefOrOut + 2,
-
-            /// <summary>
             /// Expression is returned by an ordinary r/w reference.
             /// Same as RefOrOut. The difference is just for error reporting.
             /// </summary>
-            RefReturn = RefOrOut + 3,
+            RefReturn = RefOrOut + 1,
         }
 
         private static bool RequiresRValueOnly(BindValueKind kind)

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -242,15 +242,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot take the address of a read-only local variable.
-        /// </summary>
-        internal static string ERR_AddrOnReadOnlyLocal {
-            get {
-                return ResourceManager.GetString("ERR_AddrOnReadOnlyLocal", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Agnostic assembly cannot have a processor specific module &apos;{0}&apos;..
         /// </summary>
         internal static string ERR_AgnosticToMachineModule {
@@ -8493,18 +8484,16 @@ namespace Microsoft.CodeAnalysis.CSharp {
                 return ResourceManager.GetString("ERR_RefReturnNonreturnableLocal2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot return a parameter by reference &apos;{0}&apos; because it is not a ref or out parameter.
         /// </summary>
-        internal static string ERR_RefReturnParameter
-        {
-            get
-            {
+        internal static string ERR_RefReturnParameter {
+            get {
                 return ResourceManager.GetString("ERR_RefReturnParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot return by reference a member of parameter &apos;{0}&apos; because it is not a ref or out parameter.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1356,9 +1356,6 @@
   <data name="WRN_AlwaysNull_Title" xml:space="preserve">
     <value>The result of the expression is always 'null'</value>
   </data>
-  <data name="ERR_AddrOnReadOnlyLocal" xml:space="preserve">
-    <value>Cannot take the address of a read-only local variable</value>
-  </data>
   <data name="ERR_RefReturnThis" xml:space="preserve">
     <value>Cannot return 'this' by reference.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2336,7 +2336,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             {
                 int exprTempsBefore = _expressionTemps?.Count ?? 0;
 
-                LocalDefinition temp = EmitAddress(assignmentOperator.Right, AddressKind.Writeable);
+                // NOTE: passing "ReadOnly" here. Assuming we do not have compile errors, 
+                //       We should not get an address of a copy, even if the RHS is readonly
+                LocalDefinition temp = EmitAddress(assignmentOperator.Right, AddressKind.ReadOnly);
 
                 // Generally taking a ref for the purpose of ref assignment should not be done on homeless values
                 // however, there are very rare cases when we need to get a ref off a temp in synthetic code.

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ConWithValCon = 456,
         ERR_AmbigUDConv = 457,
         WRN_AlwaysNull = 458,
-        ERR_AddrOnReadOnlyLocal = 459,
+        // ERR_AddrOnReadOnlyLocal = 459, // no longer an error
         ERR_OverrideWithConstraints = 460,
         ERR_AmbigOverride = 462,
         ERR_DecConstError = 463,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadOnlyParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadOnlyParametersTests.cs
@@ -464,8 +464,9 @@ class Program
                 Diagnostic(ErrorCode.ERR_RefReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)"));
         }
 
+        [WorkItem(22306, "https://github.com/dotnet/roslyn/issues/22306")]
         [Fact]
-        public void ReadonlyParamCannotTakePtr()
+        public void ReadonlyParamCanTakePtr()
         {
             var text = @"
 class Program
@@ -488,18 +489,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseDll);
             comp.VerifyDiagnostics(
-                // (6,20): error CS0211: Cannot take the address of the given expression
+                // (6,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
                 //         int* a = & arg1;
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "arg1").WithLocation(6, 20),
-                // (7,20): error CS0211: Cannot take the address of the given expression
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "& arg1").WithLocation(6, 18),
+                // (7,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
                 //         int* b = & arg2.Alice;
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "arg2.Alice").WithLocation(7, 20),
-                // (9,26): error CS0211: Cannot take the address of the given expression
-                //         fixed(int* c = & arg1)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "arg1").WithLocation(9, 26),
-                // (13,26): error CS0211: Cannot take the address of the given expression
-                //         fixed(int* d = & arg2.Alice)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "arg2.Alice").WithLocation(13, 26)
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "& arg2.Alice").WithLocation(7, 18)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -1383,21 +1383,17 @@ class A
     private int _i = 0;
 }";
             CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.RegularWithIOperationFeature)
-            .VerifyDiagnostics(Diagnostic(ErrorCode.ERR_InvalidAddrOp, "a + b").WithLocation(7, 18),
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "i").WithLocation(28, 23),
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "i").WithLocation(33, 24))
+            .VerifyDiagnostics(Diagnostic(ErrorCode.ERR_InvalidAddrOp, "a + b").WithLocation(7, 18))
             .VerifyAnalyzerDiagnostics(new DiagnosticAnalyzer[] { new AddressOfTestAnalyzer() }, null, null, false,
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&(a + b)").WithLocation(7, 16),
-                Diagnostic(AddressOfTestAnalyzer.InvalidAddressOfReferenceDescriptor.Id, "a + b").WithLocation(7, 18),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&a").WithLocation(9, 16),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&x").WithLocation(15, 17),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&(*p)").WithLocation(16, 12),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&p[0]").WithLocation(17, 12),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&i").WithLocation(28, 22),
-                Diagnostic(AddressOfTestAnalyzer.InvalidAddressOfReferenceDescriptor.Id, "i").WithLocation(28, 23),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&_i").WithLocation(31, 25),
-                Diagnostic(AddressOfTestAnalyzer.AddressOfDescriptor.Id, "&i").WithLocation(33, 23),
-                Diagnostic(AddressOfTestAnalyzer.InvalidAddressOfReferenceDescriptor.Id, "i").WithLocation(33, 24));
+                Diagnostic("AddressOfOperation", "&(a + b)").WithLocation(7, 16),
+                Diagnostic("InvalidAddressOfReference", "a + b").WithLocation(7, 18),
+                Diagnostic("AddressOfOperation", "&a").WithLocation(9, 16),
+                Diagnostic("AddressOfOperation", "&i").WithLocation(28, 22),
+                Diagnostic("AddressOfOperation", "&_i").WithLocation(31, 25),
+                Diagnostic("AddressOfOperation", "&i").WithLocation(33, 23),
+                Diagnostic("AddressOfOperation", "&x").WithLocation(15, 17),
+                Diagnostic("AddressOfOperation", "&(*p)").WithLocation(16, 12),
+                Diagnostic("AddressOfOperation", "&p[0]").WithLocation(17, 12));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -1371,12 +1371,12 @@ class A
         int[] ints = new int[] { 1, 2, 3 };
         foreach (int i in ints)
         {
-            int *j = &i;  // CS0459
+            int *j = &i;  
         }
 
         fixed (int *i = &_i)
         {
-            int **j = &i;  // CS0459
+            int **j = &i;  
         }
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IFixedStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IFixedStatement.cs
@@ -287,14 +287,12 @@ IOperation:  (OperationKind.None, IsInvalid) (Syntax: 'fixed (int* ... }')
               Right: IConversionExpression (Implicit, TryCast: False, Unchecked) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid) (Syntax: '&p1')
                   Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                   Operand: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32**, IsInvalid) (Syntax: '&p1')
-                      Reference: IInvalidExpression (OperationKind.InvalidExpression, Type: System.Int32*, IsInvalid) (Syntax: 'p1')
-                          Children(1):
-                              ILocalReferenceExpression: p1 (OperationKind.LocalReferenceExpression, Type: System.Int32*, IsInvalid) (Syntax: 'p1')
+                      Reference: ILocalReferenceExpression: p1 (OperationKind.LocalReferenceExpression, Type: System.Int32*, IsInvalid) (Syntax: 'p1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0459: Cannot take the address of a read-only local variable
+                // file.cs(15,22): error CS0266: Cannot implicitly convert type 'int**' to 'int'. An explicit conversion exists (are you missing a cast?)
                 //                 i3 = &p1;
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "p1").WithLocation(15, 23)
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "&p1").WithArguments("int**", "int").WithLocation(15, 22)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<FixedStatementSyntax>(source, expectedOperationTree, expectedDiagnostics,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -10260,6 +10260,7 @@ public class Test
                 Diagnostic(ErrorCode.ERR_AmbigUDConv, "h1a").WithArguments("H1<A>.implicit operator G1<A>(H1<A>)", "H0.implicit operator G0(H0)", "H1<A>", "G0"));
         }
 
+        [WorkItem(22306, "https://github.com/dotnet/roslyn/issues/22306")]
         [Fact]
         public void CS0459ERR_AddrOnReadOnlyLocal()
         {
@@ -10283,13 +10284,7 @@ class A
     private int _i = 0;
 }
 ";
-            CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (9,23): error CS0459: Cannot take the address of a read-only local variable
-                //             int *j = &i;  // CS0459
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "i"),
-                // (14,24): error CS0459: Cannot take the address of a read-only local variable
-                //             int **j = &i;  // CS0459
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "i"));
+            CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -10262,7 +10262,7 @@ public class Test
 
         [WorkItem(22306, "https://github.com/dotnet/roslyn/issues/22306")]
         [Fact]
-        public void CS0459ERR_AddrOnReadOnlyLocal()
+        public void AddrOnReadOnlyLocal()
         {
             var text = @"
 class A
@@ -10272,12 +10272,12 @@ class A
         int[] ints = new int[] { 1, 2, 3 };
         foreach (int i in ints)
         {
-            int *j = &i;  // CS0459
+            int *j = &i;  
         }
 
         fixed (int *i = &_i)
         {
-            int **j = &i;  // CS0459
+            int **j = &i;  
         }
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3235,7 +3235,7 @@ unsafe class C : Base
         var w = &(F += null); //CS0211
         var x = &(array is object); //CS0211
         var y = &(array ?? array); //CS0208, CS0211 (managed)
-        var aa = &this; //CS0208, CS0459 (readonly)
+        var aa = &this; //CS0208
         var bb = &typeof(int); //CS0208, CS0211 (managed)
         var cc = &Color.Red; //CS0211
 
@@ -3261,120 +3261,121 @@ enum Color
 }
 ";
             CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (23,14): error CS0211: Cannot take the address of the given expression
-                //         p = &1; //CS0211 (can't addr)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "1"),
-                // (24,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         p = &array[0]; //CS0212 (need fixed)
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&array[0]"),
-                // (25,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(local = 1); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local = 1"),
-                // (26,14): error CS0103: The name 'goo' does not exist in the current context
-                //         p = &goo; //CS0103 (no goo)
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "goo").WithArguments("goo"),
-                // (27,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         p = &base.f; //CS0212
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&base.f"),
-                // (28,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(local + local); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local + local"),
-                // (29,14): error CS0211: Cannot take the address of the given expression
-                //         p = &M(local); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "M(local)"),
-                // (30,14): error CS0211: Cannot take the address of the given expression
-                //         p = &func(); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "func()"),
-                // (31,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(local += local); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local += local"),
-                // (32,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(local == 0 ? local : param); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local == 0 ? local : param"),
-                // (33,15): error CS0211: Cannot take the address of the given expression
-                //         p = &((int)param); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "(int)param"),
-                // (34,14): error CS0211: Cannot take the address of the given expression
-                //         p = &default(int); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "default(int)"),
-                // (35,14): error CS0211: Cannot take the address of the given expression
-                //         p = &delegate { return 1; }; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate { return 1; }"),
-                // (36,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         p = &instanceField; //CS0212
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&instanceField"),
-                // (37,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         p = &staticField; //CS0212
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&staticField"),
-                // (38,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(local++); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local++"),
-                // (39,14): error CS0211: Cannot take the address of the given expression
-                //         p = &this[0]; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "this[0]").WithArguments("C.this[int]"),
-                // (40,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(() => 1); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "() => 1"),
-                // (41,14): error CS0211: Cannot take the address of the given expression
-                //         p = &M; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "M").WithArguments("M", "method group"),
-                // (42,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(new System.Int32()); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new System.Int32()"),
-                // (43,14): error CS0211: Cannot take the address of the given expression
-                //         p = &P; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "P").WithArguments("C.P"),
-                // (44,14): error CS0211: Cannot take the address of the given expression
-                //         p = &sizeof(int); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "sizeof(int)"),
-                // (45,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
-                //         p = &this.instanceField; //CS0212
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&this.instanceField"),
-                // (46,15): error CS0211: Cannot take the address of the given expression
-                //         p = &(+local); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "+local"),
-                // (49,16): error CS0211: Cannot take the address of the given expression
-                //         pp = &(&local); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "&local"),
-                // (51,19): error CS0211: Cannot take the address of the given expression
-                //         var q = &(new { }); //CS0208, CS0211 (managed)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new { }"),
-                // (52,19): error CS0211: Cannot take the address of the given expression
-                //         var r = &(new int[1]); //CS0208, CS0211 (managed)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new int[1]"),
-                // (53,19): error CS0211: Cannot take the address of the given expression
-                //         var s = &(array as object); //CS0208, CS0211 (managed)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array as object"),
-                // (54,17): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('System.Action')
-                //         var t = &E; //CS0208
-                Diagnostic(ErrorCode.ERR_ManagedAddr, "&E").WithArguments("System.Action"),
-                // (55,18): error CS0079: The event 'C.F' can only appear on the left hand side of += or -=
-                //         var u = &F; //CS0079 (can't use event like that)
-                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("C.F"),
-                // (56,19): error CS0211: Cannot take the address of the given expression
-                //         var v = &(E += null); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "E += null"),
-                // (57,19): error CS0211: Cannot take the address of the given expression
-                //         var w = &(F += null); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "F += null"),
-                // (58,19): error CS0211: Cannot take the address of the given expression
-                //         var x = &(array is object); //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array is object"),
-                // (59,19): error CS0211: Cannot take the address of the given expression
-                //         var y = &(array ?? array); //CS0208, CS0211 (managed)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array ?? array"),
-                // (60,19): error CS0459: Cannot take the address of a read-only local variable
-                //         var aa = &this; //CS0208, CS0459 (readonly)
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "this").WithArguments("this"),
-                // (61,19): error CS0211: Cannot take the address of the given expression
-                //         var bb = &typeof(int); //CS0208, CS0211 (managed)
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "typeof(int)"),
-                // (62,19): error CS0211: Cannot take the address of the given expression
-                //         var cc = &Color.Red; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "Color.Red"),
                 // (76,18): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
                 //         var aa = &this; //CS0212 (need fixed)
-                Diagnostic(ErrorCode.ERR_FixedNeeded, "&this"));
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&this").WithLocation(76, 18),
+                // (23,14): error CS0211: Cannot take the address of the given expression
+                //         p = &1; //CS0211 (can't addr)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "1").WithLocation(23, 14),
+                // (24,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         p = &array[0]; //CS0212 (need fixed)
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&array[0]").WithLocation(24, 13),
+                // (25,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(local = 1); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local = 1").WithLocation(25, 15),
+                // (26,14): error CS0103: The name 'goo' does not exist in the current context
+                //         p = &goo; //CS0103 (no goo)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "goo").WithArguments("goo").WithLocation(26, 14),
+                // (27,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         p = &base.f; //CS0212
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&base.f").WithLocation(27, 13),
+                // (28,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(local + local); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local + local").WithLocation(28, 15),
+                // (29,14): error CS0211: Cannot take the address of the given expression
+                //         p = &M(local); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "M(local)").WithLocation(29, 14),
+                // (30,14): error CS0211: Cannot take the address of the given expression
+                //         p = &func(); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "func()").WithLocation(30, 14),
+                // (31,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(local += local); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local += local").WithLocation(31, 15),
+                // (32,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(local == 0 ? local : param); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local == 0 ? local : param").WithLocation(32, 15),
+                // (33,15): error CS0211: Cannot take the address of the given expression
+                //         p = &((int)param); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "(int)param").WithLocation(33, 15),
+                // (34,14): error CS0211: Cannot take the address of the given expression
+                //         p = &default(int); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "default(int)").WithLocation(34, 14),
+                // (35,14): error CS0211: Cannot take the address of the given expression
+                //         p = &delegate { return 1; }; //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "delegate { return 1; }").WithLocation(35, 14),
+                // (36,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         p = &instanceField; //CS0212
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&instanceField").WithLocation(36, 13),
+                // (37,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         p = &staticField; //CS0212
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&staticField").WithLocation(37, 13),
+                // (38,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(local++); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "local++").WithLocation(38, 15),
+                // (39,14): error CS0211: Cannot take the address of the given expression
+                //         p = &this[0]; //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "this[0]").WithArguments("C.this[int]").WithLocation(39, 14),
+                // (40,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(() => 1); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "() => 1").WithLocation(40, 15),
+                // (41,14): error CS0211: Cannot take the address of the given expression
+                //         p = &M; //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "M").WithArguments("M", "method group").WithLocation(41, 14),
+                // (42,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(new System.Int32()); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new System.Int32()").WithLocation(42, 15),
+                // (43,14): error CS0211: Cannot take the address of the given expression
+                //         p = &P; //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "P").WithArguments("C.P").WithLocation(43, 14),
+                // (44,14): error CS0211: Cannot take the address of the given expression
+                //         p = &sizeof(int); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "sizeof(int)").WithLocation(44, 14),
+                // (45,13): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
+                //         p = &this.instanceField; //CS0212
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&this.instanceField").WithLocation(45, 13),
+                // (46,15): error CS0211: Cannot take the address of the given expression
+                //         p = &(+local); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "+local").WithLocation(46, 15),
+                // (49,16): error CS0211: Cannot take the address of the given expression
+                //         pp = &(&local); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "&local").WithLocation(49, 16),
+                // (51,19): error CS0211: Cannot take the address of the given expression
+                //         var q = &(new { }); //CS0208, CS0211 (managed)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new { }").WithLocation(51, 19),
+                // (52,19): error CS0211: Cannot take the address of the given expression
+                //         var r = &(new int[1]); //CS0208, CS0211 (managed)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "new int[1]").WithLocation(52, 19),
+                // (53,19): error CS0211: Cannot take the address of the given expression
+                //         var s = &(array as object); //CS0208, CS0211 (managed)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array as object").WithLocation(53, 19),
+                // (54,17): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('Action')
+                //         var t = &E; //CS0208
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "&E").WithArguments("System.Action").WithLocation(54, 17),
+                // (55,18): error CS0079: The event 'C.F' can only appear on the left hand side of += or -=
+                //         var u = &F; //CS0079 (can't use event like that)
+                Diagnostic(ErrorCode.ERR_BadEventUsageNoField, "F").WithArguments("C.F").WithLocation(55, 18),
+                // (56,19): error CS0211: Cannot take the address of the given expression
+                //         var v = &(E += null); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "E += null").WithLocation(56, 19),
+                // (57,19): error CS0211: Cannot take the address of the given expression
+                //         var w = &(F += null); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "F += null").WithLocation(57, 19),
+                // (58,19): error CS0211: Cannot take the address of the given expression
+                //         var x = &(array is object); //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array is object").WithLocation(58, 19),
+                // (59,19): error CS0211: Cannot take the address of the given expression
+                //         var y = &(array ?? array); //CS0208, CS0211 (managed)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "array ?? array").WithLocation(59, 19),
+                // (60,19): error CS0211: Cannot take the address of the given expression
+                //         var aa = &this; //CS0208
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "this").WithArguments("this").WithLocation(60, 19),
+                // (61,19): error CS0211: Cannot take the address of the given expression
+                //         var bb = &typeof(int); //CS0208, CS0211 (managed)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "typeof(int)").WithLocation(61, 19),
+                // (62,19): error CS0211: Cannot take the address of the given expression
+                //         var cc = &Color.Red; //CS0211
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "Color.Red").WithLocation(62, 19)
+            );
         }
 
         #endregion AddressOf operand kinds

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -8564,9 +8564,10 @@ public class Test
         int* pointer = &p;
     }
 }", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (6,25): error CS0211: Cannot take the address of the given expression
+                // (6,24): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
                 //         int* pointer = &p;
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "p").WithLocation(6, 25));
+                Diagnostic(ErrorCode.ERR_FixedNeeded, "&p").WithLocation(6, 24)
+                );
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3123,6 +3123,7 @@ unsafe class C
                 Diagnostic(ErrorCode.ERR_InvalidAddrOp, "x").WithArguments("x"));
         }
 
+        [WorkItem(22306, "https://github.com/dotnet/roslyn/issues/22306")]
         [Fact]
         public void AddressOfExpressionKinds_ReadOnlyLocal()
         {
@@ -3142,17 +3143,17 @@ unsafe class C
 
         foreach (int y in new int[1])
         {
-            p = &y; //CS0459
+            p = &y; 
         }
 
         using (S s = new S())
         {
-            S* sp = &s; //CS0459
+            S* sp = &s; 
         }
 
         fixed (int* a = &array[0])
         {
-            int** pp = &a; //CS0459
+            int** pp = &a; 
         }
     }
 }
@@ -3165,19 +3166,11 @@ struct S : System.IDisposable
             CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (13,14): error CS0211: Cannot take the address of the given expression
                 //         p = &x; //CS0211
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "x"),
-                // (17,18): error CS0459: Cannot take the address of a read-only local variable
-                //             p = &y; //CS0459
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "y"),
-                // (22,22): error CS0459: Cannot take the address of a read-only local variable
-                //             S* sp = &s; //CS0459
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "s"),
-                // (27,25): error CS0459: Cannot take the address of a read-only local variable
-                //             int** pp = &a; //CS0459
-                Diagnostic(ErrorCode.ERR_AddrOnReadOnlyLocal, "a"),
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "x").WithLocation(13, 14),
                 // (6,11): warning CS0649: Field 'C.array' is never assigned to, and will always have its default value null
                 //     int[] array;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "array").WithArguments("C.array", "null"));
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "array").WithArguments("C.array", "null").WithLocation(6, 11)
+                );
         }
 
         [Fact]
@@ -3839,6 +3832,7 @@ public class C
                 Diagnostic(ErrorCode.ERR_AnonymousTypePropertyAssignedBadValue, "p1 = &x").WithArguments("int*"));
         }
 
+        [WorkItem(22306, "https://github.com/dotnet/roslyn/issues/22306")]
         [WorkItem(544537, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544537")]
         [Fact]
         public void AddressOfStaticReadonlyFieldInsideFixed()
@@ -3855,10 +3849,7 @@ public class Test
 }
 ";
 
-            CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (8,27): error CS0211: Cannot take the address of the given expression
-                //         fixed (int* v1 = &R1) { }
-                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "R1"));
+            CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
         }
 
         #endregion AddressOf diagnostics


### PR DESCRIPTION
Allow taking unmanaged/pinned addresses of readonly variables.

Fixes:#22306

**Customer scenario**

Historically we require that lvalue is writable before allowing taking a pointer.
While there are ways to "cast away" readonliness, why is that even required before "casting away" most of the type system safeguards anyways?

After introducing more readonly variables in the language, the limitation becomes more apparent. - In anticipation of unsafe use, API creators avoid readonly even for safe scenarios. - Not a desirable outcome.

See for example
https://github.com/dotnet/corefx/blob/fa27201badbbce3cdb752d52593493a60c2f7d34/src/System.Memory/src/System/ReadOnlySpan.cs#L309

`public ref T DangerousGetPinnableReference()` on `ReadOnlySpan<T>` returns an _ordinary_ reference to the first element (on an otherwise readonly data type).   
It could instead return a readonly ref, but that would inconvenience the users since the main purpose is to use this method in “fixed” statement.

