### PR TITLE
Avoid accessing inferred type in error cases in IsNullable()

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if ((object)declType != null)
                 {
-                    return new BoundLocal(syntax, localSymbol, isDeclaration: true, constantValueOpt: null, type: declType.TypeSymbol, hasErrors: hasErrors);
+                    return new BoundLocal(syntax, localSymbol, isDeclaration: true, constantValueOpt: null, isNullableUnknown: false, type: declType.TypeSymbol, hasErrors: hasErrors);
                 }
 
                 return new DeconstructionVariablePendingInference(syntax, localSymbol, receiverOpt: null);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -112,19 +112,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return this.LocalSymbol; }
         }
 
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors)
-            : this(syntax, localSymbol, false, constantValueOpt, type, hasErrors)
-        {
-        }
-
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type)
-            : this(syntax, localSymbol, false, constantValueOpt, type)
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors = false)
+            : this(syntax, localSymbol, false, constantValueOpt, false, type, hasErrors)
         {
         }
 
         public BoundLocal Update(LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type)
         {
-            return this.Update(localSymbol, this.IsDeclaration, constantValueOpt, type);
+            return this.Update(localSymbol, this.IsDeclaration, constantValueOpt, this.IsNullableUnknown, type);
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             // PROTOTYPE(NullableReferenceTypes): Could we track nullability always,
             // even in C#7, but only report warnings when the feature is enabled?
-            var isNullable = includeNullability && !type.IsErrorType() ? expr.IsNullable() : null;
+            var isNullable = includeNullability ? expr.IsNullable() : null;
             return TypeSymbolWithAnnotations.Create(type, isNullable);
         }
 
@@ -197,7 +197,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.SuppressNullableWarningExpression:
                     return false;
                 case BoundKind.Local:
-                    return ((BoundLocal)expr).LocalSymbol.Type.IsNullable;
+                    {
+                        var local = (BoundLocal)expr;
+                        return local.IsNullableUnknown ? null : local.LocalSymbol.Type.IsNullable;
+                    }
                 case BoundKind.Parameter:
                     return ((BoundParameter)expr).ParameterSymbol.Type.IsNullable;
                 case BoundKind.FieldAccess:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1000,6 +1000,8 @@
     <Field Name="LocalSymbol" Type="LocalSymbol"/>
     <Field Name="IsDeclaration" Type="bool"/>
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
+    <!-- True if LocalSymbol.Type.IsNullable could not be inferred. -->
+    <Field Name="IsNullableUnknown" Type="bool"/>
   </Node>
 
   <Node Name="BoundPseudoVariable" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/VariablePendingInference.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     localSymbol.SetTypeSymbol(TypeSymbolWithAnnotations.Create(type));
-                    return new BoundLocal(this.Syntax, localSymbol, isDeclaration: true, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
+                    return new BoundLocal(this.Syntax, localSymbol, isDeclaration: true, constantValueOpt: null, isNullableUnknown: false, type: type, hasErrors: this.HasErrors || inferenceFailed);
 
                 case SymbolKind.Field:
                     var fieldSymbol = (GlobalExpressionVariable)this.VariableSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1346,13 +1346,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.PropertyAccess:
                     {
-                        var propertyAccesss = (BoundPropertyAccess)node;
-                        int slot = MakeSlot(propertyAccesss);
+                        var propertyAccess = (BoundPropertyAccess)node;
+                        int slot = MakeSlot(propertyAccess);
                         SetSlotState(slot, written);
                         if (written)
                         {
-                            NoteWrite(propertyAccesss, value, read);
-                            TrackNullableStateForAssignment(node, propertyAccesss.PropertySymbol, slot, value, valueIsNotNull);
+                            NoteWrite(propertyAccess, value, read);
+                            TrackNullableStateForAssignment(node, propertyAccess.PropertySymbol, slot, value, valueIsNotNull);
                         }
                         break;
                     }
@@ -1361,8 +1361,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (written && _performStaticNullChecks && this.State.Reachable)
                         {
-                            var indexerAccesss = (BoundIndexerAccess)node;
-                            TrackNullableStateForAssignment(node, indexerAccesss.Indexer, -1, value, valueIsNotNull);
+                            var indexerAccess = (BoundIndexerAccess)node;
+                            TrackNullableStateForAssignment(node, indexerAccess.Indexer, -1, value, valueIsNotNull);
                         }
                         break;
                     }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3638,7 +3638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundLocal : BoundExpression
     {
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors)
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type, bool hasErrors)
             : base(BoundKind.Local, syntax, type, hasErrors)
         {
 
@@ -3648,9 +3648,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.LocalSymbol = localSymbol;
             this.IsDeclaration = isDeclaration;
             this.ConstantValueOpt = constantValueOpt;
+            this.IsNullableUnknown = isNullableUnknown;
         }
 
