### PR TITLE
Avoid leaking documents if an exception is thrown in AddDocument

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -1027,7 +1027,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 lock (_gate)
                 {
-                    _documents.Add(document.Id, document);
+                    // This condition ensures that if we throw an exception for either Add operation, the document will
+                    // not be added to either collection.
+                    if (!_documentMonikers.ContainsKey(document.Key.Moniker))
+                    {
+                        _documents.Add(document.Id, document);
+                    }
+
                     _documentMonikers.Add(document.Key.Moniker, document);
                 }
 


### PR DESCRIPTION
Fixes #22723

**Customer scenario**

It's unknown exactly how a customer enters this scenario. The stack trace was found via an exception instance in a heap dump during investigation of a known `ContainedDocument` leak. This change mitigates a memory leak resulting from improper use of a Roslyn API. The offending call sequence has not yet been identified, and will continue observing an `ArgumentException` at the same location it was previously.

**Bugs this fixes:**

#22723
vso : https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20IDE/_queries/edit/512706 

**Workarounds, if any**

None.

**Risk**

Low. This code does not change the exception which was getting thrown, or the location where it was getting thrown previously. Its only change is preventing the accidental GC rooting of a `ContainedDocument` instance during the error handling process.

**Performance impact**

Improves performance for impacted users by avoiding running out of memory.

**Is this a regression from a previous update?**

Unknown; the analysis tool which identified this bug only runs on heap dumps from 15.3.

**Root cause analysis:**

See "how was the bug found".

**How was the bug found?**

Found via automated analysis of heap dumps using tools developed for the identification of #22650.

**Test documentation updated?**

N/A