### PR TITLE
Document that SDK 2.1 is now a pre-requisite for building

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -14,7 +14,7 @@ Using the command line Roslyn can be developed using the following pattern:
 1. [Visual Studio 2017 Update 3](https://www.visualstudio.com/vs/)
     - Ensure C#, VB, MSBuild and Visual Studio Extensibility are included in the selected work loads
     - Ensure Visual Studio is on Version "15.3" or greater
-1. [.NET Core SDK 2.0](https://www.microsoft.com/net/download/core)
+1. [.NET Core SDK 2.1](https://www.microsoft.com/net/download/core) (if you don't see the 2.1 SDK binaries there yet, the current previews are: [Windows x64 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.1-preview-007094/dotnet-sdk-2.1.1-preview-007094-win-x64.exe), [Windows x86 installer](https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.1.1-preview-007094/dotnet-sdk-2.1.1-preview-007094-win-x86.exe))
 1. [PowerShell 3.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on Windows 7. The download link is under the "upgrading existing Windows PowerShell" heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln


### PR DESCRIPTION
I'm following up with Lee to confirm that 2.1 bits will appear on the [official page](https://www.microsoft.com/net/download/core) and the [archive](https://github.com/dotnet/core/blob/master/release-notes/download-archive.md). Then we can remove the direct links.