### PR TITLE
reduce diagnostic tagger's usages of UI thread for synchronization

### DIFF
--- a/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Squiggles/ErrorSquiggleProducerTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -12,16 +11,13 @@ using Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Squiggles;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Test.Utilities;
@@ -174,8 +170,7 @@ class Program
         [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterDocumentRemoved()
         {
-            // we need export with workspace waiter since unregister text caused by close document is now async event
-            using (var workspace = TestWorkspace.CreateCSharp("class", exportProvider: s_exportProvider))
+            using (var workspace = TestWorkspace.CreateCSharp("class"))
             using (var wrapper = new DiagnosticTaggerWrapper<DiagnosticsSquiggleTaggerProvider>(workspace))
             {
                 var tagger = wrapper.TaggerProvider.CreateTagger<IErrorTag>(workspace.Documents.First().GetTextBuffer());
@@ -205,8 +200,7 @@ class Program
         [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public async Task TestNoErrorsAfterProjectRemoved()
         {
-            // we need export with workspace waiter since unregister text caused by close document is now async event
-            using (var workspace = TestWorkspace.CreateCSharp("class", exportProvider: s_exportProvider))
+            using (var workspace = TestWorkspace.CreateCSharp("class"))
             using (var wrapper = new DiagnosticTaggerWrapper<DiagnosticsSquiggleTaggerProvider>(workspace))
             {
                 var tagger = wrapper.TaggerProvider.CreateTagger<IErrorTag>(workspace.Documents.First().GetTextBuffer());
@@ -315,28 +309,6 @@ class Program
             {
                 return (await _producer.GetDiagnosticsAndErrorSpans(workspace)).Item2;
             }
-        }
-
-        [Shared]
-        [Export(typeof(IAsynchronousOperationListener))]
-        [Export(typeof(IAsynchronousOperationWaiter))]
-        [Feature(FeatureAttribute.Workspace)]
-        private class WorkspaceWaiter : AsynchronousOperationListener
-        {
-            internal WorkspaceWaiter()
-            {
-            }
-        }
-
-        private static ExportProvider s_exportProvider = CreateExportProvider();
-
-        private static ExportProvider CreateExportProvider()
-        {
-            var catalog = MinimalTestExportProvider.WithPart(
-                TestExportProvider.CreateAssemblyCatalogWithCSharpAndVisualBasic(),
-                typeof(WorkspaceWaiter));
-
-            return MinimalTestExportProvider.CreateExportProvider(catalog);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
     [ContentType(ContentTypeNames.RoslynContentType)]
     [ContentType(ContentTypeNames.XamlContentType)]
     [TagType(typeof(ClassificationTag))]
-    internal partial class DiagnosticsClassificationTaggerProvider : AbstractDiagnosticsTaggerProvider<ClassificationTag>
+    internal sealed class DiagnosticsClassificationTaggerProvider : AbstractDiagnosticsTaggerProvider<ClassificationTag>
     {
         private static readonly IEnumerable<Option<bool>> s_tagSourceOptions = new[] { EditorComponentOnOffOptions.Tagger, InternalFeatureOnOffOptions.Classification, ServiceComponentOnOffOptions.DiagnosticProvider };
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
     [ContentType(ContentTypeNames.RoslynContentType)]
     [ContentType(ContentTypeNames.XamlContentType)]
     [TagType(typeof(IErrorTag))]
-    internal partial class DiagnosticsSquiggleTaggerProvider : AbstractDiagnosticsAdornmentTaggerProvider<IErrorTag>
+    internal sealed class DiagnosticsSquiggleTaggerProvider : AbstractDiagnosticsAdornmentTaggerProvider<IErrorTag>
     {
         private static readonly IEnumerable<Option<bool>> s_tagSourceOptions =
             ImmutableArray.Create(EditorComponentOnOffOptions.Tagger, InternalFeatureOnOffOptions.Squiggles, ServiceComponentOnOffOptions.DiagnosticProvider);

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
-using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
-using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -23,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
     [ContentType(ContentTypeNames.RoslynContentType)]
     [ContentType(ContentTypeNames.XamlContentType)]
     [TagType(typeof(IErrorTag))]
-    internal partial class DiagnosticsSuggestionTaggerProvider :
+    internal sealed class DiagnosticsSuggestionTaggerProvider :
         AbstractDiagnosticsAdornmentTaggerProvider<IErrorTag>
     {
         private static readonly IEnumerable<Option<bool>> s_tagSourceOptions =

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
@@ -97,15 +97,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
                 }
             }
 
-            public async void Unregister(Workspace workspace, bool blockingShutdown = false)
+            public void Unregister(Workspace workspace, bool blockingShutdown = false)
             {
                 Contract.ThrowIfFalse(workspace == _workspace);
                 _source.Cancel();
 
-                // wait for analyzer work to be finished
-                await _analyzeTask.ConfigureAwait(false);
-
-                // ask it to reset its stages for the given workspace
+                // let analyzer service know that we are done with this workspace
                 _owner._analyzerService.ShutdownAnalyzerFrom(_workspace);
             }
 

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
@@ -32,16 +32,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 var id = Tuple.Create(workspace, document);
                 var diagnostic = RaiseDiagnosticEvent(set, source, workspace, document.Project.Id, document.Id, id);
 
-                var data1 = diagnosticService.GetDiagnostics(workspace, null, null, null, false, CancellationToken.None);
+                var data1 = diagnosticService.GetCachedDiagnostics(workspace, null, null, null, false, CancellationToken.None);
                 Assert.Equal(diagnostic, data1.Single());
 
-                var data2 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, null, null, false, CancellationToken.None);
+                var data2 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, null, null, false, CancellationToken.None);
                 Assert.Equal(diagnostic, data2.Single());
 
-                var data3 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, null, false, CancellationToken.None);
+                var data3 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, null, false, CancellationToken.None);
                 Assert.Equal(diagnostic, data3.Single());
 
-                var data4 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, id, false, CancellationToken.None);
+                var data4 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, id, false, CancellationToken.None);
                 Assert.Equal(diagnostic, data4.Single());
             }
         }
