### PR TITLE
Allow specifying ToolPath without ToolExe

### DIFF
--- a/src/Compilers/Core/MSBuildTask/DotnetHost.cs
+++ b/src/Compilers/Core/MSBuildTask/DotnetHost.cs
@@ -19,9 +19,19 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             CommandLineArgs = commandLineArgs;
         }
 
-        public static DotnetHost CreateUnmanagedToolInvocation(string pathToTool, string commandLineArgs)
+        public static DotnetHost CreateUnmanagedToolInvocation(string toolNameWithoutExtension, string pathToTool, string commandLineArgs)
         {
-            return new DotnetHost(null, pathToTool, commandLineArgs);
+            string toolName;
+            if (CoreClrShim.IsRunningOnCoreClr)
+            {
+                // Almost certainly will not work, but compute it anyway for consistency.
+                toolName = $"{toolNameWithoutExtension}.dll";
+            }
+            else
+            {
+                toolName = $"{toolNameWithoutExtension}.exe";
+            }
+            return new DotnetHost(toolName, pathToTool, commandLineArgs);
         }
 
         public static DotnetHost CreateManagedToolInvocation(string toolNameWithoutExtension, string commandLineArgs)

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -440,13 +440,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                         if (ToolExe != _dotnetHostInfo.ToolNameOpt)
                         {
-                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
+                            _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolNameWithoutExtension, ToolPath, commandLine);
                         }
                     }
                     else
                     {
                         // Explicitly provided ToolPath, don't try to figure anything out
-                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolPath, commandLine);
+                        _dotnetHostInfo = DotnetHost.CreateUnmanagedToolInvocation(ToolNameWithoutExtension, ToolPath, commandLine);
                     }
                 }
                 return _dotnetHostInfo;


### PR DESCRIPTION
In https://github.com/dotnet/roslyn/pull/21673, I broke the scenario of invoking msbuild with CscToolPath specified but not CscToolExe. This fixes that.

(Tangentally related is https://github.com/dotnet/roslyn/pull/22487, which is specifying CscToolExe without CscToolPath - the opposite)