### PR TITLE
Disable test discover in VS

### DIFF
--- a/Roslyn.runsettings
+++ b/Roslyn.runsettings
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<!-- This file can be removed once https://github.com/dotnet/roslyn/pull/20333 is merged. --> 
-<RunSettings>  
-  <RunConfiguration>  
-    <TestAdaptersPaths>%userprofile%\.nuget\packages\xunit.runner.visualstudio\2.2.0-beta4-build1194</TestAdaptersPaths>  
-  </RunConfiguration>   
-</RunSettings>  

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -232,7 +232,6 @@
     <xunitassertVersion>2.2.0</xunitassertVersion>
     <xunitextensibilityexecution>2.2.0</xunitextensibilityexecution>
     <xunitrunnerconsoleVersion>2.2.0</xunitrunnerconsoleVersion>
-    <xunitrunnervisualstudioVersion>2.2.0</xunitrunnervisualstudioVersion>
     <xunitrunnerwpfVersion>1.0.41</xunitrunnerwpfVersion>
   </PropertyGroup>
 

--- a/src/CodeStyle/CSharp/Tests/CSharpCodeStyleTests.csproj
+++ b/src/CodeStyle/CSharp/Tests/CSharpCodeStyleTests.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>

--- a/src/CodeStyle/Core/Tests/CodeStyleTests.csproj
+++ b/src/CodeStyle/Core/Tests/CodeStyleTests.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>

--- a/src/CodeStyle/VisualBasic/Tests/BasicCodeStyleTests.vbproj
+++ b/src/CodeStyle/VisualBasic/Tests/BasicCodeStyleTests.vbproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="System.Linq.Parallel" Version="$(SystemLinqParallelVersion)" />
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -29,7 +29,6 @@
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\PdbUtilities.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/Scripting/CSharpTest/CSharpScriptingTest.csproj
+++ b/src/Scripting/CSharpTest/CSharpScriptingTest.csproj
@@ -37,7 +37,6 @@
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
   </ItemGroup>
   <Import Project="..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/Scripting/CoreTest/ScriptingTest.csproj
+++ b/src/Scripting/CoreTest/ScriptingTest.csproj
@@ -37,7 +37,6 @@
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.VisualBasic.Scripting.Desktop.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(xunitrunnervisualstudioVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>


### PR DESCRIPTION
The test discovery is hurting our ability to load solutions quickly in
preview builds. Temporarily disabling discovery while this is being
fixed. Will re-enable once we have the fix.

