### PR TITLE
UseInferredMemberNamed codefix show treat spaces as elastic

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -39,7 +39,7 @@ class C
     void M()
     {
         int a = 1;
-        var t = ( a, 2);
+        var t = (a, 2);
     }
 }", parseOptions: s_parseOptions);
         }
@@ -110,7 +110,7 @@ class C
     void M()
     {
         int a = 1;
-        var t = new { [||]a=a, 2 };
+        var t = new { [||]a= a, 2 };
     }
 }",
 @"

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseInferredMemberN
 Class C
     Sub M()
         Dim a As Integer = 1
-        Dim t = ([||]a:=a, 2)
+        Dim t = ( [||]a:= a, 2)
     End Sub
 End Class
 ",
@@ -46,7 +46,7 @@ End Class
 Class C
     Sub M()
         Dim a As Integer = 2
-        Dim t = (1, [||]a:=a)
+        Dim t = (1,  [||]a:= a )
     End Sub
 End Class
 ",

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
             foreach (var diagnostic in diagnostics)
             {
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
-                editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia);
+                editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia | SyntaxRemoveOptions.AddElasticMarker);
             }
 
             return SpecializedTasks.EmptyTask;

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                 Dim node = root.FindNode(diagnostic.Location.SourceSpan)
                 Select Case node.Kind
                     Case SyntaxKind.NameColonEquals
-                        editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia)
+                        editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia Or SyntaxRemoveOptions.AddElasticMarker)
                         Exit Select
 
                     Case SyntaxKind.NamedFieldInitializer


### PR DESCRIPTION
**Customer scenario**

With language version 7.1, use the "simplify tuple name" feature to simplify the "a" member below:
```C#
            int a = 1;
            var t = (a: a, 2); // becomes `var t = ( a, 2);` with extra space before `a`
```

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/22347

**Workarounds, if any**
Format selection or document.

**Risk**
**Performance impact**
Low. This PR only affects this one refactoring.

**Is this a regression from a previous update?**
No.

**How was the bug found?**
Reported by customers.

@sharwell @rchande @dotnet/roslyn-ide for review. Also, please advise whether this should be considered for 15.5 or moved out to 15.later. Thanks