### PR TITLE
Allow empty CscToolPath

### DIFF
--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -32,16 +32,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             var pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
             // Desktop executes tool directly, only prepend if we're on CLI
-            if (IsCliHost(out string pathToDotnet))
+            if (pathToToolOpt != null && IsCliHost(out string pathToDotnet))
             {
-                if (pathToToolOpt != null)
-                {
-                    commandLineArgs = PrependFileToArgs(pathToToolOpt, commandLineArgs);
-                    pathToToolOpt = pathToDotnet;
-                }
+                commandLineArgs = PrependFileToArgs(pathToToolOpt, commandLineArgs);
+                pathToToolOpt = pathToDotnet;
             }
 
-            return new DotnetHost(toolName, pathToToolOpt, commandLineArgs, isManagedTool: true);
+            return new DotnetHost(pathToToolOpt, commandLineArgs, isManagedTool: true);
         }
 
         private static bool IsCliHost(out string pathToDotnet)

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             IsManagedTool = isManagedTool;
         }
 
-        public static DotnetHost CreateUnmanagedToolInvocation(string pathToTool, string commandLineArgs)
+        public static DotnetHost CreateNativeToolInvocation(string pathToTool, string commandLineArgs)
         {
             return new DotnetHost(pathToTool, commandLineArgs, isManagedTool: false);
         }

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -12,16 +12,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         public string CommandLineArgs { get; }
 
-        private DotnetHost(string toolNameOpt, string pathToToolOpt, string commandLineArgs)
+        /// <summary>
+        /// True if this tool is a managed executable, and will be invoked with `dotnet`.
+        /// False if this executable is being invoked directly.
+        /// </summary>
+        public bool IsManagedTool { get; }
+
+        private DotnetHost(string toolNameOpt, string pathToToolOpt, string commandLineArgs, bool isManagedTool)
         {
             ToolNameOpt = toolNameOpt;
             PathToToolOpt = pathToToolOpt;
             CommandLineArgs = commandLineArgs;
+            IsManagedTool = isManagedTool;
         }
 
         public static DotnetHost CreateUnmanagedToolInvocation(string pathToTool, string commandLineArgs)
         {
-            return new DotnetHost(null, pathToTool, commandLineArgs);
+            return new DotnetHost(null, pathToTool, commandLineArgs, isManagedTool: false);
         }
 
         public static DotnetHost CreateManagedToolInvocation(string toolNameWithoutExtension, string commandLineArgs)
@@ -45,7 +52,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
             }
 
