### PR TITLE
disable CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer for preview 1

### DIFF
--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -25,7 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
     /// but only for code cases where the user has provided an appropriate variable name in
     /// code that can be used).
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp), Shared]
+    //
+    // disabled for preview 1 due to some perf issue. 
+    // we will re-enable it once the issue is addressed.
+    // https://devdiv.visualstudio.com/DevDiv/_workitems?id=504089&_a=edit&triage=true 
+    // [DiagnosticAnalyzer(LanguageNames.CSharp), Shared]
     internal class CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer : AbstractCodeStyleDiagnosticAnalyzer
     {
         private const string CS0165 = nameof(CS0165); // Use of unassigned local variable 's'


### PR DESCRIPTION
**Customer scenario**

VS is unresponsive and hard to use

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/504602 (one of issue from this feedback 
https://devdiv.visualstudio.com/DevDiv/_workitems?id=504089&_a=edit&triage=true)

**Workarounds, if any**

no workaround

**Risk**

none

**Performance impact**

we are disabling an analyzer which we identified as costly one. this should improve perf.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

the analyzer is calling one of expensive check repeatedly multiple times.

**How was the bug found?**

User feedback and dogfooding.