### PR TITLE
Prevent SqlConnection from being held past an async boundary

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -94,7 +94,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
         }
 
-        private static async Task RegisterWorkspaceHostAsync(Workspace workspace, RemoteHostClient client)
+        // internal for debugging purpose
+        internal static async Task RegisterWorkspaceHostAsync(Workspace workspace, RemoteHostClient client)
         {
             var vsWorkspace = workspace as VisualStudioWorkspaceImpl;
             if (vsWorkspace == null)

--- a/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
@@ -19,7 +19,12 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.Remote
             // this is the point where we can create different kind of remote host client in future (cloud or etc)
             if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
             {
-                return await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var client = await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // register workspace host for in proc remote host client
+                await ServiceHubRemoteHostClient.RegisterWorkspaceHostAsync(workspace, client).ConfigureAwait(false);
+
+                return client;
             }
 
             return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorageService.cs
@@ -34,9 +34,11 @@ namespace Microsoft.CodeAnalysis.Esent
             return Path.Combine(workingFolderPath, StorageExtension, PersistentStorageFileName);
         }
 
-        protected override AbstractPersistentStorage OpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath)
-            => new EsentPersistentStorage(
-                OptionService, workingFolderPath, solution.FilePath, databaseFilePath, this.Release);
+        protected override bool TryOpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath, out AbstractPersistentStorage storage)
+        {
+            storage = new EsentPersistentStorage(OptionService, workingFolderPath, solution.FilePath, databaseFilePath, this.Release);
+            return true;
+        }
 
         protected override bool ShouldDeleteDatabase(Exception exception)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         // SQLITE_OPEN_TEMP_JOURNAL     = 0x00001000, /* VFS only */
         // SQLITE_OPEN_SUBJOURNAL       = 0x00002000, /* VFS only */
         // SQLITE_OPEN_MASTER_JOURNAL   = 0x00004000, /* VFS only */
-        // SQLITE_OPEN_NOMUTEX          = 0x00008000, /* Ok for sqlite3_open_v2() */
+        SQLITE_OPEN_NOMUTEX          = 0x00008000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
         SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_PRIVATECACHE     = 0x00040000, /* Ok for sqlite3_open_v2() */

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/OpenFlags.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         // SQLITE_OPEN_MASTER_JOURNAL   = 0x00004000, /* VFS only */
         // SQLITE_OPEN_NOMUTEX          = 0x00008000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_FULLMUTEX        = 0x00010000, /* Ok for sqlite3_open_v2() */
-        // SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
+        SQLITE_OPEN_SHAREDCACHE      = 0x00020000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_PRIVATECACHE     = 0x00040000, /* Ok for sqlite3_open_v2() */
         // SQLITE_OPEN_WAL              = 0x00080000, /* VFS only */
     }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Result.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Result.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         // PERM = 3,           /* Access permission denied */
         // ABORT = 4,          /* Callback routine requested an abort */
         BUSY = 5,              /* The database file is locked */
