### PR TITLE
Move C# tests to testing metadata emitted attributes through `CompileAndVerify`

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class AttributeTests : CompilingTestBase
+    public class AttributeTests : WellKnownAttributesTestBase
     {
         #region Function Tests
 
@@ -1165,7 +1165,7 @@ class C
                 Assert.Equal(1, parameters[1].GetAttributes(paramAttrType).Count());
 
                 // verify ParamArrayAttribute on p2
-                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameters[1]);
+                VerifyParamArrayAttribute(parameters[1]);
 
                 // Delegate Constructor: Doesn't have any parameter attributes
                 var ctor = (MethodSymbol)delegateType.GetMember(".ctor");
@@ -1186,7 +1186,7 @@ class C
                 Assert.Equal(0, parameters[3].GetAttributes(paramAttrType).Count());
 
                 // verify no ParamArrayAttribute on p2
-                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameters[1], expected: false);
+                VerifyParamArrayAttribute(parameters[1], expected: false);
             };
 
             CompileAndVerify(source, symbolValidator: symbolValidator);

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -1145,7 +1145,7 @@ class C
     }
 }";
 
-            Action<ModuleSymbol> symbolValidator = moduleSymbol =>
+            Func<bool, Action<ModuleSymbol>> symbolValidator = isFromMetadata => moduleSymbol =>
             {
                 var type = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
                 var paramAttrType = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("ParamAttribute");
@@ -1164,8 +1164,11 @@ class C
                 Assert.Equal("p2", parameters[1].Name);
                 Assert.Equal(1, parameters[1].GetAttributes(paramAttrType).Count());
 
-                // verify ParamArrayAttribute on p2
-                VerifyParamArrayAttribute(parameters[1]);
+                if (isFromMetadata)
+                {
+                    // verify ParamArrayAttribute on p2
+                    VerifyParamArrayAttribute(parameters[1]);
+                }
 
                 // Delegate Constructor: Doesn't have any parameter attributes
                 var ctor = (MethodSymbol)delegateType.GetMember(".ctor");
@@ -1185,11 +1188,14 @@ class C
                 Assert.Equal(0, parameters[2].GetAttributes(paramAttrType).Count());
                 Assert.Equal(0, parameters[3].GetAttributes(paramAttrType).Count());
 
-                // verify no ParamArrayAttribute on p2
-                VerifyParamArrayAttribute(parameters[1], expected: false);
+                if (isFromMetadata)
+                {
+                    // verify no ParamArrayAttribute on p2
+                    VerifyParamArrayAttribute(parameters[1], expected: false);
+                }
             };
 
-            CompileAndVerify(source, symbolValidator: symbolValidator);
+            CompileAndVerify(source, sourceSymbolValidator: symbolValidator(false), symbolValidator: symbolValidator(true));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -1145,7 +1145,7 @@ class C
     }
 }";
 
-            Func<bool, Action<ModuleSymbol>> symbolValidator = isFromSource => moduleSymbol =>
+            Action<ModuleSymbol> symbolValidator = moduleSymbol =>
             {
                 var type = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
                 var paramAttrType = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("ParamAttribute");
@@ -1165,10 +1165,7 @@ class C
                 Assert.Equal(1, parameters[1].GetAttributes(paramAttrType).Count());
 
                 // verify ParamArrayAttribute on p2
-                if (isFromSource)
-                {
-                    WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameters[1], (SourceModuleSymbol)moduleSymbol);
-                }
+                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameters[1]);
 
                 // Delegate Constructor: Doesn't have any parameter attributes
                 var ctor = (MethodSymbol)delegateType.GetMember(".ctor");
@@ -1189,13 +1186,10 @@ class C
                 Assert.Equal(0, parameters[3].GetAttributes(paramAttrType).Count());
 
                 // verify no ParamArrayAttribute on p2
-                if (isFromSource)
-                {
-                    WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameters[1], (SourceModuleSymbol)moduleSymbol, expected: false);
-                }
+                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameters[1], expected: false);
             };
 
-            CompileAndVerify(source, sourceSymbolValidator: symbolValidator(true), symbolValidator: symbolValidator(false));
+            CompileAndVerify(source, symbolValidator: symbolValidator);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -11,7 +10,6 @@ using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -4,11 +4,9 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -523,8 +521,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 }
                 else
                 {
-                    Assert.Equal(1, synthesizedDynamicAttributes.Count());
-                    var dynamicAttribute = synthesizedDynamicAttributes.First();
+                    var dynamicAttribute = synthesizedDynamicAttributes.Single();
 
                     if (expectedTransformFlags == null)
                     {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -160,62 +160,57 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 validator.ValidateAttributesForSynthesizedDelegateMembers();
             }
 
-            internal static void ValidateDynamicAttribute(Symbol symbol, bool expectedDynamicAttribute, bool[] expectedTransformFlags = null, bool forReturnType = false)
-            {
-                ValidateDynamicAttribute(symbol, expectedDynamicAttribute, expectedTransformFlags, forReturnType);
-            }
-
             private void ValidateAttributesOnNamedTypes()
             {
                 // public class Base0 { }
-                ValidateDynamicAttribute(_base0Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_base0Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Base1<T> { }
-                ValidateDynamicAttribute(_base1Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_base1Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Base2<T, U> { }
-                ValidateDynamicAttribute(_base2Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_base2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Derived<T> : Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>
                 Assert.True(_derivedClass.BaseType.ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0B 00 00 00 * 00 01 00 00 01 00 00 01 00 01 01 * 00 00 )
                 _expectedTransformFlags = new bool[] { false, true, false, false, true, false, false, true, false, true, true };
-                ValidateDynamicAttribute(_derivedClass, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_derivedClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Outer<T> : Base1<dynamic>
                 Assert.True(_outerClass.BaseType.ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(_outerClass, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_outerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Inner<U, V> : Base2<dynamic, V>
                 Assert.True(_innerClass.BaseType.ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 * 00 01 00 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true, false };
-                ValidateDynamicAttribute(_innerClass, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_innerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class InnerInner<W> : Base1<dynamic> { }
                 Assert.True(_innerInnerClass.BaseType.ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(_innerInnerClass, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_innerInnerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Outer2<T> : Base1<dynamic>
                 Assert.True(_outer2Class.BaseType.ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(_outer2Class, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_outer2Class.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Inner2<U, V> : Base0
                 Assert.False(_inner2Class.BaseType.ContainsDynamic());
-                ValidateDynamicAttribute(_inner2Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_inner2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class InnerInner2<W> : Base0 { }
                 Assert.False(_innerInner2Class.BaseType.ContainsDynamic());
-                ValidateDynamicAttribute(_innerInner2Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_innerInner2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Inner3<U>
-                ValidateDynamicAttribute(_inner3Class, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_inner3Class.GetAttributes(), expectedDynamicAttribute: false);
             }
 
             private void ValidateAttributesOnFields()
@@ -225,164 +220,164 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 //public static dynamic field1;
                 var field1 = _derivedClass.GetMember<FieldSymbol>("field1");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(field1, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(field1.GetAttributes(), expectedDynamicAttribute: true);
 
                 //public static dynamic[] field2;
                 var field2 = _derivedClass.GetMember<FieldSymbol>("field2");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(field2, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field2.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public static dynamic[][] field3;
                 var field3 = _derivedClass.GetMember<FieldSymbol>("field3");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 * 00 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true };
-                ValidateDynamicAttribute(field3, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field3.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public const dynamic field4 = null;
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
                 var field4 = _derivedClass.GetMember<FieldSymbol>("field4");
-                ValidateDynamicAttribute(field4, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(field4.GetAttributes(), expectedDynamicAttribute: true);
 
                 //public const dynamic[] field5 = null;
                 var field5 = _derivedClass.GetMember<FieldSymbol>("field5");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(field5, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field5.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public const dynamic[][] field6 = null;
                 var field6 = _derivedClass.GetMember<FieldSymbol>("field6");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 * 00 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true };
-                ValidateDynamicAttribute(field6, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field6.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public const dynamic[][] field7 = null;
                 var field7 = _derivedClass.GetMember<FieldSymbol>("field7");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 * 00 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true };
-                ValidateDynamicAttribute(field7, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field7.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<T>.Inner<int, T>.InnerInner<Outer<dynamic>> field8 = null;
                 var field8 = _derivedClass.GetMember<FieldSymbol>("field8");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 06 00 00 00 * 00 00 00 00 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, false, false, false, true };
-                ValidateDynamicAttribute(field8, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field8.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<dynamic>.Inner<T, T>.InnerInner<T> field9 = null;
                 var field9 = _derivedClass.GetMember<FieldSymbol>("field9");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 05 00 00 00 * 00 01 00 00 00 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true, false, false, false };
-                ValidateDynamicAttribute(field9, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field9.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<Outer<dynamic>.Inner<T, dynamic>>.Inner<dynamic, T>.InnerInner<T> field10 = null;
                 var field10 = _derivedClass.GetMember<FieldSymbol>("field10");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 08 00 00 00 * 00 00 01 00 01 01 00 00 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true, false, true, true, false, false };
-                ValidateDynamicAttribute(field10, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field10.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<T>.Inner<dynamic, dynamic>.InnerInner<T> field11 = null;
                 var field11 = _derivedClass.GetMember<FieldSymbol>("field11");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 05 00 00 00 * 00 00 01 01 00 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true, true, false };
-                ValidateDynamicAttribute(field11, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field11.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<T>.Inner<T, T>.InnerInner<Outer<dynamic>.Inner<T, dynamic>.InnerInner<int>> field12 = null;
                 var field12 = _derivedClass.GetMember<FieldSymbol>("field12");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 09 00 00 00 * 00 00 00 00 00 01 00 01 00 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, false, false, false, true, false, true, false };
-                ValidateDynamicAttribute(field12, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field12.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<dynamic>.Inner<Outer<T>, T>.InnerInner<dynamic> field13 = null;
                 var field13 = _derivedClass.GetMember<FieldSymbol>("field13");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 06 00 00 00 * 00 01 00 00 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true, false, false, false, true };
-                ValidateDynamicAttribute(field13, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field13.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<dynamic>.Inner<dynamic, dynamic>.InnerInner<dynamic> field14 = null;
                 var field14 = _derivedClass.GetMember<FieldSymbol>("field14");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 05 00 00 00 * 00 01 01 01 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true, true, true, true };
-                ValidateDynamicAttribute(field14, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field14.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<dynamic>.Inner<Outer<dynamic>, T>.InnerInner<dynamic>[] field15 = null;
                 var field15 = _derivedClass.GetMember<FieldSymbol>("field15");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 07 00 00 00 * 00 00 01 00 01 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, true, false, true, false, true };
-                ValidateDynamicAttribute(field15, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field15.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public Outer<dynamic>.Inner<Outer<dynamic>.Inner<T, dynamic>.InnerInner<int>, dynamic[]>.InnerInner<dynamic>[][] field16 = null;
                 var field16 = _derivedClass.GetMember<FieldSymbol>("field16");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0C 00 00 00 * 00 00 00 01 00 01 00 01 00 00 01 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, false, true, false, true, false, true, false, false, true, true };
-                ValidateDynamicAttribute(field16, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field16.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public static Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] field17 = null;
                 var field17 = _derivedClass.GetMember<FieldSymbol>("field17");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, false, false, true, false, false, true, false, false, true, false, true, true };
-                ValidateDynamicAttribute(field17, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field17.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 //public static Outer3.Inner3<dynamic> field1 = null;
                 field1 = _inner3Class.GetMember<FieldSymbol>("field1");
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(field1, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(field1.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
             }
 
             private void ValidateAttributesOnMethodReturnValueAndParameters()
             {
                 //public static dynamic F1(dynamic x) { return x; }
                 var f1 = _derivedClass.GetMember<MethodSymbol>("F1");
-                ValidateDynamicAttribute(f1, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(f1.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(f1, forReturnType: true, expectedDynamicAttribute: true);
-                ValidateDynamicAttribute(f1.Parameters[0], expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(f1.GetReturnTypeAttributes(), expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(f1.Parameters[0].GetAttributes(), expectedDynamicAttribute: true);
 
                 //public static dynamic F2(ref dynamic x) { return x; }
                 var f2 = _derivedClass.GetMember<MethodSymbol>("F2");
-                ValidateDynamicAttribute(f2, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(f2.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 )
-                ValidateDynamicAttribute(f2, forReturnType: true, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(f2.GetReturnTypeAttributes(), expectedDynamicAttribute: true);
                 _expectedTransformFlags = new bool[] { false, true };
-                ValidateDynamicAttribute(f2.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f2.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 //public static dynamic[] F3(dynamic[] x) { return x; }
                 var f3 = _derivedClass.GetMember<MethodSymbol>("F3");
-                ValidateDynamicAttribute(f3, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(f3.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
-                ValidateDynamicAttribute(f3, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
-                ValidateDynamicAttribute(f3.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f3.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f3.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 //public static Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] F4(Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] x) { return x; }
                 var f4 = _derivedClass.GetMember<MethodSymbol>("F4");
-                ValidateDynamicAttribute(f4, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(f4.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, false, false, true, false, false, true, false, false, true, false, true, true };
-                ValidateDynamicAttribute(f4, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
-                ValidateDynamicAttribute(f4.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f4.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f4.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 //public static (dynamic, object, dynamic) F5((dynamic, object, dynamic) x) { return x; }
                 var f5 = _derivedClass.GetMember<MethodSymbol>("F5");
-                ValidateDynamicAttribute(f5, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(f5.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void[System.Core] System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 00 01 01 00 00 )
                 //.param[1]
                 //.custom instance void[System.Core] System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 00 01 01 00 00 )
                 _expectedTransformFlags = new bool[] { false, true, false, true };
-                ValidateDynamicAttribute(f5, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
-                ValidateDynamicAttribute(f5.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f5.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(f5.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
             }
 
             private void ValidateAttributesOnProperty()
@@ -390,28 +385,28 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 //public static dynamic Prop1 { get { return field1; } }
                 var prop1 = _derivedClass.GetMember<PropertySymbol>("Prop1");
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(prop1, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(prop1.GetAttributes(), expectedDynamicAttribute: true);
 
                 // GetMethod
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(prop1.GetMethod, forReturnType: true, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(prop1.GetMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: true);
 
                 //public static Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>[][] Prop2 { get { return field17; } set { field17 = value; } }
                 var prop2 = _derivedClass.GetMember<PropertySymbol>("Prop2");
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, false, false, true, false, false, true, false, false, true, false, true, true };
-                ValidateDynamicAttribute(prop2, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(prop2.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // GetMethod
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
-                ValidateDynamicAttribute(prop2.GetMethod, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(prop2.GetMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // SetMethod
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0D 00 00 00 * 00 00 00 01 00 00 01 00 00 01 00 01 01 * 00 00 ) 
-                ValidateDynamicAttribute(prop2.SetMethod.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(prop2.SetMethod.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
             }
 
             private void ValidateAttributesOnIndexer()
@@ -419,24 +414,24 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 // public dynamic this[dynamic param]
                 var indexer = _derivedClass.GetIndexer<PropertySymbol>("Item");
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(indexer, expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(indexer.GetAttributes(), expectedDynamicAttribute: true);
 
                 // GetMethod
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
-                ValidateDynamicAttribute(indexer.GetMethod, forReturnType: true, expectedDynamicAttribute: true);
-                ValidateDynamicAttribute(indexer.GetMethod.Parameters[0], expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(indexer.GetMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(indexer.GetMethod.Parameters[0].GetAttributes(), expectedDynamicAttribute: true);
 
                 // SetMethod
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 ) 
                 //.param [2]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor() = ( 01 00 00 00 )
-                ValidateDynamicAttribute(indexer.SetMethod, forReturnType: true, expectedDynamicAttribute: false);
-                ValidateDynamicAttribute(indexer.SetMethod.Parameters[0], expectedDynamicAttribute: true);
-                ValidateDynamicAttribute(indexer.SetMethod.Parameters[1], expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(indexer.SetMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(indexer.SetMethod.Parameters[0].GetAttributes(), expectedDynamicAttribute: true);
+                ValidateDynamicAttribute(indexer.SetMethod.Parameters[1].GetAttributes(), expectedDynamicAttribute: true);
             }
 
             private void ValidateAttributesForPointerType()
@@ -446,7 +441,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 _expectedTransformFlags = new bool[] { false, false, false, false, false, false, false, true, false, false, true, false, false, true, false, false, false, false, true, true };
                 Assert.False(_unsafeClass.ContainsDynamic());
                 Assert.True(_unsafeClass.BaseType.ContainsDynamic());
-                ValidateDynamicAttribute(_unsafeClass, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(_unsafeClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
             }
 
             private void ValidateAttributesForNullableType()
@@ -455,7 +450,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 var nullableField = _structType.GetMember<FieldSymbol>("nullableField");
                 // .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 05 00 00 00 * 00 01 01 00 00 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true, true, false, false };
-                ValidateDynamicAttribute(nullableField, expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
+                ValidateDynamicAttribute(nullableField.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
             }
 
             private void ValidateAttributesForSynthesizedDelegateMembers()
@@ -464,7 +459,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
 
                 // .class public auto ansi sealed MyDelegate
                 //      extends [mscorlib]System.MulticastDelegate
-                ValidateDynamicAttribute(_synthesizedMyDelegateType, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(_synthesizedMyDelegateType.GetAttributes(), expectedDynamicAttribute: false);
 
                 var expectedTransformFlags = new bool[] { false, true };
 
@@ -474,11 +469,11 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 //  instance void  .ctor(object 'object',
                 //                    native int 'method') runtime managed
                 var ctor = _synthesizedMyDelegateType.InstanceConstructors[0];
-                ValidateDynamicAttribute(ctor, expectedDynamicAttribute: false);
-                ValidateDynamicAttribute(ctor, forReturnType: true, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(ctor.GetAttributes(), expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(ctor.GetReturnTypeAttributes(), expectedDynamicAttribute: false);
                 foreach (var param in ctor.Parameters)
                 {
-                    ValidateDynamicAttribute(param, expectedDynamicAttribute: false);
+                    ValidateDynamicAttribute(param.GetAttributes(), expectedDynamicAttribute: false);
                 }
 
                 // Invoke method
@@ -486,13 +481,13 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 //  .method public hidebysig newslot virtual 
                 //      instance object[]  Invoke(object[] x) runtime managed
                 var invokeMethod = _synthesizedMyDelegateType.GetMember<MethodSymbol>("Invoke");
-                ValidateDynamicAttribute(invokeMethod, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(invokeMethod.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
-                ValidateDynamicAttribute(invokeMethod, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
-                ValidateDynamicAttribute(invokeMethod.Parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(invokeMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(invokeMethod.Parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
 
                 // BeginInvoke method
                 //
@@ -502,31 +497,30 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 //      class [mscorlib]System.AsyncCallback callback,
                 //      object 'object') runtime managed
                 var beginInvokeMethod = _synthesizedMyDelegateType.GetMember<MethodSymbol>("BeginInvoke");
-                ValidateDynamicAttribute(beginInvokeMethod, expectedDynamicAttribute: false);
-                ValidateDynamicAttribute(beginInvokeMethod, forReturnType: true, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(beginInvokeMethod.GetAttributes(), expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(beginInvokeMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: false);
                 //.param [1]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 var parameters = beginInvokeMethod.Parameters;
-                ValidateDynamicAttribute(parameters[0], expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
-                ValidateDynamicAttribute(parameters[1], expectedDynamicAttribute: false);
-                ValidateDynamicAttribute(parameters[2], expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(parameters[0].GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(parameters[1].GetAttributes(), expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(parameters[2].GetAttributes(), expectedDynamicAttribute: false);
 
                 // EndInvoke method
                 //
                 // .method public hidebysig newslot virtual 
                 // instance object[]  EndInvoke(class [mscorlib]System.IAsyncResult result) runtime managed
                 var endInvokeMethod = _synthesizedMyDelegateType.GetMember<MethodSymbol>("EndInvoke");
-                ValidateDynamicAttribute(endInvokeMethod, expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(endInvokeMethod.GetAttributes(), expectedDynamicAttribute: false);
                 //.param [0]
                 //.custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
-                ValidateDynamicAttribute(endInvokeMethod, forReturnType: true, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
-                ValidateDynamicAttribute(endInvokeMethod.Parameters[0], expectedDynamicAttribute: false);
+                ValidateDynamicAttribute(endInvokeMethod.GetReturnTypeAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformFlags);
+                ValidateDynamicAttribute(endInvokeMethod.Parameters[0].GetAttributes(), expectedDynamicAttribute: false);
             }
 
-            private static void ValidateDynamicAttribute(Symbol symbol, CSharpCompilation comp, MethodSymbol dynamicAttributeCtorNoArgs,
-                 MethodSymbol dynamicAttributeCtorTransformFlags, bool expectedDynamicAttribute, bool[] expectedTransformFlags = null)
+            public static void ValidateDynamicAttribute(ImmutableArray<CSharpAttributeData> attributes, bool expectedDynamicAttribute, bool[] expectedTransformFlags = null)
             {
-                var synthesizedDynamicAttributes = symbol.GetAttributes().Where((attr) => string.Equals(attr.AttributeClass.Name, "DynamicAttribute", StringComparison.Ordinal));
+                var synthesizedDynamicAttributes = attributes.Where((attr) => string.Equals(attr.AttributeClass.Name, "DynamicAttribute", StringComparison.Ordinal));
 
                 if (!expectedDynamicAttribute)
                 {
@@ -535,35 +529,29 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 else
                 {
                     Assert.Equal(1, synthesizedDynamicAttributes.Count());
-
                     var dynamicAttribute = synthesizedDynamicAttributes.First();
-                    var expectedCtor = expectedTransformFlags == null ? dynamicAttributeCtorNoArgs : dynamicAttributeCtorTransformFlags;
-                    Assert.NotNull(expectedCtor);
-                    Assert.Equal(expectedCtor, dynamicAttribute.AttributeConstructor);
 
                     if (expectedTransformFlags == null)
                     {
-                        // Dynamic()
-                        Assert.Equal(0, dynamicAttribute.CommonConstructorArguments.Length);
+                        Assert.Empty(dynamicAttribute.AttributeConstructor.Parameters);
+                        Assert.Empty(dynamicAttribute.CommonConstructorArguments);
                     }
                     else
                     {
-                        // Dynamic(bool[] transformFlags)
-                        Assert.Equal(1, dynamicAttribute.CommonConstructorArguments.Length);
+                        Assert.Equal("System.Boolean[]", dynamicAttribute.AttributeConstructor.Parameters.Single().Type.ToTestDisplayString());
 
-                        TypedConstant argument = dynamicAttribute.CommonConstructorArguments[0];
+                        TypedConstant argument = dynamicAttribute.CommonConstructorArguments.Single();
                         Assert.Equal(TypedConstantKind.Array, argument.Kind);
 
                         ImmutableArray<TypedConstant> actualTransformFlags = argument.Values;
                         Assert.Equal(expectedTransformFlags.Length, actualTransformFlags.Length);
-                        TypeSymbol booleanType = comp.GetSpecialType(SpecialType.System_Boolean);
 
                         for (int i = 0; i < actualTransformFlags.Length; i++)
                         {
                             TypedConstant actualTransformFlag = actualTransformFlags[i];
 
                             Assert.Equal(TypedConstantKind.Primitive, actualTransformFlag.Kind);
-                            Assert.Equal(booleanType, actualTransformFlag.Type);
+                            Assert.Equal("System.Boolean", actualTransformFlag.Type.ToTestDisplayString());
                             Assert.Equal(expectedTransformFlags[i], (bool)actualTransformFlag.Value);
                         }
                     }
@@ -949,66 +937,103 @@ public class Gen2<T> : X    // CS1980
         }
 
         [Fact]
-        public void TestDynamicAttributeForSubmissionField()
+        public void TestDynamicAttributeForScript_Field()
         {
-            // Script
-            TestDynamicAttributeForSubmissionFieldHelper(parseOptions: TestOptions.Script);
+            string source = @"
+dynamic x = 0;
+";
+            var comp = CreateCompilationWithMscorlib45(
+                source: source,
+                parseOptions: TestOptions.Script,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                references: new[] { SystemCoreRef, DesktopCSharpRef });
+
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var implicitField = module.GlobalNamespace.GetTypeMember("Script").GetMember<FieldSymbol>("x");
+                DynamicAttributeValidator.ValidateDynamicAttribute(implicitField.GetAttributes(), expectedDynamicAttribute: true);
+            });
         }
 
-        private void TestDynamicAttributeForSubmissionFieldHelper(CSharpParseOptions parseOptions)
+        [Fact]
+        public void TestDynamicAttributeForScript_NoCore()
         {
-            string source = GetNoCS1980String(typeName: @"Gen<dynamic>");
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: parseOptions);
-            comp.VerifyDiagnostics();
+            string source = @"
+dynamic x = 0;
+";
 
-            // Dynamic type field
-            string source2 = @"
-dynamic x = 0;";
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
-            comp.VerifyDiagnostics();
-            var implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
-            DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, expectedDynamicAttribute: true);
-
-            // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
-            comp.VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (2,1): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // dynamic x = 0;
                 Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute"));
+        }
 
-
-            // Field type is constructed generic type with dynamic type argument
-            source2 = source + @"
+        [Fact]
+        public void TestDynamicAttributeForScript_DynamicTypeArgument()
+        {
+            var source = GetNoCS1980String(typeName: @"Gen<dynamic>") + @"
 Gen<dynamic> x = null;";
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
-            comp.VerifyDiagnostics();
-            implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
-            var expectedTransformsFlags = new bool[] { false, true };
-            DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
 
-            // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
-            comp.VerifyDiagnostics(
+            var comp = CreateCompilationWithMscorlib45(
+                source: source,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                parseOptions: TestOptions.Script,
+                references: new[] { SystemCoreRef });
+
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var implicitField = module.GlobalNamespace.GetTypeMember("Script").GetMember<FieldSymbol>("x");
+                var expectedTransformsFlags = new bool[] { false, true };
+                DynamicAttributeValidator.ValidateDynamicAttribute(implicitField.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
+            });
+        }
+
+        [Fact]
+        public void TestDynamicAttributeForScript_DynamicTypeArgument_NoCore()
+        {
+            var source = GetNoCS1980String(typeName: "Gen<dynamic>") + @"
+Gen<dynamic> x = null;";
+
+            var comp = CreateCompilationWithMscorlib45(source: source, parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (20,5): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // Gen<dynamic> x = null;
                 Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "dynamic").WithArguments("System.Runtime.CompilerServices.DynamicAttribute"));
+        }
 
+        [Fact]
+        public void TestDynamicAttributeForScript_DynamicTypeInAliasTarget()
+        {
+            var source =
+                "using X = Gen<dynamic>;"
+                + GetNoCS1980String(typeName: @"Gen<dynamic>")
+                + "X x = null;";
 
-            // Dynamic type in Alias target
-            string aliasDecl = @"using X = Gen<dynamic>;     // No CS1980";
-            source2 = aliasDecl + source + @"
-X x = null;";
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions, references: new[] { SystemCoreRef });
-            comp.VerifyDiagnostics();
-            implicitField = comp.ScriptClass.GetMember<FieldSymbol>("x");
-            DynamicAttributeValidator.ValidateDynamicAttribute(implicitField, expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
+            var comp = CreateCompilationWithMscorlib45(
+                source: source,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                parseOptions: TestOptions.Script,
+                references: new[] { SystemCoreRef });
 
-            // No reference to System.Core, generates CS1980
-            comp = CreateCompilationWithMscorlib45(source2, parseOptions: parseOptions);
-            comp.VerifyDiagnostics(
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var implicitField = module.GlobalNamespace.GetTypeMember("Script").GetMember<FieldSymbol>("x");
+                var expectedTransformsFlags = new bool[] { false, true };
+                DynamicAttributeValidator.ValidateDynamicAttribute(implicitField.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: expectedTransformsFlags);
+            });
+        }
+
+        [Fact]
+        public void TestDynamicAttributeForScript_DynamicTypeInAliasTarget_NoCore()
+        {
+            var source =
+                "using X = Gen<dynamic>;"
+                + GetNoCS1980String(typeName: @"Gen<dynamic>")
+                + "X x = null;";
+
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script).VerifyDiagnostics(
                 // (20,1): error CS1980: Cannot define a class or member that utilizes 'dynamic' because the compiler required type 'System.Runtime.CompilerServices.DynamicAttribute' cannot be found. Are you missing a reference?
                 // X x = null;
-                Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "X").WithArguments("System.Runtime.CompilerServices.DynamicAttribute"));
+                Diagnostic(ErrorCode.ERR_DynamicAttributeMissing, "X").WithArguments("System.Runtime.CompilerServices.DynamicAttribute").WithLocation(20, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -119,22 +119,23 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
             private DynamicAttributeValidator(ModuleSymbol module)
             {
                 _module = module;
+                var globalNamespace = module.GlobalNamespace;
 
-                _base0Class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Base0");
-                _base1Class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Base1");
-                _base2Class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Base2");
-                _derivedClass = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-                _outerClass = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Outer");
+                _base0Class = globalNamespace.GetMember<NamedTypeSymbol>("Base0");
+                _base1Class = globalNamespace.GetMember<NamedTypeSymbol>("Base1");
+                _base2Class = globalNamespace.GetMember<NamedTypeSymbol>("Base2");
+                _derivedClass = globalNamespace.GetMember<NamedTypeSymbol>("Derived");
+                _outerClass = globalNamespace.GetMember<NamedTypeSymbol>("Outer");
                 _innerClass = _outerClass.GetTypeMember("Inner");
                 _innerInnerClass = _innerClass.GetTypeMember("InnerInner");
-                _outer2Class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Outer2");
+                _outer2Class = globalNamespace.GetMember<NamedTypeSymbol>("Outer2");
                 _inner2Class = _outer2Class.GetTypeMember("Inner2");
                 _innerInner2Class = _inner2Class.GetTypeMember("InnerInner2");
-                _outer3Class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Outer3");
+                _outer3Class = globalNamespace.GetMember<NamedTypeSymbol>("Outer3");
                 _inner3Class = _outer3Class.GetTypeMember("Inner3");
-                _unsafeClass = module.GlobalNamespace.GetMember<NamedTypeSymbol>("UnsafeClass");
-                _structType = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Struct");
-                _synthesizedMyDelegateType = module.GlobalNamespace.GetMember<NamedTypeSymbol>("MyDelegate");
+                _unsafeClass = globalNamespace.GetMember<NamedTypeSymbol>("UnsafeClass");
+                _structType = globalNamespace.GetMember<NamedTypeSymbol>("Struct");
+                _synthesizedMyDelegateType = globalNamespace.GetMember<NamedTypeSymbol>("MyDelegate");
 
                 _expectedTransformFlags = null;
             }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -665,39 +664,37 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll, assemblyName: "Test");
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
                 },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Assert,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0050" + // length of UTF-8 string
-                            "MySecurityAttribute, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" + // attr type name
-                            "\u0001" + // number of bytes in the encoding of the named arguments
-                            "\u0000" // number of named arguments
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Assert,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0050" + // length of UTF-8 string
+                        "MySecurityAttribute, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" + // attr type name
+                        "\u0001" + // number of bytes in the encoding of the named arguments
+                        "\u0000" // number of named arguments
                 });
             });
         }
@@ -720,27 +717,25 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -762,39 +757,37 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1" + // argument value (@"User1")
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1" + // argument value (@"User1")
 
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -817,39 +810,37 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1" + // argument value (@"User1")
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1" + // argument value (@"User1")
 
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -871,47 +862,45 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Assert,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User2", // argument value (@"User2")
-                    });
-            });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Assert,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User2", // argument value (@"User2")
+                });
+        });
         }
 
         [Fact]
@@ -933,46 +922,44 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Assert,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User2", // argument value (@"User2")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Assert,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User2", // argument value (@"User2")
+                });
             });
         }
 
@@ -1001,46 +988,44 @@ namespace N2
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C2",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C2",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -1065,46 +1050,44 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo1",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo2",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo1",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo2",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -1139,80 +1122,78 @@ namespace N
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestOptional,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u001a" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "RemotingConfiguration" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0012" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "UnmanagedCode" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestOptional,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u001a" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "RemotingConfiguration" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0012" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "UnmanagedCode" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -1235,63 +1216,61 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                });
             });
         }
 
@@ -1317,92 +1296,90 @@ namespace N
             var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1", // argument value (@"User1")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Assert,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"C",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User2", // argument value (@"User2")
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Demand,
-                        ParentKind = SymbolKind.Method,
-                        ParentNameOpt = @"Goo",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User1" + // argument value (@"User1")
-                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u000e" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "Role" + // property name
-                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "User2", // argument value (@"User2")
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1", // argument value (@"User1")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Assert,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"C",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User2", // argument value (@"User2")
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Demand,
+                    ParentKind = SymbolKind.Method,
+                    ParentNameOpt = @"Goo",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User1" + // argument value (@"User1")
+                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u000e" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "Role" + // property name
+                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "User2", // argument value (@"User2")
+                });
             });
         }
 
@@ -1449,27 +1426,25 @@ public class MyClass
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.Deny,
-                        ParentKind = SymbolKind.NamedType,
-                        ParentNameOpt = @"MyClass",
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u007f" + // length of string
-                            "System.Security.Permissions.PermissionSetAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0082" + "\u008f" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u000e" + // type string
-                            "\u0003" + // length of string (small enough to fit in 1 byte)
-                            "Hex" + // property name
-                            "\u0082" + "\u0086" + // length of string
-                            hexFileContent // argument value
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.Deny,
+                    ParentKind = SymbolKind.NamedType,
+                    ParentNameOpt = @"MyClass",
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u007f" + // length of string
+                        "System.Security.Permissions.PermissionSetAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0082" + "\u008f" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u000e" + // type string
+                        "\u0003" + // length of string (small enough to fit in 1 byte)
+                        "Hex" + // property name
+                        "\u0082" + "\u0086" + // length of string
+                        hexFileContent // argument value
+                });
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
@@ -663,40 +663,43 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll, assemblyName: "Test");
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
                 },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Assert,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0050" + // length of UTF-8 string
-                        "MySecurityAttribute, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" + // attr type name
-                        "\u0001" + // number of bytes in the encoding of the named arguments
-                        "\u0000" // number of named arguments
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Assert,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0050" + // length of UTF-8 string
+                            "MySecurityAttribute, Test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" + // attr type name
+                            "\u0001" + // number of bytes in the encoding of the named arguments
+                            "\u0000" // number of named arguments
                 });
+            });
         }
 
         [Fact]
@@ -715,27 +718,30 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -754,39 +760,42 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1" + // argument value (@"User1")
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1" + // argument value (@"User1")
 
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -806,39 +815,42 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1" + // argument value (@"User1")
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1" + // argument value (@"User1")
 
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -857,46 +869,49 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Assert,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User2", // argument value (@"User2")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Assert,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User2", // argument value (@"User2")
+                    });
+            });
         }
 
         [Fact]
@@ -916,46 +931,49 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Assert,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User2", // argument value (@"User2")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Assert,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User2", // argument value (@"User2")
+                    });
+            });
         }
 
         [Fact]
@@ -981,46 +999,49 @@ namespace N2
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C2",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C2",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -1042,46 +1063,49 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo1",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo2",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo1",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo2",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -1113,79 +1137,83 @@ namespace N
                 // [assembly: SecurityPermission(SecurityAction.RequestMinimum, UnmanagedCode = true)]
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "SecurityAction.RequestMinimum").WithArguments("System.Security.Permissions.SecurityAction.RequestMinimum", "Assembly level declarative security is obsolete and is no longer enforced by the CLR by default. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information."));
 
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.RequestOptional,
-                    ParentKind = SymbolKind.Assembly,
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u001a" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u0002" + // type bool
-                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "RemotingConfiguration" + // property name
-                        "\u0001", // argument value (true)
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                    ParentKind = SymbolKind.Assembly,
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u0012" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u0002" + // type bool
-                        "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "UnmanagedCode" + // property name
-                        "\u0001", // argument value (true)
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.RequestOptional,
+                        ParentKind = SymbolKind.Assembly,
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u001a" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u0002" + // type bool
+                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "RemotingConfiguration" + // property name
+                            "\u0001", // argument value (true)
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                        ParentKind = SymbolKind.Assembly,
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u0012" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u0002" + // type bool
+                            "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "UnmanagedCode" + // property name
+                            "\u0001", // argument value (true)
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -1205,63 +1233,66 @@ namespace N
 }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                    ParentKind = SymbolKind.Assembly,
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u0015" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u0002" + // type bool
-                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "SkipVerification" + // property name
-                        "\u0001", // argument value (true)
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                        ParentKind = SymbolKind.Assembly,
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u0015" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u0002" + // type bool
+                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "SkipVerification" + // property name
+                            "\u0001", // argument value (true)
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    });
+            });
         }
 
         [Fact]
