### PR TITLE
Delay starting file watcher for metadata references in VS

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -61,6 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 if (_currentSnapshot == null)
                 {
+                    _fileChangeTracker.StartFileChangeListeningAsync();
                     UpdateSnapshot();
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -36,7 +36,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // Any legitimate change in a linked module will cause the assembly to change as well.
             _fileChangeTracker = new FileChangeTracker(provider.FileChangeService, filePath);
             _fileChangeTracker.UpdatedOnDisk += OnUpdatedOnDisk;
-            _fileChangeTracker.StartFileChangeListeningAsync();
+            // NOTE: We don't start the listening at this point because it hits the disk and we
+            // don't need to do that until someone actually asks us to see the contents, below.
         }
 
         public string FilePath


### PR DESCRIPTION
**Customer scenario**

When opening a solution in VS, Roslyn adds file watchers on assemblies referenced by the solution so it can update if any of them are changed. The issue is that the file watchers are started immediately, which causes unnecessary disk I/O during solution open because no one has actually looked at the references yet (and so changes don't make any difference). This can have an impact, especially on HDDs. Opening Roslyn on a HDD spends about 1% of the trace time setting up file watchers.

The fix is to not immediately start the file watcher but instead to wait until someone actually asks for the file (after which point they will start to care if it changes).

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/501653

**Workarounds, if any**

None.

**Risk**

Relatively low, we are just delaying starting a file watcher. It's possible this could cause something to get out of sync, but closing/reopening the project would fix it.

**Performance impact**

Improves performance, especially with solutions that have lots of references and are on HDDs.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Tracing solution load.

