### PR TITLE
Update ibc training data again (d15prerel 27010.3001)...

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -141,7 +141,7 @@
     <RestSharpVersion>105.2.3</RestSharpVersion>
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
     <RoslynDependenciesMicrosoftVisualStudioWorkspaceVersion>14.0.983-pre-ge167e81694</RoslynDependenciesMicrosoftVisualStudioWorkspaceVersion>
-    <RoslynDependenciesOptimizationDataVersion>2.6.0-beta1-62010-04</RoslynDependenciesOptimizationDataVersion>
+    <RoslynDependenciesOptimizationDataVersion>2.6.0-beta1-62205-01</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftSignToolVersion>0.3.0-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>


### PR DESCRIPTION
**Customer scenario**

Many managed language scenarios in VS (including typing and building) are currently regressed due to increased JIT'ing.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_queries?id=457718&_a=edit&triage=true

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

Should be a pure win in terms of elapsed time and image sizes

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

Infrastructure issues have delayed updates to our training data, and they have decayed over time.

**How was the bug found?**

RPS

**Test documentation updated?**

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.
