### PR TITLE
EE: Prefer parameters over locals for display class instances

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -75,15 +75,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             if (_methodNotType)
             {
                 _locals = locals;
+                _sourceMethodParametersInOrder = GetSourceMethodParametersInOrder(currentFrame, currentSourceMethod);
                 ImmutableArray<string> displayClassVariableNamesInOrder;
                 GetDisplayClassVariables(
                     currentFrame,
-                    currentSourceMethod,
                     _locals,
                     inScopeHoistedLocalSlots,
+                    _sourceMethodParametersInOrder,
                     out displayClassVariableNamesInOrder,
-                    out _displayClassVariables,
-                    out _sourceMethodParametersInOrder);
+                    out _displayClassVariables);
                 Debug.Assert(displayClassVariableNamesInOrder.Length == _displayClassVariables.Count);
                 _localsForBinding = GetLocalsForBinding(_locals, displayClassVariableNamesInOrder, _displayClassVariables);
             }
@@ -1202,64 +1202,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return builder.ToImmutableAndFree();
         }
 
-        /// <summary>
-        /// Return a mapping of captured variables (parameters, locals, and
-        /// "this") to locals. The mapping is needed to expose the original
-        /// local identifiers (those from source) in the binder.
-        /// </summary>
-        private static void GetDisplayClassVariables(
+        private static ImmutableArray<string> GetSourceMethodParametersInOrder(
             MethodSymbol method,
-            MethodSymbol sourceMethod,
-            ImmutableArray<LocalSymbol> locals,
-            ImmutableSortedSet<int> inScopeHoistedLocalSlots,
-            out ImmutableArray<string> displayClassVariableNamesInOrder,
-            out ImmutableDictionary<string, DisplayClassVariable> displayClassVariables,
-            out ImmutableArray<string> sourceMethodParametersInOrder)
+            MethodSymbol sourceMethod)
         {
-            // Calculated the shortest paths from locals to instances of display
-            // classes. There should not be two instances of the same display
-            // class immediately within any particular method.
-            var displayClassTypes = PooledHashSet<NamedTypeSymbol>.GetInstance();
-            var displayClassInstances = ArrayBuilder<DisplayClassInstanceAndFields>.GetInstance();
-
-            // Add any display class instances from locals (these will contain any hoisted locals).
-            foreach (var local in locals)
-            {
-                var name = local.Name;
-                if ((name != null) && (GeneratedNames.GetKind(name) == GeneratedNameKind.DisplayClassLocalOrField))
-                {
-                    var instance = new DisplayClassInstanceFromLocal((EELocalSymbol)local);
-                    displayClassTypes.Add(instance.Type);
-                    displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
-                }
-            }
-
-            foreach (var parameter in method.Parameters)
-            {
-                if (GeneratedNames.GetKind(parameter.Name) == GeneratedNameKind.TransparentIdentifier ||
-                    IsDisplayClassParameter(parameter))
-                {
-                    var instance = new DisplayClassInstanceFromParameter(parameter);
-                    displayClassTypes.Add(instance.Type);
-                    displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
-                }
-            }
-
             var containingType = method.ContainingType;
-            bool isIteratorOrAsyncMethod = false;
-            if (IsDisplayClassType(containingType))
-            {
-                if (!method.IsStatic)
-                {
-                    // Add "this" display class instance.
-                    var instance = new DisplayClassInstanceFromParameter(method.ThisParameter);
-                    displayClassTypes.Add(instance.Type);
-                    displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
-                }
+            bool isIteratorOrAsyncMethod = IsDisplayClassType(containingType) &&
+                GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType;
 
-                isIteratorOrAsyncMethod = GeneratedNames.GetKind(containingType.Name) == GeneratedNameKind.StateMachineType;
-            }
-            
             var parameterNamesInOrder = ArrayBuilder<string>.GetInstance();
             // For version before .NET 4.5, we cannot find the sourceMethod properly:
             // The source method coincides with the original method in the case.
@@ -1294,19 +1244,80 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 }
             }
 