@@ -1284,92 +1315,95 @@ namespace N
 ";
 
             var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
-            compilation.VerifyDiagnostics();
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                    ParentKind = SymbolKind.Assembly,
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u0015" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u0002" + // type bool
-                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "SkipVerification" + // property name
-                        "\u0001", // argument value (true)
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1", // argument value (@"User1")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Assert,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"C",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User2", // argument value (@"User2")
-                },
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Demand,
-                    ParentKind = SymbolKind.Method,
-                    ParentNameOpt = @"Goo",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User1" + // argument value (@"User1")
-                        "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                        "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u000e" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "Role" + // property name
-                        "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
-                        "User2", // argument value (@"User2")
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                        ParentKind = SymbolKind.Assembly,
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u0015" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u0002" + // type bool
+                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "SkipVerification" + // property name
+                            "\u0001", // argument value (true)
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1", // argument value (@"User1")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Assert,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"C",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User2", // argument value (@"User2")
+                    },
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Demand,
+                        ParentKind = SymbolKind.Method,
+                        ParentNameOpt = @"Goo",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User1" + // argument value (@"User1")
+                            "\u0080\u0085" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                            "System.Security.Permissions.PrincipalPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u000e" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0004" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "Role" + // property name
+                            "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
+                            "User2", // argument value (@"User2")
+                    });
+            });
         }
 
         [WorkItem(545084, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545084"), WorkItem(529492, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529492")]
@@ -1413,26 +1447,30 @@ public class MyClass
                 // [PermissionSetAttribute(SecurityAction.Deny, File = @"pset.xml")]
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "SecurityAction.Deny").WithArguments("System.Security.Permissions.SecurityAction.Deny", "Deny is obsolete and will be removed in a future release of the .NET Framework. See http://go.microsoft.com/fwlink/?LinkID=155570 for more information."));
 
-            ValidateDeclSecurity(compilation,
-                new DeclSecurityEntry
-                {
-                    ActionFlags = DeclarativeSecurityAction.Deny,
-                    ParentKind = SymbolKind.NamedType,
-                    ParentNameOpt = @"MyClass",
-                    PermissionSet =
-                        "." + // always start with a dot
-                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                        "\u007f" + // length of string
-                        "System.Security.Permissions.PermissionSetAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                        "\u0082" + "\u008f" + // number of bytes in the encoding of the named arguments
-                        "\u0001" + // number of named arguments
-                        "\u0054" + // property (vs field)
-                        "\u000e" + // type string
-                        "\u0003" + // length of string (small enough to fit in 1 byte)
-                        "Hex" + // property name
-                        "\u0082" + "\u0086" + // length of string
-                        hexFileContent // argument value
-                });
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
+                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
+                    new DeclSecurityEntry
+                    {
+                        ActionFlags = DeclarativeSecurityAction.Deny,
+                        ParentKind = SymbolKind.NamedType,
+                        ParentNameOpt = @"MyClass",
+                        PermissionSet =
+                            "." + // always start with a dot
+                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                            "\u007f" + // length of string
+                            "System.Security.Permissions.PermissionSetAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                            "\u0082" + "\u008f" + // number of bytes in the encoding of the named arguments
+                            "\u0001" + // number of named arguments
+                            "\u0054" + // property (vs field)
+                            "\u000e" + // type string
+                            "\u0003" + // length of string (small enough to fit in 1 byte)
+                            "Hex" + // property name
+                            "\u0082" + "\u0086" + // length of string
+                            hexFileContent // argument value
+                    });
+            });
         }
 
         [WorkItem(545084, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545084"), WorkItem(529492, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529492")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
@@ -900,7 +900,7 @@ namespace N
                         "\u0005" + // length of UTF-8 string (small enough to fit in 1 byte)
                         "User2", // argument value (@"User2")
                 });
-        });
+            });
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Security.cs
@@ -1302,7 +1302,21 @@ namespace N
                     // Verify assembly security attribute for unsafe dll
                     Assert.Equal(1, assemblySecurityAttributes.Count());
                     Cci.SecurityAttribute securityAttribute = assemblySecurityAttributes.Single();
-                    AttributeTests_Synthesized.VerifySkipVerificationSecurityAttribute(securityAttribute, compilation);
+                    var securityPermissionsAttribute = (CSharpAttributeData)securityAttribute.Attribute;
+
+                    Assert.Equal(compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityPermissionAttribute), securityPermissionsAttribute.AttributeClass);
+                    Assert.Equal(compilation.GetWellKnownTypeMember(WellKnownMember.System_Security_Permissions_SecurityPermissionAttribute__ctor), securityPermissionsAttribute.AttributeConstructor);
+
+                    var assemblyAttributeArgument = securityPermissionsAttribute.CommonConstructorArguments.Single();
+                    Assert.Equal(compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAction), assemblyAttributeArgument.Type);
+                    Assert.Equal(DeclarativeSecurityAction.RequestMinimum, securityAttribute.Action);
+                    Assert.Equal(DeclarativeSecurityAction.RequestMinimum, (DeclarativeSecurityAction)(int)assemblyAttributeArgument.Value);
+
+                    var assemblyAttributeNamedArgument = securityPermissionsAttribute.CommonNamedArguments.Single();
+                    Assert.Equal("SkipVerification", assemblyAttributeNamedArgument.Key);
+                    var assemblyAttributeNamedArgumentValue = assemblyAttributeNamedArgument.Value;
+                    Assert.Equal(compilation.GetSpecialType(SpecialType.System_Boolean), assemblyAttributeNamedArgumentValue.Type);
+                    Assert.Equal(true, assemblyAttributeNamedArgumentValue.Value);
 
                     // Get System.Security.Permissions.PrincipalPermissionAttribute
                     var emittedName = MetadataTypeName.FromNamespaceAndTypeName("System.Security.Permissions", "PrincipalPermissionAttribute");

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -21,7 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     /// <summary>
     /// NYI: PEVerify currently fails for netmodules with error: "The module X was expected to contain an assembly manifest".
