### PR TITLE
Allow null MethodGroup.Receiver in error cases

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             //cannot capture span-like types.
-            if (!method.IsStatic && methodGroup.Receiver.Type.IsByRefLikeType)
+            if (!method.IsStatic && methodGroup.Receiver?.Type?.IsByRefLikeType == true)
             {
                 return Conversion.NoConversion;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3581,7 +3581,8 @@ static class E
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var node = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(n => n.ToString() == "G").First();
-            model.GetSymbolInfo(node);
+            var info = model.GetSymbolInfo(node);
+            Assert.Equal("System.Object A.G(System.String s)", info.Symbol.ToTestDisplayString());
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Use a method group with an instance method but no implicit receiver.

**Bugs this fixes:**

#22757

**Workarounds, if any**

None.

**Risk**

Low risk. The fix is an additional `null` check.

**Performance impact**

None.

**Is this a regression from a previous update?**

Regression from 15.4. Found by internal customer.

