### PR TITLE
Test only change: Enable VB PDB conversion tests that involve hoisted locals

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -36,8 +36,8 @@
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.2.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta1-62217-01</MicrosoftDiaSymReaderConverterVersion>
-    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62217-01</MicrosoftDiaSymReaderConverterXmlVersion>
+    <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta1-62221-01</MicrosoftDiaSymReaderConverterVersion>
+    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62221-01</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.7.0-beta-25631</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.4.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetIBCMerge>4.7.2-alpha-00001</MicrosoftDotNetIBCMerge>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -473,7 +473,7 @@ End Class
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact>
@@ -543,7 +543,7 @@ End Class
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
@@ -622,7 +622,7 @@ End Class
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact>
@@ -693,7 +693,7 @@ End Class
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <WorkItem(1085911, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1085911")>
@@ -1026,7 +1026,7 @@ End Class"
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -235,7 +235,7 @@ End Module
             </scope>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
@@ -297,7 +297,7 @@ End Class
             </scope>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact, WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>
@@ -408,7 +408,7 @@ End Class
             </scope>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact(), WorkItem(827337, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/827337"), WorkItem(836491, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/836491")>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -4549,7 +4549,7 @@ End Class"
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
 
         <Fact>
@@ -4602,9 +4602,7 @@ End Class"
             </asyncInfo>
         </method>
     </methods>
-</symbols>, options:=PdbValidationOptions.SkipConversionValidation) ' TODO: ResumableLocals conversion (https://github.com/dotnet/symreader-converter/issues/80)
+</symbols>)
         End Sub
-
     End Class
-
 End Namespace

--- a/src/Test/PdbUtilities/Pdb/PdbValidation.cs
+++ b/src/Test/PdbUtilities/Pdb/PdbValidation.cs
@@ -376,12 +376,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 RemoveNonPortableElements(expectedXml);
             }
 
-            if (actualIsPortable || actualIsConverted)
+            if (actualIsPortable)
             {
                 RemoveElementsWithSpecifiedFormat(expectedXml, "windows");
             }
-
-            if (!actualIsPortable || actualIsConverted)
+            else 
             {
                 RemoveElementsWithSpecifiedFormat(expectedXml, "portable");
             }
@@ -437,7 +436,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private static void RemoveNonPortableElements(XElement expectedNativePdb)
         {
-            // The following elements are never presents in Portable PDB.
+            // The following elements are never present in Portable PDB.
             RemoveElements(from e in expectedNativePdb.DescendantsAndSelf()
                            where e.Name == "forwardIterator" ||
                                  e.Name == "forwardToModule" ||


### PR DESCRIPTION
Upgrades to the new version of PDB converter that implements conversion of state machine hoisted locals and enables previously skipped VB tests.