### PR TITLE
Be resilient to the OOP process going away in TodoComments and DesignerAttribute processing

### DIFF
--- a/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
             if (keepAliveSession == null)
             {
                 // The client is not currently running, so we don't know the state of the DesignerAttribute.
-                return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: false, notApplicable: true);
+                return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: false, applicable: false);
             }
 
             var result = await keepAliveSession.TryInvokeAsync<DesignerAttributeResult>(

--- a/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
@@ -67,6 +67,11 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
         private async Task<DesignerAttributeResult> ScanDesignerAttributesInRemoteHostAsync(RemoteHostClient client, Document document, CancellationToken cancellationToken)
         {
             var keepAliveSession = await TryGetKeepAliveSessionAsync(client, cancellationToken).ConfigureAwait(false);
+            if (keepAliveSession == null)
+            {
+                // The client is not currently running, so we don't know the state of the DesignerAttribute.
+                return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: false, notApplicable: true);
+            }
 
             var result = await keepAliveSession.TryInvokeAsync<DesignerAttributeResult>(
                 nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync),

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -62,6 +62,11 @@ namespace Microsoft.CodeAnalysis.TodoComments
             RemoteHostClient client, Document document, IList<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken)
         {
             var keepAliveSession = await TryGetKeepAliveSessionAsync(client, cancellationToken).ConfigureAwait(false);
+            if (keepAliveSession == null)
+            {
+                // The client is not currently running, so we don't have any results.
+                return SpecializedCollections.EmptyList<TodoComment>();
+            }
 
             var result = await keepAliveSession.TryInvokeAsync<IList<TodoComment>>(
                 nameof(IRemoteTodoCommentService.GetTodoCommentsAsync),


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=503862

Ask Mode Template
---------------------
**Customer scenario**: The OOP process going away can cause crashes in certain features that don't properly expect it.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems?id=503862

**Workarounds, if any**: None

**Risk**: Very low. This adds null checks which take scenarios that were guaranteed to fail and attempts to recover from them.

**Performance impact**: None. We now return an empty result when the OOP process goes away instead of crash.

**Is this a regression from a previous update?**: No.

**Root cause analysis:** The OOP process normally doesn't go away, so it was missed in dogfooding. I don't believe we have the kind of integration test infrastructure required to simulate the presence/absence of the OOP process changing.

**How was the bug found?** Watson