### PR TITLE
Adjust diagnostic location for lambda that cannot convert (15.later)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2680,14 +2680,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Cannot convert async {0} to intended delegate type. An async {0} may return void, Task or Task<T>, none of which are convertible to '{1}'.
                     Error(diagnostics, ErrorCode.ERR_CantConvAsyncAnonFuncReturns,
-                        syntax,
+                        syntax.GetLocationForDiagnostics(),
                         lambda.MessageID.Localize(), lambda.ReturnType);
                 }
                 else
                 {
                     // Cannot convert {0} to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
                     Error(diagnostics, ErrorCode.ERR_CantConvAnonMethReturns,
-                        syntax,
+                        syntax.GetLocationForDiagnostics(),
                         lambda.MessageID.Localize());
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2676,7 +2676,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lambda = this.ContainingMemberOrLambda as LambdaSymbol;
             if ((object)lambda != null)
             {
-                Location location = GetLocationForDiagnostics(syntax);
+                Location location = getLocationForDiagnostics(syntax);
                 if (IsInAsyncMethod())
                 {
                     // Cannot convert async {0} to intended delegate type. An async {0} may return void, Task or Task<T>, none of which are convertible to '{1}'.
@@ -2692,16 +2692,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lambda.MessageID.Localize());
                 }
             }
-        }
 
-        private static Location GetLocationForDiagnostics(SyntaxNode node)
-        {
-            if (node is LambdaExpressionSyntax lambda)
+            Location getLocationForDiagnostics(SyntaxNode node)
             {
-                return Location.Create(lambda.SyntaxTree, Text.TextSpan.FromBounds(lambda.SpanStart, lambda.ArrowToken.Span.End));
-            }
+                if (node is LambdaExpressionSyntax lambdaSyntax)
+                {
+                    return Location.Create(lambdaSyntax.SyntaxTree,
+                        Text.TextSpan.FromBounds(lambdaSyntax.SpanStart, lambdaSyntax.ArrowToken.Span.End));
+                }
+                else if (node is AnonymousMethodExpressionSyntax anonymousMethodSyntax)
+                {
+                    return Location.Create(anonymousMethodSyntax.SyntaxTree,
+                        Text.TextSpan.FromBounds(anonymousMethodSyntax.SpanStart, anonymousMethodSyntax.ParameterList.Span.End));
+                }
 
-            return node.Location;
+                return node.Location;
+            }
         }
 
         private static bool IsValidStatementExpression(SyntaxNode syntax, BoundExpression expression)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2695,15 +2695,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Location getLocationForDiagnostics(SyntaxNode node)
             {
-                if (node is LambdaExpressionSyntax lambdaSyntax)
+                switch (node)
                 {
-                    return Location.Create(lambdaSyntax.SyntaxTree,
-                        Text.TextSpan.FromBounds(lambdaSyntax.SpanStart, lambdaSyntax.ArrowToken.Span.End));
-                }
-                else if (node is AnonymousMethodExpressionSyntax anonymousMethodSyntax)
-                {
-                    return Location.Create(anonymousMethodSyntax.SyntaxTree,
-                        Text.TextSpan.FromBounds(anonymousMethodSyntax.SpanStart, anonymousMethodSyntax.ParameterList.Span.End));
+                    case LambdaExpressionSyntax lambdaSyntax:
+                        return Location.Create(lambdaSyntax.SyntaxTree,
+                            Text.TextSpan.FromBounds(lambdaSyntax.SpanStart, lambdaSyntax.ArrowToken.Span.End));
+
+                    case AnonymousMethodExpressionSyntax anonymousMethodSyntax:
+                        return Location.Create(anonymousMethodSyntax.SyntaxTree,
+                            Text.TextSpan.FromBounds(anonymousMethodSyntax.SpanStart,
+                                anonymousMethodSyntax.ParameterList?.Span.End ?? anonymousMethodSyntax.DelegateKeyword.Span.End));
                 }
 
                 return node.Location;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2676,21 +2676,32 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lambda = this.ContainingMemberOrLambda as LambdaSymbol;
             if ((object)lambda != null)
             {
+                Location location = GetLocationForDiagnostics(syntax);
                 if (IsInAsyncMethod())
                 {
                     // Cannot convert async {0} to intended delegate type. An async {0} may return void, Task or Task<T>, none of which are convertible to '{1}'.
                     Error(diagnostics, ErrorCode.ERR_CantConvAsyncAnonFuncReturns,
-                        syntax.GetLocationForDiagnostics(),
+                        location,
                         lambda.MessageID.Localize(), lambda.ReturnType);
                 }
                 else
                 {
                     // Cannot convert {0} to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
                     Error(diagnostics, ErrorCode.ERR_CantConvAnonMethReturns,
-                        syntax.GetLocationForDiagnostics(),
+                        location,
                         lambda.MessageID.Localize());
                 }
             }
+        }
+
+        private static Location GetLocationForDiagnostics(SyntaxNode node)
+        {
+            if (node is LambdaExpressionSyntax lambda)
+            {
+                return Location.Create(lambda.SyntaxTree, Text.TextSpan.FromBounds(lambda.SpanStart, lambda.ArrowToken.Span.End));
+            }
+
+            return node.Location;
         }
 
         private static bool IsValidStatementExpression(SyntaxNode syntax, BoundExpression expression)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -293,15 +293,5 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
         }
