### PR TITLE
Ref must come before 'partial' in a 'ref partial struct'

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1192,14 +1192,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             modTok = CheckFeatureAvailability(modTok,
                                 isPartialType ? MessageID.IDS_FeaturePartialTypes : MessageID.IDS_FeaturePartialMethod);
                         }
+                        else if(nextToken.Kind == SyntaxKind.NamespaceKeyword)
+                        {
+                            // Error reported in binding
+                            modTok = ConvertToKeyword(this.EatToken());
+                        }
                         else if (
                             nextToken.Kind == SyntaxKind.EnumKeyword ||
                             nextToken.Kind == SyntaxKind.DelegateKeyword ||
-                            nextToken.Kind == SyntaxKind.NamespaceKeyword ||
                             (IsPossibleStartOfTypeDeclaration(nextToken.Kind) && GetModifier(nextToken) != DeclarationModifiers.None))
                         {
-                            // Error tolerance cases.  Will report an error about these post parsing.
-                            modTok = ConvertToKeyword(this.EatToken());
+                            // Misplaced partial
+                            // TODO(https://github.com/dotnet/roslyn/issues/22439):
+                            // We should consider moving this check into binding, but avoid holding on to trees
+                            modTok = AddError(ConvertToKeyword(this.EatToken()), ErrorCode.ERR_PartialMisplaced);
                         }
                         else
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -337,24 +337,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!modifierErrors)
                 {
-                    SyntaxTokenList modifierTokens;
-                    switch (decl.SyntaxReference.GetSyntax())
-                    {
-                        case BaseTypeDeclarationSyntax type:
-                            modifierTokens = type.Modifiers;
-                            break;
-                        case DelegateDeclarationSyntax @delegate:
-                            modifierTokens = @delegate.Modifiers;
-                            break;
-                        default:
-                            // No modifier token list
-                            modifierTokens = default;
-                            break;
-                    }
-
                     mods = ModifierUtils.CheckModifiers(
                         mods, allowedModifiers, declaration.Declarations[i].NameLocation, diagnostics,
-                        modifierTokens: modifierTokens, modifierErrors: out modifierErrors);
+                        modifierTokens: null, modifierErrors: out modifierErrors);
 
                     // It is an error for the same modifier to appear multiple times.
                     if (!modifierErrors)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -327,7 +327,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (var i = 0; i < partCount; i++)
             {
-                var mods = declaration.Declarations[i].Modifiers;
+                var decl = declaration.Declarations[i];
+                var mods = decl.Modifiers;
 
                 if (partCount > 1 && (mods & DeclarationModifiers.Partial) == 0)
                 {
@@ -336,9 +337,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (!modifierErrors)
                 {
+                    SyntaxTokenList modifierTokens;
+                    switch (decl.SyntaxReference.GetSyntax())
+                    {
+                        case BaseTypeDeclarationSyntax type:
+                            modifierTokens = type.Modifiers;
+                            break;
+                        case DelegateDeclarationSyntax @delegate:
+                            modifierTokens = @delegate.Modifiers;
+                            break;
+                        default:
+                            // No modifier token list
+                            modifierTokens = default;
+                            break;
+                    }
+
                     mods = ModifierUtils.CheckModifiers(
                         mods, allowedModifiers, declaration.Declarations[i].NameLocation, diagnostics,
-                        modifierTokensOpt: null, modifierErrors: out modifierErrors);
+                        modifierTokens: modifierTokens, modifierErrors: out modifierErrors);
 
                     // It is an error for the same modifier to appear multiple times.
                     if (!modifierErrors)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
@@ -192,49 +192,52 @@ partial class C
             comp.VerifyDiagnostics(
                 // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 //     partial public static int operator + (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial"),
-                // (12,12): error CS1004: Duplicate 'public' modifier
-                //     public public public static int operator & (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "public").WithArguments("public"),
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
+                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial public static int operator + (C c1, C c2) { return 0; }
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
                 // (5,34): error CS0106: The modifier 'abstract' is not valid for this item
                 //     abstract public int operator - (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("abstract"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("abstract").WithLocation(5, 34),
                 // (5,34): error CS0558: User-defined operator 'C.operator -(C, C)' must be declared static and public
                 //     abstract public int operator - (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "-").WithArguments("C.operator -(C, C)"),
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "-").WithArguments("C.operator -(C, C)").WithLocation(5, 34),
                 // (6,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed public int operator << (C c1, int c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "<<").WithArguments("sealed"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "<<").WithArguments("sealed").WithLocation(6, 32),
                 // (6,32): error CS0558: User-defined operator 'C.operator <<(C, int)' must be declared static and public
                 //     sealed public int operator << (C c1, int c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "<<").WithArguments("C.operator <<(C, int)"),
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "<<").WithArguments("C.operator <<(C, int)").WithLocation(6, 32),
                 // (7,36): error CS0106: The modifier 'new' is not valid for this item
                 //     new public static int operator >> (C c1, int c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, ">>").WithArguments("new"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, ">>").WithArguments("new").WithLocation(7, 36),
                 // (8,41): error CS0106: The modifier 'readonly' is not valid for this item
                 //     readonly public static int operator * (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("readonly"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "*").WithArguments("readonly").WithLocation(8, 41),
                 // (9,41): error CS0106: The modifier 'volatile' is not valid for this item
                 //     volatile public static int operator % (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "%").WithArguments("volatile"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "%").WithArguments("volatile").WithLocation(9, 41),
                 // (10,33): error CS0106: The modifier 'virtual' is not valid for this item
                 //     virtual public int operator - (C c1) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("virtual").WithLocation(10, 33),
                 // (10,33): error CS0558: User-defined operator 'C.operator -(C)' must be declared static and public
                 //     virtual public int operator - (C c1) { return 0; }
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "-").WithArguments("C.operator -(C)"),
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "-").WithArguments("C.operator -(C)").WithLocation(10, 33),
                 // (11,34): error CS0106: The modifier 'override' is not valid for this item
                 //     override public int operator ~ (C c1) { return 0; }
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("override"),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "~").WithArguments("override").WithLocation(11, 34),
                 // (11,34): error CS0558: User-defined operator 'C.operator ~(C)' must be declared static and public
                 //     override public int operator ~ (C c1) { return 0; }
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "~").WithArguments("C.operator ~(C)"),
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "~").WithArguments("C.operator ~(C)").WithLocation(11, 34),
+                // (12,12): error CS1004: Duplicate 'public' modifier
+                //     public public public static int operator & (C c1, C c2) { return 0; }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "public").WithArguments("public").WithLocation(12, 12),
                 // (13,39): error CS0179: 'C.operator ^(C, C)' cannot be extern and declare a body
                 //     extern static public int operator ^ (C c1, C c2) { return 1; }
