### PR TITLE
Report binding error for typed LINQ query on a type expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -551,10 +551,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (invokedAsExtensionMethod)
                 {
-                    if (receiverOpt?.Kind == BoundKind.QueryClause && IsMemberAccessedThroughType(receiverOpt))
+                    if (IsMemberAccessedThroughType(receiverOpt))
                     {
-                        // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.
-                        diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, receiverOpt.Type, memberSymbol.Name);
+                        if (receiverOpt?.Kind == BoundKind.QueryClause)
+                        {
+                            // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.
+                            diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, receiverOpt.Type, memberSymbol.Name);
+                        }
+                        else
+                        {
+                            // An object reference is required for the non-static field, method, or property '{0}'
+                            diagnostics.Add(ErrorCode.ERR_ObjectRequired, node.Location, memberSymbol);
+                        }
                         return true;
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (IsMemberAccessedThroughType(receiverOpt))
                     {
-                        if (receiverOpt?.Kind == BoundKind.QueryClause)
+                        if (receiverOpt.Kind == BoundKind.QueryClause)
                         {
                             // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.
                             diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, receiverOpt.Type, memberSymbol.Name);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2524,7 +2524,7 @@ class Program
                 );
         }
 
-        [Fact, WorkItem(12052, "https://github.com/dotnet/roslyn/issues/12052")]
+        [Fact, WorkItem(21484, "https://github.com/dotnet/roslyn/issues/21484")]
         public void QueryOnTypeExpression()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2523,5 +2523,51 @@ class Program
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "a").WithArguments("a").WithLocation(10, 43)
                 );
         }
+
+        [Fact, WorkItem(12052, "https://github.com/dotnet/roslyn/issues/12052")]
+        public void QueryOnTypeExpression()
+        {
+            var code = @"
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void M<T>() where T : IEnumerable
+    {
+        var query1 = from object a in IEnumerable select 1;
+        var query2 = from b in IEnumerable select 2;
+
+        var query3 = from int c in IEnumerable<int> select 3;
+        var query4 = from d in IEnumerable<int> select 4;
+
+        var query5 = from object d in T select 5;
+        var query6 = from d in T select 6;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(code);
+            comp.VerifyDiagnostics(
+                // (10,22): error CS0120: An object reference is required for the non-static field, method, or property 'Enumerable.Cast<object>(IEnumerable)'
+                //         var query1 = from object a in IEnumerable select 1;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "from object a in IEnumerable").WithArguments("System.Linq.Enumerable.Cast<object>(System.Collections.IEnumerable)").WithLocation(10, 22),
+                // (11,32): error CS1934: Could not find an implementation of the query pattern for source type 'IEnumerable'.  'Select' not found.  Consider explicitly specifying the type of the range variable 'b'.
+                //         var query2 = from b in IEnumerable select 2;
+                Diagnostic(ErrorCode.ERR_QueryNoProviderCastable, "IEnumerable").WithArguments("System.Collections.IEnumerable", "Select", "b").WithLocation(11, 32),
+                // (13,22): error CS0120: An object reference is required for the non-static field, method, or property 'Enumerable.Cast<int>(IEnumerable)'
+                //         var query3 = from int c in IEnumerable<int> select 3;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "from int c in IEnumerable<int>").WithArguments("System.Linq.Enumerable.Cast<int>(System.Collections.IEnumerable)").WithLocation(13, 22),
+                // (14,49): error CS1936: Could not find an implementation of the query pattern for source type 'IEnumerable<int>'.  'Select' not found.
+                //         var query4 = from d in IEnumerable<int> select 4;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "select 4").WithArguments("System.Collections.Generic.IEnumerable<int>", "Select").WithLocation(14, 49),
+                // (16,22): error CS0120: An object reference is required for the non-static field, method, or property 'Enumerable.Cast<object>(IEnumerable)'
+                //         var query5 = from object d in T select 5;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "from object d in T").WithArguments("System.Linq.Enumerable.Cast<object>(System.Collections.IEnumerable)").WithLocation(16, 22),
+                // (17,32): error CS1936: Could not find an implementation of the query pattern for source type 'T'.  'Select' not found.
+                //         var query6 = from d in T select 6;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "T").WithArguments("T", "Select").WithLocation(17, 32)
+                );
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**
Use a type as the collection in a LINQ query with a typed variable (`from object x in IEnumerable ...`). The compiler should produce an error, but instead it fails when emitting.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/21484

**Details:**
When a LINQ query specifies a type (`from object x in y`), we will make an invocation for it: `y.Cast<object>()`. When `y` is `IEnumerable`, we find an extension method `System.Linq.Enumerable.Cast<object>(this IEnumerable)`.
After we find it, this PR adds a check and reports a diagnostic, because that is trying to invoke an extension method with a type as its receiver (but an instance is required).

Note, the error is reported from another branch of the same method (`MemberGroupFinalValidationAccessibilityChecks`) in this scenario:
```C#
class C
{
   void Cast<T>() => throw null;
   void M()
   {
       C.Cast<object>(); // error CS0120: An object reference is required for the non-static field, method, or property 'C.Cast<object>()'
    }
}
```

**Workarounds, if any**
Fix your code. But the compiler doesn't provide diagnostics pointing to the source of the error :-(

**Risk**
**Performance impact**
Low. Adding one more check during binding of queries.
Thanks @AlekseyTs for the help narrowing down a low-risk fix :-)

**Is this a regression from a previous update?**
No.

**How was the bug found?**
Reported by customer.

@dotnet/roslyn-compiler for review. Thanks