### PR TITLE
workaround NamedPipeClientStream bug where it will spin wait connection to be established consuming 100% of CPU.

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -18,11 +18,11 @@ namespace Microsoft.CodeAnalysis.Remote
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
             bool searchReferenceAssemblies, IList<PackageSource> packageSources, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var document = solution.GetDocument(documentId);
 
                     var service = document.GetLanguageService<IAddImportFeatureService>();
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var result = await service.GetFixesAsync(
                         document, span, diagnosticId, placeSystemNamespaceFirst,
                         symbolSearchService, searchReferenceAssemblies,
-                        packageSources.ToImmutableArray(), cancellationToken).ConfigureAwait(false);
+                        packageSources.ToImmutableArray(), token).ConfigureAwait(false);
 
                     return result;
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_CodeLens.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_CodeLens.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.CodeAnalysis.CodeLens;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -15,60 +13,60 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         public Task<ReferenceCount> GetReferenceCountAsync(DocumentId documentId, TextSpan textSpan, int maxResultCount, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetReferenceCountAsync, documentId.ProjectId.DebugName, cancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetReferenceCountAsync, documentId.ProjectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(solution, documentId,
-                        syntaxNode, maxResultCount, cancellationToken).ConfigureAwait(false);
+                        syntaxNode, maxResultCount, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
 
         public Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, cancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(solution, documentId,
-                        syntaxNode, cancellationToken).ConfigureAwait(false);
+                        syntaxNode, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
 
         public Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, cancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(solution, documentId,
-                        syntaxNode, cancellationToken).ConfigureAwait(false);
+                        syntaxNode, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
 
         public Task<string> GetFullyQualifiedName(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, cancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedName(solution, documentId,
-                        syntaxNode, cancellationToken).ConfigureAwait(false);
+                        syntaxNode, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -21,15 +21,15 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public Task<IList<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
-                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, cancellationToken))
+                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var project = solution.GetProject(projectId);
 
                     var data = await AbstractDesignerAttributeService.TryAnalyzeProjectInCurrentProcessAsync(
-                        project, cancellationToken).ConfigureAwait(false);
+                        project, token).ConfigureAwait(false);
 
                     if (data.Count == 0)
                     {

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -25,25 +24,25 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public Task CalculateDiagnosticsAsync(DiagnosticArguments arguments, string streamName, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
                 // if this analysis is explicitly asked by user, boost priority of this request
-                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, cancellationToken))
+                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, token))
                 using (arguments.ForcedAnalysis ? UserOperationBooster.Boost() : default)
                 {
                     try
                     {
                         // entry point for diagnostic service
-                        var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                        var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
-                        var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, cancellationToken).ConfigureAwait(false);
+                        var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, token).ConfigureAwait(false);
                         var projectId = arguments.ProjectId;
-                        var analyzers = RoslynServices.AssetService.GetGlobalAssetsOfType<AnalyzerReference>(cancellationToken);
+                        var analyzers = RoslynServices.AssetService.GetGlobalAssetsOfType<AnalyzerReference>(token);
 
                         var result = await (new DiagnosticComputer(solution.GetProject(projectId))).GetDiagnosticsAsync(
-                            analyzers, optionSet, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, cancellationToken).ConfigureAwait(false);
+                            analyzers, optionSet, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, token).ConfigureAwait(false);
 
-                        await SerializeDiagnosticResultAsync(streamName, result, cancellationToken).ConfigureAwait(false);
+                        await SerializeDiagnosticResultAsync(streamName, result, token).ConfigureAwait(false);
                     }
                     catch (IOException)
                     {

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -17,20 +17,20 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 // NOTE: In projection scenarios, we might get a set of documents to search
                 // that are not all the same language and might not exist in the OOP process
                 // (like the JS parts of a .cshtml file). Filter them out here.  This will
                 // need to be revisited if we someday support FAR between these languages.
-                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId);
                 var documentsToSearch = ImmutableHashSet.CreateRange(
                     documentIdsToSearch.Select(solution.GetDocument).WhereNotNull());
 
                 var service = document.GetLanguageService<IDocumentHighlightsService>();
                 var result = await service.GetDocumentHighlightsAsync(
-                    document, position, documentsToSearch, cancellationToken).ConfigureAwait(false);
+                    document, position, documentsToSearch, token).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableDocumentHighlights.Dehydrate);
             }, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -13,15 +13,15 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableNavigateToSearchResult>> SearchDocumentAsync(
             DocumentId documentId, string searchPattern, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var project = solution.GetDocument(documentId);
                     var result = await AbstractNavigateToSearchService.SearchDocumentInCurrentProcessAsync(
-                        project, searchPattern, cancellationToken).ConfigureAwait(false);
+                        project, searchPattern, token).ConfigureAwait(false);
 
                     return Convert(result);
                 }
@@ -31,15 +31,15 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableNavigateToSearchResult>> SearchProjectAsync(
             ProjectId projectId, string searchPattern, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var project = solution.GetProject(projectId);
                     var result = await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
-                        project, searchPattern, cancellationToken).ConfigureAwait(false);
+                        project, searchPattern, token).ConfigureAwait(false);
 
                     return Convert(result);
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         public Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var symbolAndProjectId = await symbolAndProjectIdArg.TryRehydrateAsync(
-                        solution, cancellationToken).ConfigureAwait(false);
+                        solution, token).ConfigureAwait(false);
 
                     var progressCallback = new FindReferencesProgressCallback(this);
 
