### PR TITLE
Use error=true in Obsolete attribute on IsByRefLikeAttribute for ref struct

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1135,8 +1135,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
                         ImmutableArray.Create(
-                                       new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.ByRefLikeMarker),
-                                       new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)),
+                            new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.ByRefLikeMarker), // message
+                            new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)), // error=true
                         isOptionalUse: true));
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1136,7 +1136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
                         ImmutableArray.Create(
                                        new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.ByRefLikeMarker),
-                                       new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, false)), 
+                                       new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)),
                         isOptionalUse: true));
                 }
             }

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -1497,7 +1497,9 @@ BC30668: 'S' is obsolete: 'Types with embedded references are not supported in t
     Sub M(s As S)
                ~
 ]]>))
-
+            vbCompilation.VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_UseOfObsoleteSymbol2, "S").WithArguments("S", "Types with embedded references are not supported in this version of your compiler.").WithLocation(2, 16)
+                )
         End Sub
 
         <Fact(), WorkItem(858839, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858839")>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -1469,6 +1469,37 @@ BC40000: 'Public Sub Bar()' is obsolete: 'hi'.
             compilation3.AssertTheseDiagnostics(expected2)
         End Sub
 
+        <Fact>
+        <WorkItem(22447, "https://github.com/dotnet/roslyn/issues/22447")>
+        Public Sub TestRefLikeType()
+            Dim csSource = <![CDATA[
+public ref struct S { }
+]]>
+
+            Dim csCompilation = CreateCSharpCompilation("Dll1", csSource.Value, parseOptions:=New CSharp.CSharpParseOptions(CSharp.LanguageVersion.CSharp7_2))
+            Dim ref = csCompilation.EmitToImageReference()
+
+            Dim vbSource =
+<compilation>
+    <file name="test.vb"><![CDATA[
+Module Program
+    Sub M(s As S)
+    End Sub
+End Module
+]]>
+    </file>
+</compilation>
+
+            Dim vbCompilation = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(vbSource, {ref})
+
+            vbCompilation.AssertTheseDiagnostics((<![CDATA[
+BC30668: 'S' is obsolete: 'Types with embedded references are not supported in this version of your compiler.'.
+    Sub M(s As S)
+               ~
+]]>))
+
+        End Sub
+
         <Fact(), WorkItem(858839, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858839")>
         Public Sub Bug858839_1()
             Dim source1 =


### PR DESCRIPTION
**Customer scenario**
Create a new ref-like type (new C# 7.2 feature) and refer to that type from a project that uses an older compiler (or the compiler for some other language). The ref-like type should be poisoned (produce an error) in those compilers, since they don't know how to honor the safety guarantees of such types.
But currently, the `Obsolete` attribute that we use for poisoning is only marked with error=false, which means a warning is produced on usage, rather than an error.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/22447


**Risk**
**Performance impact**
Low. We're just strengthening the poisoning by using error=true in `Obsolete`.

**Is this a regression from a previous update?**
No.