-            var parameterNames = PooledHashSet<string>.GetInstance();
-            foreach (var name in parameterNamesInOrder)
+            return parameterNamesInOrder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Return a mapping of captured variables (parameters, locals, and
+        /// "this") to locals. The mapping is needed to expose the original
+        /// local identifiers (those from source) in the binder.
+        /// </summary>
+        private static void GetDisplayClassVariables(
+            MethodSymbol method,
+            ImmutableArray<LocalSymbol> locals,
+            ImmutableSortedSet<int> inScopeHoistedLocalSlots,
+            ImmutableArray<string> parameterNamesInOrder,
+            out ImmutableArray<string> displayClassVariableNamesInOrder,
+            out ImmutableDictionary<string, DisplayClassVariable> displayClassVariables)
+        {
+            // Calculate the shortest paths from locals to instances of display
+            // classes. There should not be two instances of the same display
+            // class immediately within any particular method.
+            var displayClassInstances = ArrayBuilder<DisplayClassInstanceAndFields>.GetInstance();
+
+            foreach (var parameter in method.Parameters)
             {
-                parameterNames.Add(name);
+                if (GeneratedNames.GetKind(parameter.Name) == GeneratedNameKind.TransparentIdentifier ||
+                    IsDisplayClassParameter(parameter))
+                {
+                    var instance = new DisplayClassInstanceFromParameter(parameter);
+                    displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
+                }
             }
 
-            sourceMethodParametersInOrder = parameterNamesInOrder.ToImmutableAndFree();
+            if (IsDisplayClassType(method.ContainingType) && !method.IsStatic)
+            {
+                // Add "this" display class instance.
+                var instance = new DisplayClassInstanceFromParameter(method.ThisParameter);
+                displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
+            }
+
+            var displayClassTypes = PooledHashSet<TypeSymbol>.GetInstance();
+            foreach (var instance in displayClassInstances)
+            {
+                displayClassTypes.Add(instance.Instance.Type);
+            }
+
+            // Find any additional display class instances.
+            GetAdditionalDisplayClassInstances(displayClassTypes, displayClassInstances, startIndex: 0);
+
+            // Add any display class instances from locals (these will contain any hoisted locals).
+            // Locals are only added after finding all display class instances reachable from
+            // parameters because locals may be null (temporary locals in async state machine
+            // for instance) so we prefer parameters to locals.
+            int startIndex = displayClassInstances.Count;
+            foreach (var local in locals)
+            {
+                var name = local.Name;
+                if ((name != null) && (GeneratedNames.GetKind(name) == GeneratedNameKind.DisplayClassLocalOrField))
+                {
+                    if (displayClassTypes.Add(local.Type))
+                    {
+                        var instance = new DisplayClassInstanceFromLocal((EELocalSymbol)local);
+                        displayClassInstances.Add(new DisplayClassInstanceAndFields(instance));
+                    }
+                }
+            }
+            GetAdditionalDisplayClassInstances(displayClassTypes, displayClassInstances, startIndex);
+
+            displayClassTypes.Free();
 
             if (displayClassInstances.Any())
             {
-                // Find any additional display class instances breadth first.
-                for (int depth = 0; GetDisplayClassInstances(displayClassTypes, displayClassInstances, depth) > 0; depth++)
+                var parameterNames = PooledHashSet<string>.GetInstance();
+                foreach (var name in parameterNamesInOrder)
                 {
+                    parameterNames.Add(name);
                 }
 
                 // The locals are the set of all fields from the display classes.
@@ -1326,6 +1337,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 displayClassVariableNamesInOrder = displayClassVariableNamesInOrderBuilder.ToImmutableAndFree();
                 displayClassVariables = displayClassVariablesBuilder.ToImmutableDictionary();
                 displayClassVariablesBuilder.Free();
+                parameterNames.Free();
             }
             else
             {
@@ -1333,46 +1345,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 displayClassVariables = ImmutableDictionary<string, DisplayClassVariable>.Empty;
             }
 
-            parameterNames.Free();
-            displayClassTypes.Free();
             displayClassInstances.Free();
         }
 
-        /// <summary>
-        /// Return the set of display class instances that can be reached
-        /// from the given local. A particular display class may be reachable
-        /// from multiple locals. In those cases, the instance from the
-        /// shortest path (fewest intermediate fields) is returned.
-        /// </summary>
-        private static int GetDisplayClassInstances(
-            HashSet<NamedTypeSymbol> displayClassTypes,
+        private static void GetAdditionalDisplayClassInstances(
+            HashSet<TypeSymbol> displayClassTypes,
             ArrayBuilder<DisplayClassInstanceAndFields> displayClassInstances,
-            int depth)
+            int startIndex)
         {
-            Debug.Assert(displayClassInstances.All(p => p.Depth <= depth));
-
-            var atDepth = ArrayBuilder<DisplayClassInstanceAndFields>.GetInstance();
-            atDepth.AddRange(displayClassInstances.Where(p => p.Depth == depth));
-            Debug.Assert(atDepth.Count > 0);
-
-            int n = 0;
-            foreach (var instance in atDepth)
+            // Find any additional display class instances breadth first.
+            for (int i = startIndex; i < displayClassInstances.Count; i++)
             {
-                n += GetDisplayClassInstances(displayClassTypes, displayClassInstances, instance);
+                GetDisplayClassInstances(displayClassTypes, displayClassInstances, displayClassInstances[i]);
             }
-
-            atDepth.Free();
-            return n;
         }
 
-        private static int GetDisplayClassInstances(
-            HashSet<NamedTypeSymbol> displayClassTypes,
+        private static void GetDisplayClassInstances(
+            HashSet<TypeSymbol> displayClassTypes,
             ArrayBuilder<DisplayClassInstanceAndFields> displayClassInstances,
             DisplayClassInstanceAndFields instance)
         {
             // Display class instance. The display class fields are variables.
-            int n = 0;
-
             foreach (var member in instance.Type.GetMembers())
             {
                 if (member.Kind != SymbolKind.Field)
@@ -1410,15 +1403,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 Debug.Assert(!field.IsStatic);
 
                 // A hoisted local that is itself a display class instance.
-                if (displayClassTypes.Add((NamedTypeSymbol)field.Type))
+                if (displayClassTypes.Add(field.Type))
                 {
                     var other = instance.FromField(field);
                     displayClassInstances.Add(other);
-                    n++;
                 }
             }
-
-            return n;
         }
 
         /// <summary>
@@ -1513,13 +1503,22 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     // Only expecting duplicates for async state machine
                     // fields (that should be at the top-level).
                     Debug.Assert(displayClassVariablesBuilder[variableName].DisplayClassFields.Count() == 1);
-                    Debug.Assert(instance.Fields.Count() >= 1); // greater depth
-                    Debug.Assert((variableKind == DisplayClassVariableKind.Parameter) ||
-                        (variableKind == DisplayClassVariableKind.This));
 
-                    if (variableKind == DisplayClassVariableKind.Parameter && GeneratedNames.GetKind(instance.Type.Name) == GeneratedNameKind.LambdaDisplayClass)
+                    if (!instance.Fields.Any())
                     {
-                        displayClassVariablesBuilder[variableName] = instance.ToVariable(variableName, variableKind, field);
+                        // Prefer parameters over locals.
+                        Debug.Assert(instance.Instance is DisplayClassInstanceFromLocal);
+                    }
+                    else
+                    {
+                        Debug.Assert(instance.Fields.Count() >= 1); // greater depth
+                        Debug.Assert((variableKind == DisplayClassVariableKind.Parameter) ||
+                            (variableKind == DisplayClassVariableKind.This));
+
+                        if (variableKind == DisplayClassVariableKind.Parameter && GeneratedNames.GetKind(instance.Type.Name) == GeneratedNameKind.LambdaDisplayClass)
+                        {
+                            displayClassVariablesBuilder[variableName] = instance.ToVariable(variableName, variableKind, field);
+                        }
                     }
                 }
                 else if (variableKind != DisplayClassVariableKind.This || GeneratedNames.GetKind(instance.Type.ContainingType.Name) != GeneratedNameKind.LambdaDisplayClass)
@@ -1548,7 +1547,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return result;
         }
 
