### PR TITLE
Make StructLayout work on Mono 64-bit

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -98,7 +98,12 @@ namespace Microsoft.CodeAnalysis
         /// This structure stores the 20-byte SHA 1 hash as an inline value rather than requiring the use of
         /// <c>byte[]</c>.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = 20)]
+        /// <remarks>
+        /// Pack = 4 is specified to work around a Mono runtime behavior where on 64-bit the size of the
+        /// struct would be 24 and not 20 due to alignment (it ignores Size = 20, but Pack = 4 does it).
+        /// Without this fix the ctor would throw because it would use sizeof(Sha1Hash) == 24.
+        /// </remarks>
+        [StructLayout(LayoutKind.Explicit, Size = 20, Pack = 4)]
         private struct Sha1Hash : IEquatable<Sha1Hash>
         {
             [FieldOffset(0)]


### PR DESCRIPTION
Need to work around a Mono 64 behavior where on 64-bit the size of the struct would be 24 and not 20 due to alignment (it ignores Size = 20, but Pack = 4 does it). Without this fix the ctor would throw because it would use sizeof(Sha1Hash) == 24.

**Customer scenario**

When Roslyn is hosted in VS for Mac (64-bit Mono on Mac) reading metadata references crashes with this stack:
```
1) TestBug58060 (MonoDevelop.CSharp.Refactoring.CSharpFindReferencesProviderTests.TestBug58060)
   System.AggregateException : One or more errors occurred.
  ----> System.ArgumentException : checksum must be a SHA-1 hash
Parameter name: checksum
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x00037] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:187 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:156 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:128 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/compilerservices/TaskAwaiter.cs:535 
  at Microsoft.CodeAnalysis.FindSymbols.SyntaxTreeIndex+<GetChecksumAsync>d__53.MoveNext () [0x00087] in <b063dbb7454e41f1a6073b72b22d712e>:0 
```

**Workarounds, if any**

None known

**Risk**

Low, fix verified

**Performance impact**

None

**Is this a regression from a previous update?**

Regression since June 2017

**Root cause analysis:**

Test Roslyn on Mono 64-bit

**How was the bug found?**

Adoption of Roslyn by VS for Mac team

