### PR TITLE
[EE] Override OnClose for MetadataContextItem

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -323,6 +323,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 this.MetadataContext = metadataContext;
             }
+
+            protected override void OnClose() { }
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -324,6 +324,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 this.MetadataContext = metadataContext;
             }
 
+            // This override is needed to keep the DkmDataItem from being unloaded ahead of this component.
+            // See https://github.com/dotnet/roslyn/issues/22617.
             protected override void OnClose() { }
         }
     }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -324,7 +324,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 this.MetadataContext = metadataContext;
             }
 
-            // This override is needed to keep the DkmDataItem from being unloaded ahead of this component.
+            // This override is needed to prevent the Concord dispatcher from unloading components 
+            // under the EE when code from an EE component is currently running.
             // See https://github.com/dotnet/roslyn/issues/22617.
             protected override void OnClose() { }
         }


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/22617

**Customer scenario**

There is a crash when user attempts to debug in X64 mode with the process object unloaded at the point of attempting to read a dangling pointer returned from the GetMetaDataBytesPtr Concord API.

**Bugs this fixes:**

#22617
VSO : Bug https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=187805 

**Workarounds, if any**

Not known

**Risk**

Low. Code change is minimal. It stops Concord API from going to the component-cleaning phase, ensuring that the bytes are alive.

**Performance impact**

No

**Is this a regression from a previous update?**

There was an incomplete fix for the issue: https://github.com/dotnet/roslyn/issues/17788

**Root cause analysis:**

Please see https://github.com/dotnet/roslyn/issues/22617

**How was the bug found?**

Reliability tracking. Then, Watson dumps

**Test documentation updated?**

No (N/A?)