### PR TITLE
Adding more tests for readonly references feature

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -24166,5 +24166,39 @@ class C
 
             Assert.Equal("(System.Int32 A, System.Object B)", tupleSymbol.ConvertedType.ToTestDisplayString());
         }
+
+        [Fact]
+        public void SettingMembersOfReadOnlyTuple()
+        {
+            var text = @"
+public class C
+{
+    public static void Main()
+    {
+        var tuple = (1, 2);
+
+        tuple.Item1 = 3;
+    }
+}
+namespace System
+{
+    public readonly struct ValueTuple<T1, T2>
+    {
+        public readonly T1 Item1;
+        public readonly T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (10,9): error CS0191: A readonly field cannot be assigned to (except in a constructor or a variable initializer)
+                //         tuple.Item1 = 3;
+                Diagnostic(ErrorCode.ERR_AssgReadonly, "tuple.Item1").WithLocation(8, 9));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -9358,6 +9358,49 @@ public static class Program
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "x").WithArguments("1", "ref").WithLocation(11, 20));
         }
 
+        [Fact]
+        public void PassingArgumentsToInParameters_RefKind_Out()
+        {
+            var code = @"
+public static class Program
+{
+    public static void Method(in int p)
+    {
+        System.Console.WriteLine(p);
+    }
+    public static void Main()
+    {
+        int x;
+        Method(out x);
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (11,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
+                //         Method(out x);
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "x").WithArguments("1", "out").WithLocation(11, 20));
+        }
+
+        [Fact]
+        public void PassingArgumentsToInParameters_RefKind_In()
+        {
+            var code = @"
+public static class Program
+{
+    public static void Method(in int p)
+    {
+        System.Console.WriteLine(p);
+    }
+    public static void Main()
+    {
+        int x = 5;
+        Method(in x);
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: "5");
+        }
+
         [WorkItem(20799, "https://github.com/dotnet/roslyn/issues/20799")]
         [Fact]
         public void PassingArgumentsToInParameters_RefKind_None_WrongType()
@@ -9409,104 +9452,6 @@ public static class Program
         }
 
         [Fact]
-        public void PassingArgumentsToInParameters_RefKind_RefReadOnly()
-        {
-            var code = @"
-public static class Program
-{
-    public static void Method(in int p)
-    {
-        System.Console.WriteLine(p);
-    }
-    public static void Main()
-    {
-        int x = 5;
-        Method(ref readonly x);
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyDiagnostics(
-                // (11,20): error CS1525: Invalid expression term 'readonly'
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "readonly").WithArguments("readonly").WithLocation(11, 20),
-                // (11,20): error CS1026: ) expected
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "readonly").WithLocation(11, 20),
-                // (11,20): error CS1002: ; expected
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "readonly").WithLocation(11, 20),
-                // (11,20): error CS0106: The modifier 'readonly' is not valid for this item
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(11, 20),
-                // (11,30): error CS1001: Identifier expected
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(11, 30),
-                // (11,30): error CS1002: ; expected
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(11, 30),
-                // (11,30): error CS1513: } expected
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(11, 30),
-                // (11,29): error CS0118: 'x' is a variable but is used like a type
-                //         Method(ref readonly x);
-                Diagnostic(ErrorCode.ERR_BadSKknown, "x").WithArguments("x", "variable", "type").WithLocation(11, 29),
-                // (10,13): warning CS0219: The variable 'x' is assigned but its value is never used
-                //         int x = 5;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(10, 13)
-                );
-        }
-
-        [Fact]
-        public void PassingArgumentsToInParameters_RefKind_In()
-        {
-            var code = @"
-public static class Program
-{
-    public static void Method(in int p)
-    {
-        System.Console.WriteLine(p);
-    }
-    public static void Main()
-    {
-        int x = 5;
-        Method(in x);
-
-        byte y = 5;
-        Method(in y);
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyDiagnostics(
-                // (14,19): error CS1503: Argument 1: cannot convert from 'in byte' to 'in int'
-                //         Method(in y);
-                Diagnostic(ErrorCode.ERR_BadArgType, "y").WithArguments("1", "in byte", "in int").WithLocation(14, 19)
-                );
-        }
-
-        [Fact]
-        public void PassingArgumentsToInParameters_RefKind_Out()
-        {
-            var code = @"
-public static class Program
-{
-    public static void Method(in int p)
-    {
-        System.Console.WriteLine(p);
-    }
-    public static void Main()
-    {
-        int x = 5;
-        Method(out x);
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyDiagnostics(
-                // (11,20): error CS1615: Argument 1 may not be passed with the 'out' keyword
-                //         Method(out x);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "x").WithArguments("1", "out").WithLocation(11, 20));
-        }
-
-        [Fact]
         public void PassingInArgumentsOverloadedOnIn()
         {
             var code = @"
@@ -9536,6 +9481,52 @@ in: 5
 val: 3
 in: 2
 ");
+        }
+
+        [Fact]
+        public void PassingInArgumentsOverloadedOnInErr()
+        {
+            var code = @"
+public static class Program
+{
+    public static void Method(in int inP)
+    {
+        System.Console.WriteLine(""in: "" + inP);
+    }
+
+    public static void Method(int valP)
+    {
+        System.Console.WriteLine(""val: "" + valP);
+    }
+
+    public static void Main()
+    {
+        byte x = 5;
+        Method(in x);
+        Method('Q');
+        Method(3);
+        Method(valP: out 2);
+        Method(valP: in 2);
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                    // (17,19): error CS1503: Argument 1: cannot convert from 'in byte' to 'in int'
+                    //         Method(in x);
+                    Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "in byte", "in int").WithLocation(17, 19),
+                    // (18,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(in int)' and 'Program.Method(int)'
+                    //         Method('Q');
+                    Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(in int)", "Program.Method(int)").WithLocation(18, 9),
+                    // (19,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(in int)' and 'Program.Method(int)'
+                    //         Method(3);
+                    Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(in int)", "Program.Method(int)").WithLocation(19, 9),
+                    // (20,26): error CS1510: A ref or out value must be an assignable variable
+                    //         Method(valP: out 2);
+                    Diagnostic(ErrorCode.ERR_RefLvalueExpected, "2").WithLocation(20, 26),
+                    // (21,25): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                    //         Method(valP: in 2);
+                    Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "2").WithLocation(21, 25)
+                );
         }
 
         [Fact]
@@ -9582,49 +9573,176 @@ in: 2
         }
 
         [Fact]
-        public void PassingInArgumentsOverloadedOnInErr()
+        public void PassingInArgumentsOverloadedOnInIndexerErr()
+        {
+            var code = @"
+public class Program
+{
+    public int this[in int inP]
+    {
+        get
+        {
+            System.Console.WriteLine(""in: "" + inP);
+            return 1;
+        }
+    }
+
+    public int this[int valP]
+    {
+        get
+        {
+            System.Console.WriteLine(""val: "" + valP);
+            return 1;
+        }
+    }
+
+    public static void Main()
+    {
+        var p = new Program();
+        byte x = 5;
+
+        _ = p[in x];
+        _ = p['Q'];
+        _ = p[3];
+        _ = p[valP: out 2];
+        _ = p[inP: in 2];
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (27,18): error CS1503: Argument 1: cannot convert from 'in byte' to 'in int'
+                //         _ = p[in x];
+                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "in byte", "in int").WithLocation(27, 18),
+                // (28,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.this[in int]' and 'Program.this[int]'
+                //         _ = p['Q'];
+                Diagnostic(ErrorCode.ERR_AmbigCall, "p['Q']").WithArguments("Program.this[in int]", "Program.this[int]").WithLocation(28, 13),
+                // (29,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.this[in int]' and 'Program.this[int]'
+                //         _ = p[3];
+                Diagnostic(ErrorCode.ERR_AmbigCall, "p[3]").WithArguments("Program.this[in int]", "Program.this[int]").WithLocation(29, 13),
+                // (30,25): error CS1510: A ref or out value must be an assignable variable
+                //         _ = p[valP: out 2];
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "2").WithLocation(30, 25),
+                // (31,23): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                //         _ = p[inP: in 2];
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "2").WithLocation(31, 23));
+        }
+
+        [Fact]
+        public void PassingInArgumentsOverloadedOnIOperatorErr()
+        {
+            var code = @"
+class C
+{
+    public static int operator+(C a, C b) => 0;
+    public static int operator+(in C a, in C b) => 0;
+}
+public class Program
+{
+    public static void Main()
+    {
+        var a = new C();
+        var b = new C();
+        var result = a + b;
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (13,22): error CS0034: Operator '+' is ambiguous on operands of type 'C' and 'C'
+                //         var result = a + b;
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "a + b").WithArguments("+", "C", "C").WithLocation(13, 22));
+        }
+
+        [Fact]
+        public void PassingInArgumentsOverloadedOnInOptionalParameters()
         {
             var code = @"
 public static class Program
 {
-    public static void Method(in int inP)
+    public static void Method(in int inP = 0)
     {
         System.Console.WriteLine(""in: "" + inP);
     }
 
-    public static void Method(int valP)
+    public static void Method(int valP = 0)
     {
         System.Console.WriteLine(""val: "" + valP);
     }
 
     public static void Main()
     {
-        byte x = 5;
+        int x = 5;
         Method(in x);
-        Method('Q');
-        Method(3);
-        Method(valP: out 2);
-        Method(valP: in 2);
+        Method(valP: 3);
+        Method(inP: 2);
     }
 }";
 
-        CreateStandardCompilation(code).VerifyDiagnostics(
-                // (17,19): error CS1503: Argument 1: cannot convert from 'in byte' to 'in int'
-                //         Method(in x);
-                Diagnostic(ErrorCode.ERR_BadArgType, "x").WithArguments("1", "in byte", "in int").WithLocation(17, 19),
+            CompileAndVerify(code, expectedOutput: @"
+in: 5
+val: 3
+in: 2
+");
+        }
+
+        [Fact]
+        public void PassingInArgumentsOverloadedOnInErrOptionalParametersAmbiguous()
+        {
+            var code = @"
+public static class Program
+{
+    public static void Method(in int inP = 0)
+    {
+        System.Console.WriteLine(""in: "" + inP);
+    }
+
+    public static void Method(int valP = 0)
+    {
+        System.Console.WriteLine(""val: "" + valP);
+    }
+
+    public static void Main()
+    {
+        int x = 0;
+
+        Method();       // Should be an error
+        Method(in x);   // Should be OK
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
                 // (18,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(in int)' and 'Program.Method(int)'
-                //         Method('Q');
-                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(in int)", "Program.Method(int)").WithLocation(18, 9),
-                // (19,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(in int)' and 'Program.Method(int)'
-                //         Method(3);
-                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(in int)", "Program.Method(int)").WithLocation(19, 9),
-                // (20,26): error CS1510: A ref or out value must be an assignable variable
-                //         Method(valP: out 2);
-                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "2").WithLocation(20, 26),
-                // (21,25): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                //         Method(valP: in 2);
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "2").WithLocation(21, 25)
-            );
+                //         Method();       // Should be an error
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(in int)", "Program.Method(int)").WithLocation(18, 9));
+        }
+
+        [Fact]
+        public void PassingInArgumentsOverloadedOnInParams()
+        {
+            var code = @"
+using System;
+class Program
+{
+    void M(in int x) { Console.WriteLine(""in: "" + x); }
+    void M(params int[] p) { Console.WriteLine(""params: "" + p.Length); }
+
+    static void Main()
+    {
+        var p = new Program();
+
+        p.M();
+        p.M(1);
+        p.M(1, 2);
+
+        int x = 3;
+        p.M(in x);
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: 
+@"params: 0
+in: 1
+params: 2
+in: 3");
         }
 
         [Fact]


### PR DESCRIPTION
First commit closes #18171
Second commit makes sure correct error is reported when user defined tuple types exist with `readonly` modifier
Third commit closes #18172 

@jcouv @VSadov 
AFAIK, there is no define generic type inference with indexers or operators, because the enclosing type would need to have the generic parameter, thus making the inference happen on object creation, not operator or indexer call. Am I missing something?