### PR TITLE
Bump package versions for Preview 3

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -15,7 +15,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta2</RoslynNuGetMoniker> 
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta3</RoslynNuGetMoniker> 
 
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>

--- a/build/config/PublishData.json
+++ b/build/config/PublishData.json
@@ -5,14 +5,7 @@
             "version": "2.6.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev15.5", "dev15.5p2" ]
-        },
-        "dev15.5-preview1": {
-            "nugetKind": "PerBuildPreRelease",
-            "version": "2.6.*",
-            "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
-            "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "dev15.5p1" ]
+            "channels": [ "dev15.5", "dev15.5p3" ]
         },
         "dev/jaredpar/fix-publish": {
             "nugetKind": "PerBuildPreRelease",


### PR DESCRIPTION
Bumping our moniker to -beta3. We can also delete the Preview 1 publish info because that's now definitely dead.