-    /// TODO: Verification was disabled for net modules for now. Add it back once module support has been added.
+    /// Verification was disabled for net modules for now. Add it back once module support has been added.
+    /// See tests having verify: !outputKind.IsNetModule()
+    /// https://github.com/dotnet/roslyn/issues/23475
     /// </summary>
     public class AttributeTests_Synthesized: WellKnownAttributesTestBase
     {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -27,17 +26,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class AttributeTests_Synthesized: WellKnownAttributesTestBase
     {
         #region Theory Data
-        public static IEnumerable<object[]> OutputKindTheoryData
-        {
-            get
-            {
-                foreach (var kind in Enum.GetValues(typeof(OutputKind)))
-                {
-                    yield return new object[] { kind };
-                }
-            }
-        }
-
         public static IEnumerable<object[]> OptimizationLevelTheoryData
         {
             get
@@ -1178,7 +1166,8 @@ public class Test
 
         #region UnverifiableCode, SecurityPermission
         [Theory]
-        [MemberData(nameof(OutputKindTheoryData))]
+        [InlineData(OutputKind.DynamicallyLinkedLibrary)]
+        [InlineData(OutputKind.NetModule)]
         public void CheckUnsafeAttributes(OutputKind outputKind)
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -1206,7 +1206,7 @@ unsafe class C
 
             void validateSecurity(ModuleSymbol module)
             {
-                ValidateDeclSecurity(((PEModuleSymbol)module).Module.MetadataReader, new DeclSecurityEntry
+                ValidateDeclSecurity(module, new DeclSecurityEntry
                 {
                     ActionFlags = DeclarativeSecurityAction.RequestMinimum,
                     ParentKind = SymbolKind.Assembly,

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -7,8 +7,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -18,16 +20,104 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class AttributeTests_Synthesized : WellKnownAttributesTestBase
+    /// <summary>
+    /// NYI: PEVerify currently fails for netmodules with error: "The module X was expected to contain an assembly manifest".
+    /// TODO: Verification was disabled for net modules for now. Add it back once module support has been added.
+    /// </summary>
+    public class AttributeTests_Synthesized: WellKnownAttributesTestBase
     {
-        #region CompilerGeneratedAttribute, DebuggerBrowsableAttribute, DebuggerStepThroughAttribute, DebuggerDisplayAttribute
-
-        private static DebuggerBrowsableState GetDebuggerBrowsableState(ImmutableArray<SynthesizedAttributeData> attributes)
+        #region Theory Data
+        public static IEnumerable<object[]> OutputKindTheoryData
         {
-            return (DebuggerBrowsableState)attributes.Single(a => a.AttributeClass.Name == "DebuggerBrowsableAttribute").ConstructorArguments.First().Value;
+            get
+            {
+                foreach (var kind in Enum.GetValues(typeof(OutputKind)))
+                {
+                    yield return new object[] { kind };
+                }
+            }
         }
 
-        [Fact, WorkItem(546632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546632")]
+        public static IEnumerable<object[]> OptimizationLevelTheoryData
+        {
+            get
+            {
+                foreach (var level in Enum.GetValues(typeof(OptimizationLevel)))
+                {
+                    yield return new object[] { level };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> FullMatrixTheoryData
+        {
+            get
+            {
+                foreach (var kind in Enum.GetValues(typeof(OutputKind)))
+                {
+                    foreach (var level in Enum.GetValues(typeof(OptimizationLevel)))
+                    {
+                        yield return new object[] { kind, level };
+                    }
+                }
+            }
+        }
+        #endregion
+
+        #region Helpers
+        private void VerifyCompilationRelaxationsAttribute(CSharpAttributeData attribute, bool isSynthesized)
+        {
+            Assert.Equal("System.Runtime.CompilerServices.CompilationRelaxationsAttribute", attribute.AttributeClass.ToTestDisplayString());
+            Assert.Equal("System.Int32", attribute.AttributeConstructor.Parameters.Single().Type.ToTestDisplayString());
+            Assert.Empty(attribute.CommonNamedArguments);
+
+            int expectedArgValue = isSynthesized ? (int)CompilationRelaxations.NoStringInterning : 0;
+            Assert.Equal(1, attribute.CommonConstructorArguments.Length);
+            attribute.VerifyValue(0, TypedConstantKind.Primitive, expectedArgValue);
+        }
+
+        private void VerifyRuntimeCompatibilityAttribute(CSharpAttributeData attribute, bool isSynthesized)
+        {
+            Assert.Equal("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", attribute.AttributeClass.ToTestDisplayString());
+            Assert.Empty(attribute.AttributeConstructor.Parameters);
+            Assert.Empty(attribute.CommonConstructorArguments);
+
+            if (isSynthesized)
+            {
+                Assert.Equal(1, attribute.CommonNamedArguments.Length);
+                attribute.VerifyNamedArgumentValue<bool>(0, "WrapNonExceptionThrows", TypedConstantKind.Primitive, true);
+            }
+            else
+            {
+                Assert.Equal(0, attribute.CommonNamedArguments.Length);
+            }
+        }
+
+        private void VerifyDebuggableAttribute(CSharpAttributeData attribute, OptimizationLevel optimizations, bool isSynthesized)
+        {
+            Assert.Equal("System.Diagnostics.DebuggableAttribute", attribute.AttributeClass.ToTestDisplayString());
+            Assert.Equal("System.Diagnostics.DebuggableAttribute.DebuggingModes", attribute.AttributeConstructor.Parameters.Single().Type.ToTestDisplayString());
+            Assert.Empty(attribute.CommonNamedArguments);
+
+            Assert.Equal(1, attribute.CommonConstructorArguments.Length);
+
+            var expectedDebuggingMode = DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints;
+
+            if (isSynthesized && optimizations == OptimizationLevel.Debug)
+            {
+                expectedDebuggingMode |=
+                    DebuggableAttribute.DebuggingModes.Default |
+                    DebuggableAttribute.DebuggingModes.DisableOptimizations |
+                    DebuggableAttribute.DebuggingModes.EnableEditAndContinue;
+            }
+
+            attribute.VerifyValue(0, TypedConstantKind.Enum, (int)expectedDebuggingMode);
+        }
+        #endregion
+
+        #region CompilerGeneratedAttribute, DebuggerBrowsableAttribute, DebuggerStepThroughAttribute, DebuggerDisplayAttribute
+        [Fact]
+        [WorkItem(546632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546632")]
         public void PrivateImplementationDetails()
         {
             string source = @"
@@ -48,7 +138,8 @@ class C
             AssertEx.SetEqual(expectedAttrs, actualAttrs);
         }
 
-        [Fact, WorkItem(546958, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546958")]
+        [Fact]
+        [WorkItem(546958, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546958")]
         public void FixedSizeBuffers()
         {
             string source = @"
@@ -69,8 +160,10 @@ unsafe struct S
             AssertEx.SetEqual(expectedAttrs, actualAttrs);
         }
 
-        [Fact, WorkItem(546927, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546927")]
-        public void BackingFields()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        [WorkItem(546927, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546927")]
+        public void BackingFields_Property(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System;
@@ -81,33 +174,45 @@ class Test
     public event Func<int> MyEvent;
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(source, options: options, symbolValidator: module =>
             {
-                var comp = CreateStandardCompilation(source, options: options);
+                var peModule = (PEModuleSymbol)module;
+                var type = peModule.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
 
-                var c = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-                var p = c.GetMember<PropertySymbol>("MyProp");
-                var e = c.GetMember<EventSymbol>("MyEvent");
+                var property = type.GetMember<PEFieldSymbol>(GeneratedNames.MakeBackingFieldName("MyProp"));
+                Verify(property.Handle);
 
-                var expectedAttrs =
-                    options.OptimizationLevel == OptimizationLevel.Debug
-                    ? new[] { "CompilerGeneratedAttribute", "DebuggerBrowsableAttribute" }
-                    : new[] { "CompilerGeneratedAttribute" };
+                var eventField = (PEFieldSymbol)type.GetMember<PEEventSymbol>("MyEvent").AssociatedField;
+                Verify(eventField.Handle);
 
-                var attrs = ((SourcePropertySymbol)p).BackingField.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expectedAttrs, GetAttributeNames(attrs));
-                if (options.OptimizationLevel == OptimizationLevel.Debug)
-                    Assert.Equal(DebuggerBrowsableState.Never, GetDebuggerBrowsableState(attrs));
+                void Verify(EntityHandle token)
+                {
+                    var attributes = peModule.GetCustomAttributesForToken(token);
 
-                attrs = e.AssociatedField.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expectedAttrs, GetAttributeNames(attrs));
-                if (options.OptimizationLevel == OptimizationLevel.Debug)
-                    Assert.Equal(DebuggerBrowsableState.Never, GetDebuggerBrowsableState(attrs));
-            }
+                    if (optimizationLevel == OptimizationLevel.Debug)
+                    {
+                        Assert.Equal(2, attributes.Length);
+
+                        Assert.Equal("CompilerGeneratedAttribute", attributes[0].AttributeClass.Name);
+                        Assert.Equal("DebuggerBrowsableAttribute", attributes[1].AttributeClass.Name);
+                        Assert.Equal(DebuggerBrowsableState.Never, (DebuggerBrowsableState)attributes[1].ConstructorArguments.Single().Value);
+                    }
+                    else
+                    {
+                        Assert.Equal("CompilerGeneratedAttribute", attributes.Single().AttributeClass.Name);
+                    }
+                }
+            });
         }
 
-        [Fact, WorkItem(546927, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546927")]
-        public void Accessors()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        [WorkItem(546927, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546927")]
+        public void Accessors(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System;
@@ -119,41 +224,33 @@ abstract class C
     public event Func<int> E;
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
-            {
-                var comp = CreateStandardCompilation(source, options: options);
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
 
-                var c = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+            CompileAndVerify(source, options: options, symbolValidator: module =>
+            {
+                var peModule = (PEModuleSymbol)module;
+                var c = peModule.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+
                 var p = c.GetMember<PropertySymbol>("P");
+                Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)p.GetMethod).Handle).Single().AttributeClass.Name);
+                Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)p.SetMethod).Handle).Single().AttributeClass.Name);
+
                 // no attributes on abstract property accessors
                 var q = c.GetMember<PropertySymbol>("Q");
+                Assert.Empty(peModule.GetCustomAttributesForToken(((PEMethodSymbol)q.GetMethod).Handle));
+                Assert.Empty(peModule.GetCustomAttributesForToken(((PEMethodSymbol)q.SetMethod).Handle));
 
                 var e = c.GetMember<EventSymbol>("E");
-
-                var expected = new[] { "CompilerGeneratedAttribute" };
-
-                var attrs = p.GetMethod.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expected, GetAttributeNames(attrs));
-
-                attrs = p.SetMethod.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expected, GetAttributeNames(attrs));
-
-                attrs = q.GetMethod.GetSynthesizedAttributes();
-                Assert.Equal(0, attrs.Length);
-
-                attrs = q.SetMethod.GetSynthesizedAttributes();
-                Assert.Equal(0, attrs.Length);
-
-                attrs = e.AddMethod.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expected, GetAttributeNames(attrs));
-
-                attrs = e.RemoveMethod.GetSynthesizedAttributes();
-                AssertEx.SetEqual(expected, GetAttributeNames(attrs));
-            }
+                Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)e.AddMethod).Handle).Single().AttributeClass.Name);
+                Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)e.RemoveMethod).Handle).Single().AttributeClass.Name);
+            });
         }
 
-        [Fact]
-        public void Lambdas()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void Lambdas(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System;
@@ -167,25 +264,25 @@ class C
     }
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateStandardCompilation(source, options: options), symbolValidator: m =>
             {
-                var comp = CreateStandardCompilation(source, options: options);
+                var displayClass = m.GlobalNamespace.GetMember<NamedTypeSymbol>("C.<>c__DisplayClass0_0");
+                AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(displayClass.GetAttributes()));
 
-                CompileAndVerify(comp, symbolValidator: m =>
+                foreach (var member in displayClass.GetMembers())
                 {
-                    var displayClass = m.GlobalNamespace.GetMember<NamedTypeSymbol>("C.<>c__DisplayClass0_0");
-                    AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(displayClass.GetAttributes()));
-
-                    foreach (var member in displayClass.GetMembers())
-                    {
-                        Assert.Equal(0, member.GetAttributes().Length);
-                    }
-                });
-            }
+                    Assert.Equal(0, member.GetAttributes().Length);
+                }
+            });
         }
 
-        [Fact]
-        public void AnonymousTypes()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void AnonymousTypes(OptimizationLevel optimizationLevel)
         {
             string source = @"
 class C
@@ -196,59 +293,58 @@ class C
     }
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateStandardCompilation(source, options: options), symbolValidator: m =>
             {
-                var comp = CreateStandardCompilation(source, options: options);
+                var anon = m.ContainingAssembly.GetTypeByMetadataName("<>f__AnonymousType0`2");
 
-                CompileAndVerify(comp, symbolValidator: m =>
+                string[] expected;
+                if (options.OptimizationLevel == OptimizationLevel.Debug)
                 {
-                    var anon = m.ContainingAssembly.GetTypeByMetadataName("<>f__AnonymousType0`2");
+                    expected = new[] { "DebuggerDisplayAttribute", "CompilerGeneratedAttribute" };
+                }
+                else
+                {
+                    expected = new[] { "CompilerGeneratedAttribute" };
+                }
 
-                    string[] expected;
-                    if (options.OptimizationLevel == OptimizationLevel.Debug)
+                AssertEx.SetEqual(expected, GetAttributeNames(anon.GetAttributes()));
+
+                foreach (var member in anon.GetMembers())
+                {
+                    var actual = GetAttributeNames(member.GetAttributes());
+
+                    switch (member.Name)
                     {
-                        expected = new[] { "DebuggerDisplayAttribute", "CompilerGeneratedAttribute" };
+                        case "<X>i__Field":
+                        case "<Y>i__Field":
+                            expected = new[] { "DebuggerBrowsableAttribute" };
+                            break;
+
+                        case ".ctor":
+                        case "Equals":
+                        case "GetHashCode":
+                        case "ToString":
+                            expected = new[] { "DebuggerHiddenAttribute" };
+                            break;
+
+                        case "X":
+                        case "get_X":
+                        case "Y":
+                        case "get_Y":
+                            expected = new string[] { };
+                            break;
+
+                        default:
+                            throw TestExceptionUtilities.UnexpectedValue(member.Name);
                     }
-                    else
-                    {
-                        expected = new[] { "CompilerGeneratedAttribute" };
-                    }
 
-                    AssertEx.SetEqual(expected, GetAttributeNames(anon.GetAttributes()));
-
-                    foreach (var member in anon.GetMembers())
-                    {
-                        var actual = GetAttributeNames(member.GetAttributes());
-
-                        switch (member.Name)
-                        {
-                            case "<X>i__Field":
-                            case "<Y>i__Field":
-                                expected = new[] { "DebuggerBrowsableAttribute" };
-                                break;
-
-                            case ".ctor":
-                            case "Equals":
-                            case "GetHashCode":
-                            case "ToString":
-                                expected = new[] { "DebuggerHiddenAttribute" };
-                                break;
-
-                            case "X":
-                            case "get_X":
-                            case "Y":
-                            case "get_Y":
-                                expected = new string[] { };
-                                break;
-
-                            default:
-                                throw TestExceptionUtilities.UnexpectedValue(member.Name);
-                        }
-
-                        AssertEx.SetEqual(expected, actual);
-                    }
-                });
-            }
+                    AssertEx.SetEqual(expected, actual);
+                }
+            });
         }
 
         [Fact]
@@ -303,26 +399,27 @@ public class C
                 Assert.Equal(@"\{ X10 = {X10}, X11 = {X11}, X12 = {X12}, X13 = {X13}, X14 = {X14}, X15 = {X15}, X16 = {X16}, X17 = {X17}, X20 = {X20}, X21 = {X21} ... }",
                     GetDebuggerDisplayString(assembly, 12, 48));
             });
+
+            string GetDebuggerDisplayString(AssemblySymbol assembly, int ordinal, int fieldCount)
+            {
+                NamedTypeSymbol anon;
+                if (fieldCount == 0)
+                {
+                    anon = assembly.GetTypeByMetadataName("<>f__AnonymousType0");
+                }
+                else
+                {
+                    anon = assembly.GetTypeByMetadataName("<>f__AnonymousType" + ordinal + "`" + fieldCount);
+                }
+
+                var dd = anon.GetAttributes().Where(a => a.AttributeClass.Name == "DebuggerDisplayAttribute").Single();
+                return (string)dd.ConstructorArguments.Single().Value;
+            }
         }
 
-        private static string GetDebuggerDisplayString(AssemblySymbol assembly, int ordinal, int fieldCount)
-        {
-            NamedTypeSymbol anon;
-            if (fieldCount == 0)
-            {
-                anon = assembly.GetTypeByMetadataName("<>f__AnonymousType0");
-            }
-            else
-            {
-                anon = assembly.GetTypeByMetadataName("<>f__AnonymousType" + ordinal + "`" + fieldCount);
-            }
-
-            var dd = anon.GetAttributes().Where(a => a.AttributeClass.Name == "DebuggerDisplayAttribute").Single();
-            return (string)dd.ConstructorArguments.Single().Value;
-        }
-
-        [Fact]
-        public void Iterator()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void Iterator(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System.Collections.Generic;
@@ -335,45 +432,45 @@ public class C
     }
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateStandardCompilation(source, options: options), symbolValidator: module =>
             {
-                var comp = CreateStandardCompilation(source, options: options);
+                var iter = module.ContainingAssembly.GetTypeByMetadataName("C+<Iterator>d__0");
+                AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(iter.GetAttributes()));
 
-                CompileAndVerify(comp, symbolValidator: module =>
+                foreach (var member in iter.GetMembers().Where(member => member is MethodSymbol))
                 {
-                    var iter = module.ContainingAssembly.GetTypeByMetadataName("C+<Iterator>d__0");
-                    AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(iter.GetAttributes()));
-
-                    foreach (var member in iter.GetMembers().Where(member => member is MethodSymbol))
+                    switch (member.Name)
                     {
-                        switch (member.Name)
-                        {
-                            case ".ctor":
-                            case "System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator":
-                            case "System.Collections.IEnumerable.GetEnumerator":
-                            case "System.Collections.IEnumerator.Reset":
-                            case "System.IDisposable.Dispose":
-                            case "System.Collections.Generic.IEnumerator<System.Int32>.get_Current":
-                            case "System.Collections.IEnumerator.get_Current":
-                                AssertEx.SetEqual(new[] { "DebuggerHiddenAttribute" }, GetAttributeNames(member.GetAttributes()));
-                                break;
+                        case ".ctor":
+                        case "System.Collections.Generic.IEnumerable<System.Int32>.GetEnumerator":
+                        case "System.Collections.IEnumerable.GetEnumerator":
+                        case "System.Collections.IEnumerator.Reset":
+                        case "System.IDisposable.Dispose":
+                        case "System.Collections.Generic.IEnumerator<System.Int32>.get_Current":
+                        case "System.Collections.IEnumerator.get_Current":
+                            AssertEx.SetEqual(new[] { "DebuggerHiddenAttribute" }, GetAttributeNames(member.GetAttributes()));
+                            break;
 
-                            case "System.Collections.IEnumerator.Current":
-                            case "System.Collections.Generic.IEnumerator<System.Int32>.Current":
-                            case "MoveNext":
-                                AssertEx.SetEqual(new string[] { }, GetAttributeNames(member.GetAttributes()));
-                                break;
+                        case "System.Collections.IEnumerator.Current":
+                        case "System.Collections.Generic.IEnumerator<System.Int32>.Current":
+                        case "MoveNext":
+                            AssertEx.SetEqual(new string[] { }, GetAttributeNames(member.GetAttributes()));
+                            break;
 
-                            default:
-                                throw TestExceptionUtilities.UnexpectedValue(member.Name);
-                        }
+                        default:
+                            throw TestExceptionUtilities.UnexpectedValue(member.Name);
                     }
-                });
-            }
+                }
+            });
         }
 
-        [Fact]
-        public void Async()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void Async(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System.Threading.Tasks;
@@ -391,1239 +488,46 @@ class C
     }
 }
 ";
