### PR TITLE
Ensure partial method implementation is completed when needed

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2201,15 +2201,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            if (symbol.IsPartialDefinition())
-            {
-                MethodSymbol implementationPart = ((MethodSymbol)symbol).PartialImplementationPart;
-                if ((object)implementationPart != null)
-                {
-                    return implementationPart.IsDefinedInSourceTree(tree, span);
-                }
-            }
-
             if (symbol.Kind == SymbolKind.Method && symbol.IsImplicitlyDeclared && ((MethodSymbol)symbol).MethodKind == MethodKind.Constructor)
             {
                 // Include implicitly declared constructor if containing type is included

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -994,6 +995,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             base.ForceComplete(locationOpt, cancellationToken);
+        }
+
+        internal override bool IsDefinedInSourceTree(
+            SyntaxTree tree,
+            TextSpan? definedWithinSpan,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Since only the declaring (and not the implementing) part of a partial method appears in the member
+            // list, we need to ensure we complete the implementation part when needed.
+            return
+                base.IsDefinedInSourceTree(tree, definedWithinSpan, cancellationToken) ||
+                this.SourcePartialImplementation?.IsDefinedInSourceTree(tree, definedWithinSpan, cancellationToken) == true;
         }
 
         internal override void AfterAddingTypeMembersChecks(ConversionsBase conversions, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetUnusedImportDirectivesTests.cs
@@ -375,5 +375,61 @@ using System;
                 // using System;
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;"));
         }
+
+        [Fact, WorkItem(18348, "https://github.com/dotnet/roslyn/issues/18348")]
+        public void IncorrectUnusedUsingWhenAttributeOnParameter_01()
+        {
+            var source1 =
+@"using System.Runtime.InteropServices;
+
+partial class Program
+{
+    partial void M([Out] [In] ref int x) { }
+}";
+            var source2 =
+@"partial class Program
+{
+    partial void M(ref int x);
+}";
+            var comp = CreateStandardCompilation(new[] { source1, source2 });
+            var tree = comp.SyntaxTrees[0];
+            //comp.VerifyDiagnostics(); // doing this first hides the symptoms of the bug
+            var model = comp.GetSemanticModel(tree);
+
+            // There should be no diagnostics.
+            model.GetDiagnostics().Verify(
+                //// (1,1): hidden CS8019: Unnecessary using directive.
+                //// using System.Runtime.InteropServices;
+                //Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Runtime.InteropServices;").WithLocation(1, 1)
+                );
+        }
+
+        [Fact, WorkItem(18348, "https://github.com/dotnet/roslyn/issues/18348")]
+        public void IncorrectUnusedUsingWhenAttributeOnParameter_02()
+        {
+            var source1 =
+@"using System.Runtime.InteropServices;
+
+partial class Program
+{
+    partial void M([Out] [In] ref int x);
+}";
+            var source2 =
+@"partial class Program
+{
+    partial void M(ref int x) { }
+}";
+            var comp = CreateStandardCompilation(new[] { source1, source2 });
+            var tree = comp.SyntaxTrees[0];
+            //comp.VerifyDiagnostics(); // doing this first hides the symptoms of the bug
+            var model = comp.GetSemanticModel(tree);
+
+            // There should be no diagnostics.
+            model.GetDiagnostics().Verify(
+                //// (1,1): hidden CS8019: Unnecessary using directive.
+                //// using System.Runtime.InteropServices;
+                //Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Runtime.InteropServices;").WithLocation(1, 1)
+                );
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetUnusedImportDirectivesTests.vb
@@ -314,5 +314,57 @@ Imports System
 ~~~~~~~~~~~~~~
                 </errors>, suppressInfos:=False)
         End Sub
+
+        <Fact, WorkItem(18348, "https://github.com/dotnet/roslyn/issues/18348")>
+        Public Sub IncorrectUnusedUsingWhenAttributeOnParameter_01()
+            Dim source =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System.Runtime.InteropServices
+Partial Class Program
+    Private Sub M(<Out> <InAttribute> ByRef x As Integer)
+    End Sub
+End Class
+]]></file>
+    <file name="b.vb"><![CDATA[
+Partial Class Program
+    Partial Private Sub M(ByRef x As Integer)
+    End Sub
+End Class
+]]></file>
+</compilation>
+
+            Dim comp = CreateCompilationWithMscorlib(source)
+            Dim tree = comp.SyntaxTrees(0)
+            Dim model = comp.GetSemanticModel(tree)
+            Dim diagnostics = model.GetDiagnostics()
+            AssertTheseDiagnostics(diagnostics, <errors></errors>)
+        End Sub
+
+        <Fact, WorkItem(18348, "https://github.com/dotnet/roslyn/issues/18348")>
+        Public Sub IncorrectUnusedUsingWhenAttributeOnParameter_02()
+            Dim source =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System.Runtime.InteropServices
+Partial Class Program
+    Partial Private Sub M(<Out> <InAttribute> ByRef x As Integer)
+    End Sub
+End Class
+]]></file>
+    <file name="b.vb"><![CDATA[
+Partial Class Program
+    Private Sub M(ByRef x As Integer)
+    End Sub
+End Class
+]]></file>
+</compilation>
+
+            Dim comp = CreateCompilationWithMscorlib(source)
+            Dim tree = comp.SyntaxTrees(0)
+            Dim model = comp.GetSemanticModel(tree)
+            Dim diagnostics = model.GetDiagnostics()
+            AssertTheseDiagnostics(diagnostics, <errors></errors>)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario**

Place an attribute on a parameter of a partial implementation, where the attribute is the only thing that causes some using to be required. Then refactor "remove unnecessary usings". The bug is that the required using is removed.

**Bugs this fixes:**

Fixes #18348

**Workarounds, if any**

Don't place attributes on partial method implementation parameters.

**Risk**

Very low. The change is trivial.

**Performance impact**

Tiny. A small amount of additional logic is executed for partial methods.

**Is this a regression from a previous update?**

This has been a bug in Roslyn since VS2015.

**How was the bug found?**

Customer reported.

**Test documentation updated?**

N/A