-        // LOCKED = 6,         /* A table in the database is locked */
+        LOCKED = 6,            /* A table in the database is locked */
         NOMEM = 7,             /* A malloc() failed */
         // READONLY = 8,       /* Attempt to write a readonly database */
         // INTERRUPT = 9,      /* Operation terminated by sqlite3_interrupt()*/

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -146,6 +146,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
             catch (SqlException ex) when (ex.Result == Result.FULL ||
                                           ex.Result == Result.IOERR ||
                                           ex.Result == Result.BUSY ||
+                                          ex.Result == Result.LOCKED ||
                                           ex.Result == Result.NOMEM)
             {
                 // See documentation here: https://sqlite.org/lang_transaction.html
@@ -156,6 +157,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
                 // SQLITE_FULL: database or disk full
                 // SQLITE_IOERR: disk I/ O error
                 // SQLITE_BUSY: database in use by another process
+                // SQLITE_LOCKED: database in use by another connection in the same process
                 // SQLITE_NOMEM: out or memory
 
                 // It is recommended that applications respond to the errors listed above by

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -51,7 +51,9 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         {
             faultInjector?.OnNewConnection();
 
-            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE;
+            // Enable shared cache so that multiple connections inside of same process share cache
+            // see https://sqlite.org/threadsafe.html for more detail
+            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
             var result = (Result)raw.sqlite3_open_v2(databasePath, out var handle, (int)flags, vfs: null);
 
             if (result != Result.OK)

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -270,6 +270,8 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
             => Throw(_handle, result);
 
         public static void Throw(sqlite3 handle, Result result)
-            => throw new SqlException(result, raw.sqlite3_errmsg(handle));
+            => throw new SqlException(result,
+                raw.sqlite3_errmsg(handle) + "\r\n" +
+                raw.sqlite3_errstr(raw.sqlite3_extended_errcode(handle)));
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
 
             // Enable shared cache so that multiple connections inside of same process share cache
             // see https://sqlite.org/threadsafe.html for more detail
-            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
+            var flags = OpenFlags.SQLITE_OPEN_CREATE | OpenFlags.SQLITE_OPEN_READWRITE | OpenFlags.SQLITE_OPEN_NOMUTEX | OpenFlags.SQLITE_OPEN_SHAREDCACHE;
             var result = (Result)raw.sqlite3_open_v2(databasePath, out var handle, (int)flags, vfs: null);
 
             if (result != Result.OK)

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.Accessor.cs
@@ -58,24 +58,30 @@ namespace Microsoft.CodeAnalysis.SQLite
 
                 if (!Storage._shutdownTokenSource.IsCancellationRequested)
                 {
+                    bool haveDataId;
+                    TDatabaseId dataId;
                     using (var pooledConnection = Storage.GetPooledConnection())
                     {
-                        var connection = pooledConnection.Connection;
-                        if (TryGetDatabaseId(connection, key, out var dataId))
-                        {
-                            // Ensure all pending document writes to this name are flushed to the DB so that 
-                            // we can find them below.
-                            await FlushPendingWritesAsync(connection, key, cancellationToken).ConfigureAwait(false);
+                        haveDataId = TryGetDatabaseId(pooledConnection.Connection, key, out dataId);
+                    }
 
-                            try
+                    if (haveDataId)
+                    {
+                        // Ensure all pending document writes to this name are flushed to the DB so that 
+                        // we can find them below.
+                        await FlushPendingWritesAsync(key, cancellationToken).ConfigureAwait(false);
+
+                        try
+                        {
+                            using (var pooledConnection = Storage.GetPooledConnection())
                             {
                                 // Lookup the row from the DocumentData table corresponding to our dataId.
-                                return ReadBlob(connection, dataId);
+                                return ReadBlob(pooledConnection.Connection, dataId);
                             }
-                            catch (Exception ex)
-                            {
-                                StorageDatabaseLogger.LogException(ex);
-                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            StorageDatabaseLogger.LogException(ex);
                         }
                     }
                 }
@@ -94,33 +100,36 @@ namespace Microsoft.CodeAnalysis.SQLite
 
                 if (!Storage._shutdownTokenSource.IsCancellationRequested)
                 {
+                    bool haveDataId;
+                    TDatabaseId dataId;
                     using (var pooledConnection = Storage.GetPooledConnection())
                     {
                         // Determine the appropriate data-id to store this stream at.
-                        if (TryGetDatabaseId(pooledConnection.Connection, key, out var dataId))
+                        haveDataId = TryGetDatabaseId(pooledConnection.Connection, key, out dataId);
+                    }
+
+                    if (haveDataId)
+                    {
+                        var (bytes, length, pooled) = GetBytes(stream);
+
+                        await AddWriteTaskAsync(key, con =>
                         {
-                            var (bytes, length, pooled) = GetBytes(stream);
-
-                            await AddWriteTaskAsync(key, con =>
+                            InsertOrReplaceBlob(con, dataId, bytes, length);
+                            if (pooled)
                             {
-                                InsertOrReplaceBlob(con, dataId, bytes, length);
-                                if (pooled)
-                                {
-                                    ReturnPooledBytes(bytes);
-                                }
-                            }, cancellationToken).ConfigureAwait(false);
+                                ReturnPooledBytes(bytes);
+                            }
+                        }, cancellationToken).ConfigureAwait(false);
 
-                            return true;
-                        }
+                        return true;
                     }
                 }
 
                 return false;
             }
 
-            private Task FlushPendingWritesAsync(SqlConnection connection, TKey key, CancellationToken cancellationToken)
-                => Storage.FlushSpecificWritesAsync(
-                    connection, _writeQueueKeyToWrites, _writeQueueKeyToWriteTask, GetWriteQueueKey(key), cancellationToken);
+            private Task FlushPendingWritesAsync(TKey key, CancellationToken cancellationToken)
+                => Storage.FlushSpecificWritesAsync(_writeQueueKeyToWrites, _writeQueueKeyToWriteTask, GetWriteQueueKey(key), cancellationToken);
 
             private Task AddWriteTaskAsync(TKey key, Action<SqlConnection> action, CancellationToken cancellationToken)
                 => Storage.AddWriteTaskAsync(_writeQueueKeyToWrites, GetWriteQueueKey(key), action, cancellationToken);

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -233,6 +233,14 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
         }
 
