### PR TITLE
VB EE: Properly handle syntax errors in synthesized assignments

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -159,7 +159,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     },
                     out error);
 
-                Debug.Assert((r.ResultProperties.Flags & DkmClrCompilationResultFlags.PotentialSideEffect) == DkmClrCompilationResultFlags.PotentialSideEffect);
+                Debug.Assert(
+                    r.CompileResult == null && r.ResultProperties.Flags == default ||
+                    (r.ResultProperties.Flags & DkmClrCompilationResultFlags.PotentialSideEffect) == DkmClrCompilationResultFlags.PotentialSideEffect);
+
                 result = r.CompileResult.ToQueryResult(this.CompilerId, r.ResultProperties, runtimeInstance);
             }
             catch (Exception e) when (ExpressionEvaluatorFatalError.CrashIfFailFastEnabled(e))

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SyntaxHelpers.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SyntaxHelpers.vb
@@ -38,6 +38,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim syntaxTree = expression.CreateSyntaxTree()
             diagnostics.AddRange(syntaxTree.GetDiagnostics())
 
+            If diagnostics.HasAnyErrors Then
+                Return Nothing
+            End If
+
             ' Any Diagnostic spans produced in binding will be offset by the length of the "target" expression text.
             ' If we want to support live squiggles in debugger windows, SemanticModel, etc, we'll want to address this.
             Dim targetSyntax = SyntaxHelpers.ParseDebuggerExpressionInternal(SourceText.From(target), consumeFullText:=True)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -456,11 +456,6 @@ End Class
                     Assert.Null(result)
                     Assert.Equal("error BC30035: Syntax error.", errorMessage)
 
-                    ' 
-                    result = context.CompileAssignment("x", "", errorMessage, formatter:=DebuggerDiagnosticFormatter.Instance)
-                    Assert.Null(result)
-                    Assert.Equal("error BC30035: Syntax error.", errorMessage)
-
                     ' Format specifiers, no expression.
                     result = context.CompileExpression(",f", errorMessage, formatter:=DebuggerDiagnosticFormatter.Instance)
                     Assert.Equal("error BC30201: Expression expected.", errorMessage)


### PR DESCRIPTION
**Customer scenario**

The EE displays "Internal error in expression evaluator" when the value of local variable is set to an expression that's not syntactically correct in a Watch window.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/18531

**Workarounds, if any**

None. 

**Risk**

Small. Trivial change.

**Performance impact**

None.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The binder is able to work properly in presence of some syntax errors, but throws for others. Our EE syntax error tests only covered syntax error that was not causing the binder to throw.

**How was the bug found?**

Customer reported.
