### PR TITLE
Support field-targeted attributes on auto-properties (7.3)

### DIFF
--- a/docs/Language Feature Status.md
+++ b/docs/Language Feature Status.md
@@ -21,13 +21,19 @@ efforts behind them.
 | Feature | Branch | State | Developers | Reviewer | LDM Champ |
 | ------- | ------ | ----- | ---------- | -------- | --------- |
 | [ref readonly](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/readonly-ref.md) | master | Merged | [vsadov](https://github.com/vsadov), [omar](https://github.com/OmarTawfikw) | [cston](https://github.com/cston),[gafter](https://github.com/gafter) | [jaredpar](https://github.com/jaredpar) |
-| [blittable](https://github.com/dotnet/csharplang/pull/206) | None | Proposal | None | | [jaredpar](https://github.com/jaredpar) |
-| strongname | [strongname](https://github.com/dotnet/roslyn/tree/features/strongname) | In Progress | [Ty Overby](https://github.com/tyoverby) | | [jaredpar](https://github.com/jaredpar) |
 | [interior pointer/Span<T>/ref struct](https://github.com/dotnet/csharplang/pull/264) | master | Merged | [vsadov](https://github.com/vsadov) | [gafter](https://github.com/gafter), [jaredpar](https://github.com/jaredpar) | [jaredpar](https://github.com/jaredpar) |
 | [non-trailing named arguments](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/non-trailing-named-arguments.md) | master | Merged | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) | [jcouv](https://github.com/jcouv) |
 | [private protected](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/private-protected.md) | master | Merged | [gafter](https://github.com/gafter) | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) |
 | [conditional ref operator](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/conditional-ref.md) | master | Merged | [vsadov](https://github.com/vsadov) | [cston](https://github.com/cston) | [jaredpar](https://github.com/jaredpar) |
 | [Digit separator after base specifier](https://github.com/dotnet/roslyn/pull/20449) | master | Merged | [alrz](https://github.com/alrz) | | [gafter](https://github.com/gafter) |
+
+# C# 7.3
+
+| Feature | Branch | State | Developers | Reviewer | LDM Champ |
+| ------- | ------ | ----- | ---------- | -------- | --------- |
+| [blittable](https://github.com/dotnet/csharplang/pull/206) | None | Proposal | None | | [jaredpar](https://github.com/jaredpar) |
+| strongname | [strongname](https://github.com/dotnet/roslyn/tree/features/strongname) | In Progress | [Ty Overby](https://github.com/tyoverby) | | [jaredpar](https://github.com/jaredpar) |
+| [Attributes on backing fields](https://github.com/dotnet/csharplang/blob/master/proposals/auto-prop-field-attrs.md) | [PR](https://github.com/dotnet/roslyn/pull/22664) | In Progress | [jcouv](https://github.com/jcouv) | | [jcouv](https://github.com/jcouv) |
 
 # C# 8.0
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4166,15 +4166,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: Auto-implemented properties cannot be used inside a type marked with StructLayout(LayoutKind.Explicit).
-        /// </summary>
-        internal static string ERR_ExplicitLayoutAndAutoImplementedProperty {
-            get {
-                return ResourceManager.GetString("ERR_ExplicitLayoutAndAutoImplementedProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; explicit method implementation cannot implement &apos;{1}&apos; because it is an accessor.
         /// </summary>
         internal static string ERR_ExplicitMethodImplAccessor {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -11556,6 +11556,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Field-targeted attributes on auto-properties are not supported in language version {0}. Please use language version {1} or greater..
+        /// </summary>
+        internal static string WRN_AttributesOnBackingFieldsNotAvailable {
+            get {
+                return ResourceManager.GetString("WRN_AttributesOnBackingFieldsNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field-targeted attributes on auto-properties are not supported in this version of the language..
+        /// </summary>
+        internal static string WRN_AttributesOnBackingFieldsNotAvailable_Title {
+            get {
+                return ResourceManager.GetString("WRN_AttributesOnBackingFieldsNotAvailable_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Possible unintended reference comparison; to get a value comparison, cast the left hand side to type &apos;{0}&apos;.
         /// </summary>
         internal static string WRN_BadRefCompareLeft {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6452,7 +6452,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute.
         /// </summary>
         internal static string ERR_MissingStructOffset {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3509,6 +3509,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not use &apos;System.Runtime.CompilerServices.FixedBuffer&apos; attribute on a property.
+        /// </summary>
+        internal static string ERR_DoNotUseFixedBufferAttrOnProperty {
+            get {
+                return ResourceManager.GetString("ERR_DoNotUseFixedBufferAttrOnProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type name &apos;{0}&apos; does not exist in the type &apos;{1}&apos;.
         /// </summary>
         internal static string ERR_DottedTypeNameNotFoundInAgg {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3080,6 +3080,9 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
   <data name="ERR_DoNotUseFixedBufferAttr" xml:space="preserve">
     <value>Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.</value>
   </data>
+  <data name="ERR_DoNotUseFixedBufferAttrOnProperty" xml:space="preserve">
+    <value>Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute on a property</value>
+  </data>
   <data name="WRN_AssignmentToSelf" xml:space="preserve">
     <value>Assignment made to same variable; did you mean to assign something else?</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1732,7 +1732,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>Array initializers can only be used in a variable or field initializer. Try using a new expression instead.</value>
   </data>
   <data name="ERR_MissingStructOffset" xml:space="preserve">
-    <value>'{0}': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute</value>
+    <value>'{0}': instance field in types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute</value>
   </data>
   <data name="WRN_ExternMethodNoImplementation" xml:space="preserve">
     <value>Method, operator, or accessor '{0}' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2196,9 +2196,6 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_RecursivelyTypedVariable" xml:space="preserve">
     <value>Type of '{0}' cannot be inferred since its initializer directly or indirectly refers to the definition.</value>
   </data>
-  <data name="ERR_ExplicitLayoutAndAutoImplementedProperty" xml:space="preserve">
-    <value>'{0}': Auto-implemented properties cannot be used inside a type marked with StructLayout(LayoutKind.Explicit)</value>
-  </data>
   <data name="ERR_UnassignedThisAutoProperty" xml:space="preserve">
     <value>Auto-implemented property '{0}' must be fully assigned before control is returned to the caller.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5145,6 +5145,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TupleInferredNamesNotAvailable" xml:space="preserve">
     <value>Tuple element name '{0}' is inferred. Please use language version {1} or greater to access an element by its inferred name.</value>
   </data>
+  <data name="WRN_AttributesOnBackingFieldsNotAvailable" xml:space="preserve">
+    <value>Field-targeted attributes on auto-properties are not supported in language version {0}. Please use language version {1} or greater.</value>
+  </data>
+  <data name="WRN_AttributesOnBackingFieldsNotAvailable_Title" xml:space="preserve">
+    <value>Field-targeted attributes on auto-properties are not supported in this version of the language.</value>
+  </data>
   <data name="WRN_DefaultInSwitch" xml:space="preserve">
     <value>Did you mean to use the default switch label (`default:`) rather than `case default:`? If you really mean to use the default literal, consider `case (default):` or another literal (`case 0:` or `case null:`) as appropriate.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_MissingArgument = 839,
         //ERR_AutoPropertiesMustHaveBothAccessors = 840,
         ERR_VariableUsedBeforeDeclaration = 841,
-        ERR_ExplicitLayoutAndAutoImplementedProperty = 842,
+        //ERR_ExplicitLayoutAndAutoImplementedProperty = 842,
         ERR_UnassignedThisAutoProperty = 843,
         ERR_VariableUsedBeforeDeclarationAndHidesField = 844,
         ERR_ExpressionTreeContainsBadCoalesce = 845,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1545,6 +1545,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics introduced for C# 7.3
         ERR_FeatureNotAvailableInVersion7_3 = 8360,
         WRN_AttributesOnBackingFieldsNotAvailable = 8361,
+        ERR_DoNotUseFixedBufferAttrOnProperty = 8362,
         #endregion diagnostics introduced for C# 7.3
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1544,6 +1544,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region diagnostics introduced for C# 7.3
         ERR_FeatureNotAvailableInVersion7_3 = 8360,
+        WRN_AttributesOnBackingFieldsNotAvailable = 8361,
         #endregion diagnostics introduced for C# 7.3
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -320,6 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
+                case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -145,6 +145,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureRefExtensionMethods = MessageBase + 12728,
         IDS_StackAllocExpression = MessageBase + 12729,
         IDS_FeaturePrivateProtected = MessageBase + 12730,
+
+        IDS_FeatureAttributesOnBackingFields = MessageBase + 12731,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -184,6 +186,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                // C# 7.3 features.
+                case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
+                    return LanguageVersion.CSharp7_3;
+
                 // C# 7.2 features.
                 case MessageID.IDS_FeatureNonTrailingNamedArguments: // semantic check
                 case MessageID.IDS_FeatureLeadingDigitSeparator:

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 7.3 features.
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
-                    return LanguageVersion.CSharp7_2; // TODO Rebase and use LanguageVersion.CSharp7_3 before merging
+                    return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.
                 case MessageID.IDS_FeatureNonTrailingNamedArguments: // semantic check

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 7.3 features.
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
-                    return LanguageVersion.CSharp7_3;
+                    return LanguageVersion.CSharp7_2; // TODO Rebase and use LanguageVersion.CSharp7_3 before merging
 
                 // C# 7.2 features.
                 case MessageID.IDS_FeatureNonTrailingNamedArguments: // semantic check

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -176,6 +176,7 @@
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
                 case ErrorCode.WRN_UnreferencedLocalFunction:
+                case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -336,5 +336,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return self >= MessageID.IDS_FeatureNonTrailingNamedArguments.RequiredVersion();
         }
+
+        internal static bool AllowAttributesOnBackingFields(this LanguageVersion self)
+        {
+            return self >= MessageID.IDS_FeatureAttributesOnBackingFields.RequiredVersion();
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -56,8 +56,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal virtual Location ErrorLocation => throw ExceptionUtilities.Unreachable;
-
         internal abstract TypeSymbol GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -56,6 +56,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal virtual Location ErrorLocation => throw ExceptionUtilities.Unreachable;
+
         internal abstract TypeSymbol GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -5,8 +5,10 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -365,6 +367,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var data = GetDecodedWellKnownAttributeData();
                 return data != null ? data.Offset : null;
+            }
+        }
+
+        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+            if (this.Type.ContainsDynamic())
+            {
+                AddSynthesizedAttribute(ref attributes,
+                    DeclaringCompilation.SynthesizeDynamicAttribute(Type, CustomModifiers.Length));
+            }
+
+            if (Type.ContainsTupleNames())
+            {
+                AddSynthesizedAttribute(ref attributes,
+                    DeclaringCompilation.SynthesizeTupleNamesAttribute(Type));
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Returns a bag of applied custom attributes and data decoded from well-known attributes.
-        /// Returns null if there are no attributes applied on the symbol.
+        /// Returns an empty bag if there are no attributes applied on the symbol.
         /// </summary>
         /// <remarks>
         /// Forces binding and decoding of attributes.
@@ -108,23 +108,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return (CommonFieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
-        }
-
-        /// <summary>
-        /// Returns data decoded from special early bound well-known attributes applied to the symbol or null if there are no applied attributes.
-        /// </summary>
-        /// <remarks>
-        /// Forces binding and decoding of attributes.
-        /// </remarks>
-        private CommonFieldEarlyWellKnownAttributeData GetEarlyDecodedWellKnownAttributeData()
-        {
-            var attributesBag = _lazyCustomAttributesBag;
-            if (attributesBag == null || !attributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
-            {
-                attributesBag = this.GetAttributesBag();
-            }
-
-            return (CommonFieldEarlyWellKnownAttributeData)attributesBag.EarlyDecodedWellKnownAttributeData;
         }
 
         internal sealed override CSharpAttributeData EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -1,0 +1,371 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class FieldSymbolWithAttributesAndModifiers : FieldSymbol, IAttributeTargetSymbol
+    {
+        private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
+        protected SymbolCompletionState state;
+        internal abstract Location ErrorLocation { get; }
+        protected abstract DeclarationModifiers Modifiers { get; }
+
+        /// <summary>
+        /// Gets the syntax list of custom attributes applied on the symbol.
+        /// </summary>
+        protected abstract SyntaxList<AttributeListSyntax> AttributeDeclarationSyntaxList { get; }
+
+        protected abstract IAttributeTargetSymbol AttributeOwner { get; }
+
+        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner
+            => this.AttributeOwner;
+
+        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation
+            => AttributeLocation.Field;
+
+        AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations
+            => AttributeLocation.Field;
+
+        internal sealed override bool HasComplete(CompletionPart part)
+            => state.HasComplete(part);
+
+        public sealed override bool IsStatic
+            => (Modifiers & DeclarationModifiers.Static) != 0;
+
+        public sealed override bool IsReadOnly
+            => (Modifiers & DeclarationModifiers.ReadOnly) != 0;
+
+        public sealed override Accessibility DeclaredAccessibility
+            => ModifierUtils.EffectiveAccessibility(Modifiers);
+
+        public sealed override bool IsConst
+            => (Modifiers & DeclarationModifiers.Const) != 0;
+
+        public sealed override bool IsVolatile
+            => (Modifiers & DeclarationModifiers.Volatile) != 0;
+
+        public sealed override bool IsFixed
+            => (Modifiers & DeclarationModifiers.Fixed) != 0;
+
+        /// <summary>
+        /// Gets the attributes applied on this symbol.
+        /// Returns an empty array if there are no attributes.
+        /// </summary>
+        /// <remarks>
+        /// NOTE: This method should always be kept as a sealed override.
+        /// If you want to override attribute binding logic for a sub-class, then override <see cref="GetAttributesBag"/> method.
+        /// </remarks>
+        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
+            => this.GetAttributesBag().Attributes;
+
+        /// <summary>
+        /// Returns a bag of applied custom attributes and data decoded from well-known attributes.
+        /// Returns null if there are no attributes applied on the symbol.
+        /// </summary>
+        /// <remarks>
+        /// Forces binding and decoding of attributes.
+        /// </remarks>
+        private CustomAttributesBag<CSharpAttributeData> GetAttributesBag()
+        {
+            var bag = _lazyCustomAttributesBag;
+            if (bag != null && bag.IsSealed)
+            {
+                return bag;
+            }
+
+            if (LoadAndValidateAttributes(OneOrMany.Create(this.AttributeDeclarationSyntaxList), ref _lazyCustomAttributesBag))
+            {
+                var completed = state.NotePartComplete(CompletionPart.Attributes);
+                Debug.Assert(completed);
+            }
+
+            Debug.Assert(_lazyCustomAttributesBag.IsSealed);
+            return _lazyCustomAttributesBag;
+        }
+
+        /// <summary>
+        /// Returns data decoded from well-known attributes applied to the symbol or null if there are no applied attributes.
+        /// </summary>
+        /// <remarks>
+        /// Forces binding and decoding of attributes.
+        /// </remarks>
+        protected CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        {
+            var attributesBag = _lazyCustomAttributesBag;
+            if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
+            {
+                attributesBag = this.GetAttributesBag();
+            }
+
+            return (CommonFieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+        }
+
+        /// <summary>
+        /// Returns data decoded from special early bound well-known attributes applied to the symbol or null if there are no applied attributes.
+        /// </summary>
+        /// <remarks>
+        /// Forces binding and decoding of attributes.
+        /// </remarks>
+        private CommonFieldEarlyWellKnownAttributeData GetEarlyDecodedWellKnownAttributeData()
+        {
+            var attributesBag = _lazyCustomAttributesBag;
+            if (attributesBag == null || !attributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
+            {
+                attributesBag = this.GetAttributesBag();
+            }
+
+            return (CommonFieldEarlyWellKnownAttributeData)attributesBag.EarlyDecodedWellKnownAttributeData;
+        }
+
+        internal sealed override CSharpAttributeData EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)
+        {
+            CSharpAttributeData boundAttribute;
+            ObsoleteAttributeData obsoleteData;
+
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            {
+                if (obsoleteData != null)
+                {
+                    arguments.GetOrCreateData<CommonFieldEarlyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
+                }
+
+                return boundAttribute;
+            }
+
+            return base.EarlyDecodeWellKnownAttribute(ref arguments);
+        }
+
+        /// <summary>
+        /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
+        /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
+        /// </summary>
+        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+        {
+            get
+            {
+                var containingSourceType = (SourceMemberContainerTypeSymbol)ContainingType;
+                if (!containingSourceType.AnyMemberHasAttributes)
+                {
+                    return null;
+                }
+
+                var lazyCustomAttributesBag = _lazyCustomAttributesBag;
+                if (lazyCustomAttributesBag != null && lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
+                {
+                    var data = (CommonFieldEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
+                    return data != null ? data.ObsoleteAttributeData : null;
+                }
+
+                return ObsoleteAttributeData.Uninitialized;
+            }
+        }
+
+        internal override void DecodeWellKnownAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
+        {
+            Debug.Assert((object)arguments.AttributeSyntaxOpt != null);
+
+            var attribute = arguments.Attribute;
+            Debug.Assert(!attribute.HasErrors);
+            Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
+
+            if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
+            {
+                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NonSerializedAttribute))
+            {
+                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.FieldOffsetAttribute))
+            {
+                if (this.IsStatic || this.IsConst)
+                {
+                    // CS0637: The FieldOffset attribute is not allowed on static or const fields
+                    arguments.Diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadField, arguments.AttributeSyntaxOpt.Name.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                }
+                else
+                {
+                    int offset = attribute.CommonConstructorArguments[0].DecodeValue<int>(SpecialType.System_Int32);
+                    if (offset < 0)
+                    {
+                        // Dev10 reports CS0647: "Error emitting attribute ..."
+                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
+                        arguments.Diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
+                        offset = 0;
+                    }
+
+                    // Set field offset even if the attribute specifies an invalid value, so that
+                    // post-validation knows that the attribute is applied and reports better errors.
+                    arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().SetFieldOffset(offset);
+                }
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
+            {
+                MarshalAsAttributeDecoder<CommonFieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            {
+                // DynamicAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
+            {
+                // IsReadOnlyAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
+            {
+                // IsByRefLikeAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
+            {
+                VerifyConstantValueMatches(attribute.DecodeDateTimeConstantValue(), ref arguments);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
+            {
+                VerifyConstantValueMatches(attribute.DecodeDecimalConstantValue(), ref arguments);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
+            {
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
+            }
+        }
+
+        /// <summary>
+        /// Verify the constant value matches the default value from any earlier attribute
+        /// (DateTimeConstantAttribute or DecimalConstantAttribute).
+        /// If not, report ERR_FieldHasMultipleDistinctConstantValues.
+        /// </summary>
+        private void VerifyConstantValueMatches(ConstantValue attrValue, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
+        {
+            if (!attrValue.IsBad)
+            {
+                var data = arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>();
+                ConstantValue constValue;
+
+                if (this.IsConst)
+                {
+                    if (this.Type.SpecialType == SpecialType.System_Decimal)
+                    {
+                        constValue = this.GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
+
+                        if ((object)constValue != null && !constValue.IsBad && constValue != attrValue)
+                        {
+                            arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
+                        }
+                    }
+                    else
+                    {
+                        arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
+                    }
+
+                    if (data.ConstValue == CodeAnalysis.ConstantValue.Unset)
+                    {
+                        data.ConstValue = attrValue;
+                    }
+                }
+                else
+                {
+                    constValue = data.ConstValue;
+
+                    if (constValue != CodeAnalysis.ConstantValue.Unset)
+                    {
+                        if (constValue != attrValue)
+                        {
+                            arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
+                        }
+                    }
+                    else
+                    {
+                        data.ConstValue = attrValue;
+                    }
+                }
+            }
+        }
+
+        internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, DiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
+        {
+            Debug.Assert(!boundAttributes.IsDefault);
+            Debug.Assert(!allAttributeSyntaxNodes.IsDefault);
+            Debug.Assert(boundAttributes.Length == allAttributeSyntaxNodes.Length);
+            Debug.Assert(_lazyCustomAttributesBag != null);
+            Debug.Assert(_lazyCustomAttributesBag.IsDecodedWellKnownAttributeDataComputed);
+            Debug.Assert(symbolPart == AttributeLocation.None);
+
+            var data = (CommonFieldWellKnownAttributeData)decodedData;
+            int? fieldOffset = data != null ? data.Offset : null;
+
+            if (fieldOffset.HasValue)
+            {
+                if (this.ContainingType.Layout.Kind != LayoutKind.Explicit)
+                {
+                    Debug.Assert(boundAttributes.Any());
+
+                    // error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
+                    int i = boundAttributes.IndexOfAttribute(this, AttributeDescription.FieldOffsetAttribute);
+                    diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadStruct, allAttributeSyntaxNodes[i].Name.Location);
+                }
+            }
+            else if (!this.IsStatic && !this.IsConst)
+            {
+                if (this.ContainingType.Layout.Kind == LayoutKind.Explicit)
+                {
+                    // error CS0625: '<field>': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+                    diagnostics.Add(ErrorCode.ERR_MissingStructOffset, this.ErrorLocation, this.AttributeOwner);
+                }
+            }
+
+            base.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
+        }
+
+        internal sealed override bool HasSpecialName
+        {
+            get
+            {
+                if (this.HasRuntimeSpecialName)
+                {
+                    return true;
+                }
+
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null && data.HasSpecialNameAttribute;
+            }
+        }
+
+        internal sealed override bool IsNotSerialized
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null && data.HasNonSerializedAttribute;
+            }
+        }
+
+        internal sealed override MarshalPseudoCustomAttributeData MarshallingInformation
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null ? data.MarshallingInformation : null;
+            }
+        }
+
+        internal sealed override int? TypeLayoutOffset
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null ? data.Offset : null;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IAttributeTargetSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IAttributeTargetSymbol.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -1,26 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal abstract class SourceFieldSymbol : FieldSymbol, IAttributeTargetSymbol
+    internal abstract class SourceFieldSymbol : FieldSymbolWithAttributesAndModifiers
     {
-        protected SymbolCompletionState state;
         protected readonly SourceMemberContainerTypeSymbol containingType;
-        private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
 
         protected SourceFieldSymbol(SourceMemberContainerTypeSymbol containingType)
         {
@@ -29,58 +22,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.containingType = containingType;
         }
 
+        public abstract override string Name { get; }
+
+        protected override IAttributeTargetSymbol AttributeOwner
+        {
+            get { return this; }
+        }
+
         internal sealed override bool RequiresCompletion
         {
             get { return true; }
-        }
-
-        internal sealed override bool HasComplete(CompletionPart part)
-        {
-            return state.HasComplete(part);
-        }
-
-        public abstract override string Name { get; }
-
-        protected abstract DeclarationModifiers Modifiers { get; }
-
-        public sealed override bool IsStatic
-        {
-            get
-            {
-                return (Modifiers & DeclarationModifiers.Static) != 0;
-            }
-        }
-
-        public sealed override bool IsReadOnly
-        {
-            get
-            {
-                return (Modifiers & DeclarationModifiers.ReadOnly) != 0;
-            }
-        }
-
-        public sealed override bool IsConst
-        {
-            get
-            {
-                return (Modifiers & DeclarationModifiers.Const) != 0;
-            }
-        }
-
-        public sealed override bool IsVolatile
-        {
-            get
-            {
-                return (Modifiers & DeclarationModifiers.Volatile) != 0;
-            }
-        }
-
-        public sealed override bool IsFixed
-        {
-            get
-            {
-                return (Modifiers & DeclarationModifiers.Fixed) != 0;
-            }
         }
 
         internal bool IsNew
@@ -88,14 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return (Modifiers & DeclarationModifiers.New) != 0;
-            }
-        }
-
-        public sealed override Accessibility DeclaredAccessibility
-        {
-            get
-            {
-                return ModifierUtils.EffectiveAccessibility(Modifiers);
             }
         }
 
@@ -127,8 +70,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_FieldsInRoStruct, ErrorLocation);
             }
 
-            // TODO: Consider checking presence of core type System.Runtime.CompilerServices.IsVolatile 
-            // if there is a volatile modifier. Perhaps an appropriate error should be reported if the 
+            // TODO: Consider checking presence of core type System.Runtime.CompilerServices.IsVolatile
+            // if there is a volatile modifier. Perhaps an appropriate error should be reported if the
             // type isn't available.
         }
 
@@ -164,144 +107,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        /// <summary>
-        /// Gets the syntax list of custom attributes applied on the symbol.
-        /// </summary>
-        protected abstract SyntaxList<AttributeListSyntax> AttributeDeclarationSyntaxList { get; }
-
-        protected virtual IAttributeTargetSymbol AttributeOwner
-        {
-            get { return this; }
-        }
-
-        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner
-        {
-            get { return this.AttributeOwner; }
-        }
-
-        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation
-        {
-            get { return AttributeLocation.Field; }
-        }
-
-        AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations
-        {
-            get { return AttributeLocation.Field; }
-        }
-
-        /// <summary>
-        /// Returns a bag of applied custom attributes and data decoded from well-known attributes. Returns null if there are no attributes applied on the symbol.
-        /// </summary>
-        /// <remarks>
-        /// Forces binding and decoding of attributes.
-        /// </remarks>
-        private CustomAttributesBag<CSharpAttributeData> GetAttributesBag()
-        {
-            var bag = _lazyCustomAttributesBag;
-            if (bag != null && bag.IsSealed)
-            {
-                return bag;
-            }
-
-            if (LoadAndValidateAttributes(OneOrMany.Create(this.AttributeDeclarationSyntaxList), ref _lazyCustomAttributesBag))
-            {
-                var completed = state.NotePartComplete(CompletionPart.Attributes);
-                Debug.Assert(completed);
-            }
-
-            Debug.Assert(_lazyCustomAttributesBag.IsSealed);
-            return _lazyCustomAttributesBag;
-        }
-
-        /// <summary>
-        /// Gets the attributes applied on this symbol.
-        /// Returns an empty array if there are no attributes.
-        /// </summary>
-        /// <remarks>
-        /// NOTE: This method should always be kept as a sealed override.
-        /// If you want to override attribute binding logic for a sub-class, then override <see cref="GetAttributesBag"/> method.
-        /// </remarks>
-        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
-        {
-            return this.GetAttributesBag().Attributes;
-        }
-
-        /// <summary>
-        /// Returns data decoded from well-known attributes applied to the symbol or null if there are no applied attributes.
-        /// </summary>
-        /// <remarks>
-        /// Forces binding and decoding of attributes.
-        /// </remarks>
-        protected CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
-        {
-            var attributesBag = _lazyCustomAttributesBag;
-            if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
-            {
-                attributesBag = this.GetAttributesBag();
-            }
-
-            return (CommonFieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
-        }
-
-        /// <summary>
-        /// Returns data decoded from special early bound well-known attributes applied to the symbol or null if there are no applied attributes.
-        /// </summary>
-        /// <remarks>
-        /// Forces binding and decoding of attributes.
-        /// </remarks>
-        internal CommonFieldEarlyWellKnownAttributeData GetEarlyDecodedWellKnownAttributeData()
-        {
-            var attributesBag = _lazyCustomAttributesBag;
-            if (attributesBag == null || !attributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
-            {
-                attributesBag = this.GetAttributesBag();
-            }
-
-            return (CommonFieldEarlyWellKnownAttributeData)attributesBag.EarlyDecodedWellKnownAttributeData;
-        }
-
-        internal sealed override CSharpAttributeData EarlyDecodeWellKnownAttribute(ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)
-        {
-            CSharpAttributeData boundAttribute;
-            ObsoleteAttributeData obsoleteData;
-
-            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
-            {
-                if (obsoleteData != null)
-                {
-                    arguments.GetOrCreateData<CommonFieldEarlyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
-                }
-
-                return boundAttribute;
-            }
-
-            return base.EarlyDecodeWellKnownAttribute(ref arguments);
-        }
-
-        /// <summary>
-        /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
-        /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
-        /// </summary>
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
-        {
-            get
-            {
-                if (!this.containingType.AnyMemberHasAttributes)
-                {
-                    return null;
-                }
-
-                var lazyCustomAttributesBag = _lazyCustomAttributesBag;
-                if (lazyCustomAttributesBag != null && lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
-                {
-                    var data = (CommonFieldEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
-                    return data != null ? data.ObsoleteAttributeData : null;
-                }
-
-                return ObsoleteAttributeData.Uninitialized;
-            }
-        }
-
         internal sealed override void DecodeWellKnownAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
         {
             Debug.Assert((object)arguments.AttributeSyntaxOpt != null);
@@ -310,172 +115,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!attribute.HasErrors);
             Debug.Assert(arguments.SymbolPart == AttributeLocation.None);
 
-            DecodeWellKnownFieldAttribute(this, ref arguments, attribute);
-        }
-
-        internal static void DecodeWellKnownFieldAttribute(
-            FieldSymbol field, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, CSharpAttributeData attribute)
-        {
-            if (attribute.IsTargetAttribute(field, AttributeDescription.SpecialNameAttribute))
-            {
-                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasSpecialNameAttribute = true;
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.NonSerializedAttribute))
-            {
-                arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().HasNonSerializedAttribute = true;
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.FieldOffsetAttribute))
-            {
-                if (field.IsStatic || field.IsConst)
-                {
-                    // CS0637: The FieldOffset attribute is not allowed on static or const fields
-                    arguments.Diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadField, arguments.AttributeSyntaxOpt.Name.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
-                }
-                else
-                {
-                    int offset = attribute.CommonConstructorArguments[0].DecodeValue<int>(SpecialType.System_Int32);
-                    if (offset < 0)
-                    {
-                        // Dev10 reports CS0647: "Error emitting attribute ..."
-                        CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(0, arguments.AttributeSyntaxOpt);
-                        arguments.Diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, arguments.AttributeSyntaxOpt.GetErrorDisplayName());
-                        offset = 0;
-                    }
-
-                    // Set field offset even if the attribute specifies an invalid value, so that
-                    // post-validation knows that the attribute is applied and reports better errors.
-                    arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>().SetFieldOffset(offset);
-                }
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.MarshalAsAttribute))
-            {
-                MarshalAsAttributeDecoder<CommonFieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.FixedBufferAttribute))
+            if (attribute.IsTargetAttribute(this, AttributeDescription.FixedBufferAttribute))
             {
                 // error CS1716: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.
                 arguments.Diagnostics.Add(ErrorCode.ERR_DoNotUseFixedBufferAttr, arguments.AttributeSyntaxOpt.Name.Location);
             }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.DynamicAttribute))
-            {
-                // DynamicAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.IsReadOnlyAttribute))
-            {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.DateTimeConstantAttribute))
-            {
-                VerifyConstantValueMatches(field, attribute.DecodeDateTimeConstantValue(), ref arguments);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.DecimalConstantAttribute))
-            {
-                VerifyConstantValueMatches(field, attribute.DecodeDecimalConstantValue(), ref arguments);
-            }
-            else if (attribute.IsTargetAttribute(field, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-        }
 
-        /// <summary>
-        /// Verify the constant value matches the default value from any earlier attribute
-        /// (DateTimeConstantAttribute or DecimalConstantAttribute).
-        /// If not, report ERR_FieldHasMultipleDistinctConstantValues.
-        /// </summary>
-        private static void VerifyConstantValueMatches(FieldSymbol field, ConstantValue attrValue, ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
-        {
-            if (!attrValue.IsBad)
-            {
-                var data = arguments.GetOrCreateData<CommonFieldWellKnownAttributeData>();
-                ConstantValue constValue;
-
-                if (field.IsConst)
-                {
-                    if (field.Type.SpecialType == SpecialType.System_Decimal)
-                    {
-                        constValue = field.GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
-
-                        if ((object)constValue != null && !constValue.IsBad && constValue != attrValue)
-                        {
-                            arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
-                        }
-                    }
-                    else
-                    {
-                        arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
-                    }
-
-                    if (data.ConstValue == CodeAnalysis.ConstantValue.Unset)
-                    {
-                        data.ConstValue = attrValue;
-                    }
-                }
-                else
-                {
-                    constValue = data.ConstValue;
-
-                    if (constValue != CodeAnalysis.ConstantValue.Unset)
-                    {
-                        if (constValue != attrValue)
-                        {
-                            arguments.Diagnostics.Add(ErrorCode.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.Location);
-                        }
-                    }
-                    else
-                    {
-                        data.ConstValue = attrValue;
-                    }
-                }
-            }
-        }
-
-        internal override void PostDecodeWellKnownAttributes(ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, DiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
-        {
-            Debug.Assert(_lazyCustomAttributesBag != null);
-            Debug.Assert(_lazyCustomAttributesBag.IsDecodedWellKnownAttributeDataComputed);
-            Debug.Assert(symbolPart == AttributeLocation.None);
-
-            PostDecodeWellKnownFieldAttributes(this, boundAttributes, allAttributeSyntaxNodes, diagnostics, decodedData);
-
-            base.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
-        }
-
-        internal static void PostDecodeWellKnownFieldAttributes(FieldSymbol field, ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes, DiagnosticBag diagnostics, WellKnownAttributeData decodedData)
-        {
-            Debug.Assert(!boundAttributes.IsDefault);
-            Debug.Assert(!allAttributeSyntaxNodes.IsDefault);
-            Debug.Assert(boundAttributes.Length == allAttributeSyntaxNodes.Length);
-
-            var data = (CommonFieldWellKnownAttributeData)decodedData;
-            int? fieldOffset = data != null ? data.Offset : null;
-
-            if (fieldOffset.HasValue)
-            {
-                if (field.ContainingType.Layout.Kind != LayoutKind.Explicit)
-                {
-                    Debug.Assert(boundAttributes.Any());
-
-                    // error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
-                    int i = boundAttributes.IndexOfAttribute(field, AttributeDescription.FieldOffsetAttribute);
-                    diagnostics.Add(ErrorCode.ERR_StructOffsetOnBadStruct, allAttributeSyntaxNodes[i].Name.Location);
-                }
-            }
-            else if (!field.IsStatic && !field.IsConst)
-            {
-                if (field.ContainingType.Layout.Kind == LayoutKind.Explicit)
-                {
-                    // error CS0625: '<field>': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
-                    diagnostics.Add(ErrorCode.ERR_MissingStructOffset, field.ErrorLocation, field);
-                }
-            }
+            base.DecodeWellKnownAttribute(ref arguments);
         }
 
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
@@ -484,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (this.Type.ContainsDynamic())
             {
-                AddSynthesizedAttribute(ref attributes, 
+                AddSynthesizedAttribute(ref attributes,
                     DeclaringCompilation.SynthesizeDynamicAttribute(Type, CustomModifiers.Length));
             }
 
@@ -495,52 +141,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool HasSpecialName
-        {
-            get
-            {
-                if (this.HasRuntimeSpecialName)
-                {
-                    return true;
-                }
-
-                var data = GetDecodedWellKnownAttributeData();
-                return data != null && data.HasSpecialNameAttribute;
-            }
-        }
-
         internal sealed override bool HasRuntimeSpecialName
         {
             get
             {
                 return this.Name == WellKnownMemberNames.EnumBackingFieldName;
-            }
-        }
-
-        internal sealed override bool IsNotSerialized
-        {
-            get
-            {
-                var data = GetDecodedWellKnownAttributeData();
-                return data != null && data.HasNonSerializedAttribute;
-            }
-        }
-
-        internal sealed override MarshalPseudoCustomAttributeData MarshallingInformation
-        {
-            get
-            {
-                var data = GetDecodedWellKnownAttributeData();
-                return data != null ? data.MarshallingInformation : null;
-            }
-        }
-
-        internal sealed override int? TypeLayoutOffset
-        {
-            get
-            {
-                var data = GetDecodedWellKnownAttributeData();
-                return data != null ? data.Offset : null;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -120,24 +119,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // error CS1716: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.
                 arguments.Diagnostics.Add(ErrorCode.ERR_DoNotUseFixedBufferAttr, arguments.AttributeSyntaxOpt.Name.Location);
             }
-
-            base.DecodeWellKnownAttribute(ref arguments);
-        }
-
-        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
-        {
-            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
-
-            if (this.Type.ContainsDynamic())
+            else
             {
-                AddSynthesizedAttribute(ref attributes,
-                    DeclaringCompilation.SynthesizeDynamicAttribute(Type, CustomModifiers.Length));
-            }
-
-            if (Type.ContainsTupleNames())
-            {
-                AddSynthesizedAttribute(ref attributes,
-                    DeclaringCompilation.SynthesizeTupleNamesAttribute(Type));
+                base.DecodeWellKnownAttribute(ref arguments);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -394,16 +394,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_AutoPropertyMustOverrideSet, location, this);
             }
 
-            CheckForFieldTargetedAttribute(_isAutoProperty, syntax, diagnostics);
+            if (_isAutoProperty)
+            {
+                CheckForFieldTargetedAttribute(syntax, diagnostics);
+            }
 
             CheckForBlockAndExpressionBody(
                 syntax.AccessorList, syntax.GetExpressionBodySyntax(), syntax, diagnostics);
         }
 
-        private void CheckForFieldTargetedAttribute(bool isAutoProperty, BasePropertyDeclarationSyntax syntax, DiagnosticBag diagnostics)
+        private void CheckForFieldTargetedAttribute(BasePropertyDeclarationSyntax syntax, DiagnosticBag diagnostics)
         {
             var languageVersion = this.DeclaringCompilation.LanguageVersion;
-            if (!isAutoProperty || languageVersion.AllowAttributesOnBackingFields())
+            if (languageVersion.AllowAttributesOnBackingFields())
             {
                 return;
             }
@@ -416,7 +419,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         new CSDiagnosticInfo(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable,
                             languageVersion.ToDisplayString(),
                             new CSharpRequiredLanguageVersion(MessageID.IDS_FeatureAttributesOnBackingFields.RequiredVersion())),
-                        attribute.Location);
+                        attribute.Target.Location);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -84,8 +84,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = this.DeclaringCompilation;
 
-            Debug.Assert(!this.ContainingType.IsImplicitlyDeclared);
-            AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
+            // do not emit CompilerGenerated attributes for fields inside compiler generated types:
+            if (!this.ContainingType.IsImplicitlyDeclared)
+            {
+                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
+            }
 
             // Dev11 doesn't synthesize this attribute, the debugger has a knowledge
             // of special name C# compiler uses for backing fields, which is not desirable.

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -2,8 +2,9 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -11,10 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// <summary>
     /// Represents a compiler generated backing field for an automatically implemented property.
     /// </summary>
-    internal sealed class SynthesizedBackingFieldSymbol : SynthesizedFieldSymbolBase
+    internal sealed class SynthesizedBackingFieldSymbol : SynthesizedFieldSymbolBase, IAttributeTargetSymbol
     {
         private readonly SourcePropertySymbol _property;
         private readonly bool _hasInitializer;
+        private CustomAttributesBag<CSharpAttributeData> _lazyCustomAttributesBag;
 
         public SynthesizedBackingFieldSymbol(
             SourcePropertySymbol property,
@@ -32,7 +34,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool HasInitializer
         {
-            get { return _hasInitializer; }
+            get
+            {
+                return _hasInitializer;
+            }
         }
 
         public override Symbol AssociatedSymbol
@@ -72,15 +77,165 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override ImmutableArray<CSharpAttributeData> GetAttributes()
+            => GetAttributesBag().Attributes;
+
+        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner
+            => this;
+
+        AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations
+            => AttributeLocation.Field;
+
+        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation
+            => AttributeLocation.Field;
+
+        internal override Location ErrorLocation
+            => _property.Location;
+
+        internal sealed override int? TypeLayoutOffset
+            => GetDecodedWellKnownAttributeData()?.Offset;
+
+        internal sealed override MarshalPseudoCustomAttributeData MarshallingInformation
+            => GetDecodedWellKnownAttributeData()?.MarshallingInformation;
+
         internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
             var compilation = this.DeclaringCompilation;
 
-            // Dev11 doesn't synthesize this attribute, the debugger has a knowledge 
+            // Dev11 doesn't synthesize this attribute, the debugger has a knowledge
             // of special name C# compiler uses for backing fields, which is not desirable.
             AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDebuggerBrowsableNeverAttribute());
+        }
+
+        internal sealed override bool IsNotSerialized
+        {
+            get
+            {
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null && data.HasNonSerializedAttribute;
+            }
+        }
+
+        internal sealed override bool HasSpecialName
+        {
+            get
+            {
+                if (HasRuntimeSpecialName)
+                {
+                    return true;
+                }
+
+                var data = GetDecodedWellKnownAttributeData();
+                return data != null && data.HasSpecialNameAttribute;
+            }
+        }
+
+        /// <summary>
+        /// Returns data decoded from Obsolete attribute or null if there is no Obsolete attribute.
+        /// This property returns ObsoleteAttributeData.Uninitialized if attribute arguments haven't been decoded yet.
+        /// </summary>
+        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+        {
+            get
+            {
+                var containingType = (SourceMemberContainerTypeSymbol)_property.ContainingType;
+                if (!containingType.AnyMemberHasAttributes)
+                {
+                    return null;
+                }
+
+                var lazyCustomAttributesBag = _lazyCustomAttributesBag;
+                if (lazyCustomAttributesBag != null && lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
+                {
+                    var data = (CommonFieldEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
+                    return data?.ObsoleteAttributeData;
+                }
+
+                return ObsoleteAttributeData.Uninitialized;
+            }
+        }
+
+        /// <summary>
+        /// Returns data decoded from well-known attributes applied to the symbol or null if there are no applied attributes.
+        /// </summary>
+        /// <remarks>
+        /// Forces binding and decoding of attributes.
+        /// </remarks>
+        private CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        {
+            var attributesBag = _lazyCustomAttributesBag;
+            if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
+            {
+                attributesBag = this.GetAttributesBag();
+            }
+
+            return (CommonFieldWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+        }
+
+        /// <summary>
+        /// Returns a bag of custom attributes applied on the backing field and data decoded from well-known attributes. Returns null if there are no attributes.
+        /// </summary>
+        /// <remarks>
+        /// Forces binding and decoding of attributes.
+        /// </remarks>
+        private CustomAttributesBag<CSharpAttributeData> GetAttributesBag()
+        {
+            var bag = _lazyCustomAttributesBag;
+            if (bag != null && bag.IsSealed)
+            {
+                return bag;
+            }
+
+            // We let the property drive and track completion
+            _ = LoadAndValidateAttributes(OneOrMany.Create(_property.CSharpSyntaxNode.AttributeLists), ref _lazyCustomAttributesBag, AttributeLocation.Field);
+
+            Debug.Assert(_lazyCustomAttributesBag.IsSealed);
+            return _lazyCustomAttributesBag;
+        }
+
+        internal sealed override CSharpAttributeData EarlyDecodeWellKnownAttribute(
+            ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments)
+        {
+            CSharpAttributeData boundAttribute;
+            ObsoleteAttributeData obsoleteData;
+
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            {
+                if (obsoleteData != null)
+                {
+                    arguments.GetOrCreateData<CommonFieldEarlyWellKnownAttributeData>().ObsoleteAttributeData = obsoleteData;
+                }
+
+                return boundAttribute;
+            }
+
+            return base.EarlyDecodeWellKnownAttribute(ref arguments);
+        }
+
+        internal sealed override void DecodeWellKnownAttribute(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments)
+        {
+            Debug.Assert((object)arguments.AttributeSyntaxOpt != null);
+
+            var attribute = arguments.Attribute;
+            Debug.Assert(!attribute.HasErrors);
+            Debug.Assert(arguments.SymbolPart == AttributeLocation.Field);
+
+            SourceFieldSymbol.DecodeWellKnownFieldAttribute(this, ref arguments, attribute);
+        }
+
+        internal override void PostDecodeWellKnownAttributes(
+            ImmutableArray<CSharpAttributeData> boundAttributes, ImmutableArray<AttributeSyntax> allAttributeSyntaxNodes,
+            DiagnosticBag diagnostics, AttributeLocation symbolPart, WellKnownAttributeData decodedData)
+        {
+            Debug.Assert(_lazyCustomAttributesBag != null);
+            Debug.Assert(_lazyCustomAttributesBag.IsDecodedWellKnownAttributeDataComputed);
+            Debug.Assert(symbolPart == AttributeLocation.Field);
+
+            SourceFieldSymbol.PostDecodeWellKnownFieldAttributes(this, boundAttributes, allAttributeSyntaxNodes, diagnostics, decodedData);
+
+            base.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -84,11 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = this.DeclaringCompilation;
 
-            // do not emit CompilerGenerated attributes for fields inside compiler generated types:
-            if (!this.ContainingType.IsImplicitlyDeclared)
-            {
-                AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
-            }
+            Debug.Assert(!this.ContainingType.IsImplicitlyDeclared);
+            AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
 
             // Dev11 doesn't synthesize this attribute, the debugger has a knowledge
             // of special name C# compiler uses for backing fields, which is not desirable.

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
+        internal override ObsoleteAttributeData ObsoleteAttributeData
         {
             get { return null; }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -43,37 +43,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
 
-            AddSynthesizedFieldAttributes(ref attributes, this, this.SuppressDynamicAttribute);
-        }
-
-        internal static void AddSynthesizedFieldAttributes(
-            ref ArrayBuilder<SynthesizedAttributeData> attributes,
-            FieldSymbol field,
-            bool suppressDynamicAttribute)
-        {
-            CSharpCompilation compilation = field.DeclaringCompilation;
+            CSharpCompilation compilation = this.DeclaringCompilation;
 
             // do not emit CompilerGenerated attributes for fields inside compiler generated types:
-            if (!field.ContainingType.IsImplicitlyDeclared)
+            if (!_containingType.IsImplicitlyDeclared)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
             }
 
-            TypeSymbol type = field.Type;
-            if (!suppressDynamicAttribute &&
-                type.ContainsDynamic() &&
+            if (!this.SuppressDynamicAttribute &&
+                this.Type.ContainsDynamic() &&
                 compilation.HasDynamicEmitAttributes() &&
                 compilation.CanEmitBoolean())
             {
-                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type, field.CustomModifiers.Length));
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(this.Type, this.CustomModifiers.Length));
             }
 
-            if (type.ContainsTupleNames() &&
+            if (Type.ContainsTupleNames() &&
                 compilation.HasTupleNamesAttributes &&
                 compilation.CanEmitSpecialType(SpecialType.System_String))
             {
                 AddSynthesizedAttribute(ref attributes,
-                    compilation.SynthesizeTupleNamesAttribute(type));
+                    compilation.SynthesizeTupleNamesAttribute(Type));
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -750,15 +750,15 @@ public class Test
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
             comp.VerifyDiagnostics(
-                // (7,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                // (7,6): warning CS8361: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
                 //     [field: System.Obsolete]
-                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "[field: System.Obsolete]").WithArguments("7.2", "7.3").WithLocation(7, 5),
-                // (8,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "field:").WithArguments("7.2", "7.3").WithLocation(7, 6),
+                // (8,6): warning CS8361: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
                 //     [field: A]
-                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "[field: A]").WithArguments("7.2", "7.3").WithLocation(8, 5),
-                // (11,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "field:").WithArguments("7.2", "7.3").WithLocation(8, 6),
+                // (11,6): warning CS8361: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
                 //     [field: System.Obsolete("obsolete", error: true)]
-                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, @"[field: System.Obsolete(""obsolete"", error: true)]").WithArguments("7.2", "7.3").WithLocation(11, 5)
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "field:").WithArguments("7.2", "7.3").WithLocation(11, 6)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -1244,36 +1244,39 @@ public class Test
                     : new[] { "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
                         "System.Diagnostics.DebuggerBrowsableAttribute(System.Diagnostics.DebuggerBrowsableState.Never)" };
 
+                var constantExpected = "1844674407800451891300";
+
+                string[] decimalAttributeExpected = new[] { "System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)" };
+
                 var prop1 = @class.GetMember<PropertySymbol>("P");
                 Assert.Empty(prop1.GetAttributes());
 
                 var field1 = @class.GetMember<FieldSymbol>("<P>k__BackingField");
                 if (isFromSource)
                 {
-                    AssertEx.SetEqual(fieldAttributesExpected.Concat(new[] { "System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)" }),
-                        GetAttributeStrings(field1.GetAttributes()));
+                    AssertEx.SetEqual(fieldAttributesExpected.Concat(decimalAttributeExpected), GetAttributeStrings(field1.GetAttributes()));
                 }
                 else
                 {
                     AssertEx.SetEqual(fieldAttributesExpected, GetAttributeStrings(field1.GetAttributes()));
+                    Assert.Equal(constantExpected, field1.ConstantValue.ToString());
                 }
 
                 var prop2 = @class.GetMember<PropertySymbol>("P2");
                 Assert.Empty(prop2.GetAttributes());
 
                 var field2 = @class.GetMember<FieldSymbol>("<P2>k__BackingField");
-                AssertEx.SetEqual(fieldAttributesExpected.Concat(new[] { "System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)" }),
-                    GetAttributeStrings(field2.GetAttributes()));
+                AssertEx.SetEqual(fieldAttributesExpected.Concat(decimalAttributeExpected), GetAttributeStrings(field2.GetAttributes()));
 
                 var field3 = @class.GetMember<FieldSymbol>("field");
                 if (isFromSource)
                 {
-                    AssertEx.SetEqual(new[] { "System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)" },
-                        GetAttributeStrings(field3.GetAttributes()));
+                    AssertEx.SetEqual(decimalAttributeExpected, GetAttributeStrings(field3.GetAttributes()));
                 }
                 else
                 {
                     Assert.Empty(GetAttributeStrings(field3.GetAttributes()));
+                    Assert.Equal(constantExpected, field3.ConstantValue.ToString());
                 }
             };
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -728,6 +728,37 @@ public class A
         }
 
         [Fact]
+        public void TestFieldAttributeOnPropertyInCSharp7_2()
+        {
+            string source = @"
+public class A : System.Attribute
+{
+}
+public class Test
+{
+    [field: System.Obsolete]
+    [field: A]
+    public int P { get; set; }
+
+    [field: System.Obsolete(""obsolete"", error: true)]
+    public int P2 { get; }
+}
+";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (7,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                //     [field: System.Obsolete]
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "[field: System.Obsolete]").WithArguments("7.2", "7.3").WithLocation(7, 5),
+                // (8,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                //     [field: A]
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, "[field: A]").WithArguments("7.2", "7.3").WithLocation(8, 5),
+                // (11,5): warning CS8360: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
+                //     [field: System.Obsolete("obsolete", error: true)]
+                Diagnostic(ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable, @"[field: System.Obsolete(""obsolete"", error: true)]").WithArguments("7.2", "7.3").WithLocation(11, 5)
+                );
+        }
+
+        [Fact]
         public void TestFieldAttributesOnAutoProperty()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -728,6 +728,660 @@ public class A
         }
 
         [Fact]
+        public void TestFieldAttributesOnAutoProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = true) ]
+public class A : System.Attribute
+{
+    public A(int i) { }
+}
+[System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = true) ]
+public class B : System.Attribute
+{
+    public B(int i) { }
+}
+
+public class Test
+{
+    [field: A(1)]
+    public int P { get; set; }
+
+    [field: A(2)]
+    public int P2 { get; }
+
+    [B(3)]
+    [field: A(33)]
+    public int P3 { get; }
+
+    [property: B(4)]
+    [field: A(44)]
+    [field: A(444)]
+    public int P4 { get; }
+}
+";
+            Func<bool, Action<ModuleSymbol>> symbolValidator = isFromSource => moduleSymbol =>
+            {
+                var accessorsExpected = isFromSource ? new string[0] : new[] { "System.Runtime.CompilerServices.CompilerGeneratedAttribute" };
+
+                var @class = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+
+                var prop1 = @class.GetMember<PropertySymbol>("P");
+                Assert.Empty(prop1.GetAttributes());
+                AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(prop1.GetMethod.GetAttributes()));
+                AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(prop1.SetMethod.GetAttributes()));
+
+                if (isFromSource)
+                {
+                    var field1 = @class.GetMember<FieldSymbol>("<P>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected.Concat(new[] { "A(1)" }), GetAttributeStrings(field1.GetAttributes()));
+                }
+
+                var prop2 = @class.GetMember<PropertySymbol>("P2");
+                Assert.Empty(prop2.GetAttributes());
+                AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(prop2.GetMethod.GetAttributes()));
+                Assert.Null(prop2.SetMethod);
+
+                if (isFromSource)
+                {
+                    var field2 = @class.GetMember<FieldSymbol>("<P2>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected.Concat(new[] { "A(2)" }), GetAttributeStrings(field2.GetAttributes()));
+                }
+
+                var prop3 = @class.GetMember<PropertySymbol>("P3");
+                Assert.Equal("B(3)", prop3.GetAttributes().Single().ToString());
+                AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(prop3.GetMethod.GetAttributes()));
+                Assert.Null(prop3.SetMethod);
+
+                if (isFromSource)
+                {
+                    var field3 = @class.GetMember<FieldSymbol>("<P3>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected.Concat(new[] { "A(33)" }), GetAttributeStrings(field3.GetAttributes()));
+                }
+
+                var prop4 = @class.GetMember<PropertySymbol>("P4");
+                Assert.Equal("B(4)", prop4.GetAttributes().Single().ToString());
+                AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(prop3.GetMethod.GetAttributes()));
+                Assert.Null(prop4.SetMethod);
+
+                if (isFromSource)
+                {
+                    var field4 = @class.GetMember<FieldSymbol>("<P4>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected.Concat(new[] { "A(44)", "A(444)" }), GetAttributeStrings(field4.GetAttributes()));
+                }
+            };
+
+            var comp = CompileAndVerify(source, sourceSymbolValidator: symbolValidator(true), symbolValidator: symbolValidator(false));
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_SpecialName()
+        {
+            string source = @"
+public struct Test
+{
+    [field: System.Runtime.CompilerServices.SpecialName]
+    public static int P { get; set; }
+
+    public static int P2 { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var field1 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P>k__BackingField");
+            Assert.True(field1.HasSpecialName);
+
+            var field2 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P2>k__BackingField");
+            Assert.False(field2.HasSpecialName);
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_NonSerialized()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.NonSerialized]
+    public int P { get; set; }
+
+    public int P2 { get; set; }
+}
+";
+
+            Func<bool, Action<ModuleSymbol>> symbolValidator = isFromSource => moduleSymbol =>
+            {
+                var accessorsExpected = isFromSource ? new string[0] : new[] { "System.Runtime.CompilerServices.CompilerGeneratedAttribute" };
+
+                var @class = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+
+                var prop1 = @class.GetMember<PropertySymbol>("P");
+                Assert.Empty(prop1.GetAttributes());
+
+                if (isFromSource)
+                {
+                    var field1 = @class.GetMember<FieldSymbol>("<P>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected.Concat(new[] { "System.NonSerializedAttribute" }), GetAttributeStrings(field1.GetAttributes()));
+                    Assert.True(field1.IsNotSerialized);
+                }
+
+                var prop2 = @class.GetMember<PropertySymbol>("P2");
+                Assert.Empty(prop2.GetAttributes());
+
+                if (isFromSource)
+                {
+                    var field2 = @class.GetMember<FieldSymbol>("<P2>k__BackingField");
+                    AssertEx.SetEqual(accessorsExpected, GetAttributeStrings(field2.GetAttributes()));
+                    Assert.False(field2.IsNotSerialized);
+                }
+            };
+
+            var comp = CompileAndVerify(source, sourceSymbolValidator: symbolValidator(true), symbolValidator: symbolValidator(false));
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FieldOffset()
+        {
+            string source = @"
+public struct Test
+{
+    [field: System.Runtime.InteropServices.FieldOffset(0)]
+    public static int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,13): error CS0637: The FieldOffset attribute is not allowed on static or const fields
+                //     [field: System.Runtime.InteropServices.FieldOffset(0)]
+                Diagnostic(ErrorCode.ERR_StructOffsetOnBadField, "System.Runtime.InteropServices.FieldOffset").WithArguments("System.Runtime.InteropServices.FieldOffset").WithLocation(4, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FieldOffset2()
+        {
+            string source = @"
+public struct Test
+{
+    [field: System.Runtime.InteropServices.FieldOffset(-1)]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,56): error CS0591: Invalid value for argument to 'System.Runtime.InteropServices.FieldOffset' attribute
+                //     [field: System.Runtime.InteropServices.FieldOffset(-1)]
+                Diagnostic(ErrorCode.ERR_InvalidAttributeArgument, "-1").WithArguments("System.Runtime.InteropServices.FieldOffset").WithLocation(4, 56),
+                // (4,13): error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
+                //     [field: System.Runtime.InteropServices.FieldOffset(-1)]
+                Diagnostic(ErrorCode.ERR_StructOffsetOnBadStruct, "System.Runtime.InteropServices.FieldOffset").WithLocation(4, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FieldOffset3()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Auto)]
+public class Test
+{
+    [field: FieldOffset(4)]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
+                //     [field: FieldOffset(4)]
+                Diagnostic(ErrorCode.ERR_StructOffsetOnBadStruct, "FieldOffset").WithLocation(7, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FieldOffset4()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+
+public struct Test
+{
+    [field: FieldOffset(4)]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,13): error CS0636: The FieldOffset attribute can only be placed on members of types marked with the StructLayout(LayoutKind.Explicit)
+                //     [field: FieldOffset(4)]
+                Diagnostic(ErrorCode.ERR_StructOffsetOnBadStruct, "FieldOffset").WithLocation(6, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FieldOffset5()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct Test
+{
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,16): error CS0625: 'Test.<P>k__BackingField': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+                //     public int P { get; set; }
+                Diagnostic(ErrorCode.ERR_MissingStructOffset, "P").WithArguments("Test.<P>k__BackingField").WithLocation(7, 16)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_FixedBuffer()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.Runtime.CompilerServices.FixedBuffer(typeof(int), 0)]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,13): error CS1716: Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fixed' field modifier instead.
+                //     [field: System.Runtime.CompilerServices.FixedBuffer(typeof(int), 0)]
+                Diagnostic(ErrorCode.ERR_DoNotUseFixedBufferAttr, "System.Runtime.CompilerServices.FixedBuffer").WithLocation(4, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_DynamicAttribute()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.Runtime.CompilerServices.DynamicAttribute()]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source, references: new[] { SystemCoreRef });
+            comp.VerifyDiagnostics(
+                // (4,13): error CS1970: Do not use 'System.Runtime.CompilerServices.DynamicAttribute'. Use the 'dynamic' keyword instead.
+                //     [field: System.Runtime.CompilerServices.DynamicAttribute()]
+                Diagnostic(ErrorCode.ERR_ExplicitDynamicAttr, "System.Runtime.CompilerServices.DynamicAttribute()").WithLocation(4, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_IsReadOnlyAttribute()
+        {
+            string source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsReadOnlyAttribute : System.Attribute { }
+}
+public class Test
+{
+    [field: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS8335: Do not use 'System.Runtime.CompilerServices.IsReadOnlyAttribute'. This is reserved for compiler usage.
+                //     [field: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "System.Runtime.CompilerServices.IsReadOnlyAttribute()").WithArguments("System.Runtime.CompilerServices.IsReadOnlyAttribute").WithLocation(8, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_IsByRefLikeAttribute()
+        {
+            string source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsByRefLikeAttribute : System.Attribute { }
+}
+public class Test
+{
+    [field: System.Runtime.CompilerServices.IsByRefLikeAttribute()]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS8335: Do not use 'System.Runtime.CompilerServices.IsByRefLikeAttribute'. This is reserved for compiler usage.
+                //     [field: System.Runtime.CompilerServices.IsByRefLikeAttribute()]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "System.Runtime.CompilerServices.IsByRefLikeAttribute()").WithArguments("System.Runtime.CompilerServices.IsByRefLikeAttribute").WithLocation(8, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_DateTimeConstant()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.Runtime.CompilerServices.DateTimeConstant(123456)]
+    public System.DateTime P { get; set; }
+
+    [field: System.Runtime.CompilerServices.DateTimeConstant(123456)]
+    public int P2 { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var field1 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P>k__BackingField");
+            Assert.Equal("System.Runtime.CompilerServices.DateTimeConstantAttribute(123456)", field1.GetAttributes().Single().ToString());
+
+            var field2 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P2>k__BackingField");
+            Assert.Equal("System.Runtime.CompilerServices.DateTimeConstantAttribute(123456)", field2.GetAttributes().Single().ToString());
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_DecimalConstant()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.Runtime.CompilerServices.DecimalConstant(0, 0, 100, 100, 100)]
+    public decimal P { get; set; }
+
+    [field: System.Runtime.CompilerServices.DecimalConstant(0, 0, 100, 100, 100)]
+    public int P2 { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var field1 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P>k__BackingField");
+            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)", field1.GetAttributes().Single().ToString());
+
+            var field2 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P2>k__BackingField");
+            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 100, 100, 100)", field2.GetAttributes().Single().ToString());
+        }
+
+        [Fact]
+        public void TestWellKnownAttributeOnProperty_TupleElementNamesAttribute()
+        {
+            string source = @"
+namespace System.Runtime.CompilerServices
+{
+    public sealed class TupleElementNamesAttribute : Attribute
+    {
+        public TupleElementNamesAttribute(string[] transformNames) { }
+    }
+}
+public class Test
+{
+    [field: System.Runtime.CompilerServices.TupleElementNamesAttribute(new[] { ""hello"" })]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (11,13): error CS8138: Cannot reference 'System.Runtime.CompilerServices.TupleElementNamesAttribute' explicitly. Use the tuple syntax to define tuple names.
+                //     [field: System.Runtime.CompilerServices.TupleElementNamesAttribute(new[] { "hello" })]
+                Diagnostic(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, @"System.Runtime.CompilerServices.TupleElementNamesAttribute(new[] { ""hello"" })").WithLocation(11, 13)
+                );
+        }
+
+        [Fact]
+        public void TestWellKnownEarlyAttributeOnProperty_Obsolete()
+        {
+            string source = @"
+public class Test
+{
+    [field: System.Obsolete]
+    public int P { get; set; }
+
+    [field: System.Obsolete(""obsolete"", error: true)]
+    public int P2 { get; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var field1 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P>k__BackingField");
+            Assert.Equal("System.ObsoleteAttribute", field1.GetAttributes().Single().ToString());
+            Assert.Equal(ObsoleteAttributeKind.Obsolete, field1.ObsoleteAttributeData.Kind);
+            Assert.Null(field1.ObsoleteAttributeData.Message);
+            Assert.False(field1.ObsoleteAttributeData.IsError);
+
+            var field2 = comp.SourceModule.GlobalNamespace.GetMember<FieldSymbol>("Test.<P2>k__BackingField");
+            Assert.Equal(@"System.ObsoleteAttribute(""obsolete"", true)", field2.GetAttributes().Single().ToString());
+            Assert.Equal(ObsoleteAttributeKind.Obsolete, field2.ObsoleteAttributeData.Kind);
+            Assert.Equal("obsolete", field2.ObsoleteAttributeData.Message);
+            Assert.True(field2.ObsoleteAttributeData.IsError);
+        }
+
+        [Fact]
+        public void TestFieldAttributesOnProperty()
+        {
+            string source = @"
+public class A : System.Attribute { }
+
+public class Test
+{
+    [field: A]
+    public int P { get => throw null; set => throw null; }
+
+    [field: A]
+    public int P2 { get => throw null; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,6): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
+                //     [field: A]
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "property").WithLocation(9, 6),
+                // (6,6): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
+                //     [field: A]
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "property").WithLocation(6, 6)
+                );
+        }
+
+        [Fact]
+        public void TestFieldAttributesOnPropertyAccessors()
+        {
+            string source = @"
+public class A : System.Attribute { }
+
+public class Test
+{
+    public int P { [field: A] get => throw null; set => throw null; }
+    public int P2 { [field: A] get; set; }
+    public int P3 { [field: A] get => throw null; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,21): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //     public int P { [field: A] get => throw null; set => throw null; }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "method, return").WithLocation(6, 21),
+                // (7,22): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //     public int P2 { [field: A] get; set; }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "method, return").WithLocation(7, 22),
+                // (8,22): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'method, return'. All attributes in this block will be ignored.
+                //     public int P3 { [field: A] get => throw null; }
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "method, return").WithLocation(8, 22)
+                );
+        }
+
+        [Fact]
+        public void TestMultipleFieldAttributesOnProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = false) ]
+public class Single : System.Attribute { }
+
+[System.AttributeUsage(System.AttributeTargets.Field, AllowMultiple = true) ]
+public class Multiple : System.Attribute { }
+
+public class Test
+{
+    [field: Single]
+    [field: Single]
+    [field: Multiple]
+    [field: Multiple]
+    public int P { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (11,13): error CS0579: Duplicate 'Single' attribute
+                //     [field: Single]
+                Diagnostic(ErrorCode.ERR_DuplicateAttribute, "Single").WithArguments("Single").WithLocation(11, 13)
+                );
+        }
+
+        [Fact]
+        public void TestInheritedFieldAttributesOnOverridenProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.All, Inherited = true) ]
+public class A : System.Attribute
+{
+    public A(int i) { }
+}
+
+public class Base
+{
+    [field: A(1)]
+    [A(2)]
+    public virtual int P { get; set; }
+}
+public class Derived : Base
+{
+    public override int P { get; set; }
+}
+";
+            Action<ModuleSymbol> symbolValidator = moduleSymbol =>
+            {
+                var parent = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("Base");
+
+                var prop1 = parent.GetMember<PropertySymbol>("P");
+                Assert.Equal("A(2)", prop1.GetAttributes().Single().ToString());
+                Assert.Empty(prop1.GetMethod.GetAttributes());
+                Assert.Empty(prop1.SetMethod.GetAttributes());
+
+                var field1 = parent.GetMember<FieldSymbol>("<P>k__BackingField");
+                Assert.Equal("A(1)", field1.GetAttributes().Single().ToString());
+
+                var child = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
+
+                var prop2 = child.GetMember<PropertySymbol>("P");
+                Assert.Empty(prop2.GetAttributes());
+                Assert.Empty(prop2.GetMethod.GetAttributes());
+                Assert.Empty(prop2.SetMethod.GetAttributes());
+
+                var field2 = child.GetMember<FieldSymbol>("<P>k__BackingField");
+                Assert.Empty(field2.GetAttributes());
+            };
+
+            var comp = CompileAndVerify(source, sourceSymbolValidator: symbolValidator);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestPropertyTargetedFieldAttributesOnAutoProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.Property) ]
+public class A : System.Attribute { }
+
+public class Test
+{
+    [field: A]
+    public int P { get; set; }
+
+    [field: A]
+    public int P2 { get; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,13): error CS0592: Attribute 'A' is not valid on this declaration type. It is only valid on 'property, indexer' declarations.
+                //     [field: A]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "A").WithArguments("A", "property, indexer").WithLocation(10, 13),
+                // (7,13): error CS0592: Attribute 'A' is not valid on this declaration type. It is only valid on 'property, indexer' declarations.
+                //     [field: A]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "A").WithArguments("A", "property, indexer").WithLocation(7, 13)
+                );
+        }
+
+        [Fact]
+        public void TestClassTargetedFieldAttributesOnAutoProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.Class) ]
+public class ClassAllowed : System.Attribute { }
+
+[System.AttributeUsage(System.AttributeTargets.Field) ]
+public class FieldAllowed : System.Attribute { }
+
+public class Test
+{
+    [field: ClassAllowed] // error 1
+    [field: FieldAllowed]
+    public int P { get; set; }
+
+    [field: ClassAllowed] // error 2
+    [field: FieldAllowed]
+    public int P2 { get; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (14,13): error CS0592: Attribute 'ClassAllowed' is not valid on this declaration type. It is only valid on 'class' declarations.
+                //     [field: ClassAllowed] // error 2
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ClassAllowed").WithArguments("ClassAllowed", "class").WithLocation(14, 13),
+                // (10,13): error CS0592: Attribute 'ClassAllowed' is not valid on this declaration type. It is only valid on 'class' declarations.
+                //     [field: ClassAllowed] // error 1
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ClassAllowed").WithArguments("ClassAllowed", "class").WithLocation(10, 13)
+                );
+        }
+
+        [Fact]
+        public void TestImproperlyTargetedFieldAttributesOnProperty()
+        {
+            string source = @"
+[System.AttributeUsage(System.AttributeTargets.Property) ]
+public class A : System.Attribute { }
+
+public class Test
+{
+    [field: A]
+    public int P { get => throw null; set => throw null; }
+
+    [field: A]
+    public int P2 { get => throw null; }
+
+    [field: A]
+    public int P3 { get; set; }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,6): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
+                //     [field: A]
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "property").WithLocation(10, 6),
+                // (13,13): error CS0592: Attribute 'A' is not valid on this declaration type. It is only valid on 'property, indexer' declarations.
+                //     [field: A]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "A").WithArguments("A", "property, indexer").WithLocation(13, 13),
+                // (7,6): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
+                //     [field: A]
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "property").WithLocation(7, 6)
+                );
+        }
+
+        [Fact]
         public void TestAttributesOnEvents()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -1340,7 +1340,7 @@ class C
                 Signature(
                     "C",
                     "<P>k__BackingField",
-                    ".field [System.Runtime.CompilerServices.CompilerGeneratedAttribute()] [System.Runtime.CompilerServices.DynamicAttribute(System.Collections.ObjectModel.ReadOnlyCollection`1[System.Reflection.CustomAttributeTypedArgument])] private static System.Object[] <P>k__BackingField")
+                    ".field [System.Runtime.CompilerServices.DynamicAttribute(System.Collections.ObjectModel.ReadOnlyCollection`1[System.Reflection.CustomAttributeTypedArgument])] [System.Runtime.CompilerServices.CompilerGeneratedAttribute()] private static System.Object[] <P>k__BackingField")
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Locations.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Locations.cs
@@ -480,26 +480,24 @@ class C
 }
 ";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (10,6): warning CS0657: 'assembly' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "assembly").WithArguments("assembly", "property"),
-                // (11,6): warning CS0657: 'module' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "module").WithArguments("module", "property"),
-                // (12,6): warning CS0657: 'type' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "type").WithArguments("type", "property"),
-                // (13,6): warning CS0657: 'method' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "method").WithArguments("method", "property"),
-                // (14,6): warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "field").WithArguments("field", "property"),
-                // (16,6): warning CS0657: 'event' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "event").WithArguments("event", "property"),
-                // (17,6): warning CS0657: 'return' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "return").WithArguments("return", "property"),
-                // (18,6): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "property"),
-                // (19,6): warning CS0657: 'typevar' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "typevar").WithArguments("typevar", "property"),
-                // (20,6): warning CS0658: 'delegate' is not a recognized attribute location. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.
-                Diagnostic(ErrorCode.WRN_InvalidAttributeLocation, "delegate").WithArguments("delegate", "property"));
+                // (10,6): warning CS0657: 'assembly' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "assembly").WithArguments("assembly", "field, property").WithLocation(10, 6),
+                // (11,6): warning CS0657: 'module' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "module").WithArguments("module", "field, property").WithLocation(11, 6),
+                // (12,6): warning CS0657: 'type' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "type").WithArguments("type", "field, property").WithLocation(12, 6),
+                // (13,6): warning CS0657: 'method' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "method").WithArguments("method", "field, property").WithLocation(13, 6),
+                // (16,6): warning CS0657: 'event' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "event").WithArguments("event", "field, property").WithLocation(16, 6),
+                // (17,6): warning CS0657: 'return' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "return").WithArguments("return", "field, property").WithLocation(17, 6),
+                // (18,6): warning CS0657: 'param' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "param").WithArguments("param", "field, property").WithLocation(18, 6),
+                // (19,6): warning CS0657: 'typevar' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "typevar").WithArguments("typevar", "field, property").WithLocation(19, 6),
+                // (20,6): warning CS0658: 'delegate' is not a recognized attribute location. Valid attribute locations for this declaration are 'field, property'. All attributes in this block will be ignored.
+                Diagnostic(ErrorCode.WRN_InvalidAttributeLocation, "delegate").WithArguments("delegate", "field, property").WithLocation(20, 6));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_MarshalAs.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_MarshalAs.cs
@@ -331,6 +331,62 @@ public class X
         }
 
         [Fact]
+        [WorkItem(22512, "https://github.com/dotnet/roslyn/issues/22512")]
+        public void ComInterfacesInProperties()
+        {
+            var source = @"
+using System;
+using System.Runtime.InteropServices;
+
+public class X
+{
+    [field: MarshalAs(UnmanagedType.IDispatch, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 0, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public byte IDispatch { get; set; }
+
+    [field: MarshalAs(UnmanagedType.Interface, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 1, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public X Interface { get; set; }
+
+    [field: MarshalAs(UnmanagedType.IUnknown, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 2, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public X[] IUnknown { get; set; }
+
+    [field: MarshalAs(UnmanagedType.IUnknown, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 0x1FFFFFFF, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public int MaxValue { get; set; }
+
+    [field: MarshalAs(UnmanagedType.IUnknown, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 0x123456, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public int _123456 { get; set; }
+
+    [field: MarshalAs(UnmanagedType.IUnknown, ArraySubType = UnmanagedType.ByValTStr, IidParameterIndex = 0x1000, MarshalCookie = null, MarshalType = null, MarshalTypeRef = null, SafeArraySubType = VarEnum.VT_BSTR, SafeArrayUserDefinedSubType = null, SizeConst = -1, SizeParamIndex = -1)]
+    public X _0x1000 { get; set; }
+
+    [field: MarshalAs(UnmanagedType.IDispatch)]
+    public int Default { get; set; }
+}
+";
+            var blobs = new Dictionary<string, byte[]>
+            {
+                { "<IDispatch>k__BackingField", new byte[] { 0x1a, 0x00 } },
+                { "<Interface>k__BackingField", new byte[] { 0x1c, 0x01 } },
+                { "<IUnknown>k__BackingField",  new byte[] { 0x19, 0x02 } },
+                { "<MaxValue>k__BackingField",  new byte[] { 0x19, 0xdf, 0xff, 0xff, 0xff } },
+                { "<_123456>k__BackingField",   new byte[] { 0x19, 0xc0, 0x12, 0x34, 0x56 } },
+                { "<_0x1000>k__BackingField",   new byte[] { 0x19, 0x90, 0x00 } },
+                { "<Default>k__BackingField",   new byte[] { 0x1a } },
+            };
+
+            var verifier = CompileAndVerifyFieldMarshal(source, blobs);
+
+            using (var assembly = AssemblyMetadata.CreateFromImage(verifier.EmittedAssemblyData))
+            {
+                var compilation = CreateCompilation(new SyntaxTree[0], new[] { assembly.GetReference() });
+                foreach (NamedTypeSymbol type in compilation.GlobalNamespace.GetMembers().Where(s => s.Kind == SymbolKind.NamedType))
+                {
+                    var fields = type.GetMembers().Where(s => s.Kind == SymbolKind.Field);
+                    Assert.Empty(fields);
+                }
+            }
+        }
+
+        [Fact]
         public void ComInterfaces_Errors()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_MarshalAs.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_MarshalAs.cs
@@ -24,7 +24,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             int count = 0;
             using (var assembly = AssemblyMetadata.CreateFromImage(verifier.EmittedAssemblyData))
             {
-                var compilation = CreateCompilation(new SyntaxTree[0], new[] { assembly.GetReference() });
+                var compilation = CreateCompilation(new SyntaxTree[0], new[] { assembly.GetReference() },
+                    options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
                 foreach (NamedTypeSymbol type in compilation.GlobalNamespace.GetMembers().Where(s => s.Kind == SymbolKind.NamedType))
                 {
                     var fields = type.GetMembers().Where(s => s.Kind == SymbolKind.Field);
@@ -374,16 +376,7 @@ public class X
             };
 
             var verifier = CompileAndVerifyFieldMarshal(source, blobs);
-
-            using (var assembly = AssemblyMetadata.CreateFromImage(verifier.EmittedAssemblyData))
-            {
-                var compilation = CreateCompilation(new SyntaxTree[0], new[] { assembly.GetReference() });
-                foreach (NamedTypeSymbol type in compilation.GlobalNamespace.GetMembers().Where(s => s.Kind == SymbolKind.NamedType))
-                {
-                    var fields = type.GetMembers().Where(s => s.Kind == SymbolKind.Field);
-                    Assert.Empty(fields);
-                }
-            }
+            VerifyFieldMetadataDecoding(verifier, blobs);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
@@ -336,6 +336,7 @@ public class C : B
         }
 
         [Fact]
+        [WorkItem(22512, "https://github.com/dotnet/roslyn/issues/22512")]
         public void ExplicitFieldLayout()
         {
             string source = @"
@@ -366,6 +367,54 @@ public class A
                     switch (name)
                     {
                         case "a":
+                            expectedOffset = 4;
+                            break;
+
+                        case "b":
+                            expectedOffset = 8;
+                            break;
+
+                        default:
+                            throw TestExceptionUtilities.UnexpectedValue(name);
+                    }
+
+                    Assert.Equal(expectedOffset, field.GetOffset());
+                }
+            });
+        }
+
+        [Fact]
+        [WorkItem(22512, "https://github.com/dotnet/roslyn/issues/22512")]
+        public void ExplicitFieldLayout_OnBackingField()
+        {
+            string source = @"
+using System;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct A
+{
+    [field: FieldOffset(4)]
+    int a { get; set; }
+
+    [field: FieldOffset(8)]
+    event Action b;
+}
+";
+            CompileAndVerify(source, assemblyValidator: (assembly) =>
+            {
+                var reader = assembly.GetMetadataReader();
+                Assert.Equal(2, reader.GetTableRowCount(TableIndex.FieldLayout));
+
+                foreach (var fieldHandle in reader.FieldDefinitions)
+                {
+                    var field = reader.GetFieldDefinition(fieldHandle);
+                    string name = reader.GetString(field.Name);
+
+                    int expectedOffset;
+                    switch (name)
+                    {
+                        case "<a>k__BackingField":
                             expectedOffset = 4;
                             break;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -13794,6 +13794,7 @@ class A : IFace<int>
         }
 
         [Fact]
+        [WorkItem(22512, "https://github.com/dotnet/roslyn/issues/22512")]
         public void CS0842ERR_ExplicitLayoutAndAutoImplementedProperty()
         {
             var text = @"
@@ -13804,7 +13805,7 @@ namespace TestNamespace
     [StructLayout(LayoutKind.Explicit)]
     struct Str
     {
-        public int Num // CS0842
+        public int Num // CS0625
         {
             get;
             set;
@@ -13818,8 +13819,10 @@ namespace TestNamespace
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (9,20): error CS0842: 'TestNamespace.Str.Num': Automatically implemented properties cannot be used inside a type marked with StructLayout(LayoutKind.Explicit)
-                Diagnostic(ErrorCode.ERR_ExplicitLayoutAndAutoImplementedProperty, "Num").WithArguments("TestNamespace.Str.Num"));
+                // (9,20): error CS0625: 'Str.<Num>k__BackingField': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+                //         public int Num // CS0625
+                Diagnostic(ErrorCode.ERR_MissingStructOffset, "Num").WithArguments("TestNamespace.Str.<Num>k__BackingField").WithLocation(9, 20)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -13819,9 +13819,9 @@ namespace TestNamespace
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (9,20): error CS0625: 'Str.<Num>k__BackingField': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
+                // (9,20): error CS0625: 'Str.Num': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute
                 //         public int Num // CS0625
-                Diagnostic(ErrorCode.ERR_MissingStructOffset, "Num").WithArguments("TestNamespace.Str.<Num>k__BackingField").WithLocation(9, 20)
+                Diagnostic(ErrorCode.ERR_MissingStructOffset, "Num").WithArguments("TestNamespace.Str.Num").WithLocation(9, 20)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -247,6 +247,7 @@ class X
                         case ErrorCode.WRN_TupleLiteralNameMismatch:
                         case ErrorCode.WRN_Experimental:
                         case ErrorCode.WRN_DefaultInSwitch:
+                        case ErrorCode.WRN_AttributesOnBackingFieldsNotAvailable:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -881,6 +881,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return attributes.Select(a => a.AttributeClass.Name);
         }
 
+        internal IEnumerable<string> GetAttributeStrings(ImmutableArray<CSharpAttributeData> attributes)
+        {
+            return attributes.Select(a => a.ToString());
+        }
+
         #endregion
 
         #region Documentation Comments

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -240,7 +240,7 @@ class Program
 #error version:[|7.3|]
 }",
                 LanguageVersion.Latest,
-                new CSharpParseOptions(LanguageVersion.CSharp7_3));
+                new CSharpParseOptions(LanguageVersion.CSharp7_2));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -242,6 +242,21 @@ class Program
                 LanguageVersion.Latest,
                 new CSharpParseOptions(LanguageVersion.CSharp7_3));
         }
+
+        [Fact]
+        public async Task UpgradeProjectFromCSharp7_2ToLatest_TriggeredByAttributeOnBackingField()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class A : System.Attribute { }
+class Program
+{
+    [|[field: A]|]
+    int P { get; set; }
+}",
+                LanguageVersion.Latest,
+                new CSharpParseOptions(LanguageVersion.CSharp7_2));
+        }
 #endregion C# 7.3
 
         [Fact]

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8361 = nameof(CS8361); // warning CS8361: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320, CS1738, CS8360, CS8361);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320, CS1738, CS8361);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -30,9 +30,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8320 = nameof(CS8320); // error CS8320: Feature is not available in C# 7.2. Please use language version X or greater.
         private const string CS1738 = nameof(CS1738); // error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
         private const string CS8360 = nameof(CS8360); // error CS8360: Feature is not available in C# 7.3. Please use language version X or greater.
+        private const string CS8361 = nameof(CS8361); // warning CS8361: Field-targeted attributes on auto-properties are not supported in language version 7.2. Please use language version 7.3 or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320, CS1738, CS8360);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320, CS1738, CS8360, CS8361);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;


### PR DESCRIPTION
This is a small feature for C# 7.3.

In the following example, the field-targeted attribute is applied to the backing field instead of the property itself.

```C#
[Serializable]
public class Foo {
    [field: NonSerialized]
    public string MySecret { get; set; }
}
```
This used to be a warning: `warning CS0657: 'field' is not a valid attribute location for this declaration. Valid attribute locations for this declaration are 'property'. All attributes in this block will be ignored.`

:memo: The two failing tests are expected, as this PR needs be be rebased to get the new LanguageVersion.

:memo: No VB change. The `field` target doesn't exist in VB (only `assembly` and `module` are [supported](https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/concepts/attributes/index) as [explicit targets](http://source.roslyn.io/#Microsoft.CodeAnalysis.VisualBasic/Symbols/Source/AttributeLocation.vb,9bb23f949147f997,references)).

Fixes https://github.com/dotnet/roslyn/issues/22512
Implements https://github.com/dotnet/csharplang/issues/42
Spec https://github.com/dotnet/csharplang/blob/master/proposals/auto-prop-field-attrs.md