-        private static bool IsDisplayClassType(NamedTypeSymbol type)
+        private static bool IsDisplayClassType(TypeSymbol type)
         {
             switch (GeneratedNames.GetKind(type.Name))
             {
@@ -1686,6 +1685,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return MemberSignatureComparer.HaveSameConstraints(candidateTypeParameters, candidateTypeMap, desiredTypeParameters, desiredTypeMap);
         }
 
+        [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
         private struct DisplayClassInstanceAndFields
         {
             internal readonly DisplayClassInstance Instance;
@@ -1704,9 +1704,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 this.Fields = fields;
             }
 
-            internal NamedTypeSymbol Type
+            internal TypeSymbol Type
             {
-                get { return this.Fields.Any() ? (NamedTypeSymbol)this.Fields.Head.Type : this.Instance.Type; }
+                get { return this.Fields.Any() ? this.Fields.Head.Type : this.Instance.Type; }
             }
 
             internal int Depth
@@ -1716,7 +1716,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             internal DisplayClassInstanceAndFields FromField(FieldSymbol field)
             {
-                Debug.Assert(IsDisplayClassType((NamedTypeSymbol)field.Type) ||
+                Debug.Assert(IsDisplayClassType(field.Type) ||
                     GeneratedNames.GetKind(field.Type.Name) == GeneratedNameKind.AnonymousType);
                 return new DisplayClassInstanceAndFields(this.Instance, this.Fields.Prepend(field));
             }
@@ -1724,6 +1724,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             internal DisplayClassVariable ToVariable(string name, DisplayClassVariableKind kind, FieldSymbol field)
             {
                 return new DisplayClassVariable(name, kind, this.Instance, this.Fields.Prepend(field));
+            }
+
+            private string GetDebuggerDisplay()
+            {
+                return Instance.GetDebuggerDisplay(Fields);
             }
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/DisplayClassVariable.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
     /// A field in a display class that represents a captured
     /// variable: either a local, a parameter, or "this".
     /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal sealed class DisplayClassVariable
     {
         internal readonly string Name;
@@ -73,6 +74,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var otherFields = SubstituteFields(this.DisplayClassFields, typeMap);
             return new DisplayClassVariable(this.Name, this.Kind, otherInstance, otherFields);
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return DisplayClassInstance.GetDebuggerDisplay(DisplayClassFields);
         }
 
         private static ConsList<FieldSymbol> SubstituteFields(ConsList<FieldSymbol> fields, TypeMap typeMap)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -461,6 +463,241 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
   IL_0046:  ldarg.0
   IL_0047:  callvirt   0x0A00000E
   IL_004c:  ret
+}");
+                });
+        }
+
+        [WorkItem(482753, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=482753")]
+        [Fact]
+        public void LocalsInAsync()
+        {
+            var source =
+@"using System;
+using System.Threading.Tasks;
+class C
+{
+    static Task<object> E(object o, Func<object, bool> p)
+    {
+        throw new NotImplementedException();
+    }
+    object F()
+    {
+        throw new NotImplementedException();
+    }
+    Task G(object o)
+    {
+        throw new NotImplementedException();
+    }
+    async Task M(object x)
+    {
+        var z = await E(F(), y => x == y);
+#line 999
+        await G(z);
+    }
+}";
+            // Test with CompileExpression rather than CompileExpressions
+            // so field references in IL are named.
+            // Debug build.
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
+            WithRuntimeInstance(
+                comp,
+                references: null,
+                includeLocalSignatures: true,
+                includeIntrinsicAssembly: false,
+                validator: runtime =>
+                {
+                    var context = CreateMethodContext(runtime, "C.<M>d__3.MoveNext()", atLineNumber: 999);
+                    string error;
+                    var testData = new CompilationTestData();
+                    var result = context.CompileExpression("z ?? x", out error, testData);
+                    Assert.NotNull(result.Assembly);
+                    Assert.Null(error);
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
+                C.<M>d__3 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""object C.<M>d__3.<z>5__2""
+  IL_0006:  dup
+  IL_0007:  brtrue.s   IL_0015
+  IL_0009:  pop
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""C.<>c__DisplayClass3_0 C.<M>d__3.<>8__1""
+  IL_0010:  ldfld      ""object C.<>c__DisplayClass3_0.x""
+  IL_0015:  ret
+}");
+                });
+            // Release build.
+            comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, references: new[] { SystemCoreRef });
+            {
+                // Note from MoveNext() below that local CS$<>8__locals0 should not be
+                // used in the compiled expression to access the display class since that
+                // local is only set the first time through MoveNext() (see loc.2 below).
+                var testData = new CompilationTestData();
+                comp.EmitToArray(testData: testData);
+                testData.GetMethodData("C.<M>d__3.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()").VerifyIL(
+@"{
+  // Code size      293 (0x125)
+  .maxstack  3
+  .locals init (int V_0,
+                C V_1,
+                C.<>c__DisplayClass3_0 V_2, //CS$<>8__locals0
+                object V_3, //z
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter V_5,
+                System.Exception V_6)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<M>d__3.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C C.<M>d__3.<>4__this""
+  IL_000d:  stloc.1
+  .try
+  {
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse.s  IL_0075
+    IL_0011:  ldloc.0
+    IL_0012:  ldc.i4.1
+    IL_0013:  beq        IL_00d2
+    IL_0018:  newobj     ""C.<>c__DisplayClass3_0..ctor()""
+    IL_001d:  stloc.2
+    IL_001e:  ldloc.2
+    IL_001f:  ldarg.0
+    IL_0020:  ldfld      ""object C.<M>d__3.x""
+    IL_0025:  stfld      ""object C.<>c__DisplayClass3_0.x""
+    IL_002a:  ldloc.1
+    IL_002b:  call       ""object C.F()""
+    IL_0030:  ldloc.2
+    IL_0031:  ldftn      ""bool C.<>c__DisplayClass3_0.<M>b__0(object)""
+    IL_0037:  newobj     ""System.Func<object, bool>..ctor(object, System.IntPtr)""
+    IL_003c:  call       ""System.Threading.Tasks.Task<object> C.E(object, System.Func<object, bool>)""
+    IL_0041:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<object> System.Threading.Tasks.Task<object>.GetAwaiter()""
+    IL_0046:  stloc.s    V_4
+    IL_0048:  ldloca.s   V_4
+    IL_004a:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<object>.IsCompleted.get""
+    IL_004f:  brtrue.s   IL_0092
+    IL_0051:  ldarg.0
+    IL_0052:  ldc.i4.0
+    IL_0053:  dup
+    IL_0054:  stloc.0
+    IL_0055:  stfld      ""int C.<M>d__3.<>1__state""
+    IL_005a:  ldarg.0
+    IL_005b:  ldloc.s    V_4
+    IL_005d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<object> C.<M>d__3.<>u__1""
+    IL_0062:  ldarg.0
+    IL_0063:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__3.<>t__builder""
+    IL_0068:  ldloca.s   V_4
+    IL_006a:  ldarg.0
+    IL_006b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<object>, C.<M>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<object>, ref C.<M>d__3)""
+    IL_0070:  leave      IL_0124
+    IL_0075:  ldarg.0
+    IL_0076:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<object> C.<M>d__3.<>u__1""
+    IL_007b:  stloc.s    V_4
+    IL_007d:  ldarg.0
+    IL_007e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<object> C.<M>d__3.<>u__1""
+    IL_0083:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<object>""
+    IL_0089:  ldarg.0
+    IL_008a:  ldc.i4.m1
+    IL_008b:  dup
+    IL_008c:  stloc.0
+    IL_008d:  stfld      ""int C.<M>d__3.<>1__state""
+    IL_0092:  ldloca.s   V_4
+    IL_0094:  call       ""object System.Runtime.CompilerServices.TaskAwaiter<object>.GetResult()""
+    IL_0099:  stloc.3
+    IL_009a:  ldloc.1
+    IL_009b:  ldloc.3
+    IL_009c:  call       ""System.Threading.Tasks.Task C.G(object)""
+    IL_00a1:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter System.Threading.Tasks.Task.GetAwaiter()""
+    IL_00a6:  stloc.s    V_5
+    IL_00a8:  ldloca.s   V_5
+    IL_00aa:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter.IsCompleted.get""
+    IL_00af:  brtrue.s   IL_00ef
+    IL_00b1:  ldarg.0
+    IL_00b2:  ldc.i4.1
+    IL_00b3:  dup
+    IL_00b4:  stloc.0
+    IL_00b5:  stfld      ""int C.<M>d__3.<>1__state""
+    IL_00ba:  ldarg.0
+    IL_00bb:  ldloc.s    V_5
+    IL_00bd:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__3.<>u__2""
+    IL_00c2:  ldarg.0
+    IL_00c3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__3.<>t__builder""
+    IL_00c8:  ldloca.s   V_5
+    IL_00ca:  ldarg.0
+    IL_00cb:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<M>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<M>d__3)""
+    IL_00d0:  leave.s    IL_0124
+    IL_00d2:  ldarg.0
+    IL_00d3:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__3.<>u__2""
+    IL_00d8:  stloc.s    V_5
+    IL_00da:  ldarg.0
+    IL_00db:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter C.<M>d__3.<>u__2""
+    IL_00e0:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldc.i4.m1
+    IL_00e8:  dup
+    IL_00e9:  stloc.0
+    IL_00ea:  stfld      ""int C.<M>d__3.<>1__state""
+    IL_00ef:  ldloca.s   V_5
+    IL_00f1:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
+    IL_00f6:  leave.s    IL_0111
+  }
+  catch System.Exception
+  {
+    IL_00f8:  stloc.s    V_6
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldc.i4.s   -2
+    IL_00fd:  stfld      ""int C.<M>d__3.<>1__state""
+    IL_0102:  ldarg.0
+    IL_0103:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__3.<>t__builder""
+    IL_0108:  ldloc.s    V_6
+    IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_010f:  leave.s    IL_0124
+  }
+  IL_0111:  ldarg.0
+  IL_0112:  ldc.i4.s   -2
+  IL_0114:  stfld      ""int C.<M>d__3.<>1__state""
+  IL_0119:  ldarg.0
+  IL_011a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__3.<>t__builder""
+  IL_011f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0124:  ret
+}");
+            }
+            WithRuntimeInstance(
+                comp,
+                references: null,
+                includeLocalSignatures: true,
+                includeIntrinsicAssembly: false,
+                validator: runtime =>
+                {
+                    var context = CreateMethodContext(runtime, "C.<M>d__3.MoveNext()", atLineNumber: 999);
+                    string error;
+                    var testData = new CompilationTestData();
+                    var result = context.CompileExpression("z ?? x", out error, testData);
+                    Assert.NotNull(result.Assembly);
+                    Assert.Null(error);
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"{
+  // Code size       12 (0xc)
+  .maxstack  2
+  .locals init (int V_0,
+                C V_1,
+                C.<>c__DisplayClass3_0 V_2, //CS$<>8__locals0
+                object V_3, //z
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter V_5,
+                System.Exception V_6)
+  IL_0000:  ldloc.3
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_000b
+  IL_0004:  pop
+  IL_0005:  ldarg.0
+  IL_0006:  ldfld      ""object C.<M>d__3.x""
+  IL_000b:  ret
 }");
                 });
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1410,17 +1410,7 @@ class P
   IL_0000:  ldarg.1
   IL_0001:  ret
 }");
