### PR TITLE
Update error for missing SDK

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -480,7 +480,7 @@
       />
 
     <Error 
-      Text="The 2.0 SDK is required to build this repo"
+      Text="The 2.1 SDK is required to build this repo"
       Condition="'$(UsingMicrosoftNETSdk)' == '' AND '$(RoslynSdkProject)' == 'true'" />
   </Target> 
 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -201,7 +201,6 @@
 
   <Import Project="$(MSBuildTargetsFilePath)" Condition="'$(RoslynSdkProject)' != 'true'" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="'$(RoslynSdkProject)' == 'true'" />
-  <Import Project="Tools.props" />
 
   <!-- It looks like MSBuild has a bug on *nix where they aggressively
        directory separators from '\'to '/', even when the '\'

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -201,6 +201,7 @@
 
   <Import Project="$(MSBuildTargetsFilePath)" Condition="'$(RoslynSdkProject)' != 'true'" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="'$(RoslynSdkProject)' == 'true'" />
+  <Import Project="Tools.props" />
 
   <!-- It looks like MSBuild has a bug on *nix where they aggressively
        directory separators from '\'to '/', even when the '\'
@@ -479,8 +480,13 @@
       MSBuildMinimumDisplayVersion="MSBuild 15.3"
       />
 
+    <PropertyGroup>
+      <ShortSdkVersion Condition=" $(dotnetSdkVersion.IndexOf('-')) > 0 ">$(dotnetSdkVersion.Substring(0, $(dotnetSdkVersion.IndexOf('-'))))</ShortSdkVersion>
+      <ShortSdkVersion Condition=" $(dotnetSdkVersion.IndexOf('-')) &lt;= 0 ">$(dotnetSdkVersion)</ShortSdkVersion>
+    </PropertyGroup>
+
     <Error 
-      Text="The 2.1 SDK is required to build this repo"
+      Text="The $(ShortSdkVersion) SDK is required to build this repo"
       Condition="'$(UsingMicrosoftNETSdk)' == '' AND '$(RoslynSdkProject)' == 'true'" />
   </Target> 
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -9,6 +9,7 @@
 
   <Import Project="Packages.props" />
   <Import Project="FixedPackages.props" />
+  <Import Project="Tools.props" />
   <Import Project="Versions.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
We require SDK 2.1, but the error says "2.0".

@dotnet/roslyn-infrastructure for review. Thanks