### PR TITLE
Remove exact version requirements in our Razor NuGet packages

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -17,7 +17,7 @@
       $commitPathMessage$
     </description>
     <dependencies>
-      <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />
+      <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="$version$" />
     </dependencies>
 
     <language>en-US</language>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -3,11 +3,10 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.Remote.Razor.ServiceHub</id>
     <summary>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
+      A private package for the Razor team to grant access to certain internal APIs.
     </summary>
     <description>
-      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
-      Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+      A private package for the Razor team to grant access to certain internal APIs.
 
       Supported Platforms:
       - .NET Framework 4.6

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient</id>
     <summary>
-      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+      A private package for the Razor team to grant access to certain internal APIs.
     </summary>
     <description>
-      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+      A private package for the Razor team to grant access to certain internal APIs.
 
       Supported Platforms:
         - .NET Framework 4.6

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -16,7 +16,7 @@
       $commitPathMessage$
     </description>
     <dependencies>
-      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />
+      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$version$" />
     </dependencies>
 
     <language>en-US</language>


### PR DESCRIPTION
These packages exist to provide private binaries for private API access to the Razor team. We were requiring strict versions, but this caused problems because we only produce pre-release packages for these two packages, and they'd want to upgrade to the release-versioned equivalent packages for our actually shipping packages. Doing so meant they'd end up with a bunch of version conflicts since our shipping packages also state exact versions.

Since these are private packages, never shipped with any compat guarantee, and the dependencies aren't really meaningful in any scenario, we can just loosen these.

FYI to @MattGertz as this is a tell-mode infrastructure only change that doesn't impact our shipped bits in any way. Just changes how a partner team consumes them in a way only for them.