-        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, TypeSymbol type)
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
             : base(BoundKind.Local, syntax, type)
         {
 
@@ -3660,6 +3661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.LocalSymbol = localSymbol;
             this.IsDeclaration = isDeclaration;
             this.ConstantValueOpt = constantValueOpt;
+            this.IsNullableUnknown = isNullableUnknown;
         }
 
 
@@ -3669,16 +3671,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ConstantValue ConstantValueOpt { get; }
 
+        public bool IsNullableUnknown { get; }
+
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitLocal(this);
         }
 
-        public BoundLocal Update(LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, TypeSymbol type)
+        public BoundLocal Update(LocalSymbol localSymbol, bool isDeclaration, ConstantValue constantValueOpt, bool isNullableUnknown, TypeSymbol type)
         {
-            if (localSymbol != this.LocalSymbol || isDeclaration != this.IsDeclaration || constantValueOpt != this.ConstantValueOpt || type != this.Type)
+            if (localSymbol != this.LocalSymbol || isDeclaration != this.IsDeclaration || constantValueOpt != this.ConstantValueOpt || isNullableUnknown != this.IsNullableUnknown || type != this.Type)
             {
-                var result = new BoundLocal(this.Syntax, localSymbol, isDeclaration, constantValueOpt, type, this.HasErrors);
+                var result = new BoundLocal(this.Syntax, localSymbol, isDeclaration, constantValueOpt, isNullableUnknown, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8975,7 +8979,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitLocal(BoundLocal node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(node.LocalSymbol, node.IsDeclaration, node.ConstantValueOpt, type);
+            return node.Update(node.LocalSymbol, node.IsDeclaration, node.ConstantValueOpt, node.IsNullableUnknown, type);
         }
         public override BoundNode VisitPseudoVariable(BoundPseudoVariable node)
         {
@@ -10247,6 +10251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("localSymbol", node.LocalSymbol, null),
                 new TreeDumperNode("isDeclaration", node.IsDeclaration, null),
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
+                new TreeDumperNode("isNullableUnknown", node.IsNullableUnknown, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -16613,6 +16613,122 @@ class B
             Assert.Equal(true, symbol.Type.IsNullable);
         }
 
+        [Fact]
+        public void InferLocalType_UsedInDeclaration()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    static T F<T>(IEnumerable<T> e)
+    {
+        throw new NotImplementedException();
+    }
+    static void G()
+    {
+        var a = new[] { F(a) };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (11,27): error CS0841: Cannot use local variable 'a' before it is declared
+                //         var a = new[] { F(a) };
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "a").WithArguments("a").WithLocation(11, 27),
+                // (11,27): error CS0165: Use of unassigned local variable 'a'
+                //         var a = new[] { F(a) };
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "a").WithArguments("a").WithLocation(11, 27));
+        }
+
+        [Fact]
+        public void InferLocalType_UsedInDeclaration_Script()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+static T F<T>(IEnumerable<T> e)
+{
+    throw new NotImplementedException();
+}
+var a = new[] { F(a) };";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp8));
+            comp.VerifyDiagnostics(
+                // (7,5): error CS7019: Type of 'a' cannot be inferred since its initializer directly or indirectly refers to the definition.
+                // var a = new[] { F(a) };
+                Diagnostic(ErrorCode.ERR_RecursivelyTypedVariable, "a").WithArguments("a").WithLocation(7, 5));
+        }
+
+        [Fact]
+        public void InferLocalType_UsedBeforeDeclaration()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    static T F<T>(IEnumerable<T> e)
+    {
+        throw new NotImplementedException();
+    }
+    static void G()
+    {
+        var a = new[] { F(b) };
+        var b = a;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (11,27): error CS0841: Cannot use local variable 'b' before it is declared
+                //         var a = new[] { F(b) };
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "b").WithArguments("b").WithLocation(11, 27));
+        }
+
+        [Fact]
+        public void InferLocalType_OutVarError()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    static T F<T>(IEnumerable<T> e)
+    {
+        throw new NotImplementedException();
+    }
+    static void G()
+    {
+        dynamic d = null!;
+        d.F(out var v);
+        F(v).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (12,21): error CS8197: Cannot infer the type of implicitly-typed out variable 'v'.
+                //         d.F(out var v);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, "v").WithArguments("v").WithLocation(12, 21));
+        }
+
+        [Fact]
+        public void InferLocalType_OutVarError_Script()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+static T F<T>(IEnumerable<T> e)
+{
+    throw new NotImplementedException();
+}
+dynamic d = null!;
+d.F(out var v);
+F(v).ToString();";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp8));
+            comp.VerifyDiagnostics(
+                // (8,13): error CS8197: Cannot infer the type of implicitly-typed out variable 'v'.
+                // d.F(out var v);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, "v").WithArguments("v").WithLocation(8, 13));
+        }
+
         /// <summary>
         /// Default value for non-nullable parameter
         /// should not result in a warning at the call site.


### PR DESCRIPTION
Accessing inferred local type when calculating `IsNullable` can result in a cycle in error cases.