### PR TITLE
added completion set and fix all telemetry to track performance

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
@@ -179,8 +179,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         {
             AssertIsForeground();
 
-            // if completion is not shown to users yet, then
-            // log will be marked as cancelled.
+            // we need to distinguish a case where completion UI is shown to users and then dismissed
+            // or it got dismissed before UI is shown to users in telemetry events.
+            // we use cancellation for it. here, we raise cancellation for trackLogSession, and then
+            // call ReportPerformance. if UI is already shown, then it will become noop. if it didn't yet,
+            // then event will be fired with cancellation on.
             _trackLogSession.Cancel();
 
             ReportPerformance();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CompletionPresenterSession.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             ExecuteKeyboardCommand(IntellisenseKeyboardCommand.PageDown);
         }
 
-        public void ReportPerformance(bool force = false)
+        public void ReportPerformance()
         {
             // we only report once. after that, this becomes noop
             _logger?.Dispose();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/RoslynCompletionSet.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/RoslynCompletionSet.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -63,6 +62,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
         {
             // Do nothing.  We do *not* want the default behavior that the editor has.  We've
             // already computed the best match.
+
+            // this will get called right after completion set is painted on the screen.
+            // we will use this chance to report completion set performance
+            CompletionPresenterSession.ReportPerformance();
         }
 
         public override void Filter()

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
@@ -51,7 +51,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         private async Task<CodeAction> GetFixAllCodeActionAsync(FixAllContext fixAllContext)
         {
-            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation, fixAllContext.CancellationToken))
+            using (Logger.LogBlock(
+                FunctionId.CodeFixes_FixAllOccurrencesComputation,
+                KeyValueLogMessage.Create(LogType.UserAction, m =>
+                {
+                    m[FixAllLogger.CorrelationId] = fixAllContext.State.CorrelationId;
+                    m[FixAllLogger.FixAllScope] = fixAllContext.State.Scope.ToString();
+                }),
+                fixAllContext.CancellationToken))
             {
                 CodeAction action = null;
                 try
@@ -60,17 +67,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 }
                 catch (OperationCanceledException)
                 {
-                    FixAllLogger.LogComputationResult(completed: false);
+                    FixAllLogger.LogComputationResult(fixAllContext.State.CorrelationId, completed: false);
                 }
                 finally
                 {
                     if (action != null)
                     {
-                        FixAllLogger.LogComputationResult(completed: true);
+                        FixAllLogger.LogComputationResult(fixAllContext.State.CorrelationId, completed: true);
                     }
                     else
                     {
-                        FixAllLogger.LogComputationResult(completed: false, timedOut: true);
+                        FixAllLogger.LogComputationResult(fixAllContext.State.CorrelationId, completed: false, timedOut: true);
                     }
                 }
 
@@ -106,6 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     codeAction.Title,
                     fixAllState.Project.Language,
                     workspace,
+                    fixAllState.CorrelationId,
                     cancellationToken);
                 if (newSolution == null)
                 {
@@ -124,10 +132,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             string fixAllTopLevelHeader,
             string languageOpt,
             Workspace workspace,
+            int? correlationId = null,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesPreviewChanges, cancellationToken))
+            using (Logger.LogBlock(
+                FunctionId.CodeFixes_FixAllOccurrencesPreviewChanges,
+                KeyValueLogMessage.Create(LogType.UserAction, m =>
+                {
+                    // only set when correlation id is given
+                    // we might not have this info for suppression
+                    if (correlationId.HasValue)
+                    {
+                        m[FixAllLogger.CorrelationId] = correlationId;
+                    }
+                }),
+                cancellationToken))
             {
                 var previewService = workspace.Services.GetService<IPreviewDialogService>();
                 var glyph = languageOpt == null
@@ -148,11 +168,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (changedSolution == null)
                 {
                     // User clicked cancel.
-                    FixAllLogger.LogPreviewChangesResult(applied: false);
+                    FixAllLogger.LogPreviewChangesResult(correlationId, applied: false);
                     return null;
                 }
 
-                FixAllLogger.LogPreviewChangesResult(applied: true, allChangesApplied: changedSolution == newSolution);
+                FixAllLogger.LogPreviewChangesResult(correlationId, applied: true, allChangesApplied: changedSolution == newSolution);
                 return changedSolution;
             }
         }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
