### PR TITLE
add more detail on why connection went away in log file.

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -149,10 +149,13 @@ namespace Microsoft.CodeAnalysis.Remote
 
             if (e.Reason != DisconnectedReason.Disposed)
             {
-                // this is common for us since we close connection forcefully when operation
-                // is cancelled. use Warning level so that by default, it doesn't write out to
-                // servicehub\log files. one can still make this to write logs by opting in.
-                Log(TraceEventType.Warning, $"Client stream disconnected unexpectedly: {e.Exception?.GetType().Name} {e.Exception?.Message}");
+                // we no longer close connection forcefully. so connection shouldn't go away 
+                // in normal situation. if it happens, log why it did in more detail.
+                LogError($@"Client stream disconnected unexpectedly: 
+{nameof(e.Description)}: {e.Description}
+{nameof(e.Reason)}: {e.Reason}
+{nameof(e.LastMessage)}: {e.LastMessage}
+{nameof(e.Exception)}: {e.Exception?.ToString()}");
             }
         }
 


### PR DESCRIPTION
this is porting changes from post 15.5 branch (https://github.com/dotnet/roslyn/pull/22727)
...

**Customer scenario**

There is no user facing behavior changes.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/515511

there is no bug this is fixing. this is general improvement on service hub logging to make investigation easier.

**Workarounds, if any**

No workaround

**Risk**

N/A

**Performance impact**

N/A

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Currently, when connection goes away from service hub, we log very generic string "Client stream disconnected unexpectedly". this change log more detail data to make investigation easier.

**How was the bug found?**

dogfooding
