### PR TITLE
Fix semantic model on deconstruction-foreach expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var variables = node.Variable;
                         if (variables.IsDeconstructionLeft())
                         {
-                            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, collectionEscape, iterationVariableType);
+                            var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, collectionEscape, iterationVariableType) { WasCompilerGenerated = true } ;
                             DeclarationExpressionSyntax declaration = null;
                             ExpressionSyntax expression = null;
                             BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3870,6 +3870,7 @@ static class Extension
         }
 
         [Fact]
+        [WorkItem(22495, "https://github.com/dotnet/roslyn/issues/22495")]
         public void ForEachCollectionSymbol()
         {
             string source = @"
@@ -3885,20 +3886,16 @@ class Deconstructable
     void Deconstruct(out int i, out int j) { i = 0; j = 0; }
 }
 ";
-            CompileAndVerify(source, additionalRefs: s_valueTupleRefs, sourceSymbolValidator: (ModuleSymbol module) =>
-            {
-                var sourceModule = (SourceModuleSymbol)module;
-                var compilation = sourceModule.DeclaringCompilation;
-                var tree = compilation.SyntaxTrees.First();
-                var model = compilation.GetSemanticModel(tree);
+            var compilation = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            var tree = compilation.SyntaxTrees.First();
+            var model = compilation.GetSemanticModel(tree);
 
-                var collection = tree.GetRoot().DescendantNodes().OfType<ForEachVariableStatementSyntax>().Single().Expression;
-                Assert.Equal("x", collection.ToString());
-                var symbol = model.GetSymbolInfo(collection).Symbol;
-                Assert.Equal(SymbolKind.Parameter, symbol.Kind);
-                Assert.Equal("x", symbol.Name);
-                Assert.Equal("System.Collections.Generic.IEnumerable<Deconstructable> x", symbol.ToTestDisplayString());
-            });
+            var collection = tree.GetRoot().DescendantNodes().OfType<ForEachVariableStatementSyntax>().Single().Expression;
+            Assert.Equal("x", collection.ToString());
+            var symbol = model.GetSymbolInfo(collection).Symbol;
+            Assert.Equal(SymbolKind.Parameter, symbol.Kind);
+            Assert.Equal("x", symbol.Name);
+            Assert.Equal("System.Collections.Generic.IEnumerable<Deconstructable> x", symbol.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -57,6 +57,32 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function DeconstructionForeach() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document><![CDATA[
+using System.Collections.Generic;
+class Deconstructable
+{
+    void M(IEnumerable<Deconstructable> [|$$x|])
+    {
+        foreach (var (y1, y2) in [|x|])
+        {
+        }
+    }
+    void Deconstruct(out int i, out int j) { i = 0; j = 0; }
+}
+                            ]]></Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "x", "change", renameOverloads:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(540120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540120")>
         Public Async Function SimpleEditAndVerifyTagsPropagatedAndCommit() As Task
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -57,6 +57,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(22495, "https://github.com/dotnet/roslyn/issues/22495")>
         Public Async Function RenameDeconstructionForeachCollection() As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Async Function DeconstructionForeach() As Task
+        Public Async Function RenameDeconstructionForeachCollection() As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/22495

This was reported as a Rename and FindAllReferences issue, but it stems from a bug in the semantic model. When you ask the symbol of `x` in `foreach (var (y1, y2) in x) { ... }`, the semantic model returned `null`.
The root cause is that when building the node map (from syntax to bound node), some of the generated bound nodes (the placeholder nodes) interfered with finding the most useful bound node, because they shared the same syntax (`x`).

Here's the corrected behavior:
![image](https://user-images.githubusercontent.com/12466233/32081383-f245ffec-ba69-11e7-8a77-b4ecfc38764a.png)