@@ -73,19 +73,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 RaiseDiagnosticEvent(set, source, workspace, document.Project.Id, null, id3);
                 RaiseDiagnosticEvent(set, source, workspace, null, null, Tuple.Create(workspace));
 
-                var data1 = diagnosticService.GetDiagnostics(workspace, null, null, null, false, CancellationToken.None);
+                var data1 = diagnosticService.GetCachedDiagnostics(workspace, null, null, null, false, CancellationToken.None);
                 Assert.Equal(5, data1.Count());
 
-                var data2 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, null, null, false, CancellationToken.None);
+                var data2 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, null, null, false, CancellationToken.None);
                 Assert.Equal(4, data2.Count());
 
-                var data3 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, null, id3, false, CancellationToken.None);
+                var data3 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, null, id3, false, CancellationToken.None);
                 Assert.Equal(1, data3.Count());
 
-                var data4 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, null, false, CancellationToken.None);
+                var data4 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, null, false, CancellationToken.None);
                 Assert.Equal(2, data4.Count());
 
-                var data5 = diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, id, false, CancellationToken.None);
+                var data5 = diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, id, false, CancellationToken.None);
                 Assert.Equal(1, data5.Count());
             }
         }

--- a/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
@@ -136,15 +136,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 _solutionCrawlerService.WaitUntilCompletion_ForTestingPurposesOnly(_workspace, _incrementalAnalyzers);
             }
 
-            // if workspace waiter exist, wait for it first.
-            var workspaceWaiter = (IAsynchronousOperationWaiter)_workspace.ExportProvider.GetExports<IAsynchronousOperationListener, FeatureMetadata>()
-                        .FirstOrDefault(l => l.Metadata.FeatureName == FeatureAttribute.Workspace)?.Value;
-
-            if (workspaceWaiter != null)
-            {
-                await workspaceWaiter.CreateWaitTask();
-            }
-
             await _asyncListener.CreateWaitTask();
         }
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticUpdateSourceRegistrationService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticUpdateSourceRegistrationService.cs
@@ -10,5 +10,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         {
             // do nothing
         }
