### PR TITLE
Fix comparer for sorting enums in SymbolDisplay

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -11,12 +11,61 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class SymbolDisplayTests : CSharpTestBase
     {
+        [Fact]
+        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
+        public void Repro22507()
+        {
+            var text = @"
+using System;
+
+[Flags]
+public enum SomeTypes : long
+{
+    Default = 0,
+    TypeA = 2,
+    TypeB = 4,
+    TypeC = 1024,
+    TypeD = 1048576,
+    TypeE = 2097152,
+    TypeF = 33554432,
+    TypeG = 67108864,
+    TypeH = 134217728,
+    TypeI = 1073741824,
+    TypeJ = 2147483648,
+    TypeK = 4294967296,
+    TypeL = 1099511627776,
+    TypeM = 2199023255552,
+    TypeN = 4398046511104,
+    TypeO = 1125899906842624,
+    TypeP = 2251799813685248,
+    TypeQ = 4503599627370496,
+    TypeR = 9007199254740992,
+    TypeS = 18014398509481984,
+    TypeT = 2305843009213693952
+}
+";
+            TestSymbolDescription(
+                text,
+                g => g.GetTypeMembers("SomeTypes").Single().GetField("TypeF"),
+                SymbolDisplayFormat.MinimallyQualifiedFormat
+                    .AddMemberOptions(SymbolDisplayMemberOptions.IncludeConstantValue),
+                "SomeTypes.TypeF = 33554432",
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.FieldName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral);
+        }
+
         [Fact]
         public void TestClassNameOnlySimple()
         {

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5999,7 +5999,7 @@ class C
 
         [Fact]
         [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
-        public void SimplerEnumSortingCrash()
+        public void Repro22507()
         {
             var text = @"
 using System;
@@ -6041,53 +6041,6 @@ enum E : long
                 SymbolDisplayPartKind.NumericLiteral);
         }
 
-        [Fact]
-        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
-        public void Repro22507()
-        {
-            var text = @"
-using System;
-
-[Flags]
-public enum SomeTypes : long
-{
-    Default = 0,
-    TypeA = 2,
-    TypeB = 4,
-    TypeC = 1024,
-    TypeD = 1048576,
-    TypeE = 2097152,
-    TypeF = 33554432,
-    TypeG = 67108864,
-    TypeH = 134217728,
-    TypeI = 1073741824,
-    TypeJ = 2147483648,
-    TypeK = 4294967296,
-    TypeL = 1099511627776,
-    TypeM = 2199023255552,
-    TypeN = 4398046511104,
-    TypeO = 1125899906842624,
-    TypeP = 2251799813685248,
-    TypeQ = 4503599627370496,
-    TypeR = 9007199254740992,
-    TypeS = 18014398509481984,
-    TypeT = 2305843009213693952
-}
-";
-            TestSymbolDescription(
-                text,
-                g => g.GetTypeMembers("SomeTypes").Single().GetField("TypeF"),
-                SymbolDisplayFormat.MinimallyQualifiedFormat
-                    .AddMemberOptions(SymbolDisplayMemberOptions.IncludeConstantValue),
-                "SomeTypes.TypeF = 33554432",
-                SymbolDisplayPartKind.EnumName,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.FieldName,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.NumericLiteral);
-        }
 
         [Fact]
         public void TestRefStructs()

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -19,54 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class SymbolDisplayTests : CSharpTestBase
     {
         [Fact]
-        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
-        public void Repro22507()
-        {
-            var text = @"
-using System;
-
-[Flags]
-public enum SomeTypes : long
-{
-    Default = 0,
-    TypeA = 2,
-    TypeB = 4,
-    TypeC = 1024,
-    TypeD = 1048576,
-    TypeE = 2097152,
-    TypeF = 33554432,
-    TypeG = 67108864,
-    TypeH = 134217728,
-    TypeI = 1073741824,
-    TypeJ = 2147483648,
-    TypeK = 4294967296,
-    TypeL = 1099511627776,
-    TypeM = 2199023255552,
-    TypeN = 4398046511104,
-    TypeO = 1125899906842624,
-    TypeP = 2251799813685248,
-    TypeQ = 4503599627370496,
-    TypeR = 9007199254740992,
-    TypeS = 18014398509481984,
-    TypeT = 2305843009213693952
-}
-";
-            TestSymbolDescription(
-                text,
-                g => g.GetTypeMembers("SomeTypes").Single().GetField("TypeF"),
-                SymbolDisplayFormat.MinimallyQualifiedFormat
-                    .AddMemberOptions(SymbolDisplayMemberOptions.IncludeConstantValue),
-                "SomeTypes.TypeF = 33554432",
-                SymbolDisplayPartKind.EnumName,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.FieldName,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.NumericLiteral);
-        }
-
-        [Fact]
         public void TestClassNameOnlySimple()
         {
             var text = "class A {}";
@@ -6013,6 +5965,84 @@ class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ParameterName, // c
                 SymbolDisplayPartKind.Punctuation); // )
+        }
+
+        [Fact]
+        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
+        public void EdgeCasesForEnumFieldComparer()
+        {
+            // A bad comparer could cause sorting the enum fields
+            // to throw an exception due to inconsistency. See Repro22507
+            // for an example of this problem.
+
+            var lhs = new EnumField("E1", 0);
+            var rhs = new EnumField("E2", 0x1000_0000_0000_0000);
+
+            // This is a "reverse" comparer, so if lhs < rhs, return
+            // value should be > 0
+            // If the comparer subtracts and converts, result will be zero since
+            // the bottom 32 bits are zero
+            Assert.InRange(EnumField.Comparer.Compare(lhs, rhs), 1, int.MaxValue);
+
+            lhs = new EnumField("E1", 0);
+            rhs = new EnumField("E2", 0x1000_0000_0000_0001);
+            Assert.InRange(EnumField.Comparer.Compare(lhs, rhs), 1, int.MaxValue);
+
+            lhs = new EnumField("E1", 0x1000_0000_0000_000);
+            rhs = new EnumField("E2", 0);
+            Assert.InRange(EnumField.Comparer.Compare(lhs, rhs), int.MinValue, -1);
+
+            lhs = new EnumField("E1", 0);
+            rhs = new EnumField("E2", 0x1000_0000_8000_0000);
+            Assert.InRange(EnumField.Comparer.Compare(lhs, rhs), 1, int.MaxValue);
+        }
+
+        [Fact]
+        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
+        public void Repro22507()
+        {
+            var text = @"
+using System;
+
+[Flags]
+public enum SomeTypes : long
+{
+    Default = 0,
+    TypeA = 2,
+    TypeB = 4,
+    TypeC = 1024,
+    TypeD = 1048576,
+    TypeE = 2097152,
+    TypeF = 33554432,
+    TypeG = 67108864,
+    TypeH = 134217728,
+    TypeI = 1073741824,
+    TypeJ = 2147483648,
+    TypeK = 4294967296,
+    TypeL = 1099511627776,
+    TypeM = 2199023255552,
+    TypeN = 4398046511104,
+    TypeO = 1125899906842624,
+    TypeP = 2251799813685248,
+    TypeQ = 4503599627370496,
+    TypeR = 9007199254740992,
+    TypeS = 18014398509481984,
+    TypeT = 2305843009213693952
+}
+";
+            TestSymbolDescription(
+                text,
+                g => g.GetTypeMembers("SomeTypes").Single().GetField("TypeF"),
+                SymbolDisplayFormat.MinimallyQualifiedFormat
+                    .AddMemberOptions(SymbolDisplayMemberOptions.IncludeConstantValue),
+                "SomeTypes.TypeF = 33554432",
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.FieldName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5999,6 +5999,50 @@ class C
 
         [Fact]
         [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
+        public void SimplerEnumSortingCrash()
+        {
+            var text = @"
+using System;
+
+[Flags]
+enum E : long
+{
+    A = 0x0,
+    B = 0x400,
+    C = 0x100000,
+    D = 0x200000,
+    E = 0x2000000,
+    F = 0x4000000,
+    G = 0x8000000,
+    H = 0x40000000,
+    I = 0x80000000,
+    J = 0x20000000000,
+    K = 0x40000000000,
+    L = 0x4000000000000,
+    M = 0x8000000000000,
+    N = 0x10000000000000,
+    O = 0x20000000000000,
+    P = 0x40000000000000,
+    Q = 0x2000000000000000,
+}
+";
+            TestSymbolDescription(
+                text,
+                g => g.GetTypeMembers("E").Single().GetField("A"),
+                SymbolDisplayFormat.MinimallyQualifiedFormat
+                    .AddMemberOptions(SymbolDisplayMemberOptions.IncludeConstantValue),
+                "E.A = 0",
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.FieldName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral);
+        }
+
+        [Fact]
+        [WorkItem(22507, "https://github.com/dotnet/roslyn/issues/22507")]
         public void Repro22507()
         {
             var text = @"

--- a/src/Compilers/Core/Portable/InternalUtilities/EnumField.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumField.cs
@@ -71,10 +71,10 @@ namespace Roslyn.Utilities
             int IComparer<EnumField>.Compare(EnumField field1, EnumField field2)
             {
                 // Sort order is descending value, then ascending name.
-                var diff = unchecked((long)field2.Value - (long)field1.Value);
+                int diff = unchecked(((long)field2.Value).CompareTo((long)field1.Value));
                 return diff == 0
                     ? string.CompareOrdinal(field1.Name, field2.Name)
-                    : (int)diff;
+                    : diff;
             }
         }
     }


### PR DESCRIPTION
**Customer scenario**

When mousing over enums fields with values in the highest end of the unsigned long range,
SymbolDisplay can throw an exception while sorting the enum and crash Visual Studio.

**Bugs this fixes:**

Fixes #22507

**Workarounds, if any**

Do not hover over any enum field that is a member of an enum with one of these
enum fields.

**Risk**

This is, I believe, the minimal fix for this scenario. It's probable that any possible
fix in this area is a breaking change, but the change would be that a `Flags` enum
field shown in symbol display could result in a different order of enum members, i.e.
if the enum display for flags components was `E.A | E.B`, it could instead be `E.B | E.A`
or, in some cases, it may cause some other enum member, `E.C` that exactly matches to
be chosen instead.

To my knowledge, this is purely aesthetic. It does not affect the compiled code in any way.

**Performance impact**

Minimal, just an extra call to `long.CompareTo`.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is a somewhat esoteric edge case and it looks like this code was
translated fairly literally from C++ in the native compiler or the EE, so
it's possible that this code worked in C++ and no longer works in C#
due to correct sorting or different conversion routines.

By using standard C# idioms and library calls, this should be much more
resilient code.

**How was the bug found?**

Customer reported through VS feedback.

**Test documentation updated?**

N/A
