### PR TITLE
added assert for explicit invariant

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1598,7 +1598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             while (node != null);
 
-            done:
+done:
             return GetEnclosingBinderInternalWithinRoot(AdjustStartingNodeAccordingToNewRoot(startingNode, queryClause.Syntax),
                                       position, queryClause.Binder, queryClause.Syntax);
         }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -961,6 +961,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override IOperation GetOperationWorker(CSharpSyntaxNode node, CancellationToken cancellationToken)
         {
+            VerifyExplicitInvariant(GetStatementOrRootOperation(GetBindingRootOrInitializer(Root), cancellationToken));
+
             CSharpSyntaxNode bindingRoot = GetBindingRootOrInitializer(node);
 
             IOperation statementOrRootOperation = GetStatementOrRootOperation(bindingRoot, cancellationToken);
@@ -1596,7 +1598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             while (node != null);
 
-done:
+            done:
             return GetEnclosingBinderInternalWithinRoot(AdjustStartingNodeAccordingToNewRoot(startingNode, queryClause.Syntax),
                                       position, queryClause.Binder, queryClause.Syntax);
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19343,7 +19343,7 @@ public class Cls
                 );
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/22229")]
         public void ElementAccess_06()
         {
             var text = @"

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
@@ -95,6 +97,17 @@ namespace Microsoft.CodeAnalysis
         }
 
         protected abstract IOperation GetOperationCore(SyntaxNode node, CancellationToken cancellationToken);
+
+        internal void VerifyExplicitInvariant(IOperation operation)
+        {
+            var lookup = operation.DescendantsAndSelf().GroupBy(o => o.Syntax);
+
+            foreach (var entry in lookup)
+            {
+                // with same syntax node, there must be only 1 or 0 explicit operation
+                Debug.Assert(entry.Count(o => !o.IsImplicit) <= 1);
+            }
+        }
 
         /// <summary>
         /// Deep Clone given IOperation

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract IOperation GetOperationCore(SyntaxNode node, CancellationToken cancellationToken);
 
+        [Conditional("DEBUG")]
         internal void VerifyExplicitInvariant(IOperation operation)
         {
             var lookup = operation.DescendantsAndSelf().GroupBy(o => o.Syntax);

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -794,6 +794,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Function GetOperationWorker(node As VisualBasicSyntaxNode, cancellationToken As CancellationToken) As IOperation
+            VerifyExplicitInvariant(GetStatementOrRootOperation(DirectCast(GetBindingRoot(Root), VisualBasicSyntaxNode), cancellationToken))
+
             ' see whether we can bind smaller scope than GetBindingRoot to make perf better
             ' https://github.com/dotnet/roslyn/issues/22176
             Dim bindingRoot = DirectCast(GetBindingRoot(node), VisualBasicSyntaxNode)


### PR DESCRIPTION
this is related to this issue (https://github.com/dotnet/roslyn/issues/22229)

since @AlekseyTs's work for IsImplicit (https://github.com/dotnet/roslyn/pull/22894) is in, I can enable this debug assert in code to find violation out side of tests.