+
+        public void Shutdown(IDiagnosticUpdateSource source, Workspace workspace)
+        {
+            // do nothing
+        }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -42,29 +42,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public void ShutdownAnalyzerFrom(Workspace workspace)
         {
             // this should be only called once analyzer associated with the workspace is done.
-            // this will let diagnostic service to remove data associated with the workspace from this source
+            // DiagnosticAnalyzerService implements IDiagnosticUpdateSource and register itself to IDiagnosticService
+            // and IDiagnosticService will hold onto some data from this source to do book keeping.
+            // this will tell IDiagnosticService to drop any information related to the workspace from this
+            // otherwise, IDiagnosticService can hold onto some information which causes memory leaks.
+            //
+            // to preserve order of events, we use event queue to serialize events. we use explicit queue for it
+            // rather than using UI thread and its message queue to archieve same thing implicitly.
             var asyncToken = Listener.BeginAsyncOperation(nameof(ShutdownAnalyzerFrom));
             _eventQueue.ScheduleTask(() =>
             {
-                // workspace such as previewWorkspace, which can come and go on the fly, will use this to remove data saved. 
-                // but since this doesn't raise diagnostic removed events, if there are others
-                // who hold onto diagnostics reported, it is their responsibility to clean them up when workspace
-                // goes away
+                // workspace such as previewWorkspace, which can come and go on the fly, will use this to remove data saved
+                // in IDiagnosticService. but since diagnostic changed events are something anyone can listen to, there might
+                // be other listener who hold onto its event args reported by DiagnosticChanged event. for those, its
+                // the listener's responsibility to clean thsoe up when workspace goes away.
                 _registrationService.Shutdown(this, workspace);
             }).CompletesAsyncOperation(asyncToken);
         }
 
         private DiagnosticIncrementalAnalyzer CreateIncrementalAnalyzerCallback(Workspace workspace)
         {
-            // subscribe to active context changed event for new workspace
-            workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
-
             return new DiagnosticIncrementalAnalyzer(this, LogAggregator.GetNextId(), workspace, _hostAnalyzerManager, _hostDiagnosticUpdateSource);
-        }
-
-        private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
-        {
-            Reanalyze(e.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.NewActiveContextDocumentId), highPriority: true);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -16,18 +16,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static readonly DiagnosticEventTaskScheduler s_eventScheduler = new DiagnosticEventTaskScheduler(blockingUpperBound: 100);
 
         // use eventMap and taskQueue to serialize events