+        /// <summary>
+        /// Gets an <see cref="SqlConnection"/> from the connection pool, or creates one if none are available.
+        /// </summary>
+        /// <remarks>
+        /// Database connections have a large amount of overhead, and should be returned to the pool when they are no
+        /// longer in use. In particular, make sure to avoid letting a connection lease cross an <see langword="await"/>
+        /// boundary, as it will prevent code in the asynchronous operation from using the existing connection.
+        /// </remarks>
         private PooledConnection GetPooledConnection()
             => new PooledConnection(this, GetConnection());
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -270,12 +270,16 @@ $@"create table if not exists ""{DocumentDataTableName}"" (
     ""{DataColumnName}"" blob)");
 
                 // Also get the known set of string-to-id mappings we already have in the DB.
-                FetchStringTable(connection);
+                // Do this in one batch if possible.
+                var fetched = TryFetchStringTable(connection);
+
+                // If we weren't able to retrieve the entire string table in one batch,
+                // attempt to retrieve it for each 
+                var fetchStringTable = !fetched;
 
                 // Try to bulk populate all the IDs we'll need for strings/projects/documents.
                 // Bulk population is much faster than trying to do everything individually.
-                // Note: we don't need to fetch the string table as we did it right above this.
-                BulkPopulateIds(connection, solution, fetchStringTable: false);
+                BulkPopulateIds(connection, solution, fetchStringTable);
             }
         }
     }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorageService.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SolutionSize;
 using Microsoft.CodeAnalysis.Storage;
 using Roslyn.Utilities;
