### PR TITLE
restrict keywords that trigger <see langword> tag and don't offer tag inside XML attribute

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -426,7 +426,7 @@ class C<TKey>
         {
             await TestMissingAsync(
 @"
-/// Testing keyword inside <see lang=""nu[||]ll""/>
+/// Testing keyword inside <see langword =""nu[||]ll""/>
 class C
 {
     void WriteLine<TKey>(TKey value) { }
@@ -439,7 +439,7 @@ class C
         {
             await TestMissingAsync(
 @"
-/// Testing keyword inside <see lang=""nu[||]ll""
+/// Testing keyword inside <see langword =""nu[||]ll""
 class C
 {
     void WriteLine<TKey>(TKey value) { }

--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -19,13 +19,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ReplaceDocCommentTextWi
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable [||]interface.
+/// Testing keyword [||]null.
 class C<TKey>
 {
 }",
 
 @"
-/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+/// Testing keyword <see langword=""null""/>.
 class C<TKey>
 {
 }");
@@ -36,13 +36,13 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable interface[||].
+/// Testing keyword abstract[||].
 class C<TKey>
 {
 }",
 
 @"
-/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+/// Testing keyword <see langword=""abstract""/>.
 class C<TKey>
 {
 }");
@@ -53,13 +53,13 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable interface[||]
+/// Testing keyword static[||]
 class C<TKey>
 {
 }",
 
 @"
-/// TKey must implement the System.IDisposable <see langword=""interface""/>
+/// Testing keyword <see langword=""static""/>
 class C<TKey>
 {
 }");
@@ -70,13 +70,13 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable [|interface|].
+/// Testing keyword [|abstract|].
 class C<TKey>
 {
 }",
 
 @"
-/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+/// Testing keyword <see langword=""abstract""/>.
 class C<TKey>
 {
 }");
@@ -87,13 +87,13 @@ class C<TKey>
         {
             await TestInRegularAndScriptAsync(
 @"
-/// TKey must implement the System.IDisposable int[||]erface.
+/// Testing keyword asy[||]nc.
 class C<TKey>
 {
 }",
 
 @"
-/// TKey must implement the System.IDisposable <see langword=""interface""/>.
+/// Testing keyword <see langword=""async""/>.
 class C<TKey>
 {
 }");
@@ -408,5 +408,42 @@ class C
 }");
         }
 
+        [WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestNonApplicableKeyword()
+        {
+            await TestMissingAsync(
+@"
+/// Testing keyword interfa[||]ce.
+class C<TKey>
+{
+}");
+        }
+
+        [WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestInXMLAttribute()
+        {
+            await TestMissingAsync(
+@"
+/// Testing keyword inside <see lang=""nu[||]ll""/>
+class C
+{
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
+
+        [WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)]
+        public async Task TestInXMLAttribute2()
+        {
+            await TestMissingAsync(
+@"
+/// Testing keyword inside <see lang=""nu[||]ll""
+class C
+{
+    void WriteLine<TKey>(TKey value) { }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -16,11 +16,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ReplaceDocCommentT
         Public Async Function TestStartOfKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable [||]interface.
+''' Testing keyword [||]Nothing.
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+''' Testing keyword <see langword=""Nothing""/>.
 class C(Of TKey)
 end class")
         End Function
@@ -29,11 +29,11 @@ end class")
         Public Async Function TestStartOfKeywordCapitalized() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable [||]Interface.
+''' Testing keyword Shared[||].
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""Interface""/>.
+''' Testing keyword <see langword=""Shared""/>.
 class C(Of TKey)
 end class")
         End Function
@@ -42,11 +42,11 @@ end class")
         Public Async Function TestEndOfKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable interface[||].
+''' Testing keyword True[||].
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+''' Testing keyword <see langword=""True""/>.
 class C(Of TKey)
 end class")
         End Function
@@ -55,11 +55,11 @@ end class")
         Public Async Function TestEndOfKeyword_NewLineFollowing() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable interface[||]
+''' Testing keyword MustInherit[||]
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""interface""/>
+''' Testing keyword <see langword=""MustInherit""/>
 class C(Of TKey)
 end class")
         End Function
@@ -68,11 +68,11 @@ end class")
         Public Async Function TestSelectedKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable [|interface|].
+''' Testing keyword [|Async|].
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+''' Testing keyword <see langword=""Async""/>.
 class C(Of TKey)
 end class")
         End Function
@@ -81,11 +81,11 @@ end class")
         Public Async Function TestInsideKeyword() As Task
             Await TestInRegularAndScriptAsync(
 "
-''' TKey must implement the System.IDisposable int[||]erface.
+''' Testing keyword Aw[||]ait.
 class C(Of TKey)
 end class",
 "
-''' TKey must implement the System.IDisposable <see langword=""interface""/>.
+''' Testing keyword <see langword=""Await""/>.
 class C(Of TKey)
 end class")
         End Function
@@ -314,6 +314,40 @@ interface I
     ''' <paramref name=""value""/> has type TKey so we don't box primitives.
     sub WriteLine(Of TKey)(value as TKey)
 end interface")
+        End Function
+
+        <WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestNotApplicableKeyword() As Task
+            Await TestMissingAsync(
+"
+''' Testing keyword interf[||]ace
+class C(Of TKey)
+end class")
+        End Function
+
+        <WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestInXMLAttribute() As Task
+            Await TestMissingAsync(
+"
+''' Testing keyword inside <see lang=""nu[||]ll"">
+class C
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
+        End Function
+
+        <WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceDocCommentTextWithTag)>
+        Public Async Function TestInXMLAttribute2() As Task
+            Await TestMissingAsync(
+"
+''' Testing keyword inside <see lang=""nu[||]ll""
+class C
+    sub WriteLine(Of TKey)(value as TKey)
+    end sub
+end class")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -331,7 +331,7 @@ end class")
         Public Async Function TestInXMLAttribute() As Task
             Await TestMissingAsync(
 "
-''' Testing keyword inside <see lang=""nu[||]ll"">
+''' Testing keyword inside <see langword=""Noth[||]ing"">
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub
@@ -343,7 +343,7 @@ end class")
         Public Async Function TestInXMLAttribute2() As Task
             Await TestMissingAsync(
 "
-''' Testing keyword inside <see lang=""nu[||]ll""
+''' Testing keyword inside <see langword=""Not[||]hing""
 class C
     sub WriteLine(Of TKey)(value as TKey)
     end sub

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,15 +12,37 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
     internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
         AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
     {
+        private static HashSet<string> s_keywords = new HashSet<string>
+        {
+            SyntaxFacts.GetText(SyntaxKind.NullKeyword),
+            SyntaxFacts.GetText(SyntaxKind.StaticKeyword),
+            SyntaxFacts.GetText(SyntaxKind.VirtualKeyword),
+            SyntaxFacts.GetText(SyntaxKind.TrueKeyword),
+            SyntaxFacts.GetText(SyntaxKind.FalseKeyword),
+            SyntaxFacts.GetText(SyntaxKind.AbstractKeyword),
+            SyntaxFacts.GetText(SyntaxKind.SealedKeyword),
+            SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
+            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)
+        };
+
         protected override bool IsXmlTextToken(SyntaxToken token)
             => token.Kind() == SyntaxKind.XmlTextLiteralToken ||
                token.Kind() == SyntaxKind.XmlTextLiteralNewLineToken;
 
-        protected override bool IsAnyKeyword(string text)
-            => SyntaxFacts.GetKeywordKind(text) != SyntaxKind.None ||
-               SyntaxFacts.GetContextualKeywordKind(text) != SyntaxKind.None;
+        protected override bool IsInXMLAttribute(SyntaxToken token)
+        {
+            return (token.Parent.Kind() == SyntaxKind.XmlCrefAttribute
+                || token.Parent.Kind() == SyntaxKind.XmlNameAttribute
+                || token.Parent.Kind() == SyntaxKind.XmlTextAttribute);
+        }
+
+        protected override bool IsKeyword(string text)
+        {
+            return s_keywords.Contains(text);
+        }
 
         protected override SyntaxNode ParseExpression(string text)
             => SyntaxFactory.ParseExpression(text);
+
     }
 }

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,8 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
     internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
         AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
     {
-        private static HashSet<string> s_keywords = new HashSet<string>
-        {
+        private static readonly ImmutableHashSet<string> s_triggerKeywords = ImmutableHashSet.Create(
             SyntaxFacts.GetText(SyntaxKind.NullKeyword),
             SyntaxFacts.GetText(SyntaxKind.StaticKeyword),
             SyntaxFacts.GetText(SyntaxKind.VirtualKeyword),
@@ -22,8 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
             SyntaxFacts.GetText(SyntaxKind.AbstractKeyword),
             SyntaxFacts.GetText(SyntaxKind.SealedKeyword),
             SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)
-        };
+            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword));
 
         protected override bool IsXmlTextToken(SyntaxToken token)
             => token.Kind() == SyntaxKind.XmlTextLiteralToken ||
@@ -37,9 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
         }
 
         protected override bool IsKeyword(string text)
-        {
-            return s_keywords.Contains(text);
-        }
+            => s_triggerKeywords.Contains(text);
 
         protected override SyntaxNode ParseExpression(string text)
             => SyntaxFactory.ParseExpression(text);

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Composition
+Imports System.Collections.Generic
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 
@@ -9,18 +10,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
     Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
         Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
 
+        Private Shared s_keywords As New HashSet(Of String) From
+            {
+            SyntaxFacts.GetText(SyntaxKind.NothingKeyword),
+            SyntaxFacts.GetText(SyntaxKind.SharedKeyword),
+            SyntaxFacts.GetText(SyntaxKind.OverridableKeyword),
+            SyntaxFacts.GetText(SyntaxKind.TrueKeyword),
+            SyntaxFacts.GetText(SyntaxKind.FalseKeyword),
+            SyntaxFacts.GetText(SyntaxKind.MustInheritKeyword),
+            SyntaxFacts.GetText(SyntaxKind.NotOverridableKeyword),
+            SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
+            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword)
+            }
+
         Protected Overrides Function IsXmlTextToken(token As SyntaxToken) As Boolean
             Return token.Kind() = SyntaxKind.XmlTextLiteralToken OrElse
                    token.Kind() = SyntaxKind.DocumentationCommentLineBreakToken
         End Function
 
-        Protected Overrides Function IsAnyKeyword(text As String) As Boolean
-            Return SyntaxFacts.GetKeywordKind(text) <> SyntaxKind.None OrElse
-                   SyntaxFacts.GetContextualKeywordKind(text) <> SyntaxKind.None
+        Protected Overrides Function IsInXMLAttribute(token As SyntaxToken) As Boolean
+            Return token.Parent.IsKind(SyntaxKind.XmlAttribute)
+        End Function
+
+        Protected Overrides Function IsKeyword(text As String) As Boolean
+            Return s_keywords.Contains(text)
         End Function
 
         Protected Overrides Function ParseExpression(text As String) As SyntaxNode
             Return SyntaxFactory.ParseExpression(text)
         End Function
+
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
     Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
         Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
 
-        Private Shared s_keywords As New HashSet(Of String) From
+        Private Shared ReadOnly s_keywords As New HashSet(Of String) From
             {
             SyntaxFacts.GetText(SyntaxKind.NothingKeyword),
             SyntaxFacts.GetText(SyntaxKind.SharedKeyword),

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
         End Function
 
         Protected Overrides Function IsInXMLAttribute(token As SyntaxToken) As Boolean
-            Return token.Parent.IsKind(SyntaxKind.XmlAttribute)
+            Return token.Parent.IsKind(SyntaxKind.XmlAttribute) Or token.Parent.IsKind(SyntaxKind.XmlString)
         End Function
 
         Protected Overrides Function IsKeyword(text As String) As Boolean


### PR DESCRIPTION
Fixes #22278 by restricting the keywords that will trigger the `<see langword=" ">`  refactoring.  Also, prevents the doc comment tags from being offered when already in an XML attribute

**Customer scenario**
When a user types a keyword in a doc comments section, they are offered a refactoring to insert a `<see langword="  ">` tag.  This fix restricts the keywords that trigger the refactoring to only the most likely candidates so it isn't triggered on more common words like `is`, `as`, `for`, etc...  It also prevents the refactoring from being offered when the cursor is already in an XML attribute.

**Bugs this fixes:**
#22278 

**Workarounds, if any**
n/a

**Risk**
low, this only affects the ReplaceDocCommentTextWithTag refactoring code

**Performance impact**
low since it reduces the scenarios in which this refactoring is offered.

**Is this a regression from a previous update?**
no

**Root cause analysis:**
initial design of this feature allowed all keywords in any part of the doc comments to trigger this refactoring.  

How did we miss it?  What tests are we adding to guard against it in the future?
Tests have been updated and added to cover the new scenarios

**How was the bug found?**
internal test team

**Test documentation updated?**
n/a

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.
