### PR TITLE
Avoid showing language keywords after typing < in a doc comment

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -653,6 +653,70 @@ class C
 }", "cref", "langword");
         }
 
+        [WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task LangwordCompletionInPlainText()
+        {
+            await VerifyItemsExistAsync(@"
+class C
+{
+    /// <summary>
+    /// Some text $$
+    /// </summary>
+    static void Goo()
+    {
+    }
+}", "null", "sealed", "true", "false", "await");
+        }
+
+        [WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task LangwordCompletionAfterAngleBracket1()
+        {
+            await VerifyItemsAbsentAsync(@"
+class C
+{
+    /// <summary>
+    /// Some text <$$
+    /// </summary>
+    static void Goo()
+    {
+    }
+}", "null", "sealed", "true", "false", "await");
+        }
+
+        [WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task LangwordCompletionAfterAngleBracket2()
+        {
+            await VerifyItemsAbsentAsync(@"
+class C
+{
+    /// <summary>
+    /// Some text <s$$
+    /// </summary>
+    static void Goo()
+    {
+    }
+}", "null", "sealed", "true", "false", "await");
+        }
+
+        [WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task LangwordCompletionAfterAngleBracket3()
+        {
+            await VerifyItemsExistAsync(@"
+class C
+{
+    /// <summary>
+    /// Some text < $$
+    /// </summary>
+    static void Goo()
+    {
+    }
+}", "null", "sealed", "true", "false", "await");
+        }
+
         [WorkItem(11490, "https://github.com/dotnet/roslyn/issues/11490")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task SeeLangwordAttributeValue()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_XmlDoc.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_XmlDoc.vb
@@ -578,6 +578,31 @@ class c
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        Public Async Function InvokeWithOpenAngleCommitSeeOnTab() As Task
+
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class c
+{
+    /// $$
+    void goo() { }
+}
+            ]]></Document>)
+
+                state.SendTypeChars("<")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="see")
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+                ' /// <see cref="$$"/>
+                Await state.AssertLineTextAroundCaret("    /// <see cref=""", """/>")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function InvokeWithOpenAngleCommitSeeOnSpace() As Task
 
             Using state = TestState.CreateCSharpTestState(

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -774,6 +774,66 @@ End Class
             Await VerifyItemsExistAsync(text, "cref", "langword")
         End Function
 
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestLangwordCompletionInPlainText() As Task
+            Dim text = "
+Class C
+    ''' <summary>
+    ''' Some text $$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+"
+            Await VerifyItemsExistAsync(text, "Nothing", "Shared", "True", "False", "Await")
+        End Function
+
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function LangwordCompletionAfterAngleBracket1() As Task
+            Dim text = "
+Class C
+    ''' <summary>
+    ''' Some text <$$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+"
+            Await VerifyItemsAbsentAsync(text, "Nothing", "Shared", "True", "False", "Await")
+        End Function
+
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function LangwordCompletionAfterAngleBracket2() As Task
+            Dim text = "
+Class C
+    ''' <summary>
+    ''' Some text <s$$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+"
+            Await VerifyItemsAbsentAsync(text, "Nothing", "Shared", "True", "False", "Await")
+        End Function
+
+        <WorkItem(22789, "https://github.com/dotnet/roslyn/issues/22789")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function LangwordCompletionAfterAngleBracket3() As Task
+            Dim text = "
+Class C
+    ''' <summary>
+    ''' Some text < $$
+    ''' </summary>
+    Sub Goo()
+    End Sub
+End Class
+"
+            Await VerifyItemsExistAsync(text, "Nothing", "Shared", "True", "False", "Await")
+        End Function
+
         <WorkItem(11490, "https://github.com/dotnet/roslyn/issues/11490")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestSeeLangwordAttributeValue() As Task

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -831,7 +831,7 @@ Class C
     End Sub
 End Class
 "
-            Await VerifyItemsExistAsync(text, "Nothing", "Shared", "True", "False", "Await")
+            Await VerifyItemsAbsentAsync(text, "Nothing", "Shared", "True", "False", "Await")
         End Function
 
         <WorkItem(11490, "https://github.com/dotnet/roslyn/issues/11490")>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -101,7 +101,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement ||
                     token.Parent.Parent.IsParentKind(SyntaxKind.XmlElement))
                 {
-                    items.AddRange(GetNestedItems(declaredSymbol));
+                    // Avoid including language keywords when following < or <text, since these cases should only be
+                    // attempting to complete the XML name (which for language keywords is 'see'). While the parser
+                    // treats the 'name' in '< name' as an XML name, we don't treat it like that here so the completion
+                    // experience is consistent for '< ' and '< n'.
+                    var xmlNameOnly = token.IsKind(SyntaxKind.LessThanToken)
+                        || (token.Parent.IsKind(SyntaxKind.XmlName) && !token.HasLeadingTrivia);
+                    var includeKeywords = !xmlNameOnly;
+
+                    items.AddRange(GetNestedItems(declaredSymbol, includeKeywords));
                 }
 
                 if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement && ((XmlElementSyntax)token.Parent.Parent).StartTag.Name.LocalName.ValueText == ListElementName)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return CreateCompletionItem(prefix, "<" + prefix, suffix);
         }
 
-        protected IEnumerable<CompletionItem> GetNestedItems(ISymbol symbol)
+        protected IEnumerable<CompletionItem> GetNestedItems(ISymbol symbol, bool includeKeywords)
         {
             var items = s_nestedTagNames.Select(GetItem);
 
@@ -135,7 +135,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                              .Concat(GetTypeParamRefItems(symbol));
             }
 
-            items = items.Concat(GetKeywordNames().Select(CreateLangwordCompletionItem));
+            if (includeKeywords)
+            {
+                items = items.Concat(GetKeywordNames().Select(CreateLangwordCompletionItem));
+            }
 
             return items;
         }

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.vb
@@ -111,11 +111,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
             If grandParent.IsKind(SyntaxKind.XmlElement) Then
                 ' Avoid including language keywords when following < Or <text, since these cases should only be
-                ' attempting to complete the XML name (which for language keywords Is 'see'). While the parser
-                ' treats the 'name' in '< name' as an XML name, we don't treat it like that here so the completion
-                ' experience Is consistent for '< ' and '< n'.
-                Dim xmlNameOnly = token.IsKind(SyntaxKind.LessThanToken) OrElse
-                    (token.Parent.IsKind(SyntaxKind.XmlName) AndAlso Not token.HasLeadingTrivia)
+                ' attempting to complete the XML name (which for language keywords Is 'see'). The VB parser treats
+                ' spaces after a < character as trailing whitespace, even if an identifier follows it on the same line.
+                ' Therefore, the consistent VB experience says we never show keywords for < followed by spaces.
+                Dim xmlNameOnly = token.IsKind(SyntaxKind.LessThanToken) OrElse token.Parent.IsKind(SyntaxKind.XmlName)
                 Dim includeKeywords = Not xmlNameOnly
 
                 items.AddRange(GetNestedItems(symbol, includeKeywords))


### PR DESCRIPTION
Fixes #22789

**Customer scenario**

A user types `<se` followed by <kbd>Space</kbd> in a documentation comment. The IDE inserts `<see langword="sealed"/>`, instead of the expected `<see cref=""/>`.

**Bugs this fixes:**

#22789
[vso](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/519815)

**Workarounds, if any**

Type `<see` instead.

**Risk**

Low.

**Performance impact**

Negligible.

**Is this a regression from a previous update?**

Yes. The expected behavior is long-standing completion behavior in this context.

**Root cause analysis:**

Our testing focused on proper behavior of the new completion functionality, and missed a subtle overlap between the old and new scenarios.

**How was the bug found?**

Dogfooding.

**Test documentation updated?**

N/A