@@ -12,6 +13,7 @@ namespace Microsoft.CodeAnalysis.SQLite
 {
     internal partial class SQLitePersistentStorageService : AbstractPersistentStorageService
     {
+        private const string LockFile = "db.lock";
         private const string StorageExtension = "sqlite3";
         private const string PersistentStorageFileName = "storage.ide";
 
@@ -24,7 +26,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         {
         }
 
-        public SQLitePersistentStorageService(IOptionService optionService, IPersistentStorageFaultInjector faultInjector) 
+        public SQLitePersistentStorageService(IOptionService optionService, IPersistentStorageFaultInjector faultInjector)
             : base(optionService, testing: true)
         {
             _faultInjectorOpt = faultInjector;
@@ -36,9 +38,47 @@ namespace Microsoft.CodeAnalysis.SQLite
             return Path.Combine(workingFolderPath, StorageExtension, PersistentStorageFileName);
         }
 
-        protected override AbstractPersistentStorage OpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath)
-            => new SQLitePersistentStorage(
-                OptionService, workingFolderPath, solution.FilePath, databaseFilePath, this.Release, _faultInjectorOpt);
+        protected override bool TryOpenDatabase(
+            Solution solution, string workingFolderPath, string databaseFilePath, out AbstractPersistentStorage storage)
+        {
+            storage = null;
+
+            // try to get db ownership lock. if someone else already has the lock. it will throw
+            var dbOwnershipLock = TryGetDatabaseOwnership(databaseFilePath);
+            if (dbOwnershipLock == null)
+            {
+                return false;
+            }
+
+            storage = new SQLitePersistentStorage(
+                OptionService, workingFolderPath, solution.FilePath, databaseFilePath, this.Release, dbOwnershipLock, _faultInjectorOpt);
+
+            return true;
+        }
+
+        private static IDisposable TryGetDatabaseOwnership(string databaseFilePath)
+        {
+            return IOUtilities.PerformIO<IDisposable>(() =>
+            {
+                // make sure directory exist first.
+                EnsureDirectory(databaseFilePath);
+
+                return File.Open(
+                    Path.Combine(Path.GetDirectoryName(databaseFilePath), LockFile),
+                    FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            });
+        }
+
+        private static void EnsureDirectory(string databaseFilePath)
+        {
+            var directory = Path.GetDirectoryName(databaseFilePath);
+            if (Directory.Exists(directory))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(directory);
+        }
 
         protected override bool ShouldDeleteDatabase(Exception exception)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
@@ -52,7 +52,12 @@ namespace Microsoft.CodeAnalysis.SQLite
                 // the current string table, it will keep having problems trying to bulk populate.
                 if (fetchStringTable)
                 {
-                    FetchStringTable(connection);
+                    if (!TryFetchStringTable(connection))
+                    {
+                        // Weren't able to fetch the string table.  Have to try this again
+                        // later once the DB frees up.
+                        return;
+                    }
                 }
 
                 if (!BulkPopulateProjectIdsWorker(connection, project))

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
@@ -12,23 +12,34 @@ namespace Microsoft.CodeAnalysis.SQLite
     {
         private readonly ConcurrentDictionary<string, int> _stringToIdMap = new ConcurrentDictionary<string, int>();
 
-        private void FetchStringTable(SqlConnection connection)
+        private bool TryFetchStringTable(SqlConnection connection)
         {
-            using (var resettableStatement = connection.GetResettableStatement(
-                $@"select * from ""{StringInfoTableName}"""))
+            try
             {
-                var statement = resettableStatement.Statement;
-                while (statement.Step() == Result.ROW)
+                using (var resettableStatement = connection.GetResettableStatement(
+                    $@"select * from ""{StringInfoTableName}"""))
                 {
-                    var id = statement.GetInt32At(columnIndex: 0);
-                    var value = statement.GetStringAt(columnIndex: 1);
+                    var statement = resettableStatement.Statement;
+                    while (statement.Step() == Result.ROW)
+                    {
+                        var id = statement.GetInt32At(columnIndex: 0);
+                        var value = statement.GetStringAt(columnIndex: 1);
 
-                    // Note that TryAdd won't overwrite an existing string->id pair.  That's what
-                    // we want.  we don't want the strings we've allocated from the DB to be what
-                    // we hold onto.  We'd rather hold onto the strings we get from sources like
-                    // the workspaces.  This helps avoid unnecessary string instance duplication.
-                    _stringToIdMap.TryAdd(value, id);
+                        // Note that TryAdd won't overwrite an existing string->id pair.  That's what
+                        // we want.  we don't want the strings we've allocated from the DB to be what
+                        // we hold onto.  We'd rather hold onto the strings we get from sources like
+                        // the workspaces.  This helps avoid unnecessary string instance duplication.
+                        _stringToIdMap.TryAdd(value, id);
+                    }
                 }
+
+                return true;
+            }
+            catch (SqlException e) when (e.Result == Result.BUSY)
+            {
+                // Couldn't get access to sql database to fetch the string table.  
+                // Try again later.
+                return false;
             }
         }
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_StringIds.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.SQLite
 
                 return true;
             }
-            catch (SqlException e) when (e.Result == Result.BUSY)
+            catch (SqlException e) when (e.Result == Result.BUSY || e.Result == Result.LOCKED)
             {
                 // Couldn't get access to sql database to fetch the string table.  
                 // Try again later.

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -50,16 +50,15 @@ namespace Microsoft.CodeAnalysis.SQLite
         }
 
         private async Task FlushSpecificWritesAsync<TKey>(
-            SqlConnection connection,
             MultiDictionary<TKey, Action<SqlConnection>> keyToWriteActions,
             Dictionary<TKey, Task> keyToWriteTask,
-            TKey key, CancellationToken cancellationToken)
+            TKey key,
+            CancellationToken cancellationToken)
         {
             var writesToProcess = ArrayBuilder<Action<SqlConnection>>.GetInstance();
             try
             {
-                await FlushSpecificWritesAsync(
-                    connection, keyToWriteActions, keyToWriteTask, key, writesToProcess, cancellationToken).ConfigureAwait(false);
+                await FlushSpecificWritesAsync(keyToWriteActions, keyToWriteTask, key, writesToProcess, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -68,8 +67,9 @@ namespace Microsoft.CodeAnalysis.SQLite
         }
 
         private async Task FlushSpecificWritesAsync<TKey>(
-            SqlConnection connection, MultiDictionary<TKey, Action<SqlConnection>> keyToWriteActions,
-            Dictionary<TKey, Task> keyToWriteTask, TKey key,
+            MultiDictionary<TKey, Action<SqlConnection>> keyToWriteActions,
+            Dictionary<TKey, Task> keyToWriteTask,
+            TKey key,
             ArrayBuilder<Action<SqlConnection>> writesToProcess,
             CancellationToken cancellationToken)
         {
@@ -96,7 +96,10 @@ namespace Microsoft.CodeAnalysis.SQLite
                 // would be losing data.
                 Debug.Assert(taskCompletionSource != null);
 
-                ProcessWriteQueue(connection, writesToProcess);
+                using (var pooledConnection = GetPooledConnection())
+                {
+                    ProcessWriteQueue(pooledConnection.Connection, writesToProcess);
+                }
             }
             catch (OperationCanceledException ex)
             {

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Storage
         }
 
         protected abstract string GetDatabaseFilePath(string workingFolderPath);
-        protected abstract AbstractPersistentStorage OpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath);
+        protected abstract bool TryOpenDatabase(Solution solution, string workingFolderPath, string databaseFilePath, out AbstractPersistentStorage storage);
         protected abstract bool ShouldDeleteDatabase(Exception exception);
 
         public IPersistentStorage GetStorage(Solution solution)
@@ -235,7 +235,11 @@ namespace Microsoft.CodeAnalysis.Storage
             var databaseFilePath = GetDatabaseFilePath(workingFolderPath);
             try
             {
-                database = OpenDatabase(solution, workingFolderPath, databaseFilePath);
+                if (!TryOpenDatabase(solution, workingFolderPath, databaseFilePath, out database))
+                {
+                    return false;
+                }
+
                 database.Initialize(solution);
 
                 persistentStorage = database;

--- a/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
+++ b/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.Remote.Storage
                 }
                 else
                 {
-                    _idToStorageLocation[id] = storageLocation;
+                    // Store the esent database in a different location for the out of proc server.
+                    _idToStorageLocation[id] = Path.Combine(storageLocation, "Server");
                 }
             }
         }


