### PR TITLE
Remove PROTOTYPE markers from "private protected" feature

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -1038,7 +1038,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 case Accessibility.ProtectedOrInternal:
                     return EnvDTE.vsCMAccess.vsCMAccessProjectOrProtected;
                 case Accessibility.ProtectedAndInternal:
-                    // PROTOTYPE: there is no appropriate mapping for private protected in EnvDTE.vsCMAccess
+                    // there is no appropriate mapping for private protected in EnvDTE.vsCMAccess
+                    // See https://github.com/dotnet/roslyn/issues/22406
                     return EnvDTE.vsCMAccess.vsCMAccessProtected;
                 default:
                     throw Exceptions.ThrowEFail();

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -1422,7 +1422,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Case Accessibility.ProtectedOrInternal, Accessibility.ProtectedOrFriend
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessProjectOrProtected
                 Case Accessibility.ProtectedAndInternal, Accessibility.ProtectedAndFriend
-                    ' PROTOTYPE: there is no appropriate mapping for private protected in EnvDTE.vsCMAccess
+                    ' there is no appropriate mapping for private protected in EnvDTE.vsCMAccess
+                    ' See https://github.com/dotnet/roslyn/issues/22406
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessProject
                 Case Accessibility.Public
                     access = access Or EnvDTE.vsCMAccess.vsCMAccessPublic


### PR DESCRIPTION
Fixes #22244
Related to #22406

This is a comment-only change, to remove PROTOTYPE comments and replace by open issues.

@jcouv Please review and approve for 15.5.