-                Diagnostic(ErrorCode.ERR_ExternHasBody, "^").WithArguments("C.operator ^(C, C)"),
+                Diagnostic(ErrorCode.ERR_ExternHasBody, "^").WithArguments("C.operator ^(C, C)").WithLocation(13, 39),
                 // (14,32): error CS0501: 'C.operator +(C)' must declare a body because it is not marked abstract, extern, or partial
                 //     static public int operator + (C c1);
-                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "+").WithArguments("C.operator +(C)")
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "+").WithArguments("C.operator +(C)").WithLocation(14, 32)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5549,7 +5549,7 @@ partial class PartialPartial
             CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (1,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum E{}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(1, 14));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(1, 1));
         }
 
         [WorkItem(539120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539120")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5549,7 +5549,10 @@ partial class PartialPartial
             CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (1,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum E{}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(1, 1),
+                // (1,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial enum E{}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(1, 14));
         }
 
         [WorkItem(539120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539120")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -414,7 +414,10 @@ partial enum E { }
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
+                // (2,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial enum E { }
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 14));
         }
 
         [Fact]
@@ -426,6 +429,9 @@ partial delegate E { }
 
             // Extra errors
             CreateStandardCompilation(test).VerifyDiagnostics(
+                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial delegate E { }
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
                 // (2,20): error CS1001: Identifier expected
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(2, 20),
@@ -444,9 +450,9 @@ partial delegate E { }
                 // (2,22): error CS1022: Type or namespace definition, or end-of-file expected
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(2, 22),
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (2,20): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial delegate E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "").WithLocation(2, 20),
                 // (2,18): error CS0246: The type or namespace name 'E' could not be found (are you missing a using directive or an assembly reference?)
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "E").WithArguments("E").WithLocation(2, 18));
@@ -463,7 +469,10 @@ partial delegate void E();
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial delegate void E();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
+                // (2,23): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial delegate void E();
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 23));
         }
 
         // TODO: Extra errors

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -398,7 +398,10 @@ public class Test
 }
 ";
 
