### PR TITLE
prevent double dispose on unit test in OOP

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcMessageHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcMessageHandler.cs
@@ -21,6 +21,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             if (disposing)
             {
+                // note that this can cause double disposing of a stream if both are based on same stream.
+                // we can't check whether 2 are same because one of them could be wrapped stream such as bufferedstream which
+                // underneath points to same stream. 
                 ReceivingStream?.Dispose();
                 SendingStream?.Dispose();
             }

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Rpc.Dispose();
             _shutdownCancellationSource.Dispose();
 
-            Dispose(false);
+            Dispose(disposing: true);
 
             Logger.TraceInformation($"{DebugInstanceString} Service instance disposed");
         }


### PR DESCRIPTION
@333fred found an issue in unit test around OOP double disposing.

(https://ci.dot.net/job/dotnet_roslyn/view/Official%20Builds/job/dev15.5.x/job/windows_release_unit32/46/testReport/junit/Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting/VisualBasicReferenceHighlightingTests/TestAccessor1/)

I haven't seen this for actual VS. so wondering whether this is unit test specific issue since OOP in unit test uses mock service hub (http://source.roslyn.io/#Roslyn.Services.Test.Utilities/Remote/InProcRemostHostClient.cs,19) I created.

still made the code to guard against double dispose in product as well but made it to crash in debug.

...

found out why it is happening in unit test. it only happens in unit test due to how WrappedStream (http://source.roslyn.io/#Roslyn.Services.Test.Utilities/Remote/InProcRemostHostClient.cs,239) is tied to service.
