### PR TITLE
Only check for missing attributes when we know the syntax tree is available

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2068,23 +2068,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
-                ' If there are no attributes then this symbol is not Obsolete. Only apply this optimization for cases
-                ' where we know the syntax tree is loaded, or we could force a complete tree deserialization (and thus
-                ' no longer be an early return optimization).
-                If Not IsPartial AndAlso Not GetAttributeDeclarations().Any() Then
-                    Return Nothing
-                End If
-
-                If m_lazyCustomAttributesBag Is Nothing Then
-                    Return ObsoleteAttributeData.Uninitialized
-                End If
-
-                If m_lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed Then
-                    Dim data = DirectCast(m_lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData, TypeEarlyWellKnownAttributeData)
+                Dim lazyCustomAttributesBag = m_lazyCustomAttributesBag
+                If lazyCustomAttributesBag IsNot Nothing AndAlso lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed Then
+                    Dim data = DirectCast(lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData, CommonTypeEarlyWellKnownAttributeData)
                     Return If(data IsNot Nothing, data.ObsoleteAttributeData, Nothing)
-                Else
-                    Return ObsoleteAttributeData.Uninitialized
                 End If
+
+                For Each decl In TypeDeclaration.Declarations
+                    If decl.HasAnyAttributes Then
+                        Return ObsoleteAttributeData.Uninitialized
+                    End If
+                Next
+
+                Return Nothing
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2068,8 +2068,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend NotOverridable Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData
             Get
-                ' If there are no attributes then this symbol is not Obsolete.
-                If Not GetAttributeDeclarations().Any() Then
+                ' If there are no attributes then this symbol is not Obsolete. Only apply this optimization for cases
+                ' where we know the syntax tree is loaded, or we could force a complete tree deserialization (and thus
+                ' no longer be an early return optimization).
+                If Not IsPartial AndAlso Not GetAttributeDeclarations().Any() Then
                     Return Nothing
                 End If
 


### PR DESCRIPTION
Fixes a case where large projects repeatedly deserialized syntax trees, resulting in severe UI delays while typing.

**Customer scenario**

A large VB project contains a large number of partial classes spread across *very* large source files. While typing in the editor, memory pressure results in frequently GC reclaiming of weak references to syntax trees. Then, calls to `ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind` forces the syntax trees to be deserialized, further increasing memory pressure. The following shows a snippet of callees in PerfView where 4+GiB of memory was allocated while typing two short lines (less than 15 tokens).

![image](https://user-images.githubusercontent.com/1408396/31700455-206ef716-b38f-11e7-87c7-7e81736887b0.png)

**Bugs this fixes:**

Fixes [DevDiv 469472](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/469472).

**Workarounds, if any**

None known.

**Risk**

The risk appears to be very low, as the code was already meant to handle cases where the attribute data is not readily available.

**Performance impact**

Dramatic performance improvement for impacted users. The IDE goes from *fully unusable* to working normally.

**Is this a regression from a previous update?**

It does not appear to be a regression.

**Root cause analysis:**

Failed to test with partial class declarations that, when parsed, exceed the available memory of the process.

**How was the bug found?**

Customer reported.

**Test documentation updated?**

N/A