-            CreateStandardCompilation(test).VerifyDiagnostics();
+            CreateStandardCompilation(test).VerifyDiagnostics(
+                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial public class C  // CS0267
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
         }
 
         [Fact]
@@ -411,7 +414,7 @@ partial enum E { }
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 14));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
         }
 
         [Fact]
@@ -443,7 +446,7 @@ partial delegate E { }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(2, 22),
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial delegate E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "").WithLocation(2, 20),
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
                 // (2,18): error CS0246: The type or namespace name 'E' could not be found (are you missing a using directive or an assembly reference?)
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "E").WithArguments("E").WithLocation(2, 18));
@@ -460,7 +463,7 @@ partial delegate void E();
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial delegate void E();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 23));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
         }
 
         // TODO: Extra errors

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -13,6 +13,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
     public class ParserRegressionTests : CSharpTestBase
     {
+        [Fact]
+        public void PartialLocationInModifierList()
+        {
+            var comp = CreateStandardCompilation(@"
+class Program
+{
+    partial abstract class A {}
+    partial abstract class A {}
+
+    partial partial class B {}
+    partial partial class B {}
+
+    partial abstract struct S {}
+    partial abstract struct S {}
+}");
+            comp.VerifyDiagnostics();
+        }
+
         [WorkItem(540005, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540005")]
         [Fact]
         public void c01()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -28,7 +28,40 @@ class Program
     partial abstract struct S {}
     partial abstract struct S {}
 }");
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,13): error CS1525: Invalid expression term 'partial'
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(7, 13),
+                // (7,13): error CS1002: ; expected
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(7, 13),
+                // (8,13): error CS1525: Invalid expression term 'partial'
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(8, 13),
+                // (8,13): error CS1002: ; expected
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(8, 13),
+                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract class A {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
+                // (5,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract class A {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(5, 5),
+                // (10,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract struct S {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(10, 5),
+                // (10,29): error CS0106: The modifier 'abstract' is not valid for this item
+                //     partial abstract struct S {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("abstract").WithLocation(10, 29),
+                // (8,13): error CS0102: The type 'Program' already contains a definition for ''
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("Program", "").WithLocation(8, 13),
+                // (8,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(8, 5),
+                // (7,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
+                //     partial partial class B {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(7, 5));
         }
 
         [WorkItem(540005, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540005")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -29,6 +29,12 @@ class Program
     partial abstract struct S {}
 }");
             comp.VerifyDiagnostics(
+                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract class A {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
+                // (5,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract class A {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(5, 5),
                 // (7,13): error CS1525: Invalid expression term 'partial'
                 //     partial partial class B {}
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(7, 13),
@@ -41,15 +47,12 @@ class Program
                 // (8,13): error CS1002: ; expected
                 //     partial partial class B {}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(8, 13),
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract class A {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
-                // (5,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract class A {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(5, 5),
                 // (10,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 //     partial abstract struct S {}
                 Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(10, 5),
+                // (11,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                //     partial abstract struct S {}
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(11, 5),
                 // (10,29): error CS0106: The modifier 'abstract' is not valid for this item
                 //     partial abstract struct S {}
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("abstract").WithLocation(10, 29),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ReadOnlyStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ReadOnlyStructs.cs
@@ -170,9 +170,9 @@ class Program
 
     readonly partial struct S1{}
 
-    readonly partial ref struct S2{}
+    readonly ref partial struct S2{}
 
-    readonly partial ref struct S2{}
+    readonly ref partial struct S2{}
 }
 ";
 
@@ -198,13 +198,13 @@ class Program
 {
     readonly partial struct S1{}
 
-    readonly partial ref struct S1{}
+    readonly ref partial struct S1{}
 
     readonly partial struct S2{}
 
     partial struct S2{}
 
-    readonly partial ref struct S3{}
+    readonly ref partial struct S3{}
 
     partial struct S3{}
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -95,18 +95,118 @@ class Program
         }
 
         [Fact]
-        public void RefStructPartial()
+        public void PartialRefStruct()
         {
             var text = @"
 class Program
 {
-    partial ref struct S1{}
-
-    partial ref struct S1{}
+    partial ref struct S {}
+    partial ref struct S {}
 }
 ";
+            var comp = CreateStandardCompilation(text);
+            comp.VerifyDiagnostics(
+                // (4,13): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 13),
+                // (5,13): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 13),
+                // (5,24): error CS0102: The type 'Program' already contains a definition for 'S'
+                //     partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("Program", "S").WithLocation(5, 24));
+        }
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
+        [Fact]
+        public void RefPartialStruct()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    ref partial struct S {}
+    ref partial struct S {}
+}");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void RefPartialReadonlyStruct()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    ref partial readonly struct S {}
+    ref partial readonly struct S {}
+}");
+            comp.VerifyDiagnostics(
+                // (4,17): error CS1585: Member modifier 'readonly' must precede the member type and name
+                //     ref partial readonly struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "readonly").WithArguments("readonly").WithLocation(4, 17),
+                // (5,17): error CS1585: Member modifier 'readonly' must precede the member type and name
+                //     ref partial readonly struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "readonly").WithArguments("readonly").WithLocation(5, 17),
+                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
+                //     ref partial readonly struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+        }
+
+        [Fact]
+        public void RefReadonlyPartialStruct()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    partial ref readonly struct S {}
+    partial ref readonly struct S {}
+}");
+            comp.VerifyDiagnostics(
+                // (4,13): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     partial ref readonly struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 13),
+                // (4,26): error CS1031: Type expected
+                //     partial ref readonly struct S {}
+                Diagnostic(ErrorCode.ERR_TypeExpected, "struct").WithLocation(4, 26),
+                // (5,13): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     partial ref readonly struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 13),
+                // (5,26): error CS1031: Type expected
+                //     partial ref readonly struct S {}
+                Diagnostic(ErrorCode.ERR_TypeExpected, "struct").WithLocation(5, 26),
+                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
+                //     partial ref readonly struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+        }
+
+        [Fact]
+        public void ReadonlyPartialRefStruct()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    readonly partial ref struct S {}
+    readonly partial ref struct S {}
+}");
+            comp.VerifyDiagnostics(
+                // (4,22): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     readonly partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 22),
+                // (5,22): error CS1585: Member modifier 'ref' must precede the member type and name
+                //     readonly partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 22),
+                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
+                //     readonly partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+        }
+
+        [Fact]
+        public void ReadonlyRefPartialStruct()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    readonly ref partial struct S {}
+    readonly ref partial struct S {}
+}");
             comp.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RoundTrippingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RoundTrippingTests.cs
@@ -398,7 +398,7 @@ partial class partial
         public void TestNegBug876575()
         {
             var text = @"partial enum E{}";
-            ParseAndRoundTripping(text, errorCount: 0);
+            ParseAndRoundTripping(text, errorCount: 1);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -1844,7 +1844,7 @@ partial enum en {};
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum en {};
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "en").WithLocation(2, 14));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -1844,7 +1844,10 @@ partial enum en {};
             CreateStandardCompilation(test).VerifyDiagnostics(
                 // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
                 // partial enum en {};
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
+                // (2,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // partial enum en {};
+                Diagnostic(ErrorCode.ERR_PartialMisplaced, "en").WithLocation(2, 14));
         }
 
         [Fact]


### PR DESCRIPTION
**Customer scenario**

The previous LDM design for `ref` and `partial` on structs is that `partial` comes before `ref`. This implements the change to reverse that.

**Bugs this fixes:**

Fixes #22379 

**Risk**

This change is isolated to parsing `ref` as a modifier on structs.

**Performance impact**

None. No major new code, same parsing complexity.

**Root cause analysis:**

LDM change.