### PR TITLE
Implement escape scopes for all types of local symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2159,13 +2159,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         /// <summary>
         /// Compiler should always be synthesizing locals with correct escape semantics.
-        /// Checking scape scopes is not valid here.
+        /// Checking escape scopes is not valid here.
         /// </summary>
         internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
 
         /// <summary>
         /// Compiler should always be synthesizing locals with correct escape semantics.
-        /// Checking/assigning scape scopes is not valid here.
+        /// Checking escape scopes is not valid here.
         /// </summary>
         internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
     }

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2156,5 +2156,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             get { return RefKind.None; }
         }
+
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking scape scopes is not valid here.
+        /// </summary>
+        internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
+
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking/assigning scape scopes is not valid here.
+        /// </summary>
+        internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -332,13 +332,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Returns the scope to which a local can "escape" ref assignments or other form of aliasing
         /// Makes sense only for locals with formal scopes - i.e. source locals
         /// </summary>
-        internal virtual uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
+        internal abstract uint RefEscapeScope { get; }
 
         /// <summary>
         /// Returns the scope to which values of a local can "escape" via ordinary assignments
         /// Makes sense only for ref-like locals with formal scopes - i.e. source locals
         /// </summary>
-        internal virtual uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
+        internal abstract uint ValEscapeScope { get; }
 
         /// <summary>
         /// When a local variable's type is inferred, it may not be used in the

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -152,13 +152,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Compiler should always be synthesizing locals with correct escape semantics.
-        /// Checking scape scopes is not valid here.
+        /// Checking escape scopes is not valid here.
         /// </summary>
         internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
 
         /// <summary>
         /// Compiler should always be synthesizing locals with correct escape semantics.
-        /// Checking/assigning scape scopes is not valid here.
+        /// Checking escape scopes is not valid here.
         /// </summary>
         internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -148,6 +149,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return true; }
         }
+
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking scape scopes is not valid here.
+        /// </summary>
+        internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
+
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking/assigning scape scopes is not valid here.
+        /// </summary>
+        internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
 
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -93,6 +93,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _originalVariable.RefKind; }
         }
 
+        internal override uint ValEscapeScope => _originalVariable.ValEscapeScope;
+
+        internal override uint RefEscapeScope => _originalVariable.RefEscapeScope;
+
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag diagnostics)
         {
             return _originalVariable.GetConstantValue(node, inProgress, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -93,9 +93,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _originalVariable.RefKind; }
         }
 
-        internal override uint ValEscapeScope => _originalVariable.ValEscapeScope;
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking escape scopes is not valid here.
+        /// </summary>
+        internal override uint ValEscapeScope => throw ExceptionUtilities.Unreachable;
 
-        internal override uint RefEscapeScope => _originalVariable.RefEscapeScope;
+        /// <summary>
+        /// Compiler should always be synthesizing locals with correct escape semantics.
+        /// Checking escape scopes is not valid here.
+        /// </summary>
+        internal override uint RefEscapeScope => throw ExceptionUtilities.Unreachable;
 
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag diagnostics)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
@@ -76,5 +76,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             return result;
         }
+
+        /// <summary>
+        /// EE Symbols have no source symbols associated with them.
+        /// They should be safe to escape for evaluation purposes.
+        /// </summary>
+        internal override uint ValEscapeScope => Binder.TopLevelScope;
+
+        /// <summary>
+        /// EE Symbols have no source symbols associated with them.
+        /// They should be safe to escape for evaluation purposes.
+        /// </summary>
+        internal override uint RefEscapeScope => Binder.TopLevelScope;
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6382,5 +6382,30 @@ public class Test
             Assert.Contains(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName + "..ctor()", methodsGenerated);
             Assert.Contains(AttributeDescription.IsReadOnlyAttribute.FullName + "..ctor()", methodsGenerated);
         }
+
+        [Fact]
+        public void RefReturnNonRefLocal()
+        {
+            var source = @"
+delegate ref int D();
+class C
+{
+    static void Main()
+    {
+        int local = 0;
+    }
+    static ref int M(D d)
+    {
+        return ref d();
+    }
+}";
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
+            WithRuntimeInstance(comp, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.Main");
+                context.CompileExpression("M(() => ref local)", out var error);
+                Assert.Equal("error CS8168: Cannot return local 'local' by reference because it is not a ref local", error);
+            });
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6384,6 +6384,7 @@ public class Test
         }
 
         [Fact]
+        [WorkItem(22206, "https://github.com/dotnet/roslyn/issues/22206")]
         public void RefReturnNonRefLocal()
         {
             var source = @"


### PR DESCRIPTION
Fixes #22206

cc @dotnet/roslyn-compiler: @cston @VSadov @cston for code review.
cc @jaredpar for ask mode approval.