### PR TITLE
Ensure that we return the root IBlockOperation as the primary operati…

### DIFF
--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim methodBlock = TryCast(node, MethodBlockBaseSyntax)
                     If methodBlock IsNot Nothing Then
                         Dim paramInitializers = GetParameterInitializers(methodBlock.BlockStatement.ParameterList)
-                        Dim codeBlocks = paramInitializers.Concat(methodBlock.Statements).Concat(methodBlock.EndBlockStatement)
+                        Dim codeBlocks = paramInitializers.Concat(methodBlock)
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
                         Return
                     End If

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1178,7 +1178,8 @@ Namespace Microsoft.CodeAnalysis.Operations
                         Function(tuple)
                             Return tuple.s.Kind <> OperationKind.None OrElse
                                 tuple.bound.Kind = BoundKind.WithStatement OrElse tuple.bound.Kind = BoundKind.StopStatement OrElse
-                                tuple.bound.Kind = BoundKind.EndStatement
+                                tuple.bound.Kind = BoundKind.EndStatement OrElse tuple.bound.Kind = BoundKind.UnstructuredExceptionHandlingStatement OrElse
+                                tuple.bound.Kind = BoundKind.ResumeStatement
                         End Function).Select(Function(tuple) tuple.s).ToImmutableArray()
                 End Function)
             Dim locals As ImmutableArray(Of ILocalSymbol) = boundBlock.Locals.As(Of ILocalSymbol)()

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
@@ -1313,9 +1314,15 @@ End Class
                              </file>
                          </compilation>
 
+            ' We have 2 OperationKind.None operations in the operation tree:
+            ' (1) BoundUnstructedExceptionHandlingStatement for the method block with Resume statement
+            ' (2) BoundResumeStatement for Resume statement
             Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.RegularWithIOperationFeature)
             comp.VerifyDiagnostics()
             comp.VerifyAnalyzerDiagnostics({New NoneOperationTestAnalyzer}, Nothing, Nothing, False,
+                                           Diagnostic(NoneOperationTestAnalyzer.NoneOperationDescriptor.Id, <![CDATA[Public Sub Barney  
+        Resume  
+    End Sub]]>).WithLocation(22, 5),
                                            Diagnostic(NoneOperationTestAnalyzer.NoneOperationDescriptor.Id, "Resume").WithLocation(23, 9))
         End Sub
 
@@ -2161,6 +2168,34 @@ End Class
             comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.RegularWithIOperationFeature)
             comp.VerifyAnalyzerDiagnostics({New SemanticModelInternalAnalyzer}, Nothing, Nothing, False,
                 Diagnostic(SemanticModelInternalAnalyzer.GetOperationInternalDescriptor.Id, "1").WithLocation(3, 17))