+        private readonly IDiagnosticUpdateSourceRegistrationService _registrationService;
         private readonly EventMap _eventMap;
         private readonly SimpleTaskQueue _eventQueue;
 
         private DiagnosticAnalyzerService(IDiagnosticUpdateSourceRegistrationService registrationService) : this()
         {
+            _registrationService = registrationService;
             _eventMap = new EventMap();
 
             // use diagnostic event task scheduler so that we never flood async events queue with million of events.
             // queue itself can handle huge number of events but we are seeing OOM due to captured data in pending events.
             _eventQueue = new SimpleTaskQueue(s_eventScheduler);
 
-            registrationService.Register(this);
+            _registrationService.Register(this);
         }
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -15,8 +15,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     [Export(typeof(IDiagnosticService)), Shared]
     internal partial class DiagnosticService : IDiagnosticService
     {
-        private const string DiagnosticsUpdatedEventName = "DiagnosticsUpdated";
-
+        private const string DiagnosticsUpdatedEventName = nameof(DiagnosticsUpdated);
         private static readonly DiagnosticEventTaskScheduler s_eventScheduler = new DiagnosticEventTaskScheduler(blockingUpperBound: 100);
 
         private readonly IAsynchronousOperationListener _listener;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService_UpdateSourceRegistrationService.cs
@@ -35,6 +35,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void Shutdown(IDiagnosticUpdateSource source, Workspace workspace)
         {
+            // we use event queue to preserve order between events. listener
+            // will get all diagnostics changed async events before Shutdown happened.
             var eventToken = _listener.BeginAsyncOperation(nameof(Shutdown));
             _eventQueue.ScheduleTask(() =>
             {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -122,24 +122,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             ClearAllDiagnostics(stateSets, project.Id);
         }
 
-        public void Shutdown()
-        {
-            var stateSets = _stateManager.GetStateSets();
-
-            Owner.RaiseBulkDiagnosticsUpdated(raiseEvents =>
-            {
-                var handleActiveFile = true;
-                foreach (var stateSet in stateSets)
-                {
-                    var projectIds = stateSet.GetProjectsWithDiagnostics();
-                    foreach (var projectId in projectIds)
-                    {
-                        RaiseProjectDiagnosticsRemoved(stateSet, projectId, stateSet.GetDocumentsWithDiagnostics(projectId), handleActiveFile, raiseEvents);
-                    }
-                }
-            });
-        }
-
         private void ClearAllDiagnostics(ImmutableArray<StateSet> stateSets, ProjectId projectId)
         {
             Owner.RaiseBulkDiagnosticsUpdated(raiseEvents =>

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticService.cs
@@ -10,18 +10,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal interface IDiagnosticService
     {
         /// <summary>
-        /// Event to get notified as new diagnostics are discovered by IDiagnosticUpdateSource
+        /// Event to get notified as new diagnostics are discovered by <see cref="IDiagnosticUpdateSource"/>
+        /// This event is host wide meaning it will be raised for host workspace, misc workspace, preivew workspace and etc. workspace is significant since same project/documentId can
+        /// exist in multiple workspaces.
         /// </summary>
         event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
 
         /// <summary>
-        /// Get current diagnostics stored in IDiagnosticUpdateSource
+        /// Get cached diagnostics stored in <see cref="IDiagnosticUpdateSource"/>. diagnostics returned by it can be staled ones. not all <see cref="IDiagnosticUpdateSource"/> can provide
+        /// up to date diagnostics (ex, diagnostics from build). if one wants up to date diagnostics, it should use <see cref="IDiagnosticUpdateSource"/> directly such as <see cref="IDiagnosticAnalyzerService"/> that
+        /// provides APIs such as <see cref="IDiagnosticAnalyzerService.GetDiagnosticsAsync(Solution, ProjectId, DocumentId, bool, CancellationToken)"/> which accepts <see cref="Solution"/> snapshot to 
+        /// specify which specific snapshot it wants diagnostics from.
         /// </summary>
-        IEnumerable<DiagnosticData> GetDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics, CancellationToken cancellationToken);
+        IEnumerable<DiagnosticData> GetCachedDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get current UpdatedEventArgs stored in IDiagnosticUpdateSource
         /// </summary>
         IEnumerable<UpdatedEventArgs> GetDiagnosticsUpdatedEventArgs(Workspace workspace, ProjectId projectId, DocumentId documentId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Subscribe to document specific changes when one doesn't need to listen to host wide changes like error list.
+        /// </summary>
+        IDisposable Subscribe(Workspace workspace, DocumentId documentId, Action<DiagnosticsUpdatedArgs> action);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSourceRegistrationService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticUpdateSourceRegistrationService.cs
@@ -14,5 +14,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Currently, it doesn't support unregister since our event is asynchronous and unregistering source that deal with asynchronous event is not straight forward.
         /// </summary>
         void Register(IDiagnosticUpdateSource source);
+
+        /// <summary>
+        /// Forgot any information regarding the given workspace
+        /// from the given source
+        /// </summary>
+        void Shutdown(IDiagnosticUpdateSource source, Workspace workspace);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 public override ImmutableArray<TableItem<DiagnosticData>> GetItems()
                 {
                     var provider = _source._diagnosticService;
-                    var items = provider.GetDiagnostics(_workspace, _projectId, _documentId, _id, includeSuppressedDiagnostics: true, cancellationToken: CancellationToken.None)
+                    var items = provider.GetCachedDiagnostics(_workspace, _projectId, _documentId, _id, includeSuppressedDiagnostics: true, cancellationToken: CancellationToken.None)
                                         .Where(ShouldInclude).Select(d => new TableItem<DiagnosticData>(d, GenerateDeduplicationKey));
 
                     return items.ToImmutableArrayOrEmpty();

--- a/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
@@ -92,7 +92,7 @@ class A
                 Await listener.CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 1)
+                    diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 1)
             End Using
         End Function
 
@@ -129,7 +129,7 @@ class A
                 Await listener.CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 1)
+                    diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 1)
             End Using
         End Function
 
@@ -166,7 +166,7 @@ class A
                 Await listener.CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 2)
+                    diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 2)
             End Using
         End Function
 
@@ -204,7 +204,7 @@ class A
                 Await listener.CreateWaitTask()
 
                 Assert.True(
-                    diagnosticService.GetDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 0)
+                    diagnosticService.GetCachedDiagnostics(workspace, document.Project.Id, document.Id, Nothing, False, CancellationToken.None).Count() = 0)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -791,7 +791,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
             Public Event DiagnosticsUpdated As EventHandler(Of DiagnosticsUpdatedArgs) Implements IDiagnosticService.DiagnosticsUpdated
 
