### PR TITLE
When creating child items in Call Hierarchy, use the correct project

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
@@ -163,7 +163,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
                     }
                     else
                     {
-                        var item = await Provider.CreateItem(caller.CallingSymbol, project, caller.Locations, cancellationToken).ConfigureAwait(false);
+                        var callingProject = project.Solution.GetProject(caller.CallingSymbol.ContainingAssembly);
+                        var item = await Provider.CreateItem(caller.CallingSymbol, callingProject, caller.Locations, cancellationToken).ConfigureAwait(false);
                         callback.AddResult(item);
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/src/EditorFeatures/Test2/CallHierarchy/CallHierarchyTests.vb
+++ b/src/EditorFeatures/Test2/CallHierarchy/CallHierarchyTests.vb
@@ -176,7 +176,7 @@ public class D : I
 
         <WorkItem(981869, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/981869")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)>
-        Public Sub TestCallHierarchyCrossProjectNavigation()
+        Public Sub TestCallHierarchyCrossProjectForImplements()
             Dim input =
 <Workspace>
     <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
@@ -208,6 +208,44 @@ class CSharpIt : IChangeSignatureOptionsService
             testState.SearchRoot(root,
                                  String.Format(EditorFeaturesResources.Implements_0, "GetChangeSignatureOptions"),
                                  Sub(c)
+                                     Assert.Equal("Assembly2", c.Project.Name)
+                                 End Sub,
+                                 CallHierarchySearchScope.EntireSolution)
+        End Sub
+
+        <WorkItem(981869, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/981869")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)>
+        Public Sub TestCallHierarchyCrossProjectForCallsTo()
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+        <Document>
+public class C
+{
+    public static void $$M() { }
+}
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="Assembly2" CommonReferences="true">
+        <ProjectReference>Assembly1</ProjectReference>
+        <Document>
+using System;
+
+class D
+{
+    public void M2() { C.M(); }
+}
+
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim testState = CallHierarchyTestState.Create(input)
+            Dim root = testState.GetRoot()
+            testState.SearchRoot(root,
+                                 String.Format(EditorFeaturesResources.Calls_To_0, "M"),
+                                 Sub(c)
+                                     ' The child items should be in the second project
                                      Assert.Equal("Assembly2", c.Project.Name)
                                  End Sub,
                                  CallHierarchySearchScope.EntireSolution)

--- a/src/EditorFeatures/TestUtilities/CallHierarchy/CallHierarchyTestState.cs
+++ b/src/EditorFeatures/TestUtilities/CallHierarchy/CallHierarchyTestState.cs
@@ -158,6 +158,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
         internal void SearchRoot(CallHierarchyItem root, string displayName, Action<CallHierarchyItem> verify, CallHierarchySearchScope scope, IImmutableSet<Document> documents = null)
         {
             var callback = new MockSearchCallback(verify);
+            
+            // Assert we have the category before we try to find it to give better diagnosing
+            Assert.Contains(displayName, root.SupportedSearchCategories.Select(c => c.DisplayName));
             var category = root.SupportedSearchCategories.First(c => c.DisplayName == displayName).Name;
             if (documents != null)
             {
@@ -174,6 +177,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
         internal void SearchRoot(CallHierarchyItem root, string displayName, Action<ICallHierarchyNameItem> verify, CallHierarchySearchScope scope, IImmutableSet<Document> documents = null)
         {
             var callback = new MockSearchCallback(verify);
+            
+            // Assert we have the category before we try to find it to give better diagnosing
+            Assert.Contains(displayName, root.SupportedSearchCategories.Select(c => c.DisplayName));
             var category = root.SupportedSearchCategories.First(c => c.DisplayName == displayName).Name;
             if (documents != null)
             {

--- a/src/EditorFeatures/TestUtilities/CallHierarchy/CallHierarchyTestState.cs
+++ b/src/EditorFeatures/TestUtilities/CallHierarchy/CallHierarchyTestState.cs
@@ -91,6 +91,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
             }
         }
 
+        public static CallHierarchyTestState Create(string markup, params Type[] additionalTypes)
+        {
+            var exportProvider = CreateExportProvider(additionalTypes);
+            var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: exportProvider);
+            return new CallHierarchyTestState(workspace);
+        }
+
         public static CallHierarchyTestState Create(XElement markup, params Type[] additionalTypes)
         {
             var exportProvider = CreateExportProvider(additionalTypes);
@@ -126,31 +133,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
                 .WithParts(additionalTypes);
 
             return MinimalTestExportProvider.CreateExportProvider(catalog);
-        }
-
-        public static CallHierarchyTestState Create(string markup, params Type[] additionalTypes)
-        {
-            var exportProvider = CreateExportProvider(additionalTypes);
-            var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: exportProvider);
-            return new CallHierarchyTestState(markup, workspace);
-        }
-
-        private CallHierarchyTestState(string markup, TestWorkspace workspace)
-        {
-            this.Workspace = workspace;
-            var testDocument = Workspace.Documents.Single(d => d.CursorPosition.HasValue);
-
-            _textView = testDocument.GetTextView();
-            _subjectBuffer = testDocument.GetTextBuffer();
-
-            var provider = Workspace.GetService<CallHierarchyProvider>();
-
-            var notificationService = Workspace.Services.GetService<INotificationService>() as INotificationServiceCallback;
-            var callback = new Action<string, string, NotificationSeverity>((message, title, severity) => NotificationMessage = message);
-            notificationService.NotificationCallback = callback;
-
-            _presenter = new MockCallHierarchyPresenter();
-            _commandHandler = new CallHierarchyCommandHandler(new[] { _presenter }, provider, TestWaitIndicator.Default);
         }
 
         internal string NotificationMessage


### PR DESCRIPTION
Call Hierarchy items hold onto their project so we can relocate the symbol, but instead of using the project that contained the caller, we were creating items with the project of the original method. This meant that further expansions wouldn't work correctly.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/447120
**Workarounds, if any:** don't expand nested call hierarchies
**Risk:** low
**Performance impact:** none. Just adding a dictionary lookup.
**Is this a regression from a previous update?** this was broken when Roslyn shipped in Visual Studio 2015.
**Root cause analysis:** insufficient testing meant we never caught this regression. I've added a unit test.
**How was the bug found?** customer report.