-            foreach (var options in new[] { TestOptions.DebugDll, TestOptions.ReleaseDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
             {
-                var comp = CreateCompilationWithMscorlib45(source, options: options);
+                var goo = module.GlobalNamespace.GetMember<MethodSymbol>("C.Goo");
+                AssertEx.SetEqual(options.OptimizationLevel == OptimizationLevel.Debug ?
+                                    new[] { "AsyncStateMachineAttribute", "DebuggerStepThroughAttribute" } :
+                                    new[] { "AsyncStateMachineAttribute" }, GetAttributeNames(goo.GetAttributes()));
 
-                CompileAndVerify(comp, symbolValidator: m =>
+                var iter = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C.<Goo>d__0");
+                AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(iter.GetAttributes()));
+
+                foreach (var member in iter.GetMembers().Where(s => s.Kind == SymbolKind.Method))
                 {
-                    var goo = m.GlobalNamespace.GetMember<MethodSymbol>("C.Goo");
-                    AssertEx.SetEqual(options.OptimizationLevel == OptimizationLevel.Debug ?
-                                        new[] { "AsyncStateMachineAttribute", "DebuggerStepThroughAttribute" } :
-                                        new[] { "AsyncStateMachineAttribute" }, GetAttributeNames(goo.GetAttributes()));
-
-                    var iter = m.GlobalNamespace.GetMember<NamedTypeSymbol>("C.<Goo>d__0");
-                    AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(iter.GetAttributes()));
-
-                    foreach (var member in iter.GetMembers().Where(s => s.Kind == SymbolKind.Method))
+                    switch (member.Name)
                     {
-                        switch (member.Name)
-                        {
-                            case ".ctor":
-                                break;
+                        case ".ctor":
+                            break;
 
-                            case "SetStateMachine":
-                                AssertEx.SetEqual(new[] { "DebuggerHiddenAttribute" }, GetAttributeNames(member.GetAttributes()));
-                                break;
+                        case "SetStateMachine":
+                            AssertEx.SetEqual(new[] { "DebuggerHiddenAttribute" }, GetAttributeNames(member.GetAttributes()));
+                            break;
 
-                            case "MoveNext":
-                                AssertEx.SetEqual(new string[] { }, GetAttributeNames(member.GetAttributes()));
-                                break;
+                        case "MoveNext":
+                            AssertEx.SetEqual(new string[] { }, GetAttributeNames(member.GetAttributes()));
+                            break;
 
-                            default:
-                                throw TestExceptionUtilities.UnexpectedValue(member.Name);
-                        }
+                        default:
+                            throw TestExceptionUtilities.UnexpectedValue(member.Name);
                     }
-                });
-            }
-        }
-
-        #endregion
-
-        #region CompilationRelaxationsAttribute, RuntimeCompatibilityAttribute
-
-        private void VerifyCompilationRelaxationsAttribute(CSharpAttributeData attribute, SourceAssemblySymbol sourceAssembly, bool isSynthesized)
-        {
-            ModuleSymbol module = sourceAssembly.Modules[0];
-            NamespaceSymbol compilerServicesNS = Get_System_Runtime_CompilerServices_NamespaceSymbol(module);
-
-            NamedTypeSymbol compilationRelaxationsAttrType = compilerServicesNS.GetTypeMember("CompilationRelaxationsAttribute");
-            var compilationRelaxationsCtor = (MethodSymbol)sourceAssembly.DeclaringCompilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_CompilationRelaxationsAttribute__ctorInt32);
-
-            Assert.Equal(compilationRelaxationsAttrType, attribute.AttributeClass);
-            Assert.Equal(compilationRelaxationsCtor, attribute.AttributeConstructor);
-
-            int expectedArgValue = isSynthesized ? (int)CompilationRelaxations.NoStringInterning : 0;
-            Assert.Equal(1, attribute.CommonConstructorArguments.Length);
-            attribute.VerifyValue<int>(0, TypedConstantKind.Primitive, expectedArgValue);
-
-            Assert.Equal(0, attribute.CommonNamedArguments.Length);
-        }
-
-        private void VerifyRuntimeCompatibilityAttribute(CSharpAttributeData attribute, SourceAssemblySymbol sourceAssembly, bool isSynthesized)
-        {
-            ModuleSymbol module = sourceAssembly.Modules[0];
-            NamespaceSymbol compilerServicesNS = Get_System_Runtime_CompilerServices_NamespaceSymbol(module);
-
-            NamedTypeSymbol runtimeCompatibilityAttrType = compilerServicesNS.GetTypeMember("RuntimeCompatibilityAttribute");
-            var runtimeCompatibilityCtor = (MethodSymbol)sourceAssembly.DeclaringCompilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_RuntimeCompatibilityAttribute__ctor);
-
-            Assert.Equal(runtimeCompatibilityAttrType, attribute.AttributeClass);
-            Assert.Equal(runtimeCompatibilityCtor, attribute.AttributeConstructor);
-
-            Assert.Equal(0, attribute.CommonConstructorArguments.Length);
-
-            if (isSynthesized)
-            {
-                Assert.Equal(1, attribute.CommonNamedArguments.Length);
-                attribute.VerifyNamedArgumentValue<bool>(0, "WrapNonExceptionThrows", TypedConstantKind.Primitive, true);
-            }
-            else
-            {
-                Assert.Equal(0, attribute.CommonNamedArguments.Length);
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_01()
-        {
-            // Verify Synthesized CompilationRelaxationsAttribute
-            // Verify Synthesized RuntimeCompatibilityAttribute
-
-            var source = @"
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-
-                if (outputKind != OutputKind.NetModule)
-                {
-                    // Verify synthesized CompilationRelaxationsAttribute and RuntimeCompatibilityAttribute
-                    Assert.Equal(3, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                    VerifyDebuggableAttribute(synthesizedAttributes[2], sourceAssembly, DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints);
                 }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            }
+            });
         }
 
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_02()
-        {
-            // Verify Applied CompilationRelaxationsAttribute
-            // Verify Synthesized RuntimeCompatibilityAttribute
-
-            var source = @"
-using System.Runtime.CompilerServices;
-
-[assembly: CompilationRelaxationsAttribute(0)]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-
-                // Verify applied CompilationRelaxationsAttribute
-                var appliedAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyCompilationRelaxationsAttribute(appliedAttributes[0], sourceAssembly, isSynthesized: false);
-
-                // Verify synthesized RuntimeCompatibilityAttribute
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                if (outputKind != OutputKind.NetModule)
-                {
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyDebuggableAttribute(synthesizedAttributes[1], sourceAssembly, DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_03()
-        {
-            // Verify Synthesized CompilationRelaxationsAttribute
-            // Verify Applied RuntimeCompatibilityAttribute
-
-            var source = @"
-using System.Runtime.CompilerServices;
-
-[assembly: RuntimeCompatibilityAttribute()]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-
-                // Verify applied RuntimeCompatibilityAttribute
-                var appliedAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyRuntimeCompatibilityAttribute(appliedAttributes[0], sourceAssembly, isSynthesized: false);
-
-                // Verify synthesized CompilationRelaxationsAttribute
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                if (outputKind != OutputKind.NetModule)
-                {
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyDebuggableAttribute(synthesizedAttributes[1], sourceAssembly, DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_04()
-        {
-            // Verify Applied CompilationRelaxationsAttribute
-            // Verify Applied RuntimeCompatibilityAttribute
-
-            var source = @"
-using System.Runtime.CompilerServices;
-
-[assembly: CompilationRelaxationsAttribute(0)]
-[assembly: RuntimeCompatibilityAttribute()]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-
-                // Verify applied CompilationRelaxationsAttribute and RuntimeCompatibilityAttribute
-                var appliedAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(2, appliedAttributes.Length);
-                VerifyCompilationRelaxationsAttribute(appliedAttributes[0], sourceAssembly, isSynthesized: false);
-                VerifyRuntimeCompatibilityAttribute(appliedAttributes[1], sourceAssembly, isSynthesized: false);
-
-                // Verify no synthesized attributes
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                if (outputKind != OutputKind.NetModule)
-                {
-                    Assert.Equal(1, synthesizedAttributes.Length);
-                    VerifyDebuggableAttribute(synthesizedAttributes[0], sourceAssembly, DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_05()
-        {
-            // Verify module attributes don't suppress synthesized assembly attributes:
-
-            // Synthesized CompilationRelaxationsAttribute
-            // Synthesized RuntimeCompatibilityAttribute
-
-            var source = @"
-using System.Runtime.CompilerServices;
-
-[module: CompilationRelaxationsAttribute(0)]
-[module: RuntimeCompatibilityAttribute()]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-
-                // Verify no applied assembly attributes
-                var appliedAssemblyAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(0, appliedAssemblyAttributes.Length);
-
-                // Verify applied module attributes
-                var appliedModuleAttributes = sourceAssembly.Modules[0].GetAttributes();
-                Assert.Equal(2, appliedModuleAttributes.Length);
-                VerifyCompilationRelaxationsAttribute(appliedModuleAttributes[0], sourceAssembly, isSynthesized: false);
-                VerifyRuntimeCompatibilityAttribute(appliedModuleAttributes[1], sourceAssembly, isSynthesized: false);
-
-                // Verify synthesized assembly attributes
-                var synthesizedAssemblyAttributes = sourceAssembly.GetSynthesizedAttributes();
-                if (!outputKind.IsNetModule())
-                {
-                    Assert.Equal(3, synthesizedAssemblyAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAssemblyAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAssemblyAttributes[1], sourceAssembly, isSynthesized: true);
-                    VerifyDebuggableAttribute(synthesizedAssemblyAttributes[2], sourceAssembly, DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAssemblyAttributes.Length);
-                }
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_06()
-        {
-            // Verify missing well-known attribute types **DO NOT** generate diagnostics and silently suppress synthesizing CompilationRelaxationsAttribute and RuntimeCompatibilityAttribute.
-
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateCompilation("", options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                if (outputKind.IsApplication())
-                {
-                    compilation.VerifyDiagnostics(
-                        // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
-                        Diagnostic(ErrorCode.ERR_NoEntryPoint));
-                }
-                else
-                {
-                    compilation.VerifyDiagnostics();
-                }
-
-                // Verify no synthesized assembly attributes
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                Assert.Equal(0, synthesizedAttributes.Length);
-            }
-        }
-
-        [Fact]
-        public void TestSynthesizedAssemblyAttributes_07()
-        {
-            // Verify missing well-known attribute members **DO** generate diagnostics and suppress synthesizing CompilationRelaxationsAttribute and RuntimeCompatibilityAttribute.
-
-            var source = @"
-namespace System.Runtime.CompilerServices
-{
-    sealed public class CompilationRelaxationsAttribute : System.Attribute
-    {
-    }
-
-    sealed public class RuntimeCompatibilityAttribute : System.Attribute
-    {
-        public RuntimeCompatibilityAttribute(int dummy) {}
-    }
-}
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(outputKind, optimizationLevel: OptimizationLevel.Release));
-
-                if (!outputKind.IsNetModule())
-                {
-                    compilation.VerifyDiagnostics(
-                        // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor'
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.CompilationRelaxationsAttribute", ".ctor"),
-                        // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor'
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", ".ctor"),
-                        // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.WrapNonExceptionThrows'
-                        Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", "WrapNonExceptionThrows"));
-                }
-                else
-                {
-                    compilation.VerifyDiagnostics();
-
-                    // Verify no synthesized assembly attributes
-                    var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                    var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            }
-        }
-
-        // NYI: /addmodule support
-        // TODO: Add tests for assembly attributes emitted into netmodules which suppress synthesized CompilationRelaxationsAttribute/RuntimeCompatibilityAttribute
-
-        #endregion
-
-        #region DebuggableAttribute
-
-        private void VerifyDebuggableAttribute(CSharpAttributeData attribute, SourceAssemblySymbol sourceAssembly, DebuggableAttribute.DebuggingModes expectedDebuggingMode)
-        {
-            ModuleSymbol module = sourceAssembly.Modules[0];
-            NamespaceSymbol diagnosticsNS = Get_System_Diagnostics_NamespaceSymbol(module);
-
-            NamedTypeSymbol debuggableAttributeType = diagnosticsNS.GetTypeMember("DebuggableAttribute");
-            var debuggableAttributeCtor = (MethodSymbol)sourceAssembly.DeclaringCompilation.GetWellKnownTypeMember(WellKnownMember.System_Diagnostics_DebuggableAttribute__ctorDebuggingModes);
-
-            Assert.Equal(debuggableAttributeType, attribute.AttributeClass);
-            Assert.Equal(debuggableAttributeCtor, attribute.AttributeConstructor);
-
-            Assert.Equal(1, attribute.CommonConstructorArguments.Length);
-            attribute.VerifyValue(0, TypedConstantKind.Enum, (int)expectedDebuggingMode);
-
-            Assert.Equal(0, attribute.CommonNamedArguments.Length);
-        }
-
-        private void VerifySynthesizedDebuggableAttribute(CSharpAttributeData attribute, SourceAssemblySymbol sourceAssembly, OptimizationLevel optimizations)
-        {
-            var expectedDebuggingMode = DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints;
-
-            if (optimizations == OptimizationLevel.Debug)
-            {
-                expectedDebuggingMode |=
-                    DebuggableAttribute.DebuggingModes.Default |
-                    DebuggableAttribute.DebuggingModes.DisableOptimizations |
-                    DebuggableAttribute.DebuggingModes.EnableEditAndContinue;
-            }
-
-            VerifyDebuggableAttribute(attribute, sourceAssembly, expectedDebuggingMode);
-        }
-
-        private void TestDebuggableAttributeCommon(
-            string source,
-            Action<CSharpCompilation> validator,
-            bool includeMscorlibRef,
-            bool compileAndVerify,
-            OutputKind outputKind,
-            OptimizationLevel optimizations)
-        {
-            var compilation = CSharpCompilation.Create("comp",
-                new[] { Parse(source) },
-                includeMscorlibRef ? new[] { MscorlibRef } : null,
-                new CSharpCompilationOptions(outputKind, optimizationLevel: optimizations));
-
-            validator(compilation);
-
-            if (compileAndVerify)
-            {
-                // NYI: /addmodule support
-                // TODO: PEVerify currently fails for netmodules with error: "The module X was expected to contain an assembly manifest".
-                // TODO: Remove the 'verify' named argument once /addmodule support has been added.
-                CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes);
-            }
-        }
-
-        private void TestDebuggableAttributeMatrix(string source, Action<CSharpCompilation> validator, bool includeMscorlibRef = true, bool compileAndVerify = true)
-        {
-            foreach (OutputKind outputKind in Enum.GetValues(typeof(OutputKind)))
-            {
-                foreach (OptimizationLevel optimizations in Enum.GetValues(typeof(OptimizationLevel)))
-                {
-                    TestDebuggableAttributeCommon(source, validator, includeMscorlibRef, compileAndVerify, outputKind, optimizations);
-                }
-            }
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_01()
-        {
-            // Verify Synthesized DebuggableAttribute
-
-            var source = @"
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    Assert.Equal(3, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                    VerifySynthesizedDebuggableAttribute(synthesizedAttributes[2], sourceAssembly, options.OptimizationLevel);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_02()
-        {
-            // Verify applied assembly DebuggableAttribute suppresses synthesized DebuggableAttribute
-
-            var source = @"
-using System.Diagnostics;
-
-[assembly: DebuggableAttribute(DebuggableAttribute.DebuggingModes.Default)]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-
-                // Verify applied Debuggable attribute
-                var appliedAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyDebuggableAttribute(appliedAttributes[0], sourceAssembly, DebuggableAttribute.DebuggingModes.Default);
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_03()
-        {
-            // Verify applied module DebuggableAttribute does not suppress synthesized assembly DebuggableAttribute.
-
-            var source = @"
-using System.Diagnostics;
-
-[module: DebuggableAttribute(DebuggableAttribute.DebuggingModes.Default)]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (options.OutputKind != OutputKind.NetModule)
-                {
-                    Assert.Equal(3, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                    VerifySynthesizedDebuggableAttribute(synthesizedAttributes[2], sourceAssembly, options.OptimizationLevel);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-
-                // Verify applied Debuggable attribute
-                var appliedAttributes = sourceAssembly.Modules[0].GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyDebuggableAttribute(appliedAttributes[0], sourceAssembly, DebuggableAttribute.DebuggingModes.Default);
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_04()
-        {
-            // Applied [module: DebuggableAttribute()] and [assembly: DebuggableAttribute()]
-            // Verify no synthesized assembly DebuggableAttribute.
-
-            var source = @"
-using System.Diagnostics;
-
-[module: DebuggableAttribute(DebuggableAttribute.DebuggingModes.Default)]
-[assembly: DebuggableAttribute(DebuggableAttribute.DebuggingModes.None)]
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-
-                // Verify applied module Debuggable attribute
-                var appliedAttributes = sourceAssembly.Modules[0].GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyDebuggableAttribute(appliedAttributes[0], sourceAssembly, DebuggableAttribute.DebuggingModes.Default);
-
-                // Verify applied assembly Debuggable attribute
-                appliedAttributes = sourceAssembly.GetAttributes();
-                Assert.Equal(1, appliedAttributes.Length);
-                VerifyDebuggableAttribute(appliedAttributes[0], sourceAssembly, DebuggableAttribute.DebuggingModes.None);
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_MissingWellKnownTypeOrMember_01()
-        {
-            // Missing Well-known type DebuggableAttribute generates no diagnostics and
-            // silently suppresses synthesized DebuggableAttribute.
-
-            var source = @"
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                compilation.VerifyDiagnostics(
-                    // (2,14): error CS0518: Predefined type 'System.Object' is not defined or imported
-                    // public class Test
-                    Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Test").WithArguments("System.Object"),
-                    // (4,19): error CS0518: Predefined type 'System.Void' is not defined or imported
-                    //     public static void Main()
-                    Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void"),
-                    // (2,14): error CS1729: 'object' does not contain a constructor that takes 0 arguments
-                    // public class Test
-                    Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Test").WithArguments("object", "0"));
-
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                Assert.Equal(0, synthesizedAttributes.Length);
-            };
-
-            TestDebuggableAttributeMatrix(source, validator, includeMscorlibRef: false, compileAndVerify: false);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_MissingWellKnownTypeOrMember_02()
-        {
-            // Missing Well-known type DebuggableAttribute.DebuggingModes generates no diagnostics and
-            // silently suppresses synthesized DebuggableAttribute.
-
-            var source = @"
-using System;
-using System.Diagnostics;
-
-namespace System.Diagnostics
-{
-    public sealed class DebuggableAttribute: Attribute
-    {
-        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
-    }
-}
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_MissingWellKnownTypeOrMember_03()
-        {
-            // Inaccessible Well-known type DebuggableAttribute.DebuggingModes generates no diagnostics and
-            // silently suppresses synthesized DebuggableAttribute.
-
-            var source = @"
-using System;
-using System.Diagnostics;
-
-namespace System.Diagnostics
-{
-    public sealed class DebuggableAttribute: Attribute
-    {
-        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
-
-        private enum DebuggingModes
-        {
-            None = 0,
-            Default = 1,
-            IgnoreSymbolStoreSequencePoints = 2,
-            EnableEditAndContinue = 4,
-            DisableOptimizations = 256,
-        }
-    }
-}
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_MissingWellKnownTypeOrMember_04()
-        {
-            // Struct Well-known type DebuggableAttribute.DebuggingModes (instead of enum) generates no diagnostics and
-            // silently suppresses synthesized DebuggableAttribute.
-
-            var source = @"
-using System;
-using System.Diagnostics;
-
-namespace System.Diagnostics
-{
-    public sealed class DebuggableAttribute: Attribute
-    {
-        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
-
-        public struct DebuggingModes
-        {
-        }
-    }
-}
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        [Fact]
-        public void TestDebuggableAttribute_MissingWellKnownTypeOrMember_05()
-        {
-            // Missing DebuggableAttribute constructor generates no diagnostics and
-            // silently suppresses synthesized DebuggableAttribute.
-
-            var source = @"
-using System;
-using System.Diagnostics;
-
-namespace System.Diagnostics
-{
-    public sealed class DebuggableAttribute: Attribute
-    {
-        public enum DebuggingModes
-        {
-            None = 0,
-            Default = 1,
-            IgnoreSymbolStoreSequencePoints = 2,
-            EnableEditAndContinue = 4,
-            DisableOptimizations = 256,
-        }
-    }
-}
-
-public class Test
-{
-    public static void Main()
-    {
-    }
-}";
-            Action<CSharpCompilation> validator = (CSharpCompilation compilation) =>
-            {
-                var sourceAssembly = (SourceAssemblySymbol)compilation.Assembly;
-                var synthesizedAttributes = sourceAssembly.GetSynthesizedAttributes();
-                CSharpCompilationOptions options = compilation.Options;
-
-                if (!options.OutputKind.IsNetModule())
-                {
-                    // Verify no synthesized DebuggableAttribute.
-
-                    Assert.Equal(2, synthesizedAttributes.Length);
-                    VerifyCompilationRelaxationsAttribute(synthesizedAttributes[0], sourceAssembly, isSynthesized: true);
-                    VerifyRuntimeCompatibilityAttribute(synthesizedAttributes[1], sourceAssembly, isSynthesized: true);
-                }
-                else
-                {
-                    Assert.Equal(0, synthesizedAttributes.Length);
-                }
-            };
-
-            TestDebuggableAttributeMatrix(source, validator);
-        }
-
-        #endregion
-
-        #region UnverifiableCode, SecurityPermission(SkipVerification)
-
-        [Fact]
-        public void CheckUnsafeAttributes1()
-        {
-            string source = @"
-class C
-{
-    public static void Main()
-    {
-    }
-}";
-            var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
-            compilation.VerifyDiagnostics();
-
-            var assembly = (SourceAssemblySymbol)compilation.Assembly;
-            var assemblyAttribute = assembly.GetSecurityAttributes().Single();
-            VerifySkipVerificationSecurityAttribute(assemblyAttribute, compilation);
-
-            var module = (SourceModuleSymbol)assembly.Modules.Single();
-            var moduleAttribute = module.GetSynthesizedAttributes().Single();
-            VerifyUnverifiableCodeAttribute(moduleAttribute, compilation);
-        }
-
-        [Fact]
-        public void CheckUnsafeAttributes2()
-        {
-            string source = @"
-class C
-{
-    public static void Main()
-    {
-    }
-}";
-            var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll.WithOutputKind(OutputKind.NetModule));
-            compilation.VerifyDiagnostics();
-
-            var assembly = (SourceAssemblySymbol)compilation.Assembly;
-            var assemblyAttribute = assembly.GetSecurityAttributes().Single();
-            VerifySkipVerificationSecurityAttribute(assemblyAttribute, compilation);
-
-            var module = (SourceModuleSymbol)assembly.Modules.Single();
-            var moduleAttribute = module.GetSynthesizedAttributes().Single();
-            VerifyUnverifiableCodeAttribute(moduleAttribute, compilation);
-        }
-
-        internal static void VerifySkipVerificationSecurityAttribute(Cci.SecurityAttribute securityAttribute, CSharpCompilation compilation)
-        {
-            var assemblyAttribute = (CSharpAttributeData)securityAttribute.Attribute;
-
-            Assert.Equal(compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityPermissionAttribute), assemblyAttribute.AttributeClass);
-            Assert.Equal(compilation.GetWellKnownTypeMember(WellKnownMember.System_Security_Permissions_SecurityPermissionAttribute__ctor), assemblyAttribute.AttributeConstructor);
-
-            var assemblyAttributeArgument = assemblyAttribute.CommonConstructorArguments.Single();
-            Assert.Equal(compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAction), assemblyAttributeArgument.Type);
-            Assert.Equal(DeclarativeSecurityAction.RequestMinimum, securityAttribute.Action);
-            Assert.Equal(DeclarativeSecurityAction.RequestMinimum, (DeclarativeSecurityAction)(int)assemblyAttributeArgument.Value);
-
-            var assemblyAttributeNamedArgument = assemblyAttribute.CommonNamedArguments.Single();
-            Assert.Equal("SkipVerification", assemblyAttributeNamedArgument.Key);
-            var assemblyAttributeNamedArgumentValue = assemblyAttributeNamedArgument.Value;
-            Assert.Equal(compilation.GetSpecialType(SpecialType.System_Boolean), assemblyAttributeNamedArgumentValue.Type);
-            Assert.Equal(true, assemblyAttributeNamedArgumentValue.Value);
-        }
-
-        internal static void VerifyUnverifiableCodeAttribute(CSharpAttributeData moduleAttribute, CSharpCompilation compilation)
-        {
-            Assert.Equal(compilation.GetWellKnownType(WellKnownType.System_Security_UnverifiableCodeAttribute), moduleAttribute.AttributeClass);
-            Assert.Equal(compilation.GetWellKnownTypeMember(WellKnownMember.System_Security_UnverifiableCodeAttribute__ctor), moduleAttribute.AttributeConstructor);
-
-            Assert.Equal(0, moduleAttribute.CommonConstructorArguments.Length);
-            Assert.Equal(0, moduleAttribute.CommonNamedArguments.Length);
-        }
-
-        #endregion
-
-        #region AsyncStateMachineAttribute
-
-        [Fact]
-        public void AsyncStateMachineAttribute_Method()
-        {
-            string source = @"
-using System.Threading.Tasks;
-
-class Test
-{
-    public static async void F()
-    {
-        await Task.Delay(0);
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<F>d__0");
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "AsyncStateMachineAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-            var attributeArg = (NamedTypeSymbol)asyncMethodAttributes.Single().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeArg, stateMachine);
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_Method_Debug()
-        {
-            string source = @"
-using System.Threading.Tasks;
-
-class Test
-{
-    public static async void F()
-    {
-        await Task.Delay(0);
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<F>d__0");
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "AsyncStateMachineAttribute", "DebuggerStepThroughAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-            var attributeArg = (NamedTypeSymbol)asyncMethodAttributes.First().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeArg, stateMachine);
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_Lambda()
-        {
-            string source = @"
-using System;
-using System.Threading.Tasks;
-
-class Test
-{
-    public static void F()
-    {
-        Action f = async () => { await Task.Delay(0); };
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<>c.<<F>b__0_0>d");
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.<>c.<F>b__0_0");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "AsyncStateMachineAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-            var attributeArg = (NamedTypeSymbol)asyncMethodAttributes.Single().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeArg, stateMachine);
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_Lambda_Debug()
-        {
-            string source = @"
-using System;
-using System.Threading.Tasks;
-
-class Test
-{
-    public static void F()
-    {
-        Action f = async () => { await Task.Delay(0); };
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<>c.<<F>b__0_0>d");
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.<>c.<F>b__0_0");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "AsyncStateMachineAttribute", "DebuggerStepThroughAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-            var attributeArg = (NamedTypeSymbol)asyncMethodAttributes.First().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeArg, stateMachine);
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_GenericStateMachineClass()
-        {
-            string source = @"
-using System.Threading.Tasks;
-
-public class Test<T>
-{
-    public async void F<U>(U u) where U : Test<int>, new()
-    {
-        await Task.Delay(0);
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<F>d__0");
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "AsyncStateMachineAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-            var attributeStateMachineClass = (NamedTypeSymbol)asyncMethodAttributes.Single().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeStateMachineClass, stateMachine.ConstructUnboundGenericType());
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_MetadataOnly()
-        {
-            string source = @"
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
-class Test
-{
-    public static async void F()
-    {
-        await Task.Delay(0);
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source).
-                EmitToImageReference(new EmitOptions(metadataOnly: true));
-
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-            Assert.Empty(comp.GetMember<NamedTypeSymbol>("Test").GetMembers("<F>d__1"));
-
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            Assert.Empty(GetAttributeNames(asyncMethodAttributes));
-        }
-
-        [Fact]
-        public void AsyncStateMachineAttribute_MetadataOnly_Debug()
-        {
-            string source = @"
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
-class Test
-{
-    public static async void F()
-    {
-        await Task.Delay(0);
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll).
-                EmitToImageReference(new EmitOptions(metadataOnly: true));
-
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-            Assert.Empty(comp.GetMember<NamedTypeSymbol>("Test").GetMembers("<F>d__1"));
-
-            var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var asyncMethodAttributes = asyncMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "DebuggerStepThroughAttribute" }, GetAttributeNames(asyncMethodAttributes));
-        }
-
-        #endregion
-
-        #region IteratorStateMachineAttribute
-
-        [Fact]
-        public void IteratorStateMachineAttribute_Method()
-        {
-            string source = @"
-using System.Collections.Generic;
-
-class Test
-{
-    public static IEnumerable<int> F()
-    {
-        yield return 1;
-    }
-}
-";
-            foreach (var options in new[] { TestOptions.ReleaseDll, TestOptions.DebugDll })
-            {
-                var reference = CreateCompilationWithMscorlib45(source, options: options).EmitToImageReference();
-                var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-                var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<F>d__0");
-                var asyncMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-                var asyncMethodAttributes = asyncMethod.GetAttributes();
-                AssertEx.SetEqual(new[] { "IteratorStateMachineAttribute" }, GetAttributeNames(asyncMethodAttributes));
-
-                var attributeArg = (NamedTypeSymbol)asyncMethodAttributes.Single().ConstructorArguments.Single().Value;
-                Assert.Equal(attributeArg, stateMachine);
-            }
-        }
-
-        [Fact]
-        public void IteratorStateMachineAttribute_GenericStateMachineClass()
-        {
-            string source = @"
-using System.Collections.Generic;
-
-public class Test<T>
-{
-    public IEnumerable<int> F<U>(U u) where U : Test<int>, new()
-    {
-        yield return 1;
-    }
-}
-";
-            var reference = CreateCompilationWithMscorlib45(source).EmitToImageReference();
-            var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-
-            var stateMachine = comp.GetMember<NamedTypeSymbol>("Test.<F>d__0");
-            var iteratorMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-            var iteratorMethodAttributes = iteratorMethod.GetAttributes();
-            AssertEx.SetEqual(new[] { "IteratorStateMachineAttribute" }, GetAttributeNames(iteratorMethodAttributes));
-
-            var attributeStateMachineClass = (NamedTypeSymbol)iteratorMethodAttributes.Single().ConstructorArguments.Single().Value;
-            Assert.Equal(attributeStateMachineClass, stateMachine.ConstructUnboundGenericType());
-        }
-
-        [Fact]
-        public void IteratorStateMachineAttribute_MetadataOnly()
-        {
-            string source = @"
-using System.Collections.Generic;
-
-public class Test
-{
-    public static IEnumerable<int> F()
-    {
-        yield return 1;
-    }
-}
-";
-
-            foreach (var options in new[] { TestOptions.ReleaseDll, TestOptions.DebugDll })
-            {
-                var reference = CreateCompilationWithMscorlib45(source, options: options).
-                    EmitToImageReference(new EmitOptions(metadataOnly: true));
-
-                var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
-                Assert.Empty(comp.GetMember<NamedTypeSymbol>("Test").GetMembers("<F>d__0"));
-
-                var iteratorMethod = comp.GetMember<MethodSymbol>("Test.F");
-
-                var iteratorMethodAttributes = iteratorMethod.GetAttributes();
-                Assert.Empty(GetAttributeNames(iteratorMethodAttributes)); // We haven't bound the body, so we don't know that this is an iterator method.
-            }
-        }
-
-        #endregion
-
-        [Fact, WorkItem(431, "https://github.com/dotnet/roslyn/issues/431")]
-        public void BaseMethodWrapper()
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        [WorkItem(431, "https://github.com/dotnet/roslyn/issues/431")]
+        public void BaseMethodWrapper(OptimizationLevel optimizationLevel)
         {
             string source = @"
 using System.Threading.Tasks;
@@ -1643,16 +547,959 @@ class B : A
     }
 }
 ";
-            foreach (var options in new[] { TestOptions.ReleaseDll, TestOptions.DebugDll })
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
             {
-                var reference = CreateCompilationWithMscorlib45(source, options: options).EmitToImageReference();
-                var comp = CreateCompilationWithMscorlib45("", new[] { reference }, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
+                var attributes = module.GlobalNamespace.GetTypeMember("B").GetMember<MethodSymbol>("<>n__0").GetAttributes();
 
-                var baseMethodWrapper = comp.GetMember<MethodSymbol>("B.<>n__0");
+                AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute", "DebuggerHiddenAttribute" }, GetAttributeNames(attributes));
+            });
+        }
+        #endregion
 
-                AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute", "DebuggerHiddenAttribute" }, GetAttributeNames(baseMethodWrapper.GetAttributes()));
+        #region CompilationRelaxationsAttribute, RuntimeCompatibilityAttribute, DebuggableAttribute
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void SynthesizedAllAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[2], options.OptimizationLevel, isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedCompilationRelaxations(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+
+[assembly: CompilationRelaxationsAttribute(0)]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyRuntimeCompatibilityAttribute(attributes[0], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[1], options.OptimizationLevel, isSynthesized: true);
+                    VerifyCompilationRelaxationsAttribute(attributes[2], isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedRuntimeCompatibility(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+
+[assembly: RuntimeCompatibilityAttribute()]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[1], options.OptimizationLevel, isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[2], isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedDebuggable(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Diagnostics;
+
+[assembly: DebuggableAttribute(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[2], options.OptimizationLevel, isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedDebuggableOnBothAssemblyAndModule(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Diagnostics;
+
+[module: DebuggableAttribute(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: DebuggableAttribute(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                VerifyDebuggableAttribute(module.GetAttributes().Single(), optimizationLevel, isSynthesized: false);
+
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[2], options.OptimizationLevel, isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedCompilationRelaxationsAndRuntimeCompatibility(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+
+[assembly: CompilationRelaxationsAttribute(0)]
+[assembly: RuntimeCompatibilityAttribute()]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyDebuggableAttribute(attributes[0], options.OptimizationLevel, isSynthesized: true);
+                    VerifyCompilationRelaxationsAttribute(attributes[1], isSynthesized: false);
+                    VerifyRuntimeCompatibilityAttribute(attributes[2], isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void ModuleCompilationRelaxationsDoNotSuppressAssemblyAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+
+[module: CompilationRelaxationsAttribute(0)]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                VerifyCompilationRelaxationsAttribute(module.GetAttributes().Single(), isSynthesized: false);
+
+                var assemblyAttributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, assemblyAttributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, assemblyAttributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(assemblyAttributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(assemblyAttributes[1], isSynthesized: true);
+                    VerifyDebuggableAttribute(assemblyAttributes[2], options.OptimizationLevel, isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void ModuleDebuggableDoNotSuppressAssemblyAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+using System.Diagnostics;
+
+[module: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                VerifyDebuggableAttribute(module.GetAttributes().Single(), options.OptimizationLevel, isSynthesized: false);
+
+                var assemblyAttributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, assemblyAttributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, assemblyAttributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(assemblyAttributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(assemblyAttributes[1], isSynthesized: true);
+                    VerifyDebuggableAttribute(assemblyAttributes[2], options.OptimizationLevel, isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void MissingWellKnownAttributesNoDiagnosticsAndNoSynthesizedAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateCompilation("", options: options);
+
+            if (outputKind.IsApplication())
+            {
+                compilation.VerifyDiagnostics(
+                    // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
+                    Diagnostic(ErrorCode.ERR_NoEntryPoint));
+            }
+            else
+            {
+                CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+                {
+                    var assemblyAttributes = module.ContainingAssembly.GetAttributes();
+                    Assert.Equal(0, assemblyAttributes.Length);
+                });
             }
         }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void MissingWellKnownAttributeEnumsNoDiagnosticsAndNoSynthesizedAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var code = @"
+namespace System.Diagnostics
+{
+    public sealed class DebuggableAttribute: Attribute
+    {
+        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
+    }
+}
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateStandardCompilation(code, options: options);
+
+            CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(2, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void InaccessibleWellKnownAttributeEnumsNoDiagnosticsAndNoSynthesizedAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var code = @"
+namespace System.Diagnostics
+{
+    public sealed class DebuggableAttribute: Attribute
+    {
+        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
+
+        private enum DebuggingModes
+        {
+            None = 0,
+            Default = 1,
+            IgnoreSymbolStoreSequencePoints = 2,
+            EnableEditAndContinue = 4,
+            DisableOptimizations = 256,
+        }
+    }
+}
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateStandardCompilation(code, options: options);
+
+            CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(2, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void WellKnownAttributeMissingCtorNoDiagnosticsAndNoSynthesizedAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var code = @"
+namespace System.Diagnostics
+{
+    public sealed class DebuggableAttribute: Attribute
+    {
+        public enum DebuggingModes
+        {
+            None = 0,
+            Default = 1,
+            IgnoreSymbolStoreSequencePoints = 2,
+            EnableEditAndContinue = 4,
+            DisableOptimizations = 256,
+        }
+    }
+}
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateStandardCompilation(code, options: options);
+
+            CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(2, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void WellKnownAttributeInvalidTypeNoDiagnosticsAndNoSynthesizedAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var code = @"
+namespace System.Diagnostics
+{
+    public sealed class DebuggableAttribute: Attribute
+    {
+        public DebuggableAttribute(bool isJITTrackingEnabled, bool isJITOptimizerDisabled) {}
+
+        public struct DebuggingModes
+        {
+        }
+    }
+}
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateStandardCompilation(code, options: options);
+
+            CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(2, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[1], isSynthesized: true);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void MissingWellKnownAttributeMembersProduceDiagnostics(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    sealed public class CompilationRelaxationsAttribute : System.Attribute
+    {
+    }
+
+    sealed public class RuntimeCompatibilityAttribute : System.Attribute
+    {
+        public RuntimeCompatibilityAttribute(int dummy) {}
+    }
+}
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            var compilation = CreateStandardCompilation(source, options: options);
+
+            if (outputKind.IsNetModule())
+            {
+                CompileAndVerify(compilation, verify: Verification.Skipped, symbolValidator: module =>
+                {
+                    var assemblyAttributes = module.ContainingAssembly.GetAttributes();
+                    Assert.Equal(0, assemblyAttributes.Length);
+                });
+            }
+            else
+            {
+                compilation.VerifyDiagnostics(
+                    // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor'
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.CompilationRelaxationsAttribute", ".ctor"),
+                    // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor'
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", ".ctor"),
+                    // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.WrapNonExceptionThrows'
+                    Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", "WrapNonExceptionThrows"));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedCompilationRelaxationsOnModuleSupressesAssemblyAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var referenceComp = CreateStandardCompilation(@"
+using System.Runtime.CompilerServices;
+
+[assembly: CompilationRelaxationsAttribute(0)]
+", options: new CSharpCompilationOptions(OutputKind.NetModule, optimizationLevel: optimizationLevel));
+
+            var reference = ModuleMetadata.CreateFromImage(referenceComp.EmitToArray()).GetReference();
+
+            var source = @"
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, additionalRefs: new[] { reference }, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyRuntimeCompatibilityAttribute(attributes[0], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[1], options.OptimizationLevel, isSynthesized: true);
+                    VerifyCompilationRelaxationsAttribute(attributes[2], isSynthesized: false);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(FullMatrixTheoryData))]
+        public void AppliedRuntimeCompatibilityOnModuleSupressesAssemblyAttributes(OutputKind outputKind, OptimizationLevel optimizationLevel)
+        {
+            var referenceComp = CreateStandardCompilation(@"
+using System.Runtime.CompilerServices;
+
+[assembly: RuntimeCompatibilityAttribute()]
+", options: new CSharpCompilationOptions(OutputKind.NetModule, optimizationLevel: optimizationLevel));
+
+            var reference = ModuleMetadata.CreateFromImage(referenceComp.EmitToArray()).GetReference();
+
+            var source = @"
+
+public class Test
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var options = new CSharpCompilationOptions(outputKind, optimizationLevel: optimizationLevel);
+            CompileAndVerify(source, additionalRefs: new[] { reference }, options: options, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes, symbolValidator: module =>
+            {
+                var attributes = module.ContainingAssembly.GetAttributes();
+
+                if (outputKind.IsNetModule())
+                {
+                    Assert.Equal(0, attributes.Length);
+                }
+                else
+                {
+                    Assert.Equal(3, attributes.Length);
+
+                    VerifyCompilationRelaxationsAttribute(attributes[0], isSynthesized: true);
+                    VerifyDebuggableAttribute(attributes[1], options.OptimizationLevel, isSynthesized: true);
+                    VerifyRuntimeCompatibilityAttribute(attributes[2], isSynthesized: false);
+                }
+            });
+        }
+        #endregion
+
+        #region UnverifiableCode, SecurityPermission
+        [Theory]
+        [MemberData(nameof(OutputKindTheoryData))]
+        public void CheckUnsafeAttributes(OutputKind outputKind)
+        {
+            string source = @"
+unsafe class C
+{
+    public static void Main()
+    {
+    }
+}";
+
+            var compilation = CreateStandardCompilation(source, options: new CSharpCompilationOptions(
+                outputKind: outputKind,
+                optimizationLevel: OptimizationLevel.Release,
+                allowUnsafe: true));
+
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var unverifiableCode = module.GetAttributes().Single();
+
+                Assert.Equal("System.Security.UnverifiableCodeAttribute", unverifiableCode.AttributeClass.ToTestDisplayString());
+                Assert.Empty(unverifiableCode.AttributeConstructor.Parameters);
+                Assert.Empty(unverifiableCode.CommonConstructorArguments);
+                Assert.Empty(unverifiableCode.CommonNamedArguments);
+
+                if (outputKind.IsNetModule())
+                {
+                    // Modules security attributes are copied to assemblies they're included in
+                    var moduleReference = ModuleMetadata.CreateFromImage(compilation.EmitToArray()).GetReference();
+                    CompileAndVerify("", additionalRefs: new[] { moduleReference }, symbolValidator: validateSecurity);
+                }
+                else
+                {
+                    validateSecurity(module);
+                }
+            });
+
+            void validateSecurity(ModuleSymbol module)
+            {
+                ValidateDeclSecurity(((PEModuleSymbol)module).Module.MetadataReader, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                });
+            }
+        }
+        #endregion
+
+        #region AsyncStateMachineAttribute
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void AsyncStateMachineAttribute_Method(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+class Test
+{
+    public static async void F()
+    {
+        await Task.Delay(0);
+    }
+}";
+
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
+            {
+                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+                var stateMachine = type.GetTypeMember("<F>d__0");
+                var asyncMethod = type.GetMember<MethodSymbol>("F");
+
+                var attributes = asyncMethod.GetAttributes();
+
+                var stateMachineAttribute = attributes.First();
+                Assert.Equal("AsyncStateMachineAttribute", stateMachineAttribute.AttributeClass.Name);
+                Assert.Equal(stateMachine, stateMachineAttribute.ConstructorArguments.Single().Value);
+
+                if (optimizationLevel == OptimizationLevel.Debug)
+                {
+                    Assert.Equal(2, attributes.Length);
+                    Assert.Equal("DebuggerStepThroughAttribute", attributes.Last().AttributeClass.Name);
+                }
+                else
+                {
+                    Assert.Equal(1, attributes.Length);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void AsyncStateMachineAttribute_Lambda(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System;
+using System.Threading.Tasks;
+
+class Test
+{
+    public static void F()
+    {
+        Action f = async () => { await Task.Delay(0); };
+    }
+}";
+
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
+            {
+                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test").GetTypeMember("<>c");
+                var stateMachine = type.GetTypeMember("<<F>b__0_0>d");
+                var asyncMethod = type.GetMember<MethodSymbol>("<F>b__0_0");
+
+                var attributes = asyncMethod.GetAttributes();
+
+                var stateMachineAttribute = attributes.First();
+                Assert.Equal("AsyncStateMachineAttribute", stateMachineAttribute.AttributeClass.Name);
+                Assert.Equal(stateMachine, stateMachineAttribute.ConstructorArguments.Single().Value);
+
+                if (optimizationLevel == OptimizationLevel.Debug)
+                {
+                    Assert.Equal(2, attributes.Length);
+                    Assert.Equal("DebuggerStepThroughAttribute", attributes.Last().AttributeClass.Name);
+                }
+                else
+                {
+                    Assert.Equal(1, attributes.Length);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void AsyncStateMachineAttribute_GenericStateMachineClass(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+public class Test<T>
+{
+    public async void F<U>(U u) where U : Test<int>, new()
+    {
+        await Task.Delay(0);
+    }
+}";
+
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
+            {
+                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+                var stateMachine = type.GetTypeMember("<F>d__0");
+                var asyncMethod = type.GetMember<MethodSymbol>("F");
+
+                var attributes = asyncMethod.GetAttributes();
+
+                var stateMachineAttribute = attributes.First();
+                Assert.Equal("AsyncStateMachineAttribute", stateMachineAttribute.AttributeClass.Name);
+                Assert.Equal(stateMachine.AsUnboundGenericType(), stateMachineAttribute.ConstructorArguments.Single().Value);
+
+                if (optimizationLevel == OptimizationLevel.Debug)
+                {
+                    Assert.Equal(2, attributes.Length);
+                    Assert.Equal("DebuggerStepThroughAttribute", attributes.Last().AttributeClass.Name);
+                }
+                else
+                {
+                    Assert.Equal(1, attributes.Length);
+                }
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void AsyncStateMachineAttribute_MetadataOnly(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Threading.Tasks;
+
+class Test
+{
+    public static async void F()
+    {
+        await Task.Delay(0);
+    }
+}";
+
+            var referenceOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+            var reference = CreateCompilationWithMscorlib45(source, options: referenceOptions).EmitToImageReference(options: new EmitOptions(metadataOnly: true));
+
+            var options = TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All);
+            var compilation = CreateCompilationWithMscorlib45("", new[] { reference }, options: options);
+
+            var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+            Assert.Equal(new[] { "F", ".ctor" }, type.GetMembers().SelectAsArray(m => m.Name));
+
+            var asyncMethod = type.GetMember<MethodSymbol>("F");
+
+            if (optimizationLevel == OptimizationLevel.Debug)
+            {
+                Assert.Equal("DebuggerStepThroughAttribute", asyncMethod.GetAttributes().Single().AttributeClass.Name);
+            }
+            else
+            {
+                Assert.Empty(asyncMethod.GetAttributes());
+            }
+        }
+        #endregion
+
+        #region IteratorStateMachineAttribute
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void IteratorStateMachineAttribute_Method(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Collections.Generic;
+
+class Test
+{
+    public static IEnumerable<int> F()
+    {
+        yield return 1;
+    }
+}";
+
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
+            {
+                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+                var stateMachine = type.GetTypeMember("<F>d__0");
+                var iteratorMethod = type.GetMember<MethodSymbol>("F");
+
+                var iteratorAttribute = iteratorMethod.GetAttributes().Single();
+                Assert.Equal("IteratorStateMachineAttribute", iteratorAttribute.AttributeClass.Name);
+                Assert.Equal(stateMachine, iteratorAttribute.ConstructorArguments.Single().Value);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void IteratorStateMachineAttribute_GenericStateMachineClass(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Collections.Generic;
+
+public class Test<T>
+{
+    public IEnumerable<int> F<U>(U u) where U : Test<int>, new()
+    {
+        yield return 1;
+    }
+}";
+
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+
+            CompileAndVerify(CreateCompilationWithMscorlib45(source, options: options), symbolValidator: module =>
+            {
+                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+                var stateMachine = type.GetTypeMember("<F>d__0");
+                var iteratorMethod = type.GetMember<MethodSymbol>("F");
+
+                var iteratorAttribute = iteratorMethod.GetAttributes().Single();
+                Assert.Equal("IteratorStateMachineAttribute", iteratorAttribute.AttributeClass.Name);
+                Assert.Equal(stateMachine.AsUnboundGenericType(), iteratorAttribute.ConstructorArguments.Single().Value);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(OptimizationLevelTheoryData))]
+        public void IteratorStateMachineAttribute_MetadataOnly(OptimizationLevel optimizationLevel)
+        {
+            string source = @"
+using System.Collections.Generic;
+
+public class Test<T>
+{
+    public IEnumerable<int> F<U>(U u) where U : Test<int>, new()
+    {
+        yield return 1;
+    }
+}";
+
+            var referenceOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptimizationLevel(optimizationLevel)
+                .WithMetadataImportOptions(MetadataImportOptions.All);
+            var reference = CreateCompilationWithMscorlib45(source, options: referenceOptions).EmitToImageReference(options: new EmitOptions(metadataOnly: true));
+
+            var options = TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All);
+            var compilation = CreateCompilationWithMscorlib45("", new[] { reference }, options: options);
+
+            var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+            Assert.Equal(new[] { "F", ".ctor" }, type.GetMembers().SelectAsArray(m => m.Name));
+
+            Assert.Empty(type.GetMember<MethodSymbol>("F").GetAttributes());
+        }
+        #endregion
 
         [Fact, WorkItem(7809, "https://github.com/dotnet/roslyn/issues/7809")]
         public void SynthesizeAttributeWithUseSiteErrorFails()

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Xunit;
-using System.Linq;
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using System.Reflection.Metadata;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
-using System.Collections.Immutable;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -301,11 +301,13 @@ class C
 
             private TupleAttributeValidator(ModuleSymbol module)
             {
-                _base0Class = module.GlobalNamespace.GetTypeMember("Base0");
-                _base1Class = module.GlobalNamespace.GetTypeMember("Base1");
-                _base2Class = module.GlobalNamespace.GetTypeMember("Base2");
-                _outerClass = module.GlobalNamespace.GetTypeMember("Outer");
-                _derivedClass = module.GlobalNamespace.GetTypeMember("Derived");
+                var globalNs = module.GlobalNamespace;
+
+                _base0Class = globalNs.GetTypeMember("Base0");
+                _base1Class = globalNs.GetTypeMember("Base1");
+                _base2Class = globalNs.GetTypeMember("Base2");
+                _outerClass = globalNs.GetTypeMember("Outer");
+                _derivedClass = globalNs.GetTypeMember("Derived");
             }
 
             internal static void ValidateTupleAttributes(ModuleSymbol module)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -116,7 +115,7 @@ public class Derived<T> : Outer<(int e1, (int e2, int e3) e4)>.Inner<
 
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                TupleAttributeValidator.ValidateTupleAttributes((PEModuleSymbol)module);
+                TupleAttributeValidator.ValidateTupleAttributes(module);
             });
         }
 
@@ -142,7 +141,7 @@ namespace System.Runtime.CompilerServices
 
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                TupleAttributeValidator.ValidateTupleAttributes((PEModuleSymbol)module);
+                TupleAttributeValidator.ValidateTupleAttributes(module);
             });
         }
 
@@ -300,7 +299,7 @@ class C
                 _outerClass,
                 _derivedClass;
 
-            private TupleAttributeValidator(PEModuleSymbol module)
+            private TupleAttributeValidator(ModuleSymbol module)
             {
                 _base0Class = module.GlobalNamespace.GetTypeMember("Base0");
                 _base1Class = module.GlobalNamespace.GetTypeMember("Base1");
@@ -309,7 +308,7 @@ class C
                 _derivedClass = module.GlobalNamespace.GetTypeMember("Derived");
             }
 
-            internal static void ValidateTupleAttributes(PEModuleSymbol module)
+            internal static void ValidateTupleAttributes(ModuleSymbol module)
             {
                 var validator = new TupleAttributeValidator(module);
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -333,13 +334,13 @@ class C
 
                 var invokeMethod = delegate1.DelegateInvokeMethod;
                 Assert.NotNull(invokeMethod);
-                ValidateTupleNameAttribute(invokeMethod, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(invokeMethod.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 Assert.Equal(2, invokeMethod.ParameterCount);
                 var sender = invokeMethod.Parameters[0];
                 Assert.Equal("sender", sender.Name);
                 Assert.Equal(SpecialType.System_Object, sender.Type.SpecialType);
-                ValidateTupleNameAttribute(sender, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(sender.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 var args = invokeMethod.Parameters[1];
                 Assert.Equal("args", args.Name);
@@ -348,12 +349,12 @@ class C
                 {
                     null, null, null, "e4", "e5", "e1", "e2", "e3", null, null
                 };
-                ValidateTupleNameAttribute(args,
+                ValidateTupleNameAttribute(args.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
                 AttributeTests_Dynamic.DynamicAttributeValidator.ValidateDynamicAttribute(
-                    args,
+                    args.GetAttributes(),
                     expectedDynamicAttribute: true,
                     expectedTransformFlags: new[]
                     {
@@ -370,14 +371,14 @@ class C
                 var event1 = _derivedClass.GetMember<EventSymbol>("Event1");
                 Assert.NotNull(event1);
 
-                ValidateTupleNameAttribute(event1,
+                ValidateTupleNameAttribute(event1.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: new[]
                     {
                         "e1", "e4", null, "e2", "e3"
                     });
                 AttributeTests_Dynamic.DynamicAttributeValidator.ValidateDynamicAttribute(
-                    event1,
+                    event1.GetAttributes(),
                     expectedDynamicAttribute: true,
                     expectedTransformFlags: new[]
                     {
@@ -389,18 +390,18 @@ class C
             private void ValidateAttributesOnNamedTypes()
             {
                 // public class Base0 { }
-                ValidateTupleNameAttribute(_base0Class, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(_base0Class.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 // public class Base1<T> { }
-                ValidateTupleNameAttribute(_base1Class, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(_base1Class.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 // public class Base2<T, U> { }
-                ValidateTupleNameAttribute(_base2Class, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(_base2Class.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 // public class Outer<T> : Base1<(int key, int val)>
                 Assert.True(_outerClass.BaseType.ContainsTuple());
                 var expectedElementNames = new[] { "key", "val" };
-                ValidateTupleNameAttribute(_outerClass,
+                ValidateTupleNameAttribute(_outerClass.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
@@ -413,7 +414,7 @@ class C
                     "e10", "e13", "e14", "e11", "e12", "e17", "e22", "e15",
                     "e16", "e18", "e21", "e19", "e20"
                 };
-                ValidateTupleNameAttribute(_derivedClass,
+                ValidateTupleNameAttribute(_derivedClass.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
             }
@@ -423,24 +424,24 @@ class C
                 // public static (int e1, int e2) Field1;
                 var field1 = _derivedClass.GetMember<FieldSymbol>("Field1");
                 var expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(field1, expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
+                ValidateTupleNameAttribute(field1.GetAttributes(), expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
 
                 // public static (int e1, int e2) Field2;
                 var field2 = _derivedClass.GetMember<FieldSymbol>("Field2");
                 expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(field2, expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
+                ValidateTupleNameAttribute(field2.GetAttributes(), expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
 
                 // public static Base1<(int e1, (int e2, int e3) e4)> Field3;
                 var field3 = _derivedClass.GetMember<FieldSymbol>("Field3");
                 expectedElementNames = new[] { "e1", "e4", "e2", "e3" };
-                ValidateTupleNameAttribute(field3, expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
+                ValidateTupleNameAttribute(field3.GetAttributes(), expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
 
                 // public static ValueTuple<Base1<(int e1, (int, (dynamic, dynamic)) e2)>, int> Field4;
                 var field4 = _derivedClass.GetMember<FieldSymbol>("Field4");
                 expectedElementNames = new[] { null, null, "e1", "e2", null, null, null, null };
-                ValidateTupleNameAttribute(field4, expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
+                ValidateTupleNameAttribute(field4.GetAttributes(), expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
                 AttributeTests_Dynamic.DynamicAttributeValidator.ValidateDynamicAttribute(
-                    field4,
+                    field4.GetAttributes(),
                     expectedDynamicAttribute: true,
                     expectedTransformFlags: new[] {
                         false, false, false, false,
@@ -453,11 +454,11 @@ class C
                 //             ValueTuple<dynamic, dynamic>> Field5;
                 var field5 = _derivedClass.GetMember<FieldSymbol>("Field5");
                 expectedElementNames = new[] { "e1", "e2", "e3", "e4", null, null };
-                ValidateTupleNameAttribute(field5,
+                ValidateTupleNameAttribute(field5.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
                 AttributeTests_Dynamic.DynamicAttributeValidator.ValidateDynamicAttribute(
-                    field5,
+                    field5.GetAttributes(),
                     expectedDynamicAttribute: true,
                     expectedTransformFlags: new[]
                     {
@@ -468,7 +469,7 @@ class C
 
                 // public static Base1<(int, ValueTuple<int, ValueTuple>)> Field6;
                 var field6 = _derivedClass.GetMember<FieldSymbol>("Field6");
-                ValidateTupleNameAttribute(field6, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(field6.GetAttributes(), expectedTupleNamesAttribute: false);
                 var field6Type = Assert.IsType<ConstructedNamedTypeSymbol>(field6.Type);
                 Assert.Equal("Base1", field6Type.Name);
                 Assert.Equal(1, field6Type.TypeParameters.Length);
@@ -483,7 +484,7 @@ class C
 
                 // public static ValueTuple Field7;
                 var field7 = _derivedClass.GetMember<FieldSymbol>("Field7");
-                ValidateTupleNameAttribute(field7, expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(field7.GetAttributes(), expectedTupleNamesAttribute: false);
                 Assert.False(field7.Type.IsTupleType);
 
                 // public static (int e1, int e2, int e3, int e4, int e5, int e6, int e7, int e8, int e9) Field8;
@@ -493,7 +494,7 @@ class C
                     "e1", "e2", "e3", "e4", "e5",
                     "e6", "e7", "e8", "e9", null, null
                 };
-                ValidateTupleNameAttribute(field8, expectedTupleNamesAttribute: true,
+                ValidateTupleNameAttribute(field8.GetAttributes(), expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
                 // public static Base<(int e1, int e2, int e3, int e4, int e5, int e6, int e7, int e8, int e9)> Field9;
@@ -503,7 +504,7 @@ class C
                     "e1", "e2", "e3", "e4", "e5",
                     "e6", "e7", "e8", "e9", null, null
                 };
-                ValidateTupleNameAttribute(field9, expectedTupleNamesAttribute: true,
+                ValidateTupleNameAttribute(field9.GetAttributes(), expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
             }
 
@@ -512,39 +513,36 @@ class C
                 // public static (int e1, int e2) Method1() => (0, 0);
                 var method1 = _derivedClass.GetMember<MethodSymbol>("Method1");
                 var expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(method1,
+                ValidateTupleNameAttribute(method1.GetReturnTypeAttributes(),
                     expectedTupleNamesAttribute: true,
-                    expectedElementNames: expectedElementNames,
-                    forReturnType: true);
+                    expectedElementNames: expectedElementNames);
 
                 // public static void Method2((int e1, int e2) x) { }
                 var method2 = _derivedClass.GetMember<MethodSymbol>("Method2");
                 expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(method2.Parameters.Single(),
+                ValidateTupleNameAttribute(method2.Parameters.Single().GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
                 // public static (int e1, int e2) Method3((int e3, int e4) x) => (0, 0);
                 var method3 = _derivedClass.GetMember<MethodSymbol>("Method3");
                 expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(method3,
+                ValidateTupleNameAttribute(method3.GetReturnTypeAttributes(),
                     expectedTupleNamesAttribute: true,
-                    expectedElementNames: expectedElementNames,
-                    forReturnType: true);
+                    expectedElementNames: expectedElementNames);
                 expectedElementNames = new[] { "e3", "e4" };
-                ValidateTupleNameAttribute(method3.Parameters.Single(),
+                ValidateTupleNameAttribute(method3.Parameters.Single().GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
                 // public static (int e1, int e2) Method4(ref (int e3, int e4) x) => x;
                 var method4 = _derivedClass.GetMember<MethodSymbol>("Method4");
                 expectedElementNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(method4,
+                ValidateTupleNameAttribute(method4.GetReturnTypeAttributes(),
                     expectedTupleNamesAttribute: true,
-                    expectedElementNames: expectedElementNames,
-                    forReturnType: true);
+                    expectedElementNames: expectedElementNames);
                 expectedElementNames = new[] { "e3", "e4" };
-                ValidateTupleNameAttribute(method4.Parameters.Single(),
+                ValidateTupleNameAttribute(method4.Parameters.Single().GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedElementNames);
 
@@ -555,12 +553,9 @@ class C
                 //                ValueTuple) Method5(ref (object,dynamic) x) =>
                 //     ((0, (null, (null, null)), null, 0), default(ValueTuple));
                 var method5 = _derivedClass.GetMember<MethodSymbol>("Method5");
-                ValidateTupleNameAttribute(method5,
-                    expectedTupleNamesAttribute: false,
-                    forReturnType: true);
+                ValidateTupleNameAttribute(method5.GetReturnTypeAttributes(), expectedTupleNamesAttribute: false);
 
-                ValidateTupleNameAttribute(method5.Parameters.Single(),
-                    expectedTupleNamesAttribute: false);
+                ValidateTupleNameAttribute(method5.Parameters.Single().GetAttributes(), expectedTupleNamesAttribute: false);
 
                 // public static (int e1, int e2, int e3, int e4, int e5,
                 //                int e6, int e7, int e8, int e9) Method6() => (0, 0, 0, 0,
@@ -571,9 +566,7 @@ class C
                     "e1", "e2", "e3", "e4", "e5",
                     "e6", "e7", "e8", "e9", null, null
                 };
-                ValidateTupleNameAttribute(method6, expectedTupleNamesAttribute: true,
-                    expectedElementNames: expectedElementNames,
-                    forReturnType: true);
+                ValidateTupleNameAttribute(method6.GetReturnTypeAttributes(), expectedTupleNamesAttribute: true, expectedElementNames: expectedElementNames);
             }
 
             private void ValidateAttributesOnProperties()
@@ -581,39 +574,35 @@ class C
                 // public static (int e1, int e2) Prop1 => (0, 0);
                 var prop1 = _derivedClass.GetMember("Prop1");
                 var expectedTupleNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(prop1,
+                ValidateTupleNameAttribute(prop1.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedTupleNames);
 
                 // public static (int e1, int e2) Prop2 { get; set; }
                 var prop2 = _derivedClass.GetMember("Prop2");
                 expectedTupleNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(prop2,
+                ValidateTupleNameAttribute(prop2.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedTupleNames);
 
                 // public (int e1, int e2) this[(int e3, int e4) param]
-                var indexer = (SourcePropertySymbol)_derivedClass.GetMember("this[]");
+                var indexer = (PropertySymbol)_derivedClass.GetMember("this[]");
                 expectedTupleNames = new[] { "e1", "e2" };
-                ValidateTupleNameAttribute(indexer,
+                ValidateTupleNameAttribute(indexer.GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedTupleNames);
                 expectedTupleNames = new[] { "e3", "e4" };
-                ValidateTupleNameAttribute(indexer.Parameters.Single(),
+                ValidateTupleNameAttribute(indexer.Parameters.Single().GetAttributes(),
                     expectedTupleNamesAttribute: true,
                     expectedElementNames: expectedTupleNames);
             }
 
             private void ValidateTupleNameAttribute(
-                Symbol symbol,
+                ImmutableArray<CSharpAttributeData> attributes,
                 bool expectedTupleNamesAttribute,
-                string[] expectedElementNames = null,
-                bool forReturnType = false)
+                string[] expectedElementNames = null)
             {
-                var synthesizedTupleElementNamesAttr = symbol
-                    .GetAttributes()
-                    .Where(attr => string.Equals(attr.AttributeClass.Name, "TupleElementNamesAttribute", StringComparison.Ordinal))
-                    .AsImmutable();
+                var synthesizedTupleElementNamesAttr = attributes.Where(attr => string.Equals(attr.AttributeClass.Name, "TupleElementNamesAttribute", StringComparison.Ordinal));
 
                 if (!expectedTupleNamesAttribute)
                 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -4742,25 +4742,24 @@ namespace AttributeTest
 ";
             var compilation = CreateStandardCompilation(source);
 
-            Action<ModuleSymbol> attributeValidator = (ModuleSymbol m) =>
+            Action<ModuleSymbol> attributeValidator = (ModuleSymbol module) =>
             {
-                var ns = (NamespaceSymbol)m.GlobalNamespace.GetMember("AttributeTest");
+                var ns = (NamespaceSymbol)module.GlobalNamespace.GetMember("AttributeTest");
                 var type = (NamedTypeSymbol)ns.GetMember("MyClass");
 
                 var useParamsMethod = (MethodSymbol)type.GetMember("UseParams");
                 var paramsParameter = useParamsMethod.Parameters[0];
-                VerifyParamArrayAttribute(paramsParameter, (SourceModuleSymbol)m);
+                VerifyParamArrayAttribute((PEParameterSymbol)paramsParameter);
 
                 var noParamsMethod = (MethodSymbol)type.GetMember("NoParams");
                 var noParamsParameter = noParamsMethod.Parameters[0];
-                Assert.Equal(0, noParamsParameter.GetSynthesizedAttributes().Length);
+                Assert.Equal(0, noParamsParameter.GetAttributes().Length);
             };
 
             // Verify attributes from source and then load metadata to see attributes are written correctly.
             var comp = CompileAndVerify(
                 compilation,
-                sourceSymbolValidator: attributeValidator,
-                symbolValidator: null,
+                symbolValidator: attributeValidator,
                 expectedSignatures: new[]
                 {
                     Signature("AttributeTest.MyClass", "UseParams", ".method public hidebysig static System.Void UseParams([System.ParamArrayAttribute()] System.Int32[] list) cil managed"),

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -4742,28 +4742,26 @@ namespace AttributeTest
 ";
             var compilation = CreateStandardCompilation(source);
 
-            Action<ModuleSymbol> attributeValidator = (ModuleSymbol module) =>
-            {
-                var ns = (NamespaceSymbol)module.GlobalNamespace.GetMember("AttributeTest");
-                var type = (NamedTypeSymbol)ns.GetMember("MyClass");
-
-                var useParamsMethod = (MethodSymbol)type.GetMember("UseParams");
-                var paramsParameter = useParamsMethod.Parameters[0];
-                VerifyParamArrayAttribute(paramsParameter);
-
-                var noParamsMethod = (MethodSymbol)type.GetMember("NoParams");
-                var noParamsParameter = noParamsMethod.Parameters[0];
-                Assert.Equal(0, noParamsParameter.GetAttributes().Length);
-            };
-
             // Verify attributes from source and then load metadata to see attributes are written correctly.
             var comp = CompileAndVerify(
                 compilation,
-                symbolValidator: attributeValidator,
                 expectedSignatures: new[]
                 {
                     Signature("AttributeTest.MyClass", "UseParams", ".method public hidebysig static System.Void UseParams([System.ParamArrayAttribute()] System.Int32[] list) cil managed"),
                     Signature("AttributeTest.MyClass", "NoParams", ".method public hidebysig static System.Void NoParams(System.Object list) cil managed"),
+                },
+                symbolValidator: module =>
+                {
+                    var @namespace = module.GlobalNamespace.GetNestedNamespace("AttributeTest");
+                    var type = @namespace.GetTypeMember("MyClass");
+
+                    var useParamsMethod = type.GetMethod("UseParams");
+                    var paramsParameter = useParamsMethod.Parameters[0];
+                    VerifyParamArrayAttribute(paramsParameter);
+
+                    var noParamsMethod = type.GetMethod("NoParams");
+                    var noParamsParameter = noParamsMethod.Parameters[0];
+                    Assert.Empty(noParamsParameter.GetAttributes());
                 });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -4749,7 +4749,7 @@ namespace AttributeTest
 
                 var useParamsMethod = (MethodSymbol)type.GetMember("UseParams");
                 var paramsParameter = useParamsMethod.Parameters[0];
-                VerifyParamArrayAttribute((PEParameterSymbol)paramsParameter);
+                VerifyParamArrayAttribute(paramsParameter);
 
                 var noParamsMethod = (MethodSymbol)type.GetMember("NoParams");
                 var noParamsParameter = noParamsMethod.Parameters[0];

--- a/src/Compilers/CSharp/Test/Emit/Attributes/WellKnownAttributesTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/WellKnownAttributesTestBase.cs
@@ -79,27 +79,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        internal static void VerifyParamArrayAttribute(ParameterSymbol parameter, SourceModuleSymbol module, bool expected = true, OutputKind outputKind = OutputKind.ConsoleApplication)
+        internal static void VerifyParamArrayAttribute(PEParameterSymbol parameter, bool expected = true)
         {
             Assert.Equal(expected, parameter.IsParams);
 
-            var emitModule = new PEAssemblyBuilder(module.ContainingSourceAssembly, EmitOptions.Default, outputKind, GetDefaultModulePropertiesForSerialization(), SpecializedCollections.EmptyEnumerable<ResourceDescription>());
-            var paramArrayAttributeCtor = (MethodSymbol)emitModule.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ParamArrayAttribute__ctor);
-            bool found = false;
+            var allAttributes = ((PEModuleSymbol)parameter.ContainingModule).GetCustomAttributesForToken(parameter.Handle);
+            var paramArrayAttributes = allAttributes.Where(a => a.AttributeClass.ToTestDisplayString() == "System.ParamArrayAttribute");
 
-            var context = new EmitContext(emitModule, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
-
-            foreach (Microsoft.Cci.ICustomAttribute attr in parameter.GetSynthesizedAttributes())
+            if (expected)
             {
-                if (paramArrayAttributeCtor == (MethodSymbol)attr.Constructor(context))
-                {
-                    Assert.False(found, "Multiple ParamArrayAttribute");
-                    found = true;
-                }
+                Assert.Equal(1, paramArrayAttributes.Count());
             }
-
-            Assert.Equal(expected, found);
-            context.Diagnostics.Verify();
+            else
+            {
+                Assert.Empty(paramArrayAttributes);
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/WellKnownAttributesTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/WellKnownAttributesTestBase.cs
@@ -79,11 +79,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        internal static void VerifyParamArrayAttribute(PEParameterSymbol parameter, bool expected = true)
+        internal static void VerifyParamArrayAttribute(ParameterSymbol parameter, bool expected = true)
         {
             Assert.Equal(expected, parameter.IsParams);
 
-            var allAttributes = ((PEModuleSymbol)parameter.ContainingModule).GetCustomAttributesForToken(parameter.Handle);
+            var peParameter = (PEParameterSymbol)parameter;
+            var allAttributes = ((PEModuleSymbol)parameter.ContainingModule).GetCustomAttributesForToken(peParameter.Handle);
             var paramArrayAttributes = allAttributes.Where(a => a.AttributeClass.ToTestDisplayString() == "System.ParamArrayAttribute");
 
             if (expected)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3954,7 +3954,7 @@ class B : A
     }
 }
 ";
-            Action<ModuleSymbol> validator = module =>
+            Func<bool, Action<ModuleSymbol>> validator = isFromMetadata => module =>
             {
                 var globalNamespace = module.GlobalNamespace;
 
@@ -3981,10 +3981,13 @@ class B : A
                 Assert.Equal(ConstantValue.Null, parameterB.ExplicitDefaultConstantValue);
                 Assert.False(parameterB.IsOptional, "ParameterArray param cannot be optional");
 
-                WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameterB);
+                if (isFromMetadata)
+                {
+                    WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameterB);
+                };
             };
 
-            var verifier = CompileAndVerify(source, symbolValidator: validator, expectedOutput: @"System.Int32[]");
+            var verifier = CompileAndVerify(source, symbolValidator: validator(true), sourceSymbolValidator: validator(false), expectedOutput: @"System.Int32[]");
         }
 
         [WorkItem(543158, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543158")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3,12 +3,8 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3985,7 +3985,7 @@ class B : A
                 Assert.Equal(ConstantValue.Null, parameterB.ExplicitDefaultConstantValue);
                 Assert.False(parameterB.IsOptional, "ParameterArray param cannot be optional");
 
-                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameterB);
+                WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameterB);
             };
 
             var verifier = CompileAndVerify(source, symbolValidator: validator, expectedOutput: @"System.Int32[]");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
@@ -3957,7 +3958,7 @@ class B : A
     }
 }
 ";
-            Func<bool, Action<ModuleSymbol>> validator = isFromSource => module =>
+            Action<ModuleSymbol> validator = module =>
             {
                 var globalNamespace = module.GlobalNamespace;
 
@@ -3984,14 +3985,10 @@ class B : A
                 Assert.Equal(ConstantValue.Null, parameterB.ExplicitDefaultConstantValue);
                 Assert.False(parameterB.IsOptional, "ParameterArray param cannot be optional");
 
-                if (isFromSource)
-                {
-                    var srcModule = (SourceModuleSymbol)module;
-                    WellKnownAttributesTestBase.VerifyParamArrayAttribute(parameterB, srcModule);
-                }
+                WellKnownAttributesTestBase.VerifyParamArrayAttribute((PEParameterSymbol)parameterB);
             };
 
-            var verifier = CompileAndVerify(source, symbolValidator: validator(false), sourceSymbolValidator: validator(true), expectedOutput: @"System.Int32[]");
+            var verifier = CompileAndVerify(source, symbolValidator: validator, expectedOutput: @"System.Int32[]");
         }
 
         [WorkItem(543158, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543158")]

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -3761,7 +3761,7 @@ class C
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseDll.WithOutputKind(OutputKind.NetModule));
             compilation.VerifyDiagnostics();
 
-            CompileAndVerify(compilation, verify: false, symbolValidator: module =>
+            CompileAndVerify(compilation, verify: Verification.Skipped, symbolValidator: module =>
             {
                 //no assembly => no decl security row
                 ValidateDeclSecurity(module);
@@ -5003,13 +5003,13 @@ public class DerivingClass<T> : BaseClass<T>
         }
 
         [Fact]
-        public void CompileAndVerifyModuleInlucesAllModules()
+        public void CompileAndVerifyModuleIncludesAllModules()
         {
             // Before this change, CompileAndVerify() didn't include other modules when testing a PEModule.
             // Verify that symbols from other modules are accessible as well.
 
-            var modRef = ModuleMetadata.CreateFromImage(CreateStandardCompilation("public class A { }", options: TestOptions.ReleaseModule, assemblyName: "refMod").EmitToArray());
-            var comp = CreateStandardCompilation("public class B : A { }", references: new[] { modRef.GetReference() }, assemblyName: "sourceMod");
+            var modRef = CreateStandardCompilation("public class A { }", options: TestOptions.ReleaseModule, assemblyName: "refMod").EmitToImageReference();
+            var comp = CreateStandardCompilation("public class B : A { }", references: new[] { modRef }, assemblyName: "sourceMod");
 
             CompileAndVerify(comp, symbolValidator: module =>
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -3727,25 +3726,23 @@ class C
             var compilation = CreateStandardCompilation(source, options: TestOptions.UnsafeReleaseDll);
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -3766,8 +3763,8 @@ class C
 
             CompileAndVerify(compilation, verify: false, symbolValidator: module =>
             {
-                var peModule = (PEModuleSymbol)module;
-                ValidateDeclSecurity(peModule.GetMetadata().GetMetadataReader());//no assembly => no decl security row
+                //no assembly => no decl security row
+                ValidateDeclSecurity(module);
             });
         }
 
@@ -3798,25 +3795,23 @@ class C
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -3850,36 +3845,34 @@ class C
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u001a" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "RemotingConfiguration" + // property name
-                            "\u0001" + // argument value (true)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u001a" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "RemotingConfiguration" + // property name
+                        "\u0001" + // argument value (true)
 
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0012" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "UnmanagedCode" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0012" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "UnmanagedCode" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -3913,42 +3906,40 @@ class C
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestOptional,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u001a" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "RemotingConfiguration" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0012" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "UnmanagedCode" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestOptional,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u001a" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "RemotingConfiguration" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0012" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u000d" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "UnmanagedCode" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -3978,36 +3969,34 @@ class C
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0002" + // number of attributes (small enough to fit in 1 byte)
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0002" + // number of attributes (small enough to fit in 1 byte)
 
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u001a" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "RemotingConfiguration" + // property name
-                            "\u0001" + // argument value (true)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u001a" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "RemotingConfiguration" + // property name
+                        "\u0001" + // argument value (true)
 
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -4037,42 +4026,40 @@ class C
 
             CompileAndVerify(compilation, symbolValidator: module =>
             {
-                var assembly = (PEAssemblySymbol)module.ContainingAssembly;
-                ValidateDeclSecurity(assembly.GetMetadata().GetAssembly().GetMetadataReader(),
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestOptional,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u001a" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "RemotingConfiguration" + // property name
-                            "\u0001", // argument value (true)
-                    },
-                    new DeclSecurityEntry
-                    {
-                        ActionFlags = DeclarativeSecurityAction.RequestMinimum,
-                        ParentKind = SymbolKind.Assembly,
-                        PermissionSet =
-                            "." + // always start with a dot
-                            "\u0001" + // number of attributes (small enough to fit in 1 byte)
-                            "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
-                            "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
-                            "\u0015" + // number of bytes in the encoding of the named arguments
-                            "\u0001" + // number of named arguments
-                            "\u0054" + // property (vs field)
-                            "\u0002" + // type bool
-                            "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
-                            "SkipVerification" + // property name
-                            "\u0001", // argument value (true)
-                    });
+                ValidateDeclSecurity(module, new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestOptional,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u001a" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0015" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "RemotingConfiguration" + // property name
+                        "\u0001", // argument value (true)
+                },
+                new DeclSecurityEntry
+                {
+                    ActionFlags = DeclarativeSecurityAction.RequestMinimum,
+                    ParentKind = SymbolKind.Assembly,
+                    PermissionSet =
+                        "." + // always start with a dot
+                        "\u0001" + // number of attributes (small enough to fit in 1 byte)
+                        "\u0080\u0084" + // length of UTF-8 string (0x80 indicates a 2-byte encoding)
+                        "System.Security.Permissions.SecurityPermissionAttribute, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" + // attr type name
+                        "\u0015" + // number of bytes in the encoding of the named arguments
+                        "\u0001" + // number of named arguments
+                        "\u0054" + // property (vs field)
+                        "\u0002" + // type bool
+                        "\u0010" + // length of UTF-8 string (small enough to fit in 1 byte)
+                        "SkipVerification" + // property name
+                        "\u0001", // argument value (true)
+                });
             });
         }
 
@@ -5013,6 +5000,29 @@ public class DerivingClass<T> : BaseClass<T>
                 // (11,26): error CS0508: 'DerivingClass<T>.Method(T)': return type must be 'int' to match overridden member 'BaseClass<T>.Method(T)'
                 //     public override void Method(T input)
                 Diagnostic(ErrorCode.ERR_CantChangeReturnTypeOnOverride, "Method").WithArguments("DerivingClass<T>.Method(T)", "BaseClass<T>.Method(T)", "int").WithLocation(11, 26));
+        }
+
+        [Fact]
+        public void CompileAndVerifyModuleInlucesAllModules()
+        {
+            // Before this change, CompileAndVerify() didn't include other modules when testing a PEModule.
+            // Verify that symbols from other modules are accessible as well.
+
+            var modRef = ModuleMetadata.CreateFromImage(CreateStandardCompilation("public class A { }", options: TestOptions.ReleaseModule, assemblyName: "refMod").EmitToArray());
+            var comp = CreateStandardCompilation("public class B : A { }", references: new[] { modRef.GetReference() }, assemblyName: "sourceMod");
+
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var b = module.GlobalNamespace.GetTypeMember("B");
+                Assert.Equal("B", b.Name);
+                Assert.False(b.IsErrorType());
+                Assert.Equal("sourceMod.dll", b.ContainingModule.Name);
+
+                var a = b.BaseType;
+                Assert.Equal("A", a.Name);
+                Assert.False(a.IsErrorType());
+                Assert.Equal("refMod.netmodule", a.ContainingModule.Name);
+            });
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
@@ -107,15 +107,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         /// </summary>
         internal static void ValidateDeclSecurity(MetadataReader metadataReader, params DeclSecurityEntry[] expectedEntries)
         {
-            Assert.Equal(expectedEntries.Length, metadataReader.DeclarativeSecurityAttributes.Count);
-
             var actualEntries = new List<DeclSecurityEntry>(expectedEntries.Length);
 
             int i = 0;
             foreach (var actualHandle in metadataReader.DeclarativeSecurityAttributes)
             {
                 var actual = metadataReader.GetDeclarativeSecurityAttribute(actualHandle);
-                var expected = expectedEntries[i];
 
                 var actualPermissionSetBytes = metadataReader.GetBlobBytes(actual.PermissionSet);
                 var actualPermissionSet = new string(actualPermissionSetBytes.Select(b => (char)b).ToArray());
@@ -134,7 +131,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 i++;
             }
 
-            AssertEx.SetEqual(actualEntries, expectedEntries);
+            AssertEx.SetEqual(expectedEntries, actualEntries, itemInspector: entry => $@"{{
+    ActionFlags = {entry.ActionFlags},
+    ParentNameOpt = {entry.ParentNameOpt},
+    PermissionSet = {entry.PermissionSet},
+    ParentKind = {entry.ParentKind}
+}}");
         }
 
         private static void GetAttributeParentNameAndKind(MetadataReader metadataReader, EntityHandle token, out string name, out SymbolKind kind)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
-using System.Reflection;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -93,8 +92,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         /// <summary>
         /// Validate the contents of the DeclSecurity metadata table.
         /// </summary>
-        internal static void ValidateDeclSecurity(MetadataReader metadataReader, params DeclSecurityEntry[] expectedEntries)
+        internal static void ValidateDeclSecurity(ModuleSymbol module, params DeclSecurityEntry[] expectedEntries)
         {
+            var metadataReader = module.GetMetadata().MetadataReader;
             var actualEntries = new List<DeclSecurityEntry>(expectedEntries.Length);
 
             int i = 0;
@@ -119,7 +119,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 i++;
             }
 
-            AssertEx.SetEqual(expectedEntries, actualEntries, itemInspector: entry => $@"{{
+            AssertEx.SetEqual(expectedEntries, actualEntries, itemInspector: entry => $@"
+{{
     ActionFlags = {entry.ActionFlags},
     ParentNameOpt = {entry.ParentNameOpt},
     PermissionSet = {entry.PermissionSet},

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
@@ -90,18 +90,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         #region DeclSecurityTable Validation
-
-        /// <summary>
-        /// Validate the contents of the DeclSecurity metadata table.
-        /// </summary>
-        internal static void ValidateDeclSecurity(CSharpCompilation compilation, params DeclSecurityEntry[] expectedEntries)
-        {
-            using (var metadata = ModuleMetadata.CreateFromImage(compilation.EmitToArray()))
-            {
-                ValidateDeclSecurity(metadata.Module.GetMetadataReader(), expectedEntries);
-            }
-        }
-
         /// <summary>
         /// Validate the contents of the DeclSecurity metadata table.
         /// </summary>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -1235,14 +1235,14 @@ class C : B<string>
 ";
             Action<ModuleSymbol> validator = module =>
             {
-                var classA = module.GlobalNamespace.GetTypeMembers("A").Single();
-                var p = classA.GetMembers("P").OfType<PropertySymbol>().Single();
+                var classA = module.GlobalNamespace.GetTypeMember("A");
+                var p = classA.GetProperty("P");
                 VerifyAutoProperty(p);
-                var q = classA.GetMembers("Q").OfType<PropertySymbol>().Single();
+                var q = classA.GetProperty("Q");
                 VerifyAutoProperty(q);
 
                 var classC = module.GlobalNamespace.GetTypeMembers("C").Single();
-                p = classC.BaseType.GetMembers("P").OfType<PropertySymbol>().Single();
+                p = classC.BaseType.GetProperty("P");
                 VerifyAutoProperty(p);
                 Assert.Equal(p.Type.SpecialType, SpecialType.System_String);
                 Assert.Equal(p.GetMethod.AssociatedSymbol, p);

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -1233,49 +1233,42 @@ class C : B<string>
 {
 }
 ";
-            Func<bool, Action<ModuleSymbol>> validator = isFromSource => module =>
+            Action<ModuleSymbol> validator = module =>
             {
                 var classA = module.GlobalNamespace.GetTypeMembers("A").Single();
                 var p = classA.GetMembers("P").OfType<PropertySymbol>().Single();
-                VerifyAutoProperty(p, isFromSource);
+                VerifyAutoProperty(p);
                 var q = classA.GetMembers("Q").OfType<PropertySymbol>().Single();
-                VerifyAutoProperty(q, isFromSource);
+                VerifyAutoProperty(q);
 
                 var classC = module.GlobalNamespace.GetTypeMembers("C").Single();
                 p = classC.BaseType.GetMembers("P").OfType<PropertySymbol>().Single();
-                VerifyAutoProperty(p, isFromSource);
+                VerifyAutoProperty(p);
                 Assert.Equal(p.Type.SpecialType, SpecialType.System_String);
                 Assert.Equal(p.GetMethod.AssociatedSymbol, p);
             };
 
-            CompileAndVerify(source, sourceSymbolValidator: validator(true), symbolValidator: validator(false), options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
+            CompileAndVerify(source, symbolValidator: validator, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
         }
 
-        private static void VerifyAutoProperty(PropertySymbol property, bool isFromSource)
+        private static void VerifyAutoProperty(PropertySymbol property)
         {
-            var sourceProperty = property as SourcePropertySymbol;
-            if (sourceProperty != null)
-            {
-                Assert.True(sourceProperty.IsAutoProperty);
-                Assert.Equal(((SourceAssemblySymbol)sourceProperty.ContainingAssembly).DeclaringCompilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor),
-                    sourceProperty.BackingField.GetSynthesizedAttributes().Single().AttributeConstructor);
-            }
+            var backingField = property.ContainingType.GetField(GeneratedNames.MakeBackingFieldName(property.Name));
+            var attribute = backingField.GetAttributes().Single();
+            Assert.Equal("System.Runtime.CompilerServices.CompilerGeneratedAttribute", attribute.AttributeClass.ToTestDisplayString());
+            Assert.Empty(attribute.AttributeConstructor.Parameters);
 
-            VerifyAutoPropertyAccessor(property, property.GetMethod, isFromSource);
-            VerifyAutoPropertyAccessor(property, property.SetMethod, isFromSource);
+            VerifyAutoPropertyAccessor(property, property.GetMethod);
+            VerifyAutoPropertyAccessor(property, property.SetMethod);
         }
 
-        private static void VerifyAutoPropertyAccessor(PropertySymbol property, MethodSymbol accessor, bool isFromSource)
+        private static void VerifyAutoPropertyAccessor(PropertySymbol property, MethodSymbol accessor)
         {
             if (accessor != null)
             {
                 var method = property.ContainingType.GetMembers(accessor.Name).Single();
                 Assert.Equal(method, accessor);
                 Assert.Equal(accessor.AssociatedSymbol, property);
-                if (isFromSource)
-                {
-                    Assert.False(accessor.IsImplicitlyDeclared, "MethodSymbol.IsImplicitlyDeclared should be false for auto property accessors");
-                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -3,12 +3,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
@@ -2518,43 +2519,27 @@ static class S
         /// <summary>
         /// Roslyn bug 7782: NullRef in PeWriter.DebuggerShouldHideMethod
         /// </summary>
-        [ClrOnlyFact]
+        [Fact]
         public void ExtensionMethod_ValidateExtensionAttribute()
         {
-            var source =
-@"using System;
+            var comp = CreateStandardCompilation(@"
+using System;
 internal static class C
 {
     internal static void M1(this object o) { }
     private static void Main(string[] args) { }
 }
-";
-            Action<ModuleSymbol> validator = module =>
+", references: new[] { SystemCoreRef }, options: TestOptions.DebugExe.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            CompileAndVerify(comp, symbolValidator: module =>
             {
-                var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-
-                // Extension method.
-                var method = type.GetMember<MethodSymbol>("M1");
+                var method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<PEMethodSymbol>("M1");
                 Assert.True(method.IsExtensionMethod);
-                var parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Object);
+                Assert.Equal(method.Parameters.Single().Type.SpecialType, SpecialType.System_Object);
 
-                // Validate Extension attribute.
-                var sourceModule = (SourceModuleSymbol)module;
-                var emitModule = new PEAssemblyBuilder(sourceModule.ContainingSourceAssembly, EmitOptions.Default, OutputKind.ConsoleApplication, GetDefaultModulePropertiesForSerialization(), SpecializedCollections.EmptyEnumerable<ResourceDescription>());
-                var attrs = method.GetSynthesizedAttributes();
-                Assert.Equal(1, attrs.Length);
-                var attr = (Microsoft.Cci.ICustomAttribute)attrs.First();
-
-                var extensionAttrCtor = (MethodSymbol)emitModule.Compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor);
-                Assert.NotNull(extensionAttrCtor);
-                var context = new EmitContext(emitModule, null, new DiagnosticBag(), metadataOnly: false, includePrivateMembers: true);
-                Assert.Equal(extensionAttrCtor, attr.Constructor(context));
-                Assert.NotNull(extensionAttrCtor.ContainingType);
-                Assert.Equal(extensionAttrCtor.ContainingType, attr.GetType(context));
-                context.Diagnostics.Verify();
-            };
-            CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, sourceSymbolValidator: validator, symbolValidator: null);
+                var attr = ((PEModuleSymbol)module).GetCustomAttributesForToken(method.Handle).Single();
+                Assert.Equal("System.Runtime.CompilerServices.ExtensionAttribute", attr.AttributeClass.ToTestDisplayString());
+            });
         }
 
         [WorkItem(541327, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541327")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -8,11 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -2103,26 +2101,28 @@ using System.Runtime.CompilerServices;
 class Program
 {
     [IndexerName(""A"")]
-    int this[int x]
+    public int this[int x]
     {
         get { return 0; }
         set { }
     }
 }
 ";
-            var compilation = CreateStandardCompilation(source);
-            compilation.VerifyDiagnostics();
+            var compilation = CreateStandardCompilation(source).VerifyDiagnostics();
 
             var indexer = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Program").Indexers.Single();
             Assert.True(indexer.IsIndexer);
             Assert.Equal("A", indexer.MetadataName);
+            Assert.True(indexer.GetAttributes().Single().IsTargetAttribute(indexer, AttributeDescription.IndexerNameAttribute));
 
-            // Appears in symbol model to reflect source.
-            var attribute = indexer.GetAttributes().Single();
-            Assert.True(attribute.IsTargetAttribute(indexer, AttributeDescription.IndexerNameAttribute));
-
-            // Not emitted.
-            Assert.Equal(0, indexer.GetCustomAttributesToEmit(GetDefaultPEBuilder(compilation)).Count());
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var peIndexer = (PEPropertySymbol)module.GlobalNamespace.GetTypeMember("Program").Indexers.Single();
+                Assert.True(peIndexer.IsIndexer);
+                Assert.Equal("A", peIndexer.MetadataName);
+                Assert.Empty(peIndexer.GetAttributes());
+                Assert.Empty(((PEModuleSymbol)module).GetCustomAttributesForToken(peIndexer.Handle));
+            });
         }
 
         [WorkItem(545884, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545884")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -4,11 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1287,9 +1285,40 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
         #endregion
 
+        [Fact]
         [WorkItem(530209, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530209")]
-        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
-        public void Bug530209()
+        public void Bug530209_DecimalConstant()
+        {
+            var compilation = CreateStandardCompilation(
+@"
+public class Class1
+{
+    public const decimal d1 = -7;
+
+    public void M1(decimal d1 = -7)
+    {}
+}");
+
+            CompileAndVerify(compilation, symbolValidator: module =>
+            {
+                var peModule = (PEModuleSymbol)module;
+                var class1 = module.GlobalNamespace.GetTypeMember("Class1");
+                var field = class1.GetMember<PEFieldSymbol>("d1");
+                var parameter = (PEParameterSymbol)class1.GetMethod("M1").GetParameters().Single();
+
+                Assert.Empty(field.GetAttributes());
+                Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", peModule.GetCustomAttributesForToken(field.Handle).Single().ToString());
+                Assert.Equal(field.ConstantValue, -7m);
+
+                Assert.Empty(parameter.GetAttributes());
+                Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", peModule.GetCustomAttributesForToken(parameter.Handle).Single().ToString());
+                Assert.Equal(parameter.ExplicitDefaultValue, -7m);
+            });
+        }
+
+        [Fact]
+        [WorkItem(530209, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530209")]
+        public void Bug530209_DecimalConstant_FromIL()
         {
             var ilSource = @"
 .class public auto ansi beforefieldinit Class1
@@ -1388,69 +1417,35 @@ System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64)
 } // end of class Class1
 ";
 
-            var c1 = CreateStandardCompilation(
-@"
-public class Class1
+            var csSource = @"
+class Class2 : Class1
 {
-    public const decimal d1 = -7;
+}";
 
-    public void M1(decimal d1 = -7)
-    {}
-}");
+            CompileAndVerify(CreateCompilationWithCustomILSource(csSource, ilSource), symbolValidator: module =>
+            {
+                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType;
+                Assert.Equal("Class1", class1.ToTestDisplayString());
 
+                var field1 = class1.GetField("d1");
 
-            var class1 = c1.GetTypeByMetadataName("Class1");
-            var d1 = class1.GetMember<FieldSymbol>("d1");
-            var m1 = class1.GetMember<MethodSymbol>("M1");
+                Assert.Empty(field1.GetAttributes());
+                Assert.Equal(field1.ConstantValue, -7m);
 
-            var builder = GetDefaultPEBuilder(c1);
+                var field2 = class1.GetField("d2");
 
-            Assert.Empty(d1.GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", d1.GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(d1.ConstantValue, -7m);
-            Assert.Empty(m1.Parameters[0].GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", m1.Parameters[0].GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(m1.Parameters[0].ExplicitDefaultValue, -7m);
+                Assert.Equal(2, field2.GetAttributes().Length);
+                Assert.Null(field2.ConstantValue);
 
-            var c2 = CreateCompilationWithCustomILSource("", ilSource);
+                var parameters = class1.GetMethod("M1").GetParameters();
+                Assert.Equal(2, parameters.Count());
 
-            class1 = c2.GetTypeByMetadataName("Class1");
-            d1 = class1.GetMember<FieldSymbol>("d1");
-            var d2 = class1.GetMember<FieldSymbol>("d2");
-            m1 = class1.GetMember<MethodSymbol>("M1");
+                Assert.Empty(parameters.First().GetAttributes());
+                Assert.Equal(parameters.First().ExplicitDefaultValue, -7m);
 
-            Assert.Empty(d1.GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", d1.GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(d1.ConstantValue, -7m);
-            Assert.Equal(2, d2.GetAttributes().Length);
-            Assert.Equal(2, d2.GetCustomAttributesToEmit(builder).Count());
-            Assert.Null(d2.ConstantValue);
-            Assert.Empty(m1.Parameters[0].GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", m1.Parameters[0].GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(m1.Parameters[0].ExplicitDefaultValue, -7m);
-            Assert.Empty(m1.Parameters[1].GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DateTimeConstantAttribute(634925952000000000)", m1.Parameters[1].GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(m1.Parameters[1].ExplicitDefaultValue, new DateTime(2013, 1, 1));
-
-            var c3 = CreateCompilationWithCustomILSource("", ilSource);
-
-            class1 = c3.GetTypeByMetadataName("Class1");
-            d1 = class1.GetMember<FieldSymbol>("d1");
-            d2 = class1.GetMember<FieldSymbol>("d2");
-            m1 = class1.GetMember<MethodSymbol>("M1");
-
-            Assert.Equal(d1.ConstantValue, -7m);
-            Assert.Empty(d1.GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", d1.GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Null(d2.ConstantValue);
-            Assert.Equal(2, d2.GetAttributes().Length);
-            Assert.Equal(2, d2.GetCustomAttributesToEmit(builder).Count());
-            Assert.Equal(m1.Parameters[0].ExplicitDefaultValue, -7m);
-            Assert.Empty(m1.Parameters[0].GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DecimalConstantAttribute(0, 128, 0, 0, 7)", m1.Parameters[0].GetCustomAttributesToEmit(builder).Single().ToString());
-            Assert.Equal(m1.Parameters[1].ExplicitDefaultValue, new DateTime(2013, 1, 1));
-            Assert.Empty(m1.Parameters[1].GetAttributes());
-            Assert.Equal("System.Runtime.CompilerServices.DateTimeConstantAttribute(634925952000000000)", m1.Parameters[1].GetCustomAttributesToEmit(builder).Single().ToString());
+                Assert.Empty(parameters.Last().GetAttributes());
+                Assert.Equal(parameters.Last().ExplicitDefaultValue, new DateTime(2013, 1, 1));
+            });
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -1446,6 +1446,33 @@ class Class2 : Class1
                 Assert.Empty(parameters.Last().GetAttributes());
                 Assert.Equal(parameters.Last().ExplicitDefaultValue, new DateTime(2013, 1, 1));
             });
+
+            // Switch order of API calls
+
+            CompileAndVerify(CreateCompilationWithCustomILSource(csSource, ilSource), symbolValidator: module =>
+            {
+                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType;
+                Assert.Equal("Class1", class1.ToTestDisplayString());
+
+                var field1 = class1.GetField("d1");
+
+                Assert.Equal(field1.ConstantValue, -7m);
+                Assert.Empty(field1.GetAttributes());
+
+                var field2 = class1.GetField("d2");
+
+                Assert.Null(field2.ConstantValue);
+                Assert.Equal(2, field2.GetAttributes().Length);
+
+                var parameters = class1.GetMethod("M1").GetParameters();
+                Assert.Equal(2, parameters.Count());
+
+                Assert.Equal(parameters.First().ExplicitDefaultValue, -7m);
+                Assert.Empty(parameters.First().GetAttributes());
+
+                Assert.Equal(parameters.Last().ExplicitDefaultValue, new DateTime(2013, 1, 1));
+                Assert.Empty(parameters.Last().GetAttributes());
+            });
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -185,17 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                                                     WinRtRefs.Concat(additionalRefs ?? Enumerable.Empty<MetadataReference>()),
                                                     TestOptions.ReleaseExe);
         }
-
-        internal static PEAssemblyBuilder GetDefaultPEBuilder(CSharpCompilation compilation)
-        {
-            return new PEAssemblyBuilder(
-                (SourceAssemblySymbol)compilation.Assembly,
-                EmitOptions.Default,
-                compilation.Options.OutputKind,
-                GetDefaultModulePropertiesForSerialization(),
-                SpecializedCollections.EmptyEnumerable<ResourceDescription>());
-        }
-
+        
         protected override CompilationOptions CompilationOptionsReleaseDll
         {
             get { return TestOptions.ReleaseDll; }

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -267,24 +267,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return summary;
         }
 
-        internal static ImmutableArray<SynthesizedAttributeData> GetSynthesizedAttributes(this Symbol symbol, bool forReturnType = false)
-        {
-            var builder = CSharpTestBase.GetDefaultPEBuilder(symbol.DeclaringCompilation);
-            ArrayBuilder<SynthesizedAttributeData> attributes = null;
-
-            if (!forReturnType)
-            {
-                symbol.AddSynthesizedAttributes(builder, ref attributes);
-            }
-            else
-            {
-                Assert.True(symbol.Kind == SymbolKind.Method, "Incorrect usage of GetSynthesizedAttributes");
-                ((MethodSymbol)symbol).AddSynthesizedReturnTypeAttributes(builder, ref attributes);
-            }
-            
-            return attributes != null ? attributes.ToImmutableAndFree() : ImmutableArray.Create<SynthesizedAttributeData>();
-        }
-
         public static List<string> LookupNames(this SemanticModel model, int position, INamespaceOrTypeSymbol container = null, bool namespacesAndTypesOnly = false, bool useBaseReferenceAccessibility = false)
         {
             Assert.True(!useBaseReferenceAccessibility || (object)container == null);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
@@ -257,7 +257,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
@@ -652,7 +652,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -691,7 +691,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -730,7 +730,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -778,7 +778,7 @@ public class Outer<T, U>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
                 VerifyCustomTypeInfo(locals[0], "d", 0x04, 0x03);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{
@@ -944,7 +944,7 @@ public class Outer<T, U>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: false);
+                CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: false);
                 VerifyCustomTypeInfo(locals[0], "d", null);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
@@ -257,7 +257,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
@@ -652,7 +652,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, method.ReturnType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -691,7 +691,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((ArrayTypeSymbol)method.ReturnType).ElementType.TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -730,7 +730,7 @@ class Generic<T>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
@@ -778,7 +778,7 @@ public class Outer<T, U>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: true);
                 VerifyCustomTypeInfo(locals[0], "d", 0x04, 0x03);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{
@@ -944,7 +944,7 @@ public class Outer<T, U>
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.Null(GetDynamicAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.DynamicAttribute, expected: false);
                 VerifyCustomTypeInfo(locals[0], "d", null);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -386,9 +386,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             return MethodDebugInfo<TypeSymbol, LocalSymbol>.ReadMethodDebugInfo((ISymUnmanagedReader3)symReader, symbolProvider, MetadataTokens.GetToken(peMethod.Handle), methodVersion: 1, ilOffset: ilOffset, isVisualBasicMethod: false);
         }
         
-        internal static void CheckAttribute(AssemblyMetadata assembly, IMethodSymbol method, AttributeDescription description, bool expected)
+        internal static void CheckAttribute(IEnumerable<byte> assembly, IMethodSymbol method, AttributeDescription description, bool expected)
         {
-            var module = assembly.GetModules().Single().Module;
+            var module = AssemblyMetadata.CreateFromImage(assembly).GetModules().Single().Module;
 
             var typeHandle = module
                 .GroupTypesByNamespaceOrThrow(StringComparer.Ordinal)
@@ -404,20 +404,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             if (returnParamHandle.IsNil)
             {
                 Assert.False(expected);
-                return;
-            }
-
-            var attributes = module
-                .GetCustomAttributesOrThrow(returnParamHandle)
-                .Where(handle => module.GetTargetAttributeSignatureIndex(handle, description) != -1);
-
-            if (expected)
-            {
-                Assert.Equal(1, attributes.Count());
             }
             else
             {
-                Assert.Empty(attributes);
+                var attributes = module
+                    .GetCustomAttributesOrThrow(returnParamHandle)
+                    .Where(handle => module.GetTargetAttributeSignatureIndex(handle, description) != -1);
+
+                if (expected)
+                {
+                    Assert.Equal(1, attributes.Count());
+                }
+                else
+                {
+                    Assert.Empty(attributes);
+                }
             }
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -385,22 +385,40 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 
             return MethodDebugInfo<TypeSymbol, LocalSymbol>.ReadMethodDebugInfo((ISymUnmanagedReader3)symReader, symbolProvider, MetadataTokens.GetToken(peMethod.Handle), methodVersion: 1, ilOffset: ilOffset, isVisualBasicMethod: false);
         }
-
-        internal static SynthesizedAttributeData GetDynamicAttributeIfAny(IMethodSymbol method)
+        
+        internal static void CheckAttribute(AssemblyMetadata assembly, IMethodSymbol method, AttributeDescription description, bool expected)
         {
-            return GetAttributeIfAny(method, "System.Runtime.CompilerServices.DynamicAttribute");
-        }
+            var module = assembly.GetModules().Single().Module;
 
-        internal static SynthesizedAttributeData GetTupleElementNamesAttributeIfAny(IMethodSymbol method)
-        {
-            return GetAttributeIfAny(method, "System.Runtime.CompilerServices.TupleElementNamesAttribute");
-        }
+            var typeHandle = module
+                .GroupTypesByNamespaceOrThrow(StringComparer.Ordinal)
+                .SelectMany(group => group)
+                .Single(handle => module.GetTypeDefNameOrThrow(handle) == method.ContainingType.Name);
 
-        internal static SynthesizedAttributeData GetAttributeIfAny(IMethodSymbol method, string typeName)
-        {
-            return ((MethodSymbol)method).GetSynthesizedAttributes(forReturnType: true).
-                Where(a => a.AttributeClass.ToTestDisplayString() == typeName).
-                SingleOrDefault();
+            var methodHandle = module
+                .GetMethodsOfTypeOrThrow(typeHandle)
+                .Single(handle => module.GetMethodDefNameOrThrow(handle) == method.Name);
+
+            var returnParamHandle = module.GetParametersOfMethodOrThrow(methodHandle).FirstOrDefault();
+
+            if (returnParamHandle.IsNil)
+            {
+                Assert.False(expected);
+                return;
+            }
+
+            var attributes = module
+                .GetCustomAttributesOrThrow(returnParamHandle)
+                .Where(handle => module.GetTargetAttributeSignatureIndex(handle, description) != -1);
+
+            if (expected)
+            {
+                Assert.Equal(1, attributes.Count());
+            }
+            else
+            {
+                Assert.Empty(attributes);
+            }
         }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -390,14 +390,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         {
             var module = AssemblyMetadata.CreateFromImage(assembly).GetModules().Single().Module;
 
-            var typeHandle = module
-                .GroupTypesByNamespaceOrThrow(StringComparer.Ordinal)
-                .SelectMany(group => group)
-                .Single(handle => module.GetTypeDefNameOrThrow(handle) == method.ContainingType.Name);
+            var typeName = method.ContainingType.Name;
+            var typeHandle = module.MetadataReader.TypeDefinitions
+                .Single(handle => module.GetTypeDefNameOrThrow(handle) == typeName);
 
+            var methodName = method.Name;
             var methodHandle = module
                 .GetMethodsOfTypeOrThrow(typeHandle)
-                .Single(handle => module.GetMethodDefNameOrThrow(handle) == method.Name);
+                .Single(handle => module.GetMethodDefNameOrThrow(handle) == methodName);
 
             var returnParamHandle = module.GetParametersOfMethodOrThrow(methodHandle).FirstOrDefault();
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
                 Assert.True(method.ReturnType.IsTupleType);
-                Assert.NotNull(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
@@ -179,7 +179,7 @@ class C
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
                 Assert.True(method.ReturnType.IsTupleType);
-                Assert.Null(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: false);
                 methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
@@ -220,7 +220,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(new[] { "A\u1234", "\u1234B" }, tupleElementNames);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 Assert.True(method.ReturnType.IsTupleType);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
 string.Format(@"{{
@@ -268,7 +268,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(new[] { null, "A", "B", null }, tupleElementNames);
                 var method = (MethodSymbol)testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 var returnType = method.ReturnType;
                 Assert.False(returnType.IsTupleType);
                 Assert.True(returnType.ContainsTuple());
@@ -392,7 +392,7 @@ class C
                 Assert.Null(tupleElementNames);
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
-                Assert.Null(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: false);
                 methodData.VerifyIL(
 @"{
   // Code size       64 (0x40)
@@ -449,7 +449,7 @@ class C
                 string typeName;
                 var diagnostics = DiagnosticBag.GetInstance();
                 var testData = new CompilationTestData();
-                context.CompileGetLocals(
+                var assembly = context.CompileGetLocals(
                     locals,
                     argumentsOnly: false,
                     aliases: ImmutableArray.Create(alias),
@@ -466,7 +466,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(aliasElementNames, tupleElementNames);
                 var method = testData.Methods.Single().Value.Method;
-                Assert.NotNull(GetTupleElementNamesAttributeIfAny(method));
+                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 var returnType = (TypeSymbol)method.ReturnType;
                 Assert.False(returnType.IsTupleType);
                 Assert.True(((ArrayTypeSymbol)returnType).ElementType.IsTupleType);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
                 Assert.True(method.ReturnType.IsTupleType);
-                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
+                CheckAttribute(result.Assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
@@ -179,7 +179,7 @@ class C
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
                 Assert.True(method.ReturnType.IsTupleType);
-                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: false);
+                CheckAttribute(result.Assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: false);
                 methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
@@ -220,7 +220,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(new[] { "A\u1234", "\u1234B" }, tupleElementNames);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 Assert.True(method.ReturnType.IsTupleType);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "o", expectedILOpt:
 string.Format(@"{{
@@ -268,7 +268,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(new[] { null, "A", "B", null }, tupleElementNames);
                 var method = (MethodSymbol)testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 var returnType = method.ReturnType;
                 Assert.False(returnType.IsTupleType);
                 Assert.True(returnType.ContainsTuple());
@@ -392,7 +392,7 @@ class C
                 Assert.Null(tupleElementNames);
                 var methodData = testData.GetMethodData("<>x.<>m0");
                 var method = methodData.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(result.Assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: false);
+                CheckAttribute(result.Assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: false);
                 methodData.VerifyIL(
 @"{
   // Code size       64 (0x40)
@@ -466,7 +466,7 @@ class C
                 CustomTypeInfo.Decode(customTypeInfoId, customTypeInfo, out dynamicFlags, out tupleElementNames);
                 Assert.Equal(aliasElementNames, tupleElementNames);
                 var method = testData.Methods.Single().Value.Method;
-                CheckAttribute(AssemblyMetadata.CreateFromImage(assembly), method, AttributeDescription.TupleElementNamesAttribute, expected: true);
+                CheckAttribute(assembly, method, AttributeDescription.TupleElementNamesAttribute, expected: true);
                 var returnType = (TypeSymbol)method.ReturnType;
                 Assert.False(returnType.IsTupleType);
                 Assert.True(((ArrayTypeSymbol)returnType).ElementType.IsTupleType);

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -267,7 +267,7 @@ namespace Roslyn.Test.Utilities
             return true;
         }
 
-        public static void SetEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer = null, string message = null, string itemSeparator = "\r\n")
+        public static void SetEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer = null, string message = null, string itemSeparator = "\r\n", Func<T, string> itemInspector = null)
         {
             var expectedSet = new HashSet<T>(expected, comparer);
             var result = expected.Count() == actual.Count() && expectedSet.SetEquals(actual);
@@ -276,8 +276,8 @@ namespace Roslyn.Test.Utilities
                 if (string.IsNullOrEmpty(message))
                 {
                     message = GetAssertMessage(
-                        ToString(expected, itemSeparator),
-                        ToString(actual, itemSeparator));
+                        ToString(expected, itemSeparator, itemInspector),
+                        ToString(actual, itemSeparator, itemInspector));
                 }
 
                 Assert.True(result, message);

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -194,9 +194,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         static internal void RunValidators(CompilationVerifier verifier, Action<PEAssembly> assemblyValidator, Action<IModuleSymbol> symbolValidator)
         {
+            var emittedMetadata = verifier.GetMetadata();
+
             if (assemblyValidator != null)
             {
-                var emittedMetadata = verifier.GetMetadata();
                 Assert.Equal(MetadataImageKind.Assembly, emittedMetadata.Kind);
 
                 var assembly = ((AssemblyMetadata)emittedMetadata).GetAssembly();
@@ -205,7 +206,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (symbolValidator != null)
             {
-                var emittedMetadata = verifier.GetMetadata();
                 var reference = emittedMetadata.Kind == MetadataImageKind.Assembly
                     ? ((AssemblyMetadata)emittedMetadata).GetReference()
                     : ((ModuleMetadata)emittedMetadata).GetReference();
@@ -232,9 +232,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             verifier.Emit(expectedOutput, expectedReturnCode, args, manifestResources, emitOptions, verify, expectedSignatures);
 
-            // We're dual-purposing emitters here.  In this context, it
-            // tells the validator the version of Emit that is calling it. 
-            RunValidators(verifier, assemblyValidator, symbolValidator);
+            if (assemblyValidator != null || symbolValidator != null)
+            {
+                // We're dual-purposing emitters here.  In this context, it
+                // tells the validator the version of Emit that is calling it. 
+                RunValidators(verifier, assemblyValidator, symbolValidator);
+            }
 
             return verifier;
         }

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -196,21 +196,22 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             if (assemblyValidator != null)
             {
-                using (var emittedMetadata = AssemblyMetadata.Create(verifier.GetAllModuleMetadata()))
-                {
-                    assemblyValidator(emittedMetadata.GetAssembly());
-                }
+                var emittedMetadata = verifier.GetMetadata();
+                Assert.Equal(MetadataImageKind.Assembly, emittedMetadata.Kind);
+
+                var assembly = ((AssemblyMetadata)emittedMetadata).GetAssembly();
+                assemblyValidator(assembly);
             }
 
             if (symbolValidator != null)
             {
-                using (var emittedMetadata = AssemblyMetadata.Create(verifier.GetAllModuleMetadata()))
-                {
-                    var reference = emittedMetadata.GetReference();
-                    var moduleSymbol = verifier.GetModuleSymbolFromMetadata(reference, verifier.Compilation.Options.MetadataImportOptions);
+                var emittedMetadata = verifier.GetMetadata();
+                var reference = emittedMetadata.Kind == MetadataImageKind.Assembly
+                    ? ((AssemblyMetadata)emittedMetadata).GetReference()
+                    : ((ModuleMetadata)emittedMetadata).GetReference();
 
-                    symbolValidator(moduleSymbol);
-                }
+                var moduleSymbol = verifier.GetSymbolFromMetadata(reference, verifier.Compilation.Options.MetadataImportOptions);
+                symbolValidator(moduleSymbol);
             }
         }
 

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -204,9 +204,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (symbolValidator != null)
             {
-                var peModuleSymbol = verifier.GetModuleSymbolForEmittedImage();
-                Debug.Assert(peModuleSymbol != null);
-                symbolValidator(peModuleSymbol);
+                using (var emittedMetadata = AssemblyMetadata.Create(verifier.GetAllModuleMetadata()))
+                {
+                    var reference = emittedMetadata.GetReference();
+                    var moduleSymbol = verifier.GetModuleSymbolFromMetadata(reference, verifier.Compilation.Options.MetadataImportOptions);
+
+                    symbolValidator(moduleSymbol);
+                }
             }
         }
 

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         static internal void RunValidators(CompilationVerifier verifier, Action<PEAssembly> assemblyValidator, Action<IModuleSymbol> symbolValidator)
         {
+            Assert.True(assemblyValidator != null || symbolValidator != null);
+
             var emittedMetadata = verifier.GetMetadata();
 
             if (assemblyValidator != null)

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             var dummy = _compilation
                 .RemoveAllSyntaxTrees()
-                .WithReferences(_compilation.References.Concat(new[] { metadataReference }))
+                .AddReferences(metadataReference)
                 .WithAssemblyName("Dummy")
                 .WithOptions(_compilation.Options.WithMetadataImportOptions(importOptions));
 


### PR DESCRIPTION
Contributes to #18799

This PR has the C# part of the fixes:

* Removed the unnecessary/wrong helpers, and replaced all with `CompileAndVerify()`.
* Fixed a bug in `CompileAndVerify()` where it was not loading all modules of a multi-module compilation during symbol verification.

Please note that it is quite possible that some tests still exist testing source attributes directly, however, that was the intended behavior, and a manual pass might be required to identify, and possibly change them.