### PR TITLE
Fix bug in build-utils Ensure-SdkInPathAndData

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -179,8 +179,8 @@ function Ensure-SdkInPathAndData() {
 
     ${env:PATH} = "$cliDir;${env:PATH}"
     $sdkPath = Join-Path $cliDir "sdk\$sdkVersion"
-    Write-Host $dotnetExe
-    Write-Host $sdkPath
+    Write-Output $dotnetExe
+    Write-Output $sdkPath
     return
 }
 


### PR DESCRIPTION
I fixed this bug in https://github.com/dotnet/roslyn/pull/22346 , but as that won't be merging any time soon, I'm porting this to its own PR.

Elsewhere in the function is:

```
Write-Output (Join-Path $dotnetDir "dotnet.exe")
Write-Output $sdkPath
```

The fact these two lines were `Write-Host` caused some really subtle bugs - the first call to `Ensure-SdkInPathAndData` would fail (returning `(null, null)`), but the second time hits the other code path, and returns the correct data.

Ping @jaredpar