-
-        internal static Location GetLocationForDiagnostics(this SyntaxNode node)
-        {
-            if (node is LambdaExpressionSyntax lambda)
-            {
-                return Location.Create(lambda.SyntaxTree, Text.TextSpan.FromBounds(lambda.SpanStart, lambda.ArrowToken.Span.End));
-            }
-
-            return node.Location;
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -293,5 +293,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
         }
+
+        internal static Location GetLocationForDiagnostics(this SyntaxNode node)
+        {
+            if (node is LambdaExpressionSyntax lambda)
+            {
+                return Location.Create(lambda.SyntaxTree, Text.TextSpan.FromBounds(lambda.SpanStart, lambda.ArrowToken.Span.End));
+            }
+
+            return node.Location;
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -2529,6 +2529,32 @@ class C
                 );
         }
 
+        [Fact, WorkItem(22662, "https://github.com/dotnet/roslyn/issues/22662")]
+        public void DelegateSquigglesArea()
+        {
+            var src = @"
+class C
+{
+    void M()
+    {
+        System.Func<bool, System.Action<bool>> x = x1 => delegate(bool x2)
+        {
+            error();
+        };
+    }
+}
+";
+            var comp = CreateStandardCompilation(src);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS0103: The name 'error' does not exist in the current context
+                //             error();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(8, 13),
+                // (6,58): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+                //         System.Func<bool, System.Action<bool>> x = x1 => delegate(bool x2)
+                Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "delegate(bool x2)").WithArguments("lambda expression").WithLocation(6, 58)
+                );
+        }
+
         [Fact]
         public void ThrowExpression_Lambda()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -2474,6 +2474,61 @@ class Test1<T>
                 );
         }
 
+        [Fact, WorkItem(22662, "https://github.com/dotnet/roslyn/issues/22662")]
+        public void LambdaSquigglesArea()
+        {
+            var src = @"
+class C
+{
+    void M()
+    {
+        System.Func<bool, System.Action<bool>> x = x1 => x2 =>
+        {
+            error();
+        };
+    }
+}
+";
+            var comp = CreateStandardCompilation(src);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS0103: The name 'error' does not exist in the current context
+                //             error();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(8, 13),
+                // (6,58): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+                //         System.Func<bool, System.Action<bool>> x = x1 => x2 =>
+                Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "x2 =>").WithArguments("lambda expression").WithLocation(6, 58)
+                );
+        }
+
+        [Fact, WorkItem(22662, "https://github.com/dotnet/roslyn/issues/22662")]
+        public void LambdaSquigglesAreaInAsync()
+        {
+            var src = @"
+class C
+{
+    void M()
+    {
+        System.Func<bool, System.Threading.Tasks.Task<System.Action<bool>>> x = async x1 => x2 =>
+        {
+            error();
+        };
+    }
+}
+";
+            var comp = CreateStandardCompilation(src);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS0103: The name 'error' does not exist in the current context
+                //             error();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(8, 13),
+                // (6,93): error CS4010: Cannot convert async lambda expression to delegate type 'Task<Action<bool>>'. An async lambda expression may return void, Task or Task<T>, none of which are convertible to 'Task<Action<bool>>'.
+                //         System.Func<bool, System.Threading.Tasks.Task<System.Action<bool>>> x = async x1 => x2 =>
+                Diagnostic(ErrorCode.ERR_CantConvAsyncAnonFuncReturns, "x2 =>").WithArguments("lambda expression", "System.Threading.Tasks.Task<System.Action<bool>>").WithLocation(6, 93),
+                // (6,90): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         System.Func<bool, System.Threading.Tasks.Task<System.Action<bool>>> x = async x1 => x2 =>
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "=>").WithLocation(6, 90)
+                );
+        }
+
         [Fact]
         public void ThrowExpression_Lambda()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -2555,6 +2555,32 @@ class C
                 );
         }
 
+        [Fact, WorkItem(22662, "https://github.com/dotnet/roslyn/issues/22662")]
+        public void DelegateWithoutArgumentsSquigglesArea()
+        {
+            var src = @"
+class C
+{
+    void M()
+    {
+        System.Func<bool, System.Action> x = x1 => delegate
+        {
+            error();
+        };
+    }
+}
+";
+            var comp = CreateStandardCompilation(src);
+            comp.VerifyDiagnostics(
+                // (8,13): error CS0103: The name 'error' does not exist in the current context
+                //             error();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "error").WithArguments("error").WithLocation(8, 13),
+                // (6,52): error CS1662: Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+                //         System.Func<bool, System.Action> x = x1 => delegate
+                Diagnostic(ErrorCode.ERR_CantConvAnonMethReturns, "delegate").WithArguments("lambda expression").WithLocation(6, 52)
+                );
+        }
+
         [Fact]
         public void ThrowExpression_Lambda()
         {


### PR DESCRIPTION
When working with nested lambdas, it is very easy to end up with the inner lambda entirely squiggled, which gets in the way of identifying and fixing the problem. In such cases, the fix is to use the lambda variables and the arrow as the span to report on (instead of the entire lambda).

Before:
![image](https://user-images.githubusercontent.com/12466233/31466758-321d3790-ae8d-11e7-9394-0844a3374d88.png)

After:
![image](https://user-images.githubusercontent.com/12466233/31476658-6be88252-aebc-11e7-9665-72c8fa316ab2.png)

Fixes https://github.com/dotnet/roslyn/issues/22662