+        End Sub
+
+        <Fact>
+        Public Sub TestOperationBlockAnalyzer_EmptyMethodBody()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Public Sub M()
+    End Sub
+    
+    Public Sub M2(i as Integer)
+    End Sub
+    
+    Public Sub M3(Optional i as Integer = 0)
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.RegularWithIOperationFeature)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New OperationBlockAnalyzer}, Nothing, Nothing, False,
+                                            Diagnostic("ID", "M").WithArguments("M", "Block").WithLocation(2, 16),
+                                            Diagnostic("ID", "M2").WithArguments("M2", "Block").WithLocation(5, 16),
+                                            Diagnostic("ID", "M3").WithArguments("M3", "ParameterInitializer").WithLocation(8, 16),
+                                            Diagnostic("ID", "M3").WithArguments("M3", "Block").WithLocation(8, 16))
         End Sub
     End Class
 End Namespace

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -792,54 +792,27 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-        public sealed class OperationAnalyzer : DiagnosticAnalyzer
+        public sealed class OperationBlockAnalyzer : DiagnosticAnalyzer
         {
-            private readonly ActionKind _actionKind;
-
             public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
                 "ID",
                 "Title1",
-                "{0} diagnostic",
+                "OperationBlock for {0}: {1}",
                 "Category1",
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public enum ActionKind
-            {
-                Operation,
-                OperationBlock,
-                OperationBlockEnd
-            }
-
-            public OperationAnalyzer(ActionKind actionKind)
-            {
-                _actionKind = actionKind;
-            }
-
-            private void ReportDiagnostic(Action<Diagnostic> addDiagnostic, Location location)
-            {
-                var diagnostic = Diagnostic.Create(Descriptor, location, _actionKind);
-                addDiagnostic(diagnostic);
-            }
-
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
             public override void Initialize(AnalysisContext context)
             {
-                if (_actionKind == ActionKind.OperationBlockEnd)
+                context.RegisterOperationBlockAction(c =>
                 {
-                    context.RegisterOperationBlockStartAction(oc =>
+                    foreach (var operationRoot in c.OperationBlocks)
                     {
-                        oc.RegisterOperationBlockEndAction(c => ReportDiagnostic(c.ReportDiagnostic, c.OwningSymbol.Locations[0]));
-                    });
-                }
-                else if (_actionKind == ActionKind.Operation)
-                {
-                    context.RegisterOperationAction(c => ReportDiagnostic(c.ReportDiagnostic, c.Operation.Syntax.GetLocation()), OperationKind.VariableDeclarations);
-                }
-                else
-                {
-                    context.RegisterOperationBlockAction(c => ReportDiagnostic(c.ReportDiagnostic, c.OwningSymbol.Locations[0]));
-                }
+                        var diagnostic = Diagnostic.Create(Descriptor, c.OwningSymbol.Locations[0], c.OwningSymbol.Name, operationRoot.Kind);
+                        c.ReportDiagnostic(diagnostic);
+                    }
+                });
             }
         }
 

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -792,6 +792,58 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class OperationAnalyzer : DiagnosticAnalyzer
+        {
+            private readonly ActionKind _actionKind;
+
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+                "ID",
+                "Title1",
+                "{0} diagnostic",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public enum ActionKind
+            {
+                Operation,
+                OperationBlock,
+                OperationBlockEnd
+            }
+
+            public OperationAnalyzer(ActionKind actionKind)
+            {
+                _actionKind = actionKind;
+            }
+
+            private void ReportDiagnostic(Action<Diagnostic> addDiagnostic, Location location)
+            {
+                var diagnostic = Diagnostic.Create(Descriptor, location, _actionKind);
+                addDiagnostic(diagnostic);
+            }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                if (_actionKind == ActionKind.OperationBlockEnd)
+                {
+                    context.RegisterOperationBlockStartAction(oc =>
+                    {
+                        oc.RegisterOperationBlockEndAction(c => ReportDiagnostic(c.ReportDiagnostic, c.OwningSymbol.Locations[0]));
+                    });
+                }
+                else if (_actionKind == ActionKind.Operation)
+                {
+                    context.RegisterOperationAction(c => ReportDiagnostic(c.ReportDiagnostic, c.Operation.Syntax.GetLocation()), OperationKind.VariableDeclarations);
+                }
+                else
+                {
+                    context.RegisterOperationBlockAction(c => ReportDiagnostic(c.ReportDiagnostic, c.OwningSymbol.Locations[0]));
+                }
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         public sealed class OperationBlockAnalyzer : DiagnosticAnalyzer
         {
             public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(


### PR DESCRIPTION
…on block for VB method bodies

Previously, we used to return two different operation blocks for the statements node within the body and the end block statement. This was incorrect, and was exposed when we recently started marking the implicit return statement in the sub as IsImplicit, and ended up with no explicit operations for an empty method body.

Note that this change is needed to unblock VB operation block analyzers in roslyn-analyzers repo, which is needed to move that repo to the latest IOperation APIs.

vso :https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/517561