-            Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, reportSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As IEnumerable(Of DiagnosticData) Implements IDiagnosticService.GetDiagnostics
+            Public Function GetDiagnostics(workspace As Microsoft.CodeAnalysis.Workspace, projectId As ProjectId, documentId As DocumentId, id As Object, reportSuppressedDiagnostics As Boolean, cancellationToken As CancellationToken) As IEnumerable(Of DiagnosticData) Implements IDiagnosticService.GetCachedDiagnostics
                 Assert.NotNull(workspace)
 
                 Dim diagnostics As IEnumerable(Of DiagnosticData)
@@ -872,6 +872,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 RaiseEvent DiagnosticsUpdated(Me, DiagnosticsUpdatedArgs.DiagnosticsRemoved(
                     New ErrorId(Me, documentId), workspace, workspace.CurrentSolution, projectId, documentId))
             End Sub
+
+            Public Function Subscribe(workspace As Microsoft.CodeAnalysis.Workspace, documentId As DocumentId, action As Action(Of DiagnosticsUpdatedArgs)) As IDisposable Implements IDiagnosticService.Subscribe
+                Throw New NotImplementedException()
+            End Function
 
             Private Class ErrorId
                 Inherits BuildToolId.Base(Of TestDiagnosticService, Object)

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -231,6 +231,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Simplifier_ExpandNode,
         Simplifier_ExpandToken,
 