-                VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedILOpt:
-@"{
-  // Code size        7 (0x7)
-  .maxstack  1
-  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
-  object V_1)
-  IL_0000:  ldloc.0
-  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.y""
-  IL_0006:  ret
-}");
-                VerifyLocal(testData, typeName, locals[3], "<>m3", "x", expectedILOpt:
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
@@ -1428,6 +1418,16 @@ class P
   object V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<>c__DisplayClass1_0.x""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "y", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
+  object V_1)
+  IL_0000:  ldloc.0
+  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.y""
   IL_0006:  ret
 }");
                 Assert.Equal(locals.Count, 4);

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/DisplayClassVariable.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/DisplayClassVariable.vb
@@ -16,6 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     ''' A field in a display class that represents a captured variable:
     ''' either a local, a parameter, or "me".
     ''' </summary>
+    <DebuggerDisplay("{GetDebuggerDisplay(), nq}")>
     Friend NotInheritable Class DisplayClassVariable
 
         Friend ReadOnly Name As String
@@ -72,6 +73,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Function SubstituteFields(otherInstance As DisplayClassInstance, typeMap As TypeSubstitution) As DisplayClassVariable
             Dim otherFields = SubstituteFields(Me.DisplayClassFields, typeMap)
             Return New DisplayClassVariable(Me.Name, Me.Kind, otherInstance, otherFields)
+        End Function
+
+        Private Function GetDebuggerDisplay() As String
+            Return DisplayClassInstance.GetDebuggerDisplay(DisplayClassFields)
         End Function
 
         Private Shared Function SubstituteFields(fields As ConsList(Of FieldSymbol), typeMap As TypeSubstitution) As ConsList(Of FieldSymbol)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/CompileExpressionsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/CompileExpressionsTests.vb
@@ -1,0 +1,253 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeGen
+Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Roslyn.Test.Utilities
+Imports Xunit
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
+
+    Public Class CompileExpressionsTests
+        Inherits ExpressionCompilerTestBase
+
+        <WorkItem(482753, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=482753")>
+        <Fact>
+        Public Sub LocalsInAsync()
+            Const source =
+"Imports System
+Imports System.Threading.Tasks
+Class C
+    Shared Function E(o As Object, p As Func(Of Object, Boolean)) As Task(Of Object)
+        Throw New NotImplementedException()
+    End Function
+    Function F() As Object
+        Throw New NotImplementedException()
+    End Function
+    Function G(o As Object) As Task(Of Object)
+        Throw New NotImplementedException()
+    End Function
+    Async Function M(x As Object) As Task
+        Dim z = Await E(F(), Function(y) x = y)
+#ExternalSource(""Test"", 999)
+        Await G(z)
+#End ExternalSource
+    End Function
+End Class"
+            ' Test with CompileExpression rather than CompileExpressions
+            ' so field references in IL are named.
+            ' Debug build.
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(
+                {VisualBasicSyntaxTree.ParseText(source)},
+                options:=TestOptions.DebugDll,
+                references:={SystemCoreRef})
+            Dim testData As CompilationTestData
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.VB$StateMachine_4_M.MoveNext()", atLineNumber:=999)
+                    Dim errorMessage As String = Nothing
+                    testData = New CompilationTestData()
+                    Dim result = context.CompileExpression("If(z, x)", errorMessage, testData)
+                    Assert.NotNull(result.Assembly)
+                    Assert.Null(errorMessage)
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (Integer V_0,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_1,
+                C.VB$StateMachine_4_M V_2,
+                Object V_3,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C.VB$StateMachine_4_M.$VB$ResumableLocal_z$1 As Object""
+  IL_0006:  dup
+  IL_0007:  brtrue.s   IL_0015
+  IL_0009:  pop
+  IL_000a:  ldarg.0
+  IL_000b:  ldfld      ""C.VB$StateMachine_4_M.$VB$ResumableLocal_$VB$Closure_$0 As C._Closure$__4-0""
+  IL_0010:  ldfld      ""C._Closure$__4-0.$VB$Local_x As Object""
+  IL_0015:  ret
+}")
+                End Sub)
+            ' Release build.
+            comp = CreateCompilationWithMscorlib45AndVBRuntime(
+                {VisualBasicSyntaxTree.ParseText(source)},
+                options:=TestOptions.ReleaseDll,
+                references:={SystemCoreRef})
+            ' Note from MoveNext() below that local $VB$Closure_0 should not be
+            ' used in the compiled expression to access the display class since that
+            ' local is only set the first time through MoveNext() (see loc.1 below).
+            testData = New CompilationTestData()
+            comp.EmitToArray(testData:=testData)
+            testData.GetMethodData("C.VB$StateMachine_4_M.MoveNext()").VerifyIL(
+                "{
+  // Code size      338 (0x152)
+  .maxstack  3
+  .locals init (Integer V_0,
+                C._Closure$__4-0 V_1, //$VB$Closure_0
+                Object V_2, //z
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_3,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C.VB$StateMachine_4_M.$State As Integer""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0076
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  beq        IL_00e9
+    IL_0011:  newobj     ""Sub C._Closure$__4-0..ctor()""
+    IL_0016:  stloc.1
+    IL_0017:  ldloc.1
+    IL_0018:  ldarg.0
+    IL_0019:  ldfld      ""C.VB$StateMachine_4_M.$VB$Local_x As Object""
+    IL_001e:  stfld      ""C._Closure$__4-0.$VB$Local_x As Object""
+    IL_0023:  ldarg.0
+    IL_0024:  ldfld      ""C.VB$StateMachine_4_M.$VB$Me As C""
+    IL_0029:  callvirt   ""Function C.F() As Object""
+    IL_002e:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+    IL_0033:  ldloc.1
+    IL_0034:  ldftn      ""Function C._Closure$__4-0._Lambda$__0(Object) As Boolean""
+    IL_003a:  newobj     ""Sub System.Func(Of Object, Boolean)..ctor(Object, System.IntPtr)""
+    IL_003f:  call       ""Function C.E(Object, System.Func(Of Object, Boolean)) As System.Threading.Tasks.Task(Of Object)""
+    IL_0044:  callvirt   ""Function System.Threading.Tasks.Task(Of Object).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0049:  stloc.3
+    IL_004a:  ldloca.s   V_3
+    IL_004c:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Object).get_IsCompleted() As Boolean""
+    IL_0051:  brtrue.s   IL_0092
+    IL_0053:  ldarg.0
+    IL_0054:  ldc.i4.0
+    IL_0055:  dup
+    IL_0056:  stloc.0
+    IL_0057:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+    IL_005c:  ldarg.0
+    IL_005d:  ldloc.3
+    IL_005e:  stfld      ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0063:  ldarg.0
+    IL_0064:  ldflda     ""C.VB$StateMachine_4_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder""
+    IL_0069:  ldloca.s   V_3
+    IL_006b:  ldarg.0
+    IL_006c:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Object), C.VB$StateMachine_4_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Object), ByRef C.VB$StateMachine_4_M)""
+    IL_0071:  leave      IL_0151
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.m1
+    IL_0078:  dup
+    IL_0079:  stloc.0
+    IL_007a:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+    IL_007f:  ldarg.0
+    IL_0080:  ldfld      ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0085:  stloc.3
+    IL_0086:  ldarg.0
+    IL_0087:  ldflda     ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_008c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0092:  ldloca.s   V_3
+    IL_0094:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Object).GetResult() As Object""
+    IL_0099:  ldloca.s   V_3
+    IL_009b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_00a1:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+    IL_00a6:  stloc.2
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldfld      ""C.VB$StateMachine_4_M.$VB$Me As C""
+    IL_00ad:  ldloc.2
+    IL_00ae:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+    IL_00b3:  callvirt   ""Function C.G(Object) As System.Threading.Tasks.Task(Of Object)""
+    IL_00b8:  callvirt   ""Function System.Threading.Tasks.Task(Of Object).GetAwaiter() As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_00bd:  stloc.s    V_4
+    IL_00bf:  ldloca.s   V_4
+    IL_00c1:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Object).get_IsCompleted() As Boolean""
+    IL_00c6:  brtrue.s   IL_0106
+    IL_00c8:  ldarg.0
+    IL_00c9:  ldc.i4.1
+    IL_00ca:  dup
+    IL_00cb:  stloc.0
+    IL_00cc:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+    IL_00d1:  ldarg.0
+    IL_00d2:  ldloc.s    V_4
+    IL_00d4:  stfld      ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_00d9:  ldarg.0
+    IL_00da:  ldflda     ""C.VB$StateMachine_4_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder""
+    IL_00df:  ldloca.s   V_4
+    IL_00e1:  ldarg.0
+    IL_00e2:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.TaskAwaiter(Of Object), C.VB$StateMachine_4_M)(ByRef System.Runtime.CompilerServices.TaskAwaiter(Of Object), ByRef C.VB$StateMachine_4_M)""
+    IL_00e7:  leave.s    IL_0151
+    IL_00e9:  ldarg.0
+    IL_00ea:  ldc.i4.m1
+    IL_00eb:  dup
+    IL_00ec:  stloc.0
+    IL_00ed:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldfld      ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_00f8:  stloc.s    V_4
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldflda     ""C.VB$StateMachine_4_M.$A0 As System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0100:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0106:  ldloca.s   V_4
+    IL_0108:  call       ""Function System.Runtime.CompilerServices.TaskAwaiter(Of Object).GetResult() As Object""
+    IL_010d:  pop
+    IL_010e:  ldloca.s   V_4
+    IL_0110:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter(Of Object)""
+    IL_0116:  leave.s    IL_013c
+  }
+  catch System.Exception
+  {
+    IL_0118:  dup
+    IL_0119:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
+    IL_011e:  stloc.s    V_5
+    IL_0120:  ldarg.0
+    IL_0121:  ldc.i4.s   -2
+    IL_0123:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+    IL_0128:  ldarg.0
+    IL_0129:  ldflda     ""C.VB$StateMachine_4_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder""
+    IL_012e:  ldloc.s    V_5
+    IL_0130:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0135:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
+    IL_013a:  leave.s    IL_0151
+  }
+  IL_013c:  ldarg.0
+  IL_013d:  ldc.i4.s   -2
+  IL_013f:  dup
+  IL_0140:  stloc.0
+  IL_0141:  stfld      ""C.VB$StateMachine_4_M.$State As Integer""
+  IL_0146:  ldarg.0
+  IL_0147:  ldflda     ""C.VB$StateMachine_4_M.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder""
+  IL_014c:  call       ""Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0151:  ret
+}")
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.VB$StateMachine_4_M.MoveNext()", atLineNumber:=999)
+                    Dim errorMessage As String = Nothing
+                    testData = New CompilationTestData()
+                    Dim result = context.CompileExpression("If(z, x)", errorMessage, testData)
+                    Assert.NotNull(result.Assembly)
+                    Assert.Null(errorMessage)
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size       12 (0xc)
+  .maxstack  2
+  .locals init (Integer V_0,
+                C._Closure$__4-0 V_1, //$VB$Closure_0
+                Object V_2, //z
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_3,
+                System.Runtime.CompilerServices.TaskAwaiter(Of Object) V_4,
+                System.Exception V_5)
+  IL_0000:  ldloc.2
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_000b
+  IL_0004:  pop
+  IL_0005:  ldarg.0
+  IL_0006:  ldfld      ""C.VB$StateMachine_4_M.$VB$Local_x As Object""
+  IL_000b:  ret
+}")
+                End Sub)
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -728,6 +728,7 @@ End Class
   IL_0001:  ldfld      ""C._Closure$__2-1.$VB$Local_w As Integer""
   IL_0006:  ret
 }")
+                    locals.Free()
                 End Sub)
         End Sub
 
@@ -807,17 +808,7 @@ End Class
   IL_0000:  ldarg.1
   IL_0001:  ret
 }")
-                    VerifyLocal(testData, typeName, locals(2), "<>m2", "y", expectedILOpt:=
-"{
-  // Code size        7 (0x7)
-  .maxstack  1
-  .locals init (C._Closure$__2-0 V_0, //$VB$Closure_0
-                Object V_1)
-  IL_0000:  ldloc.0
-  IL_0001:  ldfld      ""C._Closure$__2-0.$VB$Local_y As Object""
-  IL_0006:  ret
-}")
-                    VerifyLocal(testData, typeName, locals(3), "<>m3", "x", expectedILOpt:=
+                    VerifyLocal(testData, typeName, locals(2), "<>m2", "x", expectedILOpt:=
 "{
   // Code size        7 (0x7)
   .maxstack  1
@@ -827,6 +818,17 @@ End Class
   IL_0001:  ldfld      ""C._Closure$__2-1.$VB$Local_x As Object""
   IL_0006:  ret
 }")
+                    VerifyLocal(testData, typeName, locals(3), "<>m3", "y", expectedILOpt:=
+"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (C._Closure$__2-0 V_0, //$VB$Closure_0
+                Object V_1)
+  IL_0000:  ldloc.0
+  IL_0001:  ldfld      ""C._Closure$__2-0.$VB$Local_y As Object""
+  IL_0006:  ret
+}")
+                    locals.Free()
                 End Sub)
         End Sub
 
@@ -1811,6 +1813,7 @@ End Class
   IL_0009:  newobj     ""Sub Date..ctor(Long)""
   IL_000e:  ret
 }")
+                    locals.Free()
                 End Sub)
         End Sub
 
@@ -1850,6 +1853,7 @@ End Class
   IL_0006:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
   IL_000b:  ret
 }")
+                    locals.Free()
                 End Sub)
         End Sub
 
@@ -2013,6 +2017,7 @@ End Class
                     Dim typeVariablesType = DirectCast(method.ReturnType, NamedTypeSymbol)
                     Assert.Equal("T", typeVariablesType.TypeParameters.Single().Name)
                     Assert.Equal("T", typeVariablesType.TypeArguments.Single().Name)
+                    locals.Free()
                 End Sub)
         End Sub
 


### PR DESCRIPTION
**Customer scenario**

Evaluate certain hoisted locals or parameters in a `RELEASE` build of an `async` method. The result may be a `NullReferenceException`.

**Bugs this fixes:**

482753

**Workarounds, if any**

Avoid evaluating locals and parameters in `async` methods in `RELEASE` build.

**Risk**

Medium risk since the fix changes the method used to walk display class instances. That method is used for lambdas, `async` methods, and iterator methods.

**Performance impact**

None

**Is this a regression from a previous update?**

Regression from legacy EE perhaps.

**How was the bug found?**

Partner team

