### PR TITLE
Update xml docs on LanguageVersion (15.later)

### DIFF
--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -45,23 +45,27 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// C# language version 5
         /// </summary>
         /// <remarks> 
-        /// Features: async.
+        /// Features: async, caller info attributes.
         /// </remarks>
         CSharp5 = 5,
 
-        /// <summary> 
+        /// <summary>
         /// C# language version 6
         /// </summary>
         /// <remarks>
         /// <para>Features:</para>
         /// <list type="bullet">
-        /// <item><description>Using of a static class</description></item> 
-        /// <item><description>Auto-property initializers</description></item> 
-        /// <item><description>Expression-bodied methods and properties</description></item> 
-        /// <item><description>Null-propagating operator ?.</description></item> 
-        /// <item><description>Exception filters</description></item> 
-        /// </list> 
-        /// </remarks> 
+        /// <item><description>Using of a static class</description></item>
+        /// <item><description>Exception filters</description></item>
+        /// <item><description>Await in catch/finally blocks</description></item>
+        /// <item><description>Auto-property initializers</description></item>
+        /// <item><description>Expression-bodied methods and properties</description></item>
+        /// <item><description>Null-propagating operator ?.</description></item>
+        /// <item><description>String interpolation</description></item>
+        /// <item><description>nameof operator</description></item>
+        /// <item><description>Dictionary initializer</description></item>
+        /// </list>
+        /// </remarks>
         CSharp6 = 6,
 
         /// <summary>
@@ -93,7 +97,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <list type="bullet">
         /// <item><description>Async Main</description></item>
         /// <item><description>Default literal</description></item>
-        /// <item><description>Reference assemblies</description></item>
         /// <item><description>Inferred tuple element names</description></item>
         /// <item><description>Pattern-matching with generics</description></item>
         /// </list>

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -16,17 +16,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         Default = 0,
 
         /// <summary>
-        /// C# language version 1.0.
+        /// C# language version 1
         /// </summary>
         CSharp1 = 1,
 
         /// <summary>
-        /// C# language version 2.0.
+        /// C# language version 2
         /// </summary>
         CSharp2 = 2,
 
         /// <summary>
-        /// C# language version 3.0.
+        /// C# language version 3
         /// </summary>
         /// <remarks> 
         /// Features: LINQ.
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         CSharp3 = 3,
 
         /// <summary>
-        /// C# language version 4.0.
+        /// C# language version 4
         /// </summary>
         /// <remarks> 
         /// Features: dynamic.
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         CSharp4 = 4,
 
         /// <summary>
-        /// C# language version 5.0.
+        /// C# language version 5
         /// </summary>
         /// <remarks> 
         /// Features: async.
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         CSharp5 = 5,
 
         /// <summary> 
-        /// C# language version 6.0.
+        /// C# language version 6
         /// </summary>
         /// <remarks>
         /// <para>Features:</para>
@@ -65,18 +65,56 @@ namespace Microsoft.CodeAnalysis.CSharp
         CSharp6 = 6,
 
         /// <summary>
-        /// C# language version 7.
+        /// C# language version 7.0
         /// </summary>
+        /// <remarks>
+        /// <para>Features:</para>
+        /// <list type="bullet">
+        /// <item><description>Out variables</description></item>
+        /// <item><description>Pattern-matching</description></item>
+        /// <item><description>Tuples</description></item>
+        /// <item><description>Deconstruction</description></item>
+        /// <item><description>Discards</description></item>
+        /// <item><description>Local functions</description></item>
+        /// <item><description>Digit separators</description></item>
+        /// <item><description>Ref returns and locals</description></item>
+        /// <item><description>Generalized async return types</description></item>
+        /// <item><description>More expression-bodied members</description></item>
+        /// <item><description>Throw expressions</description></item>
+        /// </list>
+        /// </remarks>
         CSharp7 = 7,
 
         /// <summary>
         /// C# language version 7.1
         /// </summary>
+        /// <remarks>
+        /// <para>Features:</para>
+        /// <list type="bullet">
+        /// <item><description>Async Main</description></item>
+        /// <item><description>Default literal</description></item>
+        /// <item><description>Reference assemblies</description></item>
+        /// <item><description>Inferred tuple element names</description></item>
+        /// <item><description>Pattern-matching with generics</description></item>
+        /// </list>
+        /// </remarks>
         CSharp7_1 = 701,
 
         /// <summary>
         /// C# language version 7.2
         /// </summary>
+        /// <remarks>
+        /// <para>Features:</para>
+        /// <list type="bullet">
+        /// <item><description>Ref readonly</description></item>
+        /// <item><description>Ref and readonly structs</description></item>
+        /// <item><description>Ref extensions</description></item>
+        /// <item><description>Conditional ref operator</description></item>
+        /// <item><description>Private protected</description></item>
+        /// <item><description>Digit separators after base specifier</description></item>
+        /// <item><description>Non-trailing named arguments</description></item>
+        /// </list>
+        /// </remarks>
         CSharp7_2 = 702,
 
         /// <summary>


### PR DESCRIPTION
I noticed that some entries in the enum had xml docs, but recent ones didn't. Filling in the gaps.

Fixes https://github.com/dotnet/roslyn/issues/22701