@@ -4,16 +4,12 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
@@ -87,7 +83,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             this.AssertIsForeground();
-            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, cancellationToken))
+
+            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = _fixAllState.CorrelationId), cancellationToken))
             {
                 base.InnerInvoke(progressTracker, cancellationToken);
             }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/FixAllSuggestedAction.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         {
             this.AssertIsForeground();
 
-            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = _fixAllState.CorrelationId), cancellationToken))
+            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesSession, FixAllLogger.CreateCorrelationLogMessage(_fixAllState.CorrelationId), cancellationToken))
             {
                 base.InnerInvoke(progressTracker, cancellationToken);
             }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -6,10 +6,9 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Imaging;
@@ -164,10 +163,37 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 // We'll now show progress as we apply the action.
                 progressTracker.Clear();
 
-                // Note: we want to block the UI thread here so the user cannot modify anything while the codefix applies
-                EditHandler.ApplyAsync(Workspace, getFromDocument(),
-                    operations.ToImmutableArray(), CodeAction.Title,
-                    progressTracker, cancellationToken).Wait(cancellationToken);
+                using (Logger.LogBlock(
+                    FunctionId.CodeFixes_ApplyChanges, KeyValueLogMessage.Create(LogType.UserAction, m => CreateLogProperties(m)), cancellationToken))
+                {
+                    // Note: we want to block the UI thread here so the user cannot modify anything while the codefix applies
+                    EditHandler.ApplyAsync(Workspace, getFromDocument(),
+                        operations.ToImmutableArray(), CodeAction.Title,
+                        progressTracker, cancellationToken).Wait(cancellationToken);
+                }
+            }
+        }
+
+        private void CreateLogProperties(Dictionary<string, object> map)
+        {
+            // set various correlation info
+            if (CodeAction is CodeFixes.FixSomeCodeAction fixSome)
+            {
+                // fix all correlation info
+                map[CodeFixes.FixAllLogger.CorrelationId] = fixSome.FixAllState.CorrelationId;
+                map[CodeFixes.FixAllLogger.FixAllScope] = fixSome.FixAllState.Scope.ToString();
+            }
+
+            if (TryGetTelemetryId(out Guid telemetryId))
+            {
+                // Lightbulb correlation info
+                map["TelemetryId"] = telemetryId.ToString();
+            }
+
+            if (this is ITelemetryDiagnosticID<string> diagnosticId)
+            {
+                // save what it is actually fixing
+                map["DiagnosticId"] = diagnosticId.GetDiagnosticID();
             }
         }
 

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -50,16 +50,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             if (documentsAndDiagnosticsToFixMap?.Any() == true)
             {
-                FixAllLogger.LogDiagnosticsStats(documentsAndDiagnosticsToFixMap);
+                FixAllLogger.LogDiagnosticsStats(fixAllState.CorrelationId, documentsAndDiagnosticsToFixMap);
 
                 var diagnosticsAndCodeActions = await GetDiagnosticsAndCodeActions(
                     documentsAndDiagnosticsToFixMap, fixAllState, cancellationToken).ConfigureAwait(false);
 
                 if (diagnosticsAndCodeActions.Length > 0)
                 {
-                    using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Merge, cancellationToken))
+                    var functionId = FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Merge;
+                    using (Logger.LogBlock(
+                        functionId,
+                        KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
+                        cancellationToken))
                     {
-                        FixAllLogger.LogFixesToMergeStats(diagnosticsAndCodeActions.Length);
+                        FixAllLogger.LogFixesToMergeStats(functionId, fixAllState.CorrelationId, diagnosticsAndCodeActions.Length);
                         return await TryGetMergedFixAsync(
                             diagnosticsAndCodeActions, fixAllState, cancellationToken).ConfigureAwait(false);
                     }