### PR DESCRIPTION
Fixes #22650

Rather than place a hard cap on the number of connections, I updated the code to ensure database connections are only held for the duration where they are actually in use.

CC: @dotnet/roslyn-ide @heejaechang @CyrusNajmabadi @onyxmaster

**Customer scenario**

A customer opens a large solution with 15.3 or 15.4. The IDE is at high risk for encountering OOM errors.

**Bugs this fixes:**

#22650 
[DevDiv 507560](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/507560)

**Workarounds, if any**

None

**Risk**

Relatively low.

**Performance impact**

For scenarios where database writes to disk are slow, performance is improved by allowing database connection sharing.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

As a best guess:

1. Our drives are faster, so we didn't observe the stalls locally (a local reproducer would mean we could sample the native allocations at runtime to get call stacks, as opposed to looking at a heap dump post-mortem)
2. The memory allocation impacting the process was a native memory allocation, which we were aware in statistics but did not have insight into the cause (we now know to treat the managed `SqlConnection` and `sqlite3` objects as heavier to account for this, similar to what we already did for `MemoryMappedView`)

**How was the bug found?**

The 425600 byte allocation pattern was discovered by Lee Culver on the .NET Fundamentals team. Text contents in some of these blocks made me suspicious of SQLite, leading me to search for "425600 SQLite". The value appeared twice in interesting results:

https://forums.plex.tv/discussion/256008/pms-crashes-randomly-under-load

> ERROR - SQLITE3:1B3E069A, 7, failed to allocate 425600 bytes of memory

http://iamoracleadmin.blogspot.com/p/sqlite-cheat-sheet.html

> Largest Allocation: 425600 bytes

I then used PerfView to review the number of connections present in the managed heap, and found it exactly matched the number of native allocations.

**Test documentation updated?**

N/A