### PR TITLE
remove duplicated references in BasicCompilerSyntaxTest project

### DIFF
--- a/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Syntax/BasicCompilerSyntaxTest.vbproj
@@ -20,9 +20,6 @@
     <ProjectReference Include="..\..\..\Test\Resources\Core\CompilerTestResources.csproj" />
     <ProjectReference Include="..\..\..\Test\Utilities\VisualBasic\BasicCompilerTestUtilities.vbproj" />
     <ProjectReference Include="..\..\Portable\BasicCodeAnalysis.vbproj" />
-    <ProjectReference Include="..\..\Portable\BasicCodeAnalysis.vbproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\PdbUtilities.csproj" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
this is test only change. I am cleaning this up since it causes issues on MSBuildWorkspace. unlike VSWorkspace, MSBuildWorkspace just bail out on invalid csproj.