### PR TITLE
Uncomment and fix CodeGeneration tests

### DIFF
--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "0.5R");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddExpression1()
         {
             Test(
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 + 2");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddExpression2()
         {
             Test(
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 + 2 + 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddExpression3()
         {
             Test(
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 + 2 + 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMultiplyExpression1()
         {
             Test(
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 * 2");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMultiplyExpression2()
         {
             Test(
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 * 2 * 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMultiplyExpression3()
         {
             Test(
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 * 2 * 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBinaryAndExpression1()
         {
             Test(
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 And 2");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBinaryOrExpression1()
         {
             Test(
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 Or 2");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalAndExpression1()
         {
             Test(
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 AndAlso 2");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalOrExpression1()
         {
             Test(
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "E.M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestConditionalExpression1()
         {
             Test(
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "E(n1:=a, n2:=b)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestIsExpression()
         {
             Test(
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "TypeOf a Is SomeType");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAsExpression()
         {
             Test(
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "TryCast(a, SomeType)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestNotExpression()
         {
             Test(
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "Not a");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestCastExpression()
         {
             Test(
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "DirectCast(a, SomeType)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestNegateExpression()
         {
             Test(

--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
@@ -1,436 +1,434 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
-#if false
-namespace Roslyn.Services.Editor.UnitTests.CodeGeneration
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
 {
+    [Trait(Traits.Feature, Traits.Features.CodeGeneration)]
     public class ExpressionGenerationTests : AbstractCodeGenerationTests
     {
-        [WpfFact]
+        [Fact]
         public void TestFalseExpression()
         {
-            TestExpression(
-                f => f.CreateFalseExpression(),
+            Test(
+                f => f.FalseLiteralExpression(),
                 cs: "false",
                 vb: "False");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestTrueExpression()
         {
-            TestExpression(
-                f => f.CreateTrueExpression(),
+            Test(
+                f => f.TrueLiteralExpression(),
                 cs: "true",
                 vb: "True");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestNullExpression()
         {
-            TestExpression(
-                f => f.CreateNullExpression(),
+            Test(
+                f => f.NullLiteralExpression(),
                 cs: "null",
                 vb: "Nothing");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestThisExpression()
         {
-            TestExpression(
-                f => f.CreateThisExpression(),
+            Test(
+                f => f.ThisExpression(),
                 cs: "this",
                 vb: "Me");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestBaseExpression()
         {
-            TestExpression(
-                f => f.CreateBaseExpression(),
+            Test(
+                f => f.BaseExpression(),
                 cs: "base",
                 vb: "MyBase");
         }
 
-        [WpfFact]
-        public void TestInt32ConstantExpression0()
+        [Fact]
+        public void TestInt32LiteralExpression0()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0),
+            Test(
+                f => f.LiteralExpression(0),
                 cs: "0",
                 vb: "0");
         }
 
-        [WpfFact]
-        public void TestInt32ConstantExpression1()
+        [Fact]
+        public void TestInt32LiteralExpression1()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(1),
+            Test(
+                f => f.LiteralExpression(1),
                 cs: "1",
                 vb: "1");
         }
 
-        [WpfFact]
-        public void TestInt64ConstantExpression0()
+        [Fact]
+        public void TestInt64LiteralExpression0()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0L),
+            Test(
+                f => f.LiteralExpression(0L),
                 cs: "0L",
-                vb: "0&");
+                vb: "0L");
         }
 
-        [WpfFact]
-        public void TestInt64ConstantExpression1()
+        [Fact]
+        public void TestInt64LiteralExpression1()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(1L),
+            Test(
+                f => f.LiteralExpression(1L),
                 cs: "1L",
-                vb: "1&");
+                vb: "1L");
         }
 
-        [WpfFact]
-        public void TestSingleConstantExpression0()
+        [Fact]
+        public void TestSingleLiteralExpression0()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0.0f),
+            Test(
+                f => f.LiteralExpression(0.0f),
                 cs: "0F",
-                vb: "0!");
+                vb: "0F");
         }
 
-        [WpfFact]
-        public void TestSingleConstantExpression1()
+        [Fact]
+        public void TestSingleLiteralExpression1()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0.5F),
+            Test(
+                f => f.LiteralExpression(0.5F),
                 cs: "0.5F",
-                vb: "0.5!");
+                vb: "0.5F");
         }
 
-        [WpfFact]
-        public void TestDoubleConstantExpression0()
+        [Fact]
+        public void TestDoubleLiteralExpression0()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0.0d),
-                cs: "0",
-                vb: "0");
+            Test(
+                f => f.LiteralExpression(0.0d),
+                cs: "0D",
+                vb: "0R");
         }
 
-        [WpfFact]
-        public void TestDoubleConstantExpression1()
+        [Fact]
+        public void TestDoubleLiteralExpression1()
         {
-            TestExpression(
-                f => f.CreateConstantExpression(0.5D),
-                cs: "0.5",
-                vb: "0.5");
+            Test(
+                f => f.LiteralExpression(0.5D),
+                cs: "0.5D",
+                vb: "0.5R");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddExpression1()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.AddExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 + 2",
                 vb: "1 + 2");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddExpression2()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.AddExpression(
+                    f.LiteralExpression(1),
+                    f.AddExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 + 2 + 3",
                 vb: "1 + 2 + 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddExpression3()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.AddExpression(
+                    f.AddExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "1 + 2 + 3",
                 vb: "1 + 2 + 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMultiplyExpression1()
         {
-            TestExpression(
-                f => f.CreateMultiplyExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.MultiplyExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 * 2",
                 vb: "1 * 2");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMultiplyExpression2()
         {
-            TestExpression(
-                f => f.CreateMultiplyExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateMultiplyExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.MultiplyExpression(
+                    f.LiteralExpression(1),
+                    f.MultiplyExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 * 2 * 3",
                 vb: "1 * 2 * 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMultiplyExpression3()
         {
-            TestExpression(
-                f => f.CreateMultiplyExpression(
-                    f.CreateMultiplyExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.MultiplyExpression(
+                    f.MultiplyExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "1 * 2 * 3",
                 vb: "1 * 2 * 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestBinaryAndExpression1()
         {
-            TestExpression(
-                f => f.CreateBinaryAndExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.BitwiseAndExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 & 2",
                 vb: "1 And 2");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestBinaryOrExpression1()
         {
-            TestExpression(
-                f => f.CreateBinaryOrExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.BitwiseOrExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 | 2",
                 vb: "1 Or 2");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalAndExpression1()
         {
-            TestExpression(
-                f => f.CreateLogicalAndExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.LogicalAndExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 && 2",
                 vb: "1 AndAlso 2");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalOrExpression1()
         {
-            TestExpression(
-                f => f.CreateLogicalOrExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateConstantExpression(2)),
+            Test(
+                f => f.LogicalOrExpression(
+                    f.LiteralExpression(1),
+                    f.LiteralExpression(2)),
                 cs: "1 || 2",
                 vb: "1 OrElse 2");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestMemberAccess1()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateIdentifierName("M")),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.IdentifierName("E"),
+                    f.IdentifierName("M")),
                 cs: "E.M",
                 vb: "E.M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestConditionalExpression1()
         {
-            TestExpression(
-                f => f.CreateConditionalExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateIdentifierName("T"),
-                    f.CreateIdentifierName("F")),
+            Test(
+                f => f.ConditionalExpression(
+                    f.IdentifierName("E"),
+                    f.IdentifierName("T"),
+                    f.IdentifierName("F")),
                 cs: "E ? T : F",
                 vb: "If(E, T, F)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestInvocation1()
         {
-            TestExpression(
-                f => f.CreateInvocationExpression(
-                    f.CreateIdentifierName("E")),
+            Test(
+                f => f.InvocationExpression(
+                    f.IdentifierName("E")),
                 cs: "E()",
                 vb: "E()");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestInvocation2()
         {
-            TestExpression(
-                f => f.CreateInvocationExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument(f.CreateIdentifierName("a"))),
+            Test(
+                f => f.InvocationExpression(
+                    f.IdentifierName("E"),
+                    f.Argument(f.IdentifierName("a"))),
                 cs: "E(a)",
                 vb: "E(a)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestInvocation3()
         {
-            TestExpression(
-                f => f.CreateInvocationExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument("n", RefKind.None, f.CreateIdentifierName("a"))),
+            Test(
+                f => f.InvocationExpression(
+                    f.IdentifierName("E"),
+                    f.Argument("n", RefKind.None, f.IdentifierName("a"))),
                 cs: "E(n: a)",
                 vb: "E(n:=a)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestInvocation4()
         {
-            TestExpression(
-                f => f.CreateInvocationExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument(null, RefKind.Out, f.CreateIdentifierName("a")),
-                    f.CreateArgument(null, RefKind.Ref, f.CreateIdentifierName("b"))),
+            Test(
+                f => f.InvocationExpression(
+                    f.IdentifierName("E"),
+                    f.Argument(null, RefKind.Out, f.IdentifierName("a")),
+                    f.Argument(null, RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E(out a, ref b)",
                 vb: "E(a, b)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestInvocation5()
         {
-            TestExpression(
-                f => f.CreateInvocationExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument("n1", RefKind.Out, f.CreateIdentifierName("a")),
-                    f.CreateArgument("n2", RefKind.Ref, f.CreateIdentifierName("b"))),
+            Test(
+                f => f.InvocationExpression(
+                    f.IdentifierName("E"),
+                    f.Argument("n1", RefKind.Out, f.IdentifierName("a")),
+                    f.Argument("n2", RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E(n1: out a, n2: ref b)",
                 vb: "E(n1:=a, n2:=b)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestElementAccess1()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateIdentifierName("E")),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.IdentifierName("E")),
                 cs: "E[]",
                 vb: "E()");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestElementAccess2()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument(f.CreateIdentifierName("a"))),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.IdentifierName("E"),
+                    f.Argument(f.IdentifierName("a"))),
                 cs: "E[a]",
                 vb: "E(a)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestElementAccess3()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument("n", RefKind.None, f.CreateIdentifierName("a"))),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.IdentifierName("E"),
+                    f.Argument("n", RefKind.None, f.IdentifierName("a"))),
                 cs: "E[n: a]",
                 vb: "E(n:=a)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestElementAccess4()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument(null, RefKind.Out, f.CreateIdentifierName("a")),
-                    f.CreateArgument(null, RefKind.Ref, f.CreateIdentifierName("b"))),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.IdentifierName("E"),
+                    f.Argument(null, RefKind.Out, f.IdentifierName("a")),
+                    f.Argument(null, RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E[out a, ref b]",
                 vb: "E(a, b)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestElementAccess5()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateIdentifierName("E"),
-                    f.CreateArgument("n1", RefKind.Out, f.CreateIdentifierName("a")),
-                    f.CreateArgument("n2", RefKind.Ref, f.CreateIdentifierName("b"))),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.IdentifierName("E"),
+                    f.Argument("n1", RefKind.Out, f.IdentifierName("a")),
+                    f.Argument("n2", RefKind.Ref, f.IdentifierName("b"))),
                 cs: "E[n1: out a, n2: ref b]",
                 vb: "E(n1:=a, n2:=b)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestIsExpression()
         {
-            TestExpression(
-                f => f.CreateIsExpression(
-                    f.CreateIdentifierName("a"),
+            Test(
+                f => f.IsTypeExpression(
+                    f.IdentifierName("a"),
                     CreateClass("SomeType")),
                 cs: "a is SomeType",
                 vb: "TypeOf a Is SomeType");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAsExpression()
         {
-            TestExpression(
-                f => f.CreateAsExpression(
-                    f.CreateIdentifierName("a"),
+            Test(
+                f => f.TryCastExpression(
+                    f.IdentifierName("a"),
                     CreateClass("SomeType")),
                 cs: "a as SomeType",
                 vb: "TryCast(a, SomeType)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestNotExpression()
         {
-            TestExpression(
-                f => f.CreateLogicalNotExpression(
-                    f.CreateIdentifierName("a")),
+            Test(
+                f => f.LogicalNotExpression(
+                    f.IdentifierName("a")),
                 cs: "!a",
                 vb: "Not a");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestCastExpression()
         {
-            TestExpression(
-                f => f.CreateCastExpression(
+            Test(
+                f => f.CastExpression(
                     CreateClass("SomeType"),
-                    f.CreateIdentifierName("a")),
+                    f.IdentifierName("a")),
                 cs: "(SomeType)a",
                 vb: "DirectCast(a, SomeType)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestNegateExpression()
         {
-            TestExpression(
-                f => f.CreateNegateExpression(
-                    f.CreateIdentifierName("a")),
+            Test(
+                f => f.NegateExpression(
+                    f.IdentifierName("a")),
                 cs: "-a",
                 vb: "-a");
         }
     }
 }
-#endif

--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
@@ -1,360 +1,362 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
-#if false
-namespace Roslyn.Services.Editor.UnitTests.CodeGeneration
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
 {
+    [Trait(Traits.Feature, Traits.Features.CodeGeneration)]
     public class ExpressionPrecedenceGenerationTests : AbstractCodeGenerationTests
     {
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddMultiplyPrecedence1()
         {
-            TestExpression(
-                f => f.CreateMultiplyExpression(
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.MultiplyExpression(
+                    f.AddExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "(1 + 2) * 3",
                 vb: "(1 + 2) * 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddMultiplyPrecedence2()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                    f.CreateMultiplyExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.AddExpression(
+                    f.MultiplyExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "1 * 2 + 3",
                 vb: "1 * 2 + 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddMultiplyPrecedence3()
         {
-            TestExpression(
-                f => f.CreateMultiplyExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.MultiplyExpression(
+                    f.LiteralExpression(1),
+                    f.AddExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 * (2 + 3)",
                 vb: "1 * (2 + 3)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAddMultiplyPrecedence4()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateMultiplyExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.AddExpression(
+                    f.LiteralExpression(1),
+                    f.MultiplyExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 + 2 * 3",
                 vb: "1 + 2 * 3");
         }
 
-        [WpfFact]
-        public void TestBinaryAndOrPrecedence1()
+        [Fact(Skip = "parens")]
+        public void TestBitwiseAndOrPrecedence1()
         {
-            TestExpression(
-                f => f.CreateBinaryAndExpression(
-                    f.CreateBinaryOrExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.BitwiseAndExpression(
+                    f.BitwiseOrExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "(1 | 2) & 3",
                 vb: "(1 Or 2) And 3");
         }
 
-        [WpfFact]
-        public void TestBinaryAndOrPrecedence2()
+        [Fact(Skip = "parens")]
+        public void TestBitwiseAndOrPrecedence2()
         {
-            TestExpression(
-                f => f.CreateBinaryOrExpression(
-                    f.CreateBinaryAndExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.BitwiseOrExpression(
+                    f.BitwiseAndExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "1 & 2 | 3",
                 vb: "1 And 2 Or 3");
         }
 
-        [WpfFact]
-        public void TestBinaryAndOrPrecedence3()
+        [Fact(Skip = "parens")]
+        public void TestBitwiseAndOrPrecedence3()
         {
-            TestExpression(
-                f => f.CreateBinaryAndExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateBinaryOrExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.BitwiseAndExpression(
+                    f.LiteralExpression(1),
+                    f.BitwiseOrExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 & (2 | 3)",
                 vb: "1 And (2 Or 3)");
         }
 
-        [WpfFact]
-        public void TestBinaryAndOrPrecedence4()
+        [Fact(Skip = "parens")]
+        public void TestBitwiseAndOrPrecedence4()
         {
-            TestExpression(
-                f => f.CreateBinaryOrExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateBinaryAndExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.BitwiseOrExpression(
+                    f.LiteralExpression(1),
+                    f.BitwiseAndExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 | 2 & 3",
                 vb: "1 Or 2 And 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalAndOrPrecedence1()
         {
-            TestExpression(
-                f => f.CreateLogicalAndExpression(
-                    f.CreateLogicalOrExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.LogicalAndExpression(
+                    f.LogicalOrExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "(1 || 2) && 3",
                 vb: "(1 OrElse 2) AndAlso 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalAndOrPrecedence2()
         {
-            TestExpression(
-                f => f.CreateLogicalOrExpression(
-                    f.CreateLogicalAndExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateConstantExpression(3)),
+            Test(
+                f => f.LogicalOrExpression(
+                    f.LogicalAndExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.LiteralExpression(3)),
                 cs: "1 && 2 || 3",
                 vb: "1 AndAlso 2 OrElse 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalAndOrPrecedence3()
         {
-            TestExpression(
-                f => f.CreateLogicalAndExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateLogicalOrExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.LogicalAndExpression(
+                    f.LiteralExpression(1),
+                    f.LogicalOrExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 && (2 || 3)",
                 vb: "1 AndAlso (2 OrElse 3)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestLogicalAndOrPrecedence4()
         {
-            TestExpression(
-                f => f.CreateLogicalOrExpression(
-                    f.CreateConstantExpression(1),
-                    f.CreateLogicalAndExpression(
-                        f.CreateConstantExpression(2),
-                        f.CreateConstantExpression(3))),
+            Test(
+                f => f.LogicalOrExpression(
+                    f.LiteralExpression(1),
+                    f.LogicalAndExpression(
+                        f.LiteralExpression(2),
+                        f.LiteralExpression(3))),
                 cs: "1 || 2 && 3",
                 vb: "1 OrElse 2 AndAlso 3");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfAdd1()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateIdentifierName("M")),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.AddExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.IdentifierName("M")),
                 cs: "(1 + 2).M",
                 vb: "(1 + 2).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestConditionalExpression1()
         {
-            TestExpression(
-                f => f.CreateConditionalExpression(
-                    f.CreateAssignExpression(
-                        f.CreateIdentifierName("E1"),
-                        f.CreateIdentifierName("E2")),
-                    f.CreateIdentifierName("T"),
-                    f.CreateIdentifierName("F")),
-                cs: "(E1 = E2) ? T : F");
+            Test(
+                f => f.ConditionalExpression(
+                    f.AssignmentStatement(
+                        f.IdentifierName("E1"),
+                        f.IdentifierName("E2")),
+                    f.IdentifierName("T"),
+                    f.IdentifierName("F")),
+                cs: "(E1 = E2) ? T : F",
+                vb: null);
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestConditionalExpression2()
         {
-            TestExpression(
-                f => f.CreateAddExpression(
-                        f.CreateConditionalExpression(
-                            f.CreateIdentifierName("E1"),
-                            f.CreateIdentifierName("T1"),
-                            f.CreateIdentifierName("F1")),
-                        f.CreateConditionalExpression(
-                            f.CreateIdentifierName("E2"),
-                            f.CreateIdentifierName("T2"),
-                            f.CreateIdentifierName("F2"))),
-                cs: "(E1 ? T1 : F1) + (E2 ? T2 : F2)");
+            Test(
+                f => f.AddExpression(
+                        f.ConditionalExpression(
+                            f.IdentifierName("E1"),
+                            f.IdentifierName("T1"),
+                            f.IdentifierName("F1")),
+                        f.ConditionalExpression(
+                            f.IdentifierName("E2"),
+                            f.IdentifierName("T2"),
+                            f.IdentifierName("F2"))),
+                cs: "(E1 ? T1 : F1) + (E2 ? T2 : F2)",
+                vb: null);
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfElementAccess()
         {
-            TestExpression(
-                f => f.CreateElementAccessExpression(
-                    f.CreateAddExpression(
-                        f.CreateConstantExpression(1),
-                        f.CreateConstantExpression(2)),
-                    f.CreateArgument(f.CreateIdentifierName("M"))),
+            Test(
+                f => f.ElementAccessExpression(
+                    f.AddExpression(
+                        f.LiteralExpression(1),
+                        f.LiteralExpression(2)),
+                    f.Argument(f.IdentifierName("M"))),
                 cs: "(1 + 2)[M]",
                 vb: "(1 + 2)(M)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfIsExpression()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateIsExpression(
-                        f.CreateIdentifierName("a"),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.IsTypeExpression(
+                        f.IdentifierName("a"),
                         CreateClass("SomeType")),
-                    f.CreateIdentifierName("M")),
+                    f.IdentifierName("M")),
                 cs: "(a is SomeType).M",
                 vb: "(TypeOf a Is SomeType).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestIsOfMemberAccessExpression()
         {
-            TestExpression(
-                f => f.CreateIsExpression(
-                    f.CreateMemberAccessExpression(
-                        f.CreateIdentifierName("a"),
-                        f.CreateIdentifierName("M")),
+            Test(
+                f => f.IsTypeExpression(
+                    f.MemberAccessExpression(
+                        f.IdentifierName("a"),
+                        f.IdentifierName("M")),
                     CreateClass("SomeType")),
                 cs: "a.M is SomeType",
                 vb: "TypeOf a.M Is SomeType");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfAsExpression()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateAsExpression(
-                        f.CreateIdentifierName("a"),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.TryCastExpression(
+                        f.IdentifierName("a"),
                         CreateClass("SomeType")),
-                    f.CreateIdentifierName("M")),
+                    f.IdentifierName("M")),
                 cs: "(a as SomeType).M",
                 vb: "TryCast(a, SomeType).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestAsOfMemberAccessExpression()
         {
-            TestExpression(
-                f => f.CreateAsExpression(
-                         f.CreateMemberAccessExpression(
-                            f.CreateIdentifierName("a"),
-                            f.CreateIdentifierName("M")),
+            Test(
+                f => f.TryCastExpression(
+                         f.MemberAccessExpression(
+                            f.IdentifierName("a"),
+                            f.IdentifierName("M")),
                         CreateClass("SomeType")),
                 cs: "a.M as SomeType",
                 vb: "TryCast(a.M, SomeType)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfNotExpression()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateLogicalNotExpression(
-                        f.CreateIdentifierName("a")),
-                    f.CreateIdentifierName("M")),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.LogicalNotExpression(
+                        f.IdentifierName("a")),
+                    f.IdentifierName("M")),
                 cs: "(!a).M",
                 vb: "(Not a).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestNotOfMemberAccessExpression()
         {
-            TestExpression(
-                f => f.CreateLogicalNotExpression(
-                    f.CreateMemberAccessExpression(
-                        f.CreateIdentifierName("a"),
-                        f.CreateIdentifierName("M"))),
+            Test(
+                f => f.LogicalNotExpression(
+                    f.MemberAccessExpression(
+                        f.IdentifierName("a"),
+                        f.IdentifierName("M"))),
                 cs: "!a.M",
                 vb: "Not a.M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfCastExpression()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateCastExpression(
+            Test(
+                f => f.MemberAccessExpression(
+                    f.CastExpression(
                         CreateClass("SomeType"),
-                        f.CreateIdentifierName("a")),
-                    f.CreateIdentifierName("M")),
+                        f.IdentifierName("a")),
+                    f.IdentifierName("M")),
                 cs: "((SomeType)a).M",
                 vb: "DirectCast(a, SomeType).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestCastOfAddExpression()
         {
-            TestExpression(
-                f => f.CreateCastExpression(
+            Test(
+                f => f.CastExpression(
                     CreateClass("SomeType"),
-                    f.CreateAddExpression(
-                        f.CreateIdentifierName("a"),
-                        f.CreateIdentifierName("b"))),
+                    f.AddExpression(
+                        f.IdentifierName("a"),
+                        f.IdentifierName("b"))),
                 cs: "(SomeType)(a + b)",
                 vb: "DirectCast(a + b, SomeType)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestNegateOfAddExpression()
         {
-            TestExpression(
-                f => f.CreateNegateExpression(
-                    f.CreateAddExpression(
-                        f.CreateIdentifierName("a"),
-                        f.CreateIdentifierName("b"))),
+            Test(
+                f => f.NegateExpression(
+                    f.AddExpression(
+                        f.IdentifierName("a"),
+                        f.IdentifierName("b"))),
                 cs: "-(a + b)",
                 vb: "-(a + b)");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestMemberAccessOffOfNegate()
         {
-            TestExpression(
-                f => f.CreateMemberAccessExpression(
-                    f.CreateNegateExpression(
-                        f.CreateIdentifierName("a")),
-                    f.CreateIdentifierName("M")),
+            Test(
+                f => f.MemberAccessExpression(
+                    f.NegateExpression(
+                        f.IdentifierName("a")),
+                    f.IdentifierName("M")),
                 cs: "(-a).M",
                 vb: "(-a).M");
         }
 
-        [WpfFact]
+        [Fact(Skip = "parens")]
         public void TestNegateOfMemberAccess()
         {
-            TestExpression(f =>
-                f.CreateNegateExpression(
-                    f.CreateMemberAccessExpression(
-                        f.CreateIdentifierName("a"),
-                        f.CreateIdentifierName("M"))),
+            Test(f =>
+                f.NegateExpression(
+                    f.MemberAccessExpression(
+                        f.IdentifierName("a"),
+                        f.IdentifierName("M"))),
                 cs: "-a.M",
                 vb: "-a.M");
         }
     }
 }
-#endif

--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
     [Trait(Traits.Feature, Traits.Features.CodeGeneration)]
     public class ExpressionPrecedenceGenerationTests : AbstractCodeGenerationTests
     {
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddMultiplyPrecedence1()
         {
             Test(
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(1 + 2) * 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddMultiplyPrecedence2()
         {
             Test(
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 * 2 + 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddMultiplyPrecedence3()
         {
             Test(
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 * (2 + 3)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAddMultiplyPrecedence4()
         {
             Test(
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 + 2 * 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBitwiseAndOrPrecedence1()
         {
             Test(
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(1 Or 2) And 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBitwiseAndOrPrecedence2()
         {
             Test(
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 And 2 Or 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBitwiseAndOrPrecedence3()
         {
             Test(
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 And (2 Or 3)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestBitwiseAndOrPrecedence4()
         {
             Test(
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 Or 2 And 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalAndOrPrecedence1()
         {
             Test(
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(1 OrElse 2) AndAlso 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalAndOrPrecedence2()
         {
             Test(
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 AndAlso 2 OrElse 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalAndOrPrecedence3()
         {
             Test(
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 AndAlso (2 OrElse 3)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestLogicalAndOrPrecedence4()
         {
             Test(
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "1 OrElse 2 AndAlso 3");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfAdd1()
         {
             Test(
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(1 + 2).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestConditionalExpression1()
         {
             Test(
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: null);
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestConditionalExpression2()
         {
             Test(
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: null);
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfElementAccess()
         {
             Test(
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(1 + 2)(M)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfIsExpression()
         {
             Test(
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(TypeOf a Is SomeType).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestIsOfMemberAccessExpression()
         {
             Test(
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "TypeOf a.M Is SomeType");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfAsExpression()
         {
             Test(
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "TryCast(a, SomeType).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestAsOfMemberAccessExpression()
         {
             Test(
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "TryCast(a.M, SomeType)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfNotExpression()
         {
             Test(
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(Not a).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestNotOfMemberAccessExpression()
         {
             Test(
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "Not a.M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfCastExpression()
         {
             Test(
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "DirectCast(a, SomeType).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestCastOfAddExpression()
         {
             Test(
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "DirectCast(a + b, SomeType)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestNegateOfAddExpression()
         {
             Test(
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "-(a + b)");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestMemberAccessOffOfNegate()
         {
             Test(
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 vb: "(-a).M");
         }
 
-        [Fact(Skip = "parens")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/26586")]
         public void TestNegateOfMemberAccess()
         {
             Test(f =>

--- a/src/EditorFeatures/Test/CodeGeneration/NameGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/NameGenerationTests.cs
@@ -1,127 +1,127 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
-#if false
-namespace Roslyn.Services.Editor.UnitTests.CodeGeneration
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
 {
+    [Trait(Traits.Feature, Traits.Features.CodeGeneration)]
     public class NameGenerationTests : AbstractCodeGenerationTests
     {
-        [WpfFact]
+        [Fact]
         public void TestIdentifierName()
         {
-            TestName(
-                f => f.CreateIdentifierName("a"),
+            Test(
+                f => f.IdentifierName("a"),
                 cs: "a",
                 vb: "a");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestIdentifierNameCSharpKeyword()
         {
-            TestName(
-                f => f.CreateIdentifierName("int"),
+            Test(
+                f => f.IdentifierName("int"),
                 cs: "@int",
                 vb: "int");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestIdentifierNameVisualBasicKeyword()
         {
-            TestName(
-                f => f.CreateIdentifierName("Integer"),
+            Test(
+                f => f.IdentifierName("Integer"),
                 cs: "Integer",
                 vb: "[Integer]");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestGenericName1()
         {
-            TestName(
-                f => f.CreateGenericName("Outer", CreateClass("Inner1")),
+            Test(
+                f => f.GenericName("Outer", CreateClass("Inner1")),
                 cs: "Outer<Inner1>",
                 vb: "Outer(Of Inner1)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestGenericName2()
         {
-            TestName(
-                f => f.CreateGenericName("Outer", CreateClass("Inner1"), CreateClass("Inner2")),
+            Test(
+                f => f.GenericName("Outer", CreateClass("Inner1"), CreateClass("Inner2")),
                 cs: "Outer<Inner1, Inner2>",
                 vb: "Outer(Of Inner1, Inner2)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestGenericNameCSharpKeyword()
         {
-            TestName(
-                f => f.CreateGenericName("int", CreateClass("string"), CreateClass("bool")),
+            Test(
+                f => f.GenericName("int", CreateClass("string"), CreateClass("bool")),
                 cs: "@int<@string, @bool>",
                 vb: "int(Of [string], bool)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestGenericNameVisualBasicKeyword()
         {
-            TestName(
-                f => f.CreateGenericName("Integer", CreateClass("String"), CreateClass("Boolean")),
+            Test(
+                f => f.GenericName("Integer", CreateClass("String"), CreateClass("Boolean")),
                 cs: "Integer<String, Boolean>",
                 vb: "[Integer](Of [String], [Boolean])");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestQualifiedName1()
         {
-            TestName(
-                f => f.CreateQualifiedName(f.CreateIdentifierName("Outer"), f.CreateIdentifierName("Inner1")),
+            Test(
+                f => f.QualifiedName(f.IdentifierName("Outer"), f.IdentifierName("Inner1")),
                 cs: "Outer.Inner1",
                 vb: "Outer.Inner1");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestQualifiedNameCSharpKeywords1()
         {
-            TestName(
-                f => f.CreateQualifiedName(f.CreateIdentifierName("int"), f.CreateIdentifierName("string")),
+            Test(
+                f => f.QualifiedName(f.IdentifierName("int"), f.IdentifierName("string")),
                 cs: "@int.@string",
-                vb: "int.string");
+                vb: "int.[string]");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestQualifiedNameVBKeywords1()
         {
-            TestName(
-                f => f.CreateQualifiedName(f.CreateIdentifierName("Integer"), f.CreateIdentifierName("String")),
+            Test(
+                f => f.QualifiedName(f.IdentifierName("Integer"), f.IdentifierName("String")),
                 cs: "Integer.String",
-                vb: "[Integer].String");
+                vb: "[Integer].[String]");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestQualifiedGenericName1()
         {
-            TestName(
-                f => f.CreateQualifiedName(
-                    f.CreateIdentifierName("One"),
-                    f.CreateGenericName("Outer",
+            Test(
+                f => f.QualifiedName(
+                    f.IdentifierName("One"),
+                    f.GenericName("Outer",
                         CreateClass("Inner1"),
                         CreateClass("Inner2"))),
                 cs: "One.Outer<Inner1, Inner2>",
                 vb: "One.Outer(Of Inner1, Inner2)");
         }
 
-        [WpfFact]
+        [Fact]
         public void TestQualifiedGenericName2()
         {
-            TestName(
-                f => f.CreateQualifiedName(
-                    f.CreateGenericName("Outer",
+            Test(
+                f => f.QualifiedName(
+                    f.GenericName("Outer",
                         CreateClass("Inner1"),
                         CreateClass("Inner2")),
-                    f.CreateIdentifierName("One")),
+                    f.IdentifierName("One")),
                 cs: "Outer<Inner1, Inner2>.One",
                 vb: "Outer(Of Inner1, Inner2).One");
         }
     }
 }
-#endif


### PR DESCRIPTION
I don't know why these tests were commented out using `#if false`, but I think they should be either uncommented or deleted.

What I did:

1. Removed the `#if`s.
2. Fixed the tests.
3. Added `[Trait(Traits.Feature, Traits.Features.CodeGeneration)]`.
4. Added `Skip` to tests that I didn't know how to fix.

Regarding 4., several tests in [`ExpressionGenerationTests`](https://github.com/dotnet/roslyn/blob/7dfc2fa/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs) (and I assume all tests in [`ExpressionPrecedenceGenerationTests`](https://github.com/dotnet/roslyn/blob/7dfc2fa/src/EditorFeatures/Test/CodeGeneration/ExpressionPrecedenceGenerationTests.cs)) fail, because the code generator creates unnecessary parentheses. I'm not sure what is the right way to test those, so I have added `Skip = "parens"` to those tests (and didn't uncomment `ExpressionPrecedenceGenerationTests`).

---

In case `master` is not the right branch for this kind of PR at the moment, feel free to retarget it to a different branch.