+        ForegroundNotificationService_Added,
         ForegroundNotificationService_Processed,
         ForegroundNotificationService_NotifyOnForeground,
 

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -4,10 +4,13 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleTypeExpression(System.Collec
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleTypeExpression(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> elements) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleTypeExpression(params Microsoft.CodeAnalysis.SyntaxNode[] elements) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithAccessorDeclarations(Microsoft.CodeAnalysis.SyntaxNode declaration, params Microsoft.CodeAnalysis.SyntaxNode[] accessorDeclarations) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.WorkspaceChangedEventArgs
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetAccessorDeclaration(Microsoft.CodeAnalysis.Accessibility accessibility = Microsoft.CodeAnalysis.Accessibility.NotApplicable, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements = null) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.SetAccessorDeclaration(Microsoft.CodeAnalysis.Accessibility accessibility = Microsoft.CodeAnalysis.Accessibility.NotApplicable, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements = null) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleElementExpression(Microsoft.CodeAnalysis.SyntaxNode type, string name = null) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleExpression(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.WithAccessorDeclarations(Microsoft.CodeAnalysis.SyntaxNode declaration, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> accessorDeclarations) -> Microsoft.CodeAnalysis.SyntaxNode
+readonly Microsoft.CodeAnalysis.WorkspaceChangedEventArgs.NewWorkspace -> Microsoft.CodeAnalysis.Workspace
+readonly Microsoft.CodeAnalysis.WorkspaceChangedEventArgs.OldWorkspace -> Microsoft.CodeAnalysis.Workspace
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Ref.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Editing.SyntaxEditorExtensions.InsertParameter(this Microsoft.CodeAnalysis.Editing.SyntaxEditor editor, Microsoft.CodeAnalysis.SyntaxNode declaration, int index, Microsoft.CodeAnalysis.SyntaxNode parameter) -> void

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
@@ -15,20 +15,26 @@ namespace Microsoft.CodeAnalysis
         public Workspace Workspace => _registeredWorkspace;
         public event EventHandler WorkspaceChanged;
 
-        internal void SetWorkspaceAndRaiseEvents(Workspace workspace)
-        {
-            SetWorkspace(workspace);
-            RaiseEvents();
-        }
-
         internal void SetWorkspace(Workspace workspace)
         {
             _registeredWorkspace = workspace;
         }
 
-        internal void RaiseEvents()
+        internal void RaiseEvents(Workspace oldWorkspace, Workspace newWorkspace)
         {
-            WorkspaceChanged?.Invoke(this, EventArgs.Empty);
+            WorkspaceChanged?.Invoke(this, new WorkspaceChangedEventArgs(oldWorkspace, newWorkspace));
+        }
+    }
+
+    internal sealed class WorkspaceChangedEventArgs : EventArgs
+    {
+        public readonly Workspace OldWorkspace;
+        public readonly Workspace NewWorkspace;
+
+        public WorkspaceChangedEventArgs(Workspace oldWorkspace, Workspace newWorkspace)
+        {
+            OldWorkspace = oldWorkspace;
+            NewWorkspace = newWorkspace;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
@@ -26,12 +26,21 @@ namespace Microsoft.CodeAnalysis
         }
     }
 
-    internal sealed class WorkspaceChangedEventArgs : EventArgs
+    public sealed class WorkspaceChangedEventArgs : EventArgs
     {
+        /// <summary>
+        /// Point to old workspace it was associated with. it can be null
+        /// if it was never associated with a workspace before
+        /// </summary>
         public readonly Workspace OldWorkspace;
+
+        /// <summary>
+        /// Point to new workspace it is associated with. it can be null
+        /// if it is being removed.
+        /// </summary>
         public readonly Workspace NewWorkspace;
 
-        public WorkspaceChangedEventArgs(Workspace oldWorkspace, Workspace newWorkspace)
+        internal WorkspaceChangedEventArgs(Workspace oldWorkspace, Workspace newWorkspace)
         {
             OldWorkspace = oldWorkspace;
             NewWorkspace = newWorkspace;


### PR DESCRIPTION
**Customer scenario**

Customer is working on a VS. doing code fix and watching previews, applying fix all and etc, and suddenly VS crash due to OOM.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/512757

**Workarounds, if any**

there is no easy workaround.

**Risk**

I don't see risk of crash, but since it is highly visible area (tagger), we probably want more dogfooding time for this.

**Performance impact**

it should move more work to background thread, and reduce need for UI thread. in turn, improving responsiveness and memory.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

this one is hard to pin point to 1 issue. but caused by several different fixes. 

first, we made all state management to happen on UI thread to remove any potential race. and that caused us to use more FG than before.

second, we merged preview only tagger with regular diagnostic tagger, making preview tagger to be as expansive as normal diagnostic tagger meaning it uses same amount of UI threads since it now has same states tracking as normal ones.

third, along with that, some filtering on BG got removed which was there to reduce work on FG since all those are changed to be done on FG. 

forth, diagnostic tagger didn't pass cancellation token all the way through, leaving already cancelled works in the UI work queue.

fifth, foreground work queue cleaned up cancelled works too lazily and let cancelled work to pile up.

..

this reduces demand for UI thread, but due to the fact that UI thread can be blocked (due to exclusive operation running such as Fix All, or model dialog box or Wait dialog box and more), we can't completely get rid of pending requests for UI threads. but with this change, we should have way less chance to hit 2.1 million pending UI requests.

**How was the bug found?**

MemoryWatson