@@ -74,7 +78,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             FixAllState fixAllState, CancellationToken cancellationToken)
         {
             var fixesBag = new ConcurrentBag<(Diagnostic diagnostic, CodeAction action)>();
-            using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Fixes, cancellationToken))
+            using (Logger.LogBlock(
+                FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Fixes,
+                KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
+                cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -131,10 +138,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             if (projectsAndDiagnosticsToFixMap != null && projectsAndDiagnosticsToFixMap.Any())
             {
-                FixAllLogger.LogDiagnosticsStats(projectsAndDiagnosticsToFixMap);
+                FixAllLogger.LogDiagnosticsStats(fixAllState.CorrelationId, projectsAndDiagnosticsToFixMap);
 
                 var bag = new ConcurrentBag<(Diagnostic diagnostic, CodeAction action)>();
-                using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Fixes, cancellationToken))
+                using (Logger.LogBlock(
+                    FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Fixes,
+                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
+                    cancellationToken))
                 {
                     var projects = projectsAndDiagnosticsToFixMap.Keys;
                     var tasks = projects.Select(p => AddProjectFixesAsync(
@@ -146,9 +156,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 var result = bag.ToImmutableArray();
                 if (result.Length > 0)
                 {
-                    using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Merge, cancellationToken))
+                    var functionId = FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Merge;
+                    using (Logger.LogBlock(functionId, cancellationToken))
                     {
-                        FixAllLogger.LogFixesToMergeStats(result.Length);
+                        FixAllLogger.LogFixesToMergeStats(functionId, fixAllState.CorrelationId, result.Length);
                         return await TryGetMergedFixAsync(
                             result, fixAllState, cancellationToken).ConfigureAwait(false);
                     }

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -58,10 +58,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 if (diagnosticsAndCodeActions.Length > 0)
                 {
                     var functionId = FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Merge;
-                    using (Logger.LogBlock(
-                        functionId,
-                        KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
-                        cancellationToken))
+                    using (Logger.LogBlock(functionId, FixAllLogger.CreateCorrelationLogMessage(fixAllState.CorrelationId), cancellationToken))
                     {
                         FixAllLogger.LogFixesToMergeStats(functionId, fixAllState.CorrelationId, diagnosticsAndCodeActions.Length);
                         return await TryGetMergedFixAsync(
@@ -80,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             var fixesBag = new ConcurrentBag<(Diagnostic diagnostic, CodeAction action)>();
             using (Logger.LogBlock(
                 FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Fixes,
-                KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
+                FixAllLogger.CreateCorrelationLogMessage(fixAllState.CorrelationId),
                 cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -143,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 var bag = new ConcurrentBag<(Diagnostic diagnostic, CodeAction action)>();
                 using (Logger.LogBlock(
                     FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Fixes,
-                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllState.CorrelationId),
+                    FixAllLogger.CreateCorrelationLogMessage(fixAllState.CorrelationId),
                     cancellationToken))
                 {
                     var projects = projectsAndDiagnosticsToFixMap.Keys;

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
@@ -56,7 +56,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 var cancellationToken = fixAllContext.CancellationToken;
 
-                using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, cancellationToken))
+                using (Logger.LogBlock(
+                    FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Diagnostics,
+                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllContext.State.CorrelationId),
+                    cancellationToken))
                 {
                     var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
                     var projectsToFix = ImmutableArray<Project>.Empty;
@@ -179,7 +182,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             internal virtual async Task<ImmutableDictionary<Project, ImmutableArray<Diagnostic>>> GetProjectDiagnosticsToFixAsync(
                 FixAllContext fixAllContext)
             {
-                using (Logger.LogBlock(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, fixAllContext.CancellationToken))
+                using (Logger.LogBlock(
+                    FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Diagnostics,
+                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllContext.State.CorrelationId),
+                    fixAllContext.CancellationToken))
                 {
                     var project = fixAllContext.Project;
                     if (project != null)

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.DiagnosticProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
                 using (Logger.LogBlock(
                     FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Diagnostics,
-                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllContext.State.CorrelationId),
+                    FixAllLogger.CreateCorrelationLogMessage(fixAllContext.State.CorrelationId),
                     cancellationToken))
                 {
                     var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 using (Logger.LogBlock(
                     FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Diagnostics,
-                    KeyValueLogMessage.Create(LogType.UserAction, m => m[FixAllLogger.CorrelationId] = fixAllContext.State.CorrelationId),
+                    FixAllLogger.CreateCorrelationLogMessage(fixAllContext.State.CorrelationId),
                     fixAllContext.CancellationToken))
                 {
                     var project = fixAllContext.Project;

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
@@ -146,5 +146,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 m[TotalFixesToMerge] = count;
             }));
         }
+
+        public static LogMessage CreateCorrelationLogMessage(int correlationId)
+        {
+            return KeyValueLogMessage.Create(LogType.UserAction, m => m[CorrelationId] = correlationId);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
 
@@ -14,123 +12,138 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// </summary>
     internal static class FixAllLogger
     {
+        // correlation id of all events related to same instance of fix all
+        public const string CorrelationId = nameof(CorrelationId);
+
         // Fix all context logging.
-        private const string s_codeFixProvider = "CodeFixProvider";
-        private const string s_codeActionEquivalenceKey = "CodeActionEquivalenceKey";
-        private const string s_fixAllScope = "FixAllScope";
-        private const string s_languageName = "LanguageName";
-        private const string s_documentCount = "DocumentCount";
+        private const string CodeFixProvider = nameof(CodeFixProvider);
+        private const string CodeActionEquivalenceKey = nameof(CodeActionEquivalenceKey);
+        public const string FixAllScope = nameof(FixAllScope);
+        private const string LanguageName = nameof(LanguageName);
+        private const string DocumentCount = nameof(DocumentCount);
 
         // Fix all computation result logging.
-        private const string s_result = "Result";
-        private const string s_completed = "Completed";
-        private const string s_timedOut = "TimedOut";
-        private const string s_cancelled = "Cancelled";
-        private const string s_allChangesApplied = "AllChangesApplied";
-        private const string s_subsetOfChangesApplied = "SubsetOfChangesApplied";
+        private const string Result = nameof(Result);
+        private const string Completed = nameof(Completed);
+        private const string TimedOut = nameof(TimedOut);
+        private const string Cancelled = nameof(Cancelled);
+        private const string AllChangesApplied = nameof(AllChangesApplied);
+        private const string SubsetOfChangesApplied = nameof(SubsetOfChangesApplied);
 
         // Diagnostics and fixes logging.
-        private const string s_documentsWithDiagnosticsToFix = "DocumentsWithDiagnosticsToFix";
-        private const string s_projectsWithDiagnosticsToFix = "ProjectsWithDiagnosticsToFix";
-        private const string s_totalDiagnosticsToFix = "TotalDiagnosticsToFix";
-        private const string s_totalFixesToMerge = "TotalFixesToMerge";
+        private const string DocumentsWithDiagnosticsToFix = nameof(DocumentsWithDiagnosticsToFix);
+        private const string ProjectsWithDiagnosticsToFix = nameof(ProjectsWithDiagnosticsToFix);
+        private const string TotalDiagnosticsToFix = nameof(TotalDiagnosticsToFix);
+        private const string TotalFixesToMerge = nameof(TotalFixesToMerge);
 
         public static void LogState(FixAllState fixAllState, bool isInternalCodeFixProvider)
         {
             Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesContext, KeyValueLogMessage.Create(m =>
             {
+                m[CorrelationId] = fixAllState.CorrelationId;
+
                 if (isInternalCodeFixProvider)
                 {
-                    m[s_codeFixProvider] = fixAllState.CodeFixProvider.GetType().FullName;
-                    m[s_codeActionEquivalenceKey] = fixAllState.CodeActionEquivalenceKey;
-                    m[s_languageName] = fixAllState.Project.Language;
+                    m[CodeFixProvider] = fixAllState.CodeFixProvider.GetType().FullName;
+                    m[CodeActionEquivalenceKey] = fixAllState.CodeActionEquivalenceKey;
+                    m[LanguageName] = fixAllState.Project.Language;
                 }
                 else
                 {
-                    m[s_codeFixProvider] = fixAllState.CodeFixProvider.GetType().FullName.GetHashCode().ToString();
-                    m[s_codeActionEquivalenceKey] = fixAllState.CodeActionEquivalenceKey != null ? fixAllState.CodeActionEquivalenceKey.GetHashCode().ToString() : null;
-                    m[s_languageName] = fixAllState.Project.Language.GetHashCode().ToString();
+                    m[CodeFixProvider] = fixAllState.CodeFixProvider.GetType().FullName.GetHashCode().ToString();
+                    m[CodeActionEquivalenceKey] = fixAllState.CodeActionEquivalenceKey != null ? fixAllState.CodeActionEquivalenceKey.GetHashCode().ToString() : null;
+                    m[LanguageName] = fixAllState.Project.Language.GetHashCode().ToString();
                 }
 
-                m[s_fixAllScope] = fixAllState.Scope.ToString();
+                m[FixAllScope] = fixAllState.Scope.ToString();
                 switch (fixAllState.Scope)
                 {
                     case CodeFixes.FixAllScope.Project:
-                        m[s_documentCount] = fixAllState.Project.DocumentIds.Count;
+                        m[DocumentCount] = fixAllState.Project.DocumentIds.Count;
                         break;
 
                     case CodeFixes.FixAllScope.Solution:
-                        m[s_documentCount] = fixAllState.Solution.Projects.Sum(p => p.DocumentIds.Count);
+                        m[DocumentCount] = fixAllState.Solution.Projects.Sum(p => p.DocumentIds.Count);
                         break;
                 }
             }));
         }
 
-        public static void LogComputationResult(bool completed, bool timedOut = false)
+        public static void LogComputationResult(int correlationId, bool completed, bool timedOut = false)
         {
             Contract.ThrowIfTrue(completed && timedOut);
 
             string value;
             if (completed)
             {
-                value = s_completed;
+                value = Completed;
             }
             else if (timedOut)
             {
-                value = s_timedOut;
+                value = TimedOut;
             }
             else
             {
-                value = s_cancelled;
+                value = Cancelled;
             }
 
             Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation, KeyValueLogMessage.Create(m =>
             {
-                m[s_result] = value;
+                m[CorrelationId] = correlationId;
+                m[Result] = value;
             }));
         }
 
-        public static void LogPreviewChangesResult(bool applied, bool allChangesApplied = true)
+        public static void LogPreviewChangesResult(int? correlationId, bool applied, bool allChangesApplied = true)
         {
             string value;
             if (applied)
             {
-                value = allChangesApplied ? s_allChangesApplied : s_subsetOfChangesApplied;
+                value = allChangesApplied ? AllChangesApplied : SubsetOfChangesApplied;
             }
             else
             {
-                value = s_cancelled;
+                value = Cancelled;
             }
 
             Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesPreviewChanges, KeyValueLogMessage.Create(m =>
             {
-                m[s_result] = value;
+                // we might not have this info for suppression
+                if (correlationId.HasValue)
+                {
+                    m[CorrelationId] = correlationId;
+                }
+
+                m[Result] = value;
             }));
         }
 
-        public static void LogDiagnosticsStats(ImmutableDictionary<Document, ImmutableArray<Diagnostic>> documentsAndDiagnosticsToFixMap)
+        public static void LogDiagnosticsStats(int correlationId, ImmutableDictionary<Document, ImmutableArray<Diagnostic>> documentsAndDiagnosticsToFixMap)
         {
-            Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, KeyValueLogMessage.Create(m =>
+            Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Document_Diagnostics, KeyValueLogMessage.Create(m =>
             {
-                m[s_documentsWithDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Count;
-                m[s_totalDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
+                m[CorrelationId] = correlationId;
+                m[DocumentsWithDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Count;
+                m[TotalDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
             }));
         }
 
-        public static void LogDiagnosticsStats(ImmutableDictionary<Project, ImmutableArray<Diagnostic>> projectsAndDiagnosticsToFixMap)
+        public static void LogDiagnosticsStats(int correlationId, ImmutableDictionary<Project, ImmutableArray<Diagnostic>> projectsAndDiagnosticsToFixMap)
         {
-            Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, KeyValueLogMessage.Create(m =>
+            Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Project_Diagnostics, KeyValueLogMessage.Create(m =>
             {
-                m[s_projectsWithDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Count;
-                m[s_totalDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
+                m[CorrelationId] = correlationId;
+                m[ProjectsWithDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Count;
+                m[TotalDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
             }));
         }
 
-        public static void LogFixesToMergeStats(int count)
+        public static void LogFixesToMergeStats(FunctionId functionId, int correlationId, int count)
         {
-            Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Merge, KeyValueLogMessage.Create(m =>
+            Logger.Log(functionId, KeyValueLogMessage.Create(m =>
             {
-                m[s_totalFixesToMerge] = count;
+                m[CorrelationId] = correlationId;
+                m[TotalFixesToMerge] = count;
             }));
         }
     }

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllState.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -12,6 +13,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal partial class FixAllState
     {
+        internal readonly int CorrelationId = LogAggregator.GetNextId();
+
         internal FixAllContext.DiagnosticProvider DiagnosticProvider { get; }
 
         public FixAllProvider FixAllProvider { get; }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -281,10 +281,14 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         CodeFixes_FixAllOccurrencesSession,
         CodeFixes_FixAllOccurrencesContext,
         CodeFixes_FixAllOccurrencesComputation,
-        CodeFixes_FixAllOccurrencesComputation_Diagnostics,
-        CodeFixes_FixAllOccurrencesComputation_Fixes,
-        CodeFixes_FixAllOccurrencesComputation_Merge,
+        CodeFixes_FixAllOccurrencesComputation_Document_Diagnostics,
+        CodeFixes_FixAllOccurrencesComputation_Project_Diagnostics,
+        CodeFixes_FixAllOccurrencesComputation_Document_Fixes,
+        CodeFixes_FixAllOccurrencesComputation_Project_Fixes,
+        CodeFixes_FixAllOccurrencesComputation_Document_Merge,
+        CodeFixes_FixAllOccurrencesComputation_Project_Merge,
         CodeFixes_FixAllOccurrencesPreviewChanges,
+        CodeFixes_ApplyChanges,
 
         SolutionExplorer_AnalyzerItemSource_GetItems,
         SolutionExplorer_DiagnosticItemSource_GetItems,
@@ -395,5 +399,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Experiment_ABTesting,
         AssetStorage_ForceGC,
         RemoteHost_Bitness,
+        Intellisense_Completion,
     }
 }


### PR DESCRIPTION
**Customer scenario**

There is no user experience changes on this PR. this is strictly telemetry changes which doesn't include any PII info.

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

there is no workaround

**Risk**

I don't see any risk on this change

**Performance impact**

it does send out a few more data than before. but all those are only sent after features are invoked by users explicitly (completion set and fix all).

**Is this a regression from a previous update?**

no

**Root cause analysis:**

this is not a bug fix, so there is no root cause. we just didn't send this perf info before.

**How was the bug found?**

we added new tracking perf scenario (completion set and fix all)