-            return new DotnetHost(toolName, pathToToolOpt, commandLineArgs);
+            return new DotnetHost(toolName, pathToToolOpt, commandLineArgs, isManagedTool: true);
         }
 
         private static bool IsCliHost(out string pathToDotnet)

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -6,8 +6,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 {
     internal sealed class DotnetHost
     {
-        public string ToolNameOpt { get; }
-
         public string PathToToolOpt { get; }
 
         public string CommandLineArgs { get; }
@@ -18,9 +16,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         public bool IsManagedTool { get; }
 
-        private DotnetHost(string toolNameOpt, string pathToToolOpt, string commandLineArgs, bool isManagedTool)
+        private DotnetHost(string pathToToolOpt, string commandLineArgs, bool isManagedTool)
         {
-            ToolNameOpt = toolNameOpt;
             PathToToolOpt = pathToToolOpt;
             CommandLineArgs = commandLineArgs;
             IsManagedTool = isManagedTool;
@@ -28,28 +25,20 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         public static DotnetHost CreateUnmanagedToolInvocation(string pathToTool, string commandLineArgs)
         {
-            return new DotnetHost(null, pathToTool, commandLineArgs, isManagedTool: false);
+            return new DotnetHost(pathToTool, commandLineArgs, isManagedTool: false);
         }
 
-        public static DotnetHost CreateManagedToolInvocation(string toolNameWithoutExtension, string commandLineArgs)
+        public static DotnetHost CreateManagedToolInvocation(string toolName, string commandLineArgs)
         {
-            string pathToToolOpt;
-            string toolName;
+            var pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
+            // Desktop executes tool directly, only prepend if we're on CLI
             if (IsCliHost(out string pathToDotnet))
             {
-                toolName = $"{toolNameWithoutExtension}.dll";
-                pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
                 if (pathToToolOpt != null)
                 {
                     commandLineArgs = PrependFileToArgs(pathToToolOpt, commandLineArgs);
                     pathToToolOpt = pathToDotnet;
                 }
-            }
-            else
-            {
-                // Desktop executes tool directly
-                toolName = $"{toolNameWithoutExtension}.exe";
-                pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
             }
 
             return new DotnetHost(toolName, pathToToolOpt, commandLineArgs, isManagedTool: true);

--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -12,23 +12,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         /// <summary>
         /// True if this tool is a managed executable, and will be invoked with `dotnet`.
-        /// False if this executable is being invoked directly.
+        /// False if this executable is being invoked directly
+        /// (it may still be a managed executable, but will be invoked directly).
         /// </summary>
-        public bool IsManagedTool { get; }
+        public bool IsManagedInvocation { get; }
 
-        private DotnetHost(string pathToToolOpt, string commandLineArgs, bool isManagedTool)
+        private DotnetHost(string pathToToolOpt, string commandLineArgs, bool isManagedInvocation)
         {
             PathToToolOpt = pathToToolOpt;
             CommandLineArgs = commandLineArgs;
-            IsManagedTool = isManagedTool;
+            IsManagedInvocation = isManagedInvocation;
         }
 
-        public static DotnetHost CreateNativeToolInvocation(string pathToTool, string commandLineArgs)
+        public static DotnetHost CreateNativeInvocationTool(string pathToTool, string commandLineArgs)
         {
-            return new DotnetHost(pathToTool, commandLineArgs, isManagedTool: false);
+            return new DotnetHost(pathToTool, commandLineArgs, isManagedInvocation: false);
         }
 
-        public static DotnetHost CreateManagedToolInvocation(string toolName, string commandLineArgs)
+        public static DotnetHost CreateManagedInvocationTool(string toolName, string commandLineArgs)
         {
             var pathToToolOpt = Utilities.GenerateFullPathToTool(toolName);
             // Desktop executes tool directly, only prepend if we're on CLI
@@ -38,7 +39,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 pathToToolOpt = pathToDotnet;
             }
 
-            return new DotnetHost(pathToToolOpt, commandLineArgs, isManagedTool: true);
+            return new DotnetHost(pathToToolOpt, commandLineArgs, isManagedInvocation: true);
         }
 
         private static bool IsCliHost(out string pathToDotnet)

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolName, Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(ToolName, Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -192,9 +192,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     var commandLine = commandLineBuilder.ToString();
 
                     // ToolExe delegates back to ToolName if the override is not
-                    // set.  So, if ToolExe != ToolName, we know ToolExe is
-                    // explicitly overriden - so use it as a native invocation.
-                    if (string.IsNullOrEmpty(ToolPath) || ToolExe == ToolName)
+                    // set.  So, if ToolExe == ToolName, we know ToolExe is not
+                    // explicitly overriden.  So, if both ToolPath is unset and
+                    // ToolExe == ToolName, we know nothing is overridden, and
+                    // we can use our own csc.
+                    if (string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName)
                     {
                         _dotnetHostInfo = DotnetHost.CreateManagedInvocationTool(ToolName, commandLine);
                     }
@@ -202,7 +204,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath ?? "", ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -196,13 +196,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // explicitly overriden - so use it as a native invocation.
                     if (string.IsNullOrEmpty(ToolPath) || ToolExe == ToolName)
                     {
-                        _dotnetHostInfo = DotnetHost.CreateManagedToolInvocation(ToolName, commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateManagedInvocationTool(ToolName, commandLine);
                     }
                     else
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -201,7 +202,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(ToolName, Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -440,13 +440,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                         if (ToolExe != _dotnetHostInfo.ToolNameOpt)
                         {
-                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
+                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolExe, commandLine);
                         }
                     }
                     else
                     {
                         // Explicitly provided ToolPath, don't try to figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             try
             {
                 if (!UseSharedCompilation ||
-                !string.IsNullOrEmpty(ToolPath) ||
+                !DotnetHostInfo.IsManagedTool ||
                 !BuildServerConnection.IsCompilerServerSupported)
                 {
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolName, Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -421,9 +421,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     var commandLine = commandLineBuilder.ToString();
 
                     // ToolExe delegates back to ToolName if the override is not
-                    // set.  So, if ToolExe != ToolName, we know ToolExe is
-                    // explicitly overriden - so use it as a native invocation.
-                    if (string.IsNullOrEmpty(ToolPath) || ToolExe == ToolName)
+                    // set.  So, if ToolExe == ToolName, we know ToolExe is not
+                    // explicitly overriden.  So, if both ToolPath is unset and
+                    // ToolExe == ToolName, we know nothing is overridden, and
+                    // we can use our own csc.
+                    if (string.IsNullOrEmpty(ToolPath) && ToolExe == ToolName)
                     {
                         _dotnetHostInfo = DotnetHost.CreateManagedInvocationTool(ToolName, commandLine);
                     }
@@ -431,7 +433,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath ?? "", ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;
@@ -453,6 +455,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     return $"{ToolNameWithoutExtension}.exe";
                 }
             }
+        }
+
+        /// <summary>
+        /// Method for testing only
+        /// </summary>
+        public string GeneratePathToTool()
+        {
+            return GenerateFullPathToTool();
         }
 
         /// <summary>
@@ -486,7 +496,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             try
             {
                 if (!UseSharedCompilation ||
-                !DotnetHostInfo.IsManagedTool ||
+                !DotnetHostInfo.IsManagedInvocation ||
                 !BuildServerConnection.IsCompilerServerSupported)
                 {
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
@@ -703,6 +713,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension();
             AddResponseFileCommands(commandLineBuilder);
             return commandLineBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Method for testing only
+        /// </summary>
+        public string GenerateCommandLine()
+        {
+            return GenerateCommandLineCommands();
         }
 
         protected override string GenerateCommandLineCommands()

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -425,13 +425,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // explicitly overriden - so use it as a native invocation.
                     if (string.IsNullOrEmpty(ToolPath) || ToolExe == ToolName)
                     {
-                        _dotnetHostInfo = DotnetHost.CreateManagedToolInvocation(ToolName, commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateManagedInvocationTool(ToolName, commandLine);
                     }
                     else
                     {
                         // Explicitly provided ToolPath or ToolExe, don't try to
                         // figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateNativeToolInvocation(Path.Combine(ToolPath, ToolExe), commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateNativeInvocationTool(Path.Combine(ToolPath, ToolExe), commandLine);
                     }
                 }
                 return _dotnetHostInfo;

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.CodeAnalysis.BuildTasks;
 using Xunit;
 using Moq;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {
@@ -333,6 +334,41 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
             csc.SharedCompilationId = "testPipeName";
             Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void EmptyCscToolPath()
+        {
+            var csc = new Csc();
+            csc.ToolPath = "";
+            csc.ToolExe = Path.Combine("path", "to", "custom_csc");
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal(Path.Combine("path", "to", "custom_csc"), csc.GeneratePathToTool());
+
+            csc = new Csc();
+            csc.ToolExe = Path.Combine("path", "to", "custom_csc");
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.Equal(Path.Combine("path", "to", "custom_csc"), csc.GeneratePathToTool());
+        }
+
+        [Fact]
+        public void EmptyCscToolExe()
+        {
+            var csc = new Csc();
+            csc.ToolPath = Path.Combine("path", "to", "custom_csc");
+            csc.ToolExe = "";
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            Assert.Equal("", csc.GenerateCommandLine());
+            // StartsWith because it can be csc.exe or csc.dll
+            Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
+
+            csc = new Csc();
+            csc.ToolPath = Path.Combine("path", "to", "custom_csc");
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            Assert.Equal("", csc.GenerateCommandLine());
+            Assert.StartsWith(Path.Combine("path", "to", "custom_csc", "csc."), csc.GeneratePathToTool());
         }
     }
 }


### PR DESCRIPTION
May fix https://github.com/dotnet/roslyn/issues/22478 , but I don't know how to repro without a system-wide install, and therefore don't know how to test this change.

The important change is:

    _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolExe, commandLine);