@@ -45,23 +45,23 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     await SymbolFinder.FindReferencesInCurrentProcessAsync(
                         symbolAndProjectId.Value, solution,
-                        progressCallback, documents, cancellationToken).ConfigureAwait(false);
+                        progressCallback, documents, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
 
         public Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async () =>
+            return RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
                     var convertedType = System.Convert.ChangeType(value, typeCode);
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
 
                     var progressCallback = new FindLiteralReferencesProgressCallback(this);
                     await SymbolFinder.FindLiteralReferencesInCurrentProcessAsync(
-                        convertedType, solution, progressCallback, cancellationToken).ConfigureAwait(false);
+                        convertedType, solution, progressCallback, token).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
@@ -69,17 +69,17 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var project = solution.GetProject(projectId);
 
                     using (var query = SearchQuery.Create(name, searchKind))
                     {
                         var result = await DeclarationFinder.FindAllDeclarationsWithNormalQueryInCurrentProcessAsync(
-                            project, query, criteria, cancellationToken).ConfigureAwait(false);
+                            project, query, criteria, token).ConfigureAwait(false);
 
                         return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
                     }
@@ -90,13 +90,13 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
             string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
-                        solution, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
+                        solution, name, ignoreCase, criteria, token).ConfigureAwait(false);
 
                     return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
                 }
@@ -106,15 +106,15 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
             ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var project = solution.GetProject(projectId);
 
                     var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
-                        project, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
+                        project, name, ignoreCase, criteria, token).ConfigureAwait(false);
 
                     return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
                 }
@@ -124,15 +124,15 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<IList<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 using (UserOperationBooster.Boost())
                 {
-                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(token).ConfigureAwait(false);
                     var project = solution.GetProject(projectId);
 
                     var result = await DeclarationFinder.FindSourceDeclarationsWithPatternInCurrentProcessAsync(
-                        project, pattern, criteria, cancellationToken).ConfigureAwait(false);
+                        project, pattern, criteria, token).ConfigureAwait(false);
 
                     return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
@@ -25,20 +25,21 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, IList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(
+            PinnedSolutionInfo solutionInfo, DocumentId documentId, IList<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
-                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, cancellationToken))
+                using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, token))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(solutionInfo, token).ConfigureAwait(false);
                     var document = solution.GetDocument(documentId);
 
                     var service = document.GetLanguageService<ITodoCommentService>();
                     if (service != null)
                     {
                         // todo comment service supported
-                        return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
+                        return await service.GetTodoCommentsAsync(document, tokens, token).ConfigureAwait(false);
                     }
 
                     return SpecializedCollections.EmptyList<TodoComment>();

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)
         {
-            return RunServiceAsync(() =>
+            return RunServiceAsync(_ =>
             {
                 return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
             }, CancellationToken.None);
@@ -34,10 +34,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task<IList<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 var results = await _updateEngine.FindPackagesWithTypeAsync(
-                    source, name, arity, cancellationToken).ConfigureAwait(false);
+                    source, name, arity, token).ConfigureAwait(false);
 
                 return results;
             }, cancellationToken).ConfigureAwait(false);
@@ -45,10 +45,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task<IList<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 var results = await _updateEngine.FindPackagesWithAssemblyAsync(
-                    source, assemblyName, cancellationToken).ConfigureAwait(false);
+                    source, assemblyName, token).ConfigureAwait(false);
 
                 return results;
             }, cancellationToken).ConfigureAwait(false);
@@ -56,10 +56,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task<IList<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
         {
-            return await RunServiceAsync(async () =>
+            return await RunServiceAsync(async token =>
             {
                 var results = await _updateEngine.FindReferenceAssembliesWithTypeAsync(
-                    name, arity, cancellationToken).ConfigureAwait(false);
+                    name, arity, token).ConfigureAwait(false);
 
                 return results;
             }, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
workaround is barrowed from service hub -
http://index/?query=NamedPipeClientStream&rightProject=Microsoft.ServiceHub.Client&file=NamedPipeClientStreamExtensions.cs&line=15

also made servicehub to use merged cancellation token as workaround for Microsoft/vs-streamjsonrpc#64

.....................

**Customer scenario**

User starts to use Roslyn (C# or VB projects). after for a while, ServiceHub.RoslynCodeAnalysis32.exe process starts to consume a lot of CPU and ends up consuming 100% of it all the time.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/503885

**Workarounds, if any**

There is no workaround.

**Risk**

I don't see any risk.

**Performance impact**

this should make perf same as before by cancelling operation correctly.

**Is this a regression from a previous update?**

Yes. this regressed when we moved to new cancellation support from StreamJsonRpc. missed some subtle cancellation issue when cancellation and disconnection happens right after each other. 

in previous version (15.4.x), we used our own mechanism for cancellation which didn't have this issue. moving to new native cancellation support helped us to reuse same connection improving perf, but caused us to regress cancellation support.

**Root cause analysis:**

when cancellation is raised in VS and connection is closed right away, cancellation sometimes doesn't get raised in service hub side. just disconnection happens. and service in service hub side doesn't know it has been cancelled. and keep doing what it was doing. that combined with NamedPipeClientStream.ConnectAsync issue (https://github.com/dotnet/corefx/issues/7635), it ends up consuming 100% cpu waiting pipe that already gone.

more detail is on Microsoft/vs-streamjsonrpc#64.

**How was the bug found?**

Dogfooding.
