### PR TITLE
Reduce DocumentId array allocations

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState_Checksum.cs
@@ -31,12 +31,10 @@ namespace Microsoft.CodeAnalysis
         {
             using (Logger.LogBlock(FunctionId.ProjectState_ComputeChecksumsAsync, FilePath, cancellationToken))
             {
-                // get states by id order to have deterministic checksum
-                var orderedDocumentIds = ChecksumCache.GetOrCreate(DocumentIds, _ => DocumentIds.OrderBy(id => id.Id).ToImmutableArray());
-                var documentChecksumsTasks = orderedDocumentIds.Select(id => DocumentStates[id].GetChecksumAsync(cancellationToken));
-
-                var orderedAdditionalDocumentIds = ChecksumCache.GetOrCreate(AdditionalDocumentIds, _ => AdditionalDocumentIds.OrderBy(id => id.Id).ToImmutableArray());
-                var additionalDocumentChecksumTasks = orderedAdditionalDocumentIds.Select(id => AdditionalDocumentStates[id].GetChecksumAsync(cancellationToken));
+                // Here, we use the _documentStates and _additionalDocumentStates and visit them in order; we ensure that those are
+                // sorted by ID so we have a consistent sort.
+                var documentChecksumsTasks = _documentStates.Select(pair => pair.Value.GetChecksumAsync(cancellationToken));
+                var additionalDocumentChecksumTasks = _additionalDocumentStates.Select(pair => pair.Value.GetChecksumAsync(cancellationToken));
 
                 var serializer = new Serializer(_solutionServices.Workspace);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         }
 
         private static void Find<T>(
-            ImmutableDictionary<DocumentId, T> values,
+            IImmutableDictionary<DocumentId, T> values,
             HashSet<Checksum> searchingChecksumsLeft,
             Dictionary<Checksum, object> result,
             CancellationToken cancellationToken) where T : TextDocumentState

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -413,17 +413,17 @@ namespace Microsoft.CodeAnalysis.Remote
             return GetDocumentMapAsync(project, project.State.DocumentStates, documents);
         }
 
-        private async Task<Dictionary<DocumentId, DocumentStateChecksums>> GetDocumentMapAsync<T>(Project project, ImmutableDictionary<DocumentId, T> states, HashSet<Checksum> documents)
+        private async Task<Dictionary<DocumentId, DocumentStateChecksums>> GetDocumentMapAsync<T>(Project project, IImmutableDictionary<DocumentId, T> states, HashSet<Checksum> documents)
             where T : TextDocumentState
         {
             var map = new Dictionary<DocumentId, DocumentStateChecksums>();
 
             foreach (var kv in states)
             {
-                var doucmentChecksums = await kv.Value.GetStateChecksumsAsync(_cancellationToken).ConfigureAwait(false);
-                if (documents.Contains(doucmentChecksums.Checksum))
+                var documentChecksums = await kv.Value.GetStateChecksumsAsync(_cancellationToken).ConfigureAwait(false);
+                if (documents.Contains(documentChecksums.Checksum))
                 {
-                    map.Add(kv.Key, doucmentChecksums);
+                    map.Add(kv.Key, documentChecksums);
                 }
             }
 


### PR DESCRIPTION
**Customer scenario:** Customer has projects that have a large number of files (like 10s of thousands) that they try to open. We create lots of allocations of arrays for no good reason, which might be leading to OOMs per some of the dumps @sharwell has been looking at.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/489472
**Workarounds, if any:** nope.
**Risk:** low. Just changing one immutable type for another in non-public class.
**Performance impact:** theory is this will help. ImmutableArray is intended for small, non-changing lists, and this switches it over to ImmutableList. That will create a number of small allocations in the open case, but that should be better for the GC than large arrays that might be created. Once we're in the steady state we might be slightly slower because enumerating ImmutableList is slightly more expensive than ImmutableArray, but that would be negligible.
**Is this a regression from a previous update?** nope.
**Root cause analysis:** choice of data structure wasn't correct for scale we see.
**How was the bug found?** @sharwell looking at telemetry reports.
