### PR TITLE
Implement FindReferences for deconstructions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             conversion = Conversion.Deconstruction;
 
             // Figure out the deconstruct method (if one is required) and determine the types we get from the RHS at this level
-            var deconstructInfo = default(DeconstructionInfo);
+            var deconstructMethod = default(DeconstructMethodInfo);
             if (type.IsTupleType)
             {
                 // tuple literal such as `(1, 2)`, `(null, null)`, `(x.P, y.M())`
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                deconstructInfo = new DeconstructionInfo(deconstructInvocation, inputPlaceholder, outPlaceholders);
+                deconstructMethod = new DeconstructMethodInfo(deconstructInvocation, inputPlaceholder, outPlaceholders);
 
                 tupleOrDeconstructedTypes = outPlaceholders.SelectAsArray(p => p.Type);
                 SetInferredTypes(variables, tupleOrDeconstructedTypes, diagnostics);
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 nestedConversions.Add(nestedConversion);
             }
 
-            conversion = new Conversion(ConversionKind.Deconstruction, deconstructInfo, nestedConversions.ToImmutableAndFree());
+            conversion = new Conversion(ConversionKind.Deconstruction, deconstructMethod, nestedConversions.ToImmutableAndFree());
 
             return !hasErrors;
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -71,14 +71,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private class DeconstructionUncommonData : UncommonData
         {
-            internal DeconstructionUncommonData(DeconstructionInfo deconstructionInfoOpt, ImmutableArray<Conversion> nestedConversions)
-                : base(false, false, default(UserDefinedConversionResult), null, nestedConversions)
+            internal DeconstructionUncommonData(DeconstructMethodInfo deconstructMethodInfoOpt, ImmutableArray<Conversion> nestedConversions)
+                : base(isExtensionMethod: false, isArrayIndex: false, conversionResult: default, conversionMethod: null, nestedConversions)
             {
                 Debug.Assert(!nestedConversions.IsDefaultOrEmpty);
-                DeconstructionInfo = deconstructionInfoOpt;
+                DeconstructMethodInfo = deconstructMethodInfoOpt;
             }
 
-            readonly internal DeconstructionInfo DeconstructionInfo;
+            readonly internal DeconstructMethodInfo DeconstructMethodInfo;
         }
 
         private Conversion(
@@ -131,12 +131,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 nestedConversions: nestedConversions);
         }
 
-        internal Conversion(ConversionKind kind, DeconstructionInfo deconstructionInfo, ImmutableArray<Conversion> nestedConversions)
+        internal Conversion(ConversionKind kind, DeconstructMethodInfo deconstructMethodInfo, ImmutableArray<Conversion> nestedConversions)
         {
             Debug.Assert(kind == ConversionKind.Deconstruction);
 
             this._kind = kind;
-            _uncommonData = new DeconstructionUncommonData(deconstructionInfo, nestedConversions);
+            _uncommonData = new DeconstructionUncommonData(deconstructMethodInfo, nestedConversions);
         }
 
         internal Conversion SetConversionMethod(MethodSymbol conversionMethod)
@@ -353,18 +353,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                         UserDefinedConversionAnalysis analysis = conversionResult.Results[conversionResult.Best];
                         return analysis.Operator;
                     }
+
+                    if (uncommonData is DeconstructionUncommonData deconstruction
+                        && deconstruction.DeconstructMethodInfo.Invocation is BoundCall call)
+                    {
+                        return call.Method;
+                    }
                 }
 
                 return null;
             }
         }
 
-        internal DeconstructionInfo DeconstructionInfo
+        internal DeconstructMethodInfo DeconstructionInfo
         {
             get
             {
                 var uncommonData = (DeconstructionUncommonData)_uncommonData;
-                return uncommonData == null ? default(DeconstructionInfo) : uncommonData.DeconstructionInfo;
+                return uncommonData == null ? default(DeconstructMethodInfo) : uncommonData.DeconstructMethodInfo;
             }
         }
 
@@ -973,9 +979,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     }
 
     /// <summary>Stores all the information from binding for calling a Deconstruct method.</summary>
-    internal struct DeconstructionInfo
+    internal struct DeconstructMethodInfo
     {
-        internal DeconstructionInfo(BoundExpression invocation, BoundDeconstructValuePlaceholder inputPlaceholder,
+        internal DeconstructMethodInfo(BoundExpression invocation, BoundDeconstructValuePlaceholder inputPlaceholder,
             ImmutableArray<BoundDeconstructValuePlaceholder> outputPlaceholders)
         {
              (Invocation, InputPlaceholder, OutputPlaceholders) = (invocation, inputPlaceholder, outputPlaceholders);
@@ -984,6 +990,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         readonly internal BoundExpression Invocation;
         readonly internal BoundDeconstructValuePlaceholder InputPlaceholder;
         readonly internal ImmutableArray<BoundDeconstructValuePlaceholder> OutputPlaceholders;
-        internal bool IsDefault => (object)Invocation == null;
+        internal bool IsDefault => Invocation is null;
     }
 }

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -745,6 +745,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        public static DeconstructionInfo GetDeconstructionInfo(this SemanticModel semanticModel, AssignmentExpressionSyntax assignment)
+        {
+            return semanticModel is CSharpSemanticModel csmodel ? csmodel.GetDeconstructionInfo(assignment) : default;
+        }
+
+        public static DeconstructionInfo GetDeconstructionInfo(this SemanticModel semanticModel, ForEachVariableStatementSyntax @foreach)
+        {
+            return semanticModel is CSharpSemanticModel csmodel ? csmodel.GetDeconstructionInfo(@foreach) : default;
+        }
+
         public static AwaitExpressionInfo GetAwaitExpressionInfo(this SemanticModel semanticModel, AwaitExpressionSyntax awaitExpression)
         {
             var csmodel = semanticModel as CSharpSemanticModel;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -4403,6 +4403,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         public abstract ForEachStatementInfo GetForEachStatementInfo(CommonForEachStatementSyntax node);
 
         /// <summary>
+        /// Gets deconstruction assignment info.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        public abstract DeconstructionInfo GetDeconstructionInfo(AssignmentExpressionSyntax node);
+
+        /// <summary>
+        /// Gets deconstruction foreach info.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        public abstract DeconstructionInfo GetDeconstructionInfo(ForEachVariableStatementSyntax node);
+
+        /// <summary>
         /// Gets await expression info.
         /// </summary>
         /// <param name="node">The node.</param>

--- a/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    // Deconstructions are represented internally as a tree of conversions, but
+    // since they are not conversions from the language perspective we use a wrapper to
+    // abstract the public API from the implementation.
+
+    /// <summary>
+    /// The representation of a deconstruction as a tree of Deconstruct methods and conversions.
+    /// Methods only appear in non-terminal nodes. All terminal nodes have a Conversion.
+    ///
+    /// Here's an example:
+    /// A deconstruction like `(int x1, (long x2, long x3)) = deconstructable1` with
+    /// `Deconstructable1.Deconstruct(out int y1, out Deconstructable2 y2)` and
+    /// `Deconstructable2.Deconstruct(out int z1, out int z2)` is represented as 5 DeconstructionInfo nodes.
+    ///
+    /// The top-level node has a <see cref="Method"/> (Deconstructable1.Deconstruct), no <see cref="Conversion"/>, but has two <see cref="Nested"/> nodes.
+    /// Its first nested node has no <see cref="Method"/>, but has a <see cref="Conversion"/> (Identity).
+    /// Its second nested node has a <see cref="Method"/> (Deconstructable2.Deconstruct), no <see cref="Conversion"/>, and two <see cref="Nested"/> nodes.
+    /// Those last two nested nodes have no <see cref="Method"/>, but each have a <see cref="Conversion"/> (ImplicitNumeric, from int to long).
+    /// </summary>
+    public struct DeconstructionInfo
+    {
+        private readonly Conversion _conversion;
+
+        /// <summary>
+        /// The Deconstruct method (if any) for this non-terminal position in the deconstruction tree.
+        /// </summary>
+        public IMethodSymbol Method
+        {
+            get
+            {
+                return _conversion.Kind == ConversionKind.Deconstruction
+                    ? _conversion.Method
+                    : null;
+            }
+        }
+
+        /// <summary>
+        /// The conversion for a terminal position in the deconstruction tree.
+        /// </summary>
+        public Conversion? Conversion
+        {
+            get
+            {
+                return _conversion.Kind == ConversionKind.Deconstruction
+                    ? null
+                    : (Conversion?)_conversion;
+            }
+        }
+
+        /// <summary>
+        /// The children for this deconstruction node.
+        /// </summary>
+        public ImmutableArray<DeconstructionInfo> Nested
+        {
+            get
+            {
+                var underlyingConversions = _conversion.UnderlyingConversions;
+
+                return underlyingConversions.IsDefault
+                    ? ImmutableArray<DeconstructionInfo>.Empty
+                    : underlyingConversions.SelectAsArray(c => new DeconstructionInfo(c));
+            }
+        }
+
+        internal DeconstructionInfo(Conversion conversion)
+        {
+            _conversion = conversion;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -837,6 +837,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                 enumeratorInfoOpt.CurrentConversion);
         }
 
+        public override DeconstructionInfo GetDeconstructionInfo(AssignmentExpressionSyntax node)
+        {
+            var boundDeconstruction = GetUpperBoundNode(node) as BoundDeconstructionAssignmentOperator;
+            if (boundDeconstruction is null)
+            {
+                return default;
+            }
+
+            var boundConversion = boundDeconstruction.Right;
+            Debug.Assert(boundConversion != null || boundDeconstruction.HasAnyErrors);
+
+            return new DeconstructionInfo(boundConversion.Conversion);
+        }
+
+        public override DeconstructionInfo GetDeconstructionInfo(ForEachVariableStatementSyntax node)
+        {
+            var boundForEach = (BoundForEachStatement)GetUpperBoundNode(node);
+            if (boundForEach is null)
+            {
+                return default;
+            }
+
+            var boundDeconstruction = boundForEach.DeconstructionOpt;
+            Debug.Assert(boundDeconstruction != null || boundForEach.HasAnyErrors);
+
+            return new DeconstructionInfo(boundDeconstruction.DeconstructionAssignment.Right.Conversion);
+        }
+
         private BoundQueryClause GetBoundQueryClause(CSharpSyntaxNode node)
         {
             CheckSyntaxNode(node);

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2170,5 +2170,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             MemberSemanticModel memberModel = GetMemberModel(node);
             return memberModel == null ? default(ForEachStatementInfo) : memberModel.GetForEachStatementInfo(node);
         }
+
+        public override DeconstructionInfo GetDeconstructionInfo(AssignmentExpressionSyntax node)
+        {
+            MemberSemanticModel memberModel = GetMemberModel(node);
+            return memberModel?.GetDeconstructionInfo(node) ?? default;
+        }
+
+        public override DeconstructionInfo GetDeconstructionInfo(ForEachVariableStatementSyntax node)
+        {
+            MemberSemanticModel memberModel = GetMemberModel(node);
+            return memberModel?.GetDeconstructionInfo(node) ?? default;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return EvaluateSideEffectingArgumentToTemp(evalConversion, effects, ref temps);
         }
 
-        private ImmutableArray<BoundExpression> InvokeDeconstructMethod(DeconstructionInfo deconstruction, BoundExpression target,
+        private ImmutableArray<BoundExpression> InvokeDeconstructMethod(DeconstructMethodInfo deconstruction, BoundExpression target,
             ArrayBuilder<BoundExpression> effects, ref ArrayBuilder<LocalSymbol> temps)
         {
             AddPlaceholderReplacement(deconstruction.InputPlaceholder, target);

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,9 +1,8 @@
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
-static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
 Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool
-Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Semantics.CommonConversion
+Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Operations.CommonConversion
 Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
 Microsoft.CodeAnalysis.CSharp.DeconstructionInfo.Conversion.get -> Microsoft.CodeAnalysis.CSharp.Conversion?
 Microsoft.CodeAnalysis.CSharp.DeconstructionInfo.Method.get -> Microsoft.CodeAnalysis.IMethodSymbol
@@ -15,7 +14,7 @@ Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
-static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Semantics.IConversionExpression conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
+static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax assignment) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.ForEachVariableStatementSyntax foreach) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,15 +1,22 @@
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
-Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Operations.CommonConversion
-Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_2 = 702 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
+Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool
+Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Semantics.CommonConversion
+Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
+Microsoft.CodeAnalysis.CSharp.DeconstructionInfo.Conversion.get -> Microsoft.CodeAnalysis.CSharp.Conversion?
+Microsoft.CodeAnalysis.CSharp.DeconstructionInfo.Method.get -> Microsoft.CodeAnalysis.IMethodSymbol
+Microsoft.CodeAnalysis.CSharp.DeconstructionInfo.Nested.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CSharp.DeconstructionInfo>
+Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_2 = 702 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
+static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Semantics.IConversionExpression conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
+static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax assignment) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
+static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.ForEachVariableStatementSyntax foreach) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.RefType(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
-Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -701,3 +701,4 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.V
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitVariableDeclarator(Microsoft.CodeAnalysis.Operations.IVariableDeclaratorOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitVariableInitializer(Microsoft.CodeAnalysis.Operations.IVariableInitializerOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitWhileLoop(Microsoft.CodeAnalysis.Operations.IWhileLoopOperation operation, TArgument argument) -> TResult
+const Microsoft.CodeAnalysis.WellKnownMemberNames.DeconstructMethodName = "Deconstruct" -> string

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -254,6 +254,11 @@ namespace Microsoft.CodeAnalysis
         public const string GetEnumeratorMethodName = "GetEnumerator";
 
         /// <summary>
+        /// The required name for the <c>Deconstruct</c> method used in a deconstruction.
+        /// </summary>
+        public const string DeconstructMethodName = "Deconstruct";
+
+        /// <summary>
         /// The required name for the <c>MoveNext</c> method used in a ForEach statement.
         /// </summary>
         public const string MoveNextMethodName = "MoveNext";

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1482,5 +1482,26 @@ public struct ValueTuple&lt;T1&gt;
                 await state.AssertTag("ValueTuple", "ValueTuple2");
             }
         }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameTrackingOnDeconstruct()
+        {
+            var code = @"
+class C
+{
+    void Deconstruct$$(out int x1, out int x2) { x1 = 1; x2 = 2; }
+    void M()
+    {
+        var (y1, y2) = this;
+    }
+}";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("2");
+                await state.AssertTag("Deconstruct", "Deconstruct2");
+            }
+        }
+
     }
 }

--- a/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
@@ -49,6 +49,54 @@ class C
             End Using
         End Sub
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameDeconstructCausesConflictInDeconstructionAssignment()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void M()
+    {
+        {|deconstructconflict:var (y1, y2)|} = this;
+    }
+
+    public void [|$$Deconstruct|](out int x1, out int x2) { x1 = 1; x2 = 2; }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Deconstruct2")
+
+                result.AssertLabeledSpansAre("deconstructconflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameDeconstructCausesConflictInDeconstructionForEach()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    void M()
+    {
+        foreach({|deconstructconflict:var (y1, y2)|} in new[] { this })
+        {
+        }
+    }
+
+    public void [|$$Deconstruct|](out int x1, out int x2) { x1 = 1; x2 = 2; }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Deconstruct2")
+
+                result.AssertLabeledSpansAre("deconstructconflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
+
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextInVBCausesConflictInForEach()

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -84,6 +84,34 @@ class Deconstructable
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameDeconstructMethodInDeconstructionForeach() As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document><![CDATA[
+using System.Collections.Generic;
+class Deconstructable
+{
+    void M(IEnumerable<Deconstructable> x)
+    {
+        foreach (var (y1, y2) in x)
+        {
+        }
+        var (z1, z2) = this;
+        [|Deconstruct|](out var t1, out var t2);
+    }
+    void [|$$Deconstruct|](out int i, out int j) { i = 0; j = 0; }
+}
+                            ]]></Document>
+                        </Project>
+                    </Workspace>)
+
+                Await VerifyRenameOptionChangedSessionCommit(workspace, "Deconstruct", "Changed", renameOverloads:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(540120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540120")>
         Public Async Function SimpleEditAndVerifyTagsPropagatedAndCommit() As Task
             Using workspace = CreateWorkspaceWithWaiter(

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -996,5 +996,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return to.WithPrependedLeadingTrivia(finalTrivia)
                      .WithAdditionalAnnotations(Formatter.Annotation);
         }
+
+        public static bool IsInDeconstructionLeft(this SyntaxNode node, out SyntaxNode deconstructionLeft)
+        {
+            SyntaxNode previous = null;
+            for (var current = node; current != null; current = current.GetParent())
+            {
+                if ((current is AssignmentExpressionSyntax assignment && previous == assignment.Left && assignment.IsDeconstruction()) ||
+                    (current is ForEachVariableStatementSyntax @foreach && previous == @foreach.Variable))
+                {
+                    deconstructionLeft = previous;
+                    return true;
+                }
+
+                if (current is StatementSyntax)
+                {
+                    break;
+                }
+
+                previous = current;
+            }
+
+            deconstructionLeft = null;
+            return false;
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -245,6 +245,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node is ForEachStatementSyntax;
         }
 
+        public bool IsDeconstructionForEachStatement(SyntaxNode node)
+            => node is ForEachVariableStatementSyntax;
+
+        public bool IsDeconstructionAssignment(SyntaxNode node)
+            => node is AssignmentExpressionSyntax assignment && assignment.IsDeconstruction();
+
+        public Location GetDeconstructionReferenceLocation(SyntaxNode node)
+        {
+            var tree = node.SyntaxTree;
+            switch (node)
+            {
+                case AssignmentExpressionSyntax assignment:
+                    return assignment.Left.GetLocation();
+
+                case ForEachVariableStatementSyntax @foreach:
+                    return @foreach.Variable.GetLocation();
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
+            }
+        }
+
         public bool IsLockStatement(SyntaxNode node)
         {
             return node is LockStatementSyntax;

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -975,10 +975,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
             // Handle renaming of symbols used for foreach
             bool implicitReferencesMightConflict = renameSymbol.Kind == SymbolKind.Property &&
                                                 string.Compare(renameSymbol.Name, "Current", StringComparison.OrdinalIgnoreCase) == 0;
-            implicitReferencesMightConflict = implicitReferencesMightConflict ||
-                                                (renameSymbol.Kind == SymbolKind.Method &&
-                                                    (string.Compare(renameSymbol.Name, "MoveNext", StringComparison.OrdinalIgnoreCase) == 0 ||
-                                                    string.Compare(renameSymbol.Name, "GetEnumerator", StringComparison.OrdinalIgnoreCase) == 0));
+
+            implicitReferencesMightConflict =
+                implicitReferencesMightConflict ||
+                    (renameSymbol.Kind == SymbolKind.Method &&
+                        (string.Compare(renameSymbol.Name, WellKnownMemberNames.MoveNextMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        string.Compare(renameSymbol.Name, WellKnownMemberNames.GetEnumeratorMethodName, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        string.Compare(renameSymbol.Name, WellKnownMemberNames.DeconstructMethodName, StringComparison.OrdinalIgnoreCase) == 0));
 
             // TODO: handle Dispose for using statement and Add methods for collection initializers.
 
@@ -995,6 +998,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                         {
                             case SyntaxKind.ForEachKeyword:
                                 return ImmutableArray.Create(((CommonForEachStatementSyntax)token.Parent).Expression.GetLocation());
+                        }
+
+                        if (token.Parent.IsInDeconstructionLeft(out var deconstructionLeft))
+                        {
+                            return ImmutableArray.Create(deconstructionLeft.GetLocation());
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsThisConstructorInitializer,
                 bool containsBaseConstructorInitializer,
                 bool containsElementAccessExpression,
-                bool containsIndexerMemberCref) :
+                bool containsIndexerMemberCref,
+                bool containsDeconstruction) :
                 this(predefinedTypes, predefinedOperators,
                      ConvertToContainingNodeFlag(
                          containsForEachStatement,
@@ -34,7 +35,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsThisConstructorInitializer,
                          containsBaseConstructorInitializer,
                          containsElementAccessExpression,
-                         containsIndexerMemberCref))
+                         containsIndexerMemberCref,
+                         containsDeconstruction))
             {
             }
 
@@ -53,7 +55,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsThisConstructorInitializer,
                 bool containsBaseConstructorInitializer,
                 bool containsElementAccessExpression,
-                bool containsIndexerMemberCref)
+                bool containsIndexerMemberCref,
+                bool containsDeconstruction)
             {
                 var containingNodes = ContainingNodes.None;
 
@@ -65,6 +68,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 containingNodes = containsBaseConstructorInitializer ? (containingNodes | ContainingNodes.ContainsBaseConstructorInitializer) : containingNodes;
                 containingNodes = containsElementAccessExpression ? (containingNodes | ContainingNodes.ContainsElementAccessExpression) : containingNodes;
                 containingNodes = containsIndexerMemberCref ? (containingNodes | ContainingNodes.ContainsIndexerMemberCref) : containingNodes;
+                containingNodes = containsDeconstruction ? (containingNodes | ContainingNodes.ContainsDeconstruction) : containingNodes;
 
                 return containingNodes;
             }
@@ -77,6 +81,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             public bool ContainsForEachStatement
                 => (_containingNodes & ContainingNodes.ContainsForEachStatement) == ContainingNodes.ContainsForEachStatement;
+
+            public bool ContainsDeconstruction
+                => (_containingNodes & ContainingNodes.ContainsDeconstruction) == ContainingNodes.ContainsDeconstruction;
 
             public bool ContainsLockStatement
                 => (_containingNodes & ContainingNodes.ContainsLockStatement) == ContainingNodes.ContainsLockStatement;
@@ -135,6 +142,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsBaseConstructorInitializer = 1 << 5,
                 ContainsElementAccessExpression = 1 << 6,
                 ContainsIndexerMemberCref = 1 << 7,
+                ContainsDeconstruction = 1 << 8,
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var containsBaseConstructorInitializer = false;
                 var containsElementAccess = false;
                 var containsIndexerMemberCref = false;
+                var containsDeconstruction = false;
 
                 var predefinedTypes = (int)PredefinedType.None;
                 var predefinedOperators = (int)PredefinedOperator.None;
@@ -91,6 +92,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             containsQueryExpression = containsQueryExpression || syntaxFacts.IsQueryExpression(node);
                             containsElementAccess = containsElementAccess || syntaxFacts.IsElementAccessExpression(node);
                             containsIndexerMemberCref = containsIndexerMemberCref || syntaxFacts.IsIndexerMemberCRef(node);
+
+                            containsDeconstruction = containsDeconstruction || syntaxFacts.IsDeconstructionAssignment(node)
+                                || syntaxFacts.IsDeconstructionForEachStatement(node);
 
                             // We've received a number of error reports where DeclaredSymbolInfo.GetSymbolAsync() will
                             // crash because the document's syntax root doesn't contain the span of the node returned
@@ -198,7 +202,8 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                             containsThisConstructorInitializer,
                             containsBaseConstructorInitializer,
                             containsElementAccess,
-                            containsIndexerMemberCref),
+                            containsIndexerMemberCref,
+                            containsDeconstruction),
                     new DeclarationInfo(
                             declaredSymbolInfos.ToImmutableAndFree()));
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ProbablyContainsInt64Value(long value) => _literalInfo.ProbablyContainsInt64Value(value);
 
         public bool ContainsForEachStatement => _contextInfo.ContainsForEachStatement;
+        public bool ContainsDeconstruction => _contextInfo.ContainsDeconstruction;
         public bool ContainsLockStatement => _contextInfo.ContainsLockStatement;
         public bool ContainsUsingStatement => _contextInfo.ContainsUsingStatement;
         public bool ContainsQueryExpression => _contextInfo.ContainsQueryExpression;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private const string SerializationFormat = "10";
+        private const string SerializationFormat = "11";
 
         public readonly Checksum Checksum;
 

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -90,6 +90,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         ForEachSymbols GetForEachSymbols(SemanticModel semanticModel, SyntaxNode forEachStatement);
 
+        ImmutableArray<IMethodSymbol> GetDeconstructionAssignmentMethods(SemanticModel semanticModel, SyntaxNode node);
+
+        ImmutableArray<IMethodSymbol> GetDeconstructionForEachMethods(SemanticModel semanticModel, SyntaxNode node);
+
         bool IsAssignableTo(ITypeSymbol fromSymbol, ITypeSymbol toSymbol, Compilation compilation);
 
         bool IsPartial(ITypeSymbol typeSymbol, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsStatement(SyntaxNode node);
         bool IsParameter(SyntaxNode node);
         bool IsVariableDeclarator(SyntaxNode node);
+        bool IsDeconstructionAssignment(SyntaxNode node);
+        bool IsDeconstructionForEachStatement(SyntaxNode node);
 
         /// <summary>
         /// Returns true for nodes that represent the body of a method.
@@ -335,6 +337,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         SyntaxTokenList GetModifiers(SyntaxNode node);
         SyntaxNode WithModifiers(SyntaxNode node, SyntaxTokenList modifiers);
+
+        Location GetDeconstructionReferenceLocation(SyntaxNode node);
     }
 
     [Flags]

--- a/src/Workspaces/CoreTest/FindReferencesTests.cs
+++ b/src/Workspaces/CoreTest/FindReferencesTests.cs
@@ -322,7 +322,11 @@ namespace M
 
         private static void Verify(ReferencedSymbol reference, HashSet<int> expectedMatchedLines)
         {
-            void verifier(Location location) => Assert.True(expectedMatchedLines.Remove(location.GetLineSpan().StartLinePosition.Line));
+            void verifier(Location location)
+            {
+                var line = location.GetLineSpan().StartLinePosition.Line;
+                Assert.True(expectedMatchedLines.Remove(line), $"An unexpected reference was found on line number {line}.");
+            }
 
             foreach (var location in reference.Locations)
             {

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -253,6 +253,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
+        Public Function GetDeconstructionAssignmentMethods(model As SemanticModel, deconstruction As SyntaxNode) As ImmutableArray(Of IMethodSymbol) Implements ISemanticFactsService.GetDeconstructionAssignmentMethods
+            Return ImmutableArray(Of IMethodSymbol).Empty
+        End Function
+
+        Public Function GetDeconstructionForEachMethods(model As SemanticModel, deconstruction As SyntaxNode) As ImmutableArray(Of IMethodSymbol) Implements ISemanticFactsService.GetDeconstructionForEachMethods
+            Return ImmutableArray(Of IMethodSymbol).Empty
+        End Function
+
         Public Function IsAssignableTo(fromSymbol As ITypeSymbol, toSymbol As ITypeSymbol, compilation As Compilation) As Boolean Implements ISemanticFactsService.IsAssignableTo
             Return fromSymbol IsNot Nothing AndAlso toSymbol IsNot Nothing AndAlso DirectCast(compilation, VisualBasicCompilation).ClassifyConversion(fromSymbol, toSymbol).IsWidening
         End Function

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -239,6 +239,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return TypeOf node Is ForEachStatementSyntax
         End Function
 
+        Public Function IsDeconstructionAssignment(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsDeconstructionAssignment
+            Return False
+        End Function
+
+        Public Function IsDeconstructionForEachStatement(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsDeconstructionForEachStatement
+            Return False
+        End Function
+
         Public Function IsLockStatement(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsLockStatement
             Return TypeOf node Is SyncLockStatementSyntax
         End Function
@@ -1689,5 +1697,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             type = cast.Type
             expression = cast.Expression
         End Sub
+
+        Public Function GetDeconstructionReferenceLocation(node As SyntaxNode) As Location Implements ISyntaxFactsService.GetDeconstructionReferenceLocation
+            Throw New NotImplementedException()
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Implements "Find All References" for `Deconstruct` methods. It is similar to how FAR works on methods that participate in `foreach`.

Fixes https://github.com/dotnet/roslyn/issues/18963

From the compiler side, the change is to expose information about deconstructions (assignment/declarations and foreach) via new public APIs. Since deconstructions are not conversions in the language, but they are implemented using nested conversions (like tuple conversions) with a deconstruction method, I'm using a wrapper class around deconstruction conversion objects to abstract from the implementation.
The existing `DeconstructionInfo` class (which is internal) was renamed to `DeconstructMethodInfo`.

From the IDE side, we now keep track of whether a document uses any deconstructions (just like we do for `foreach`) and we can scan through a document to find all the `Deconstruct` method symbols that are references. That's the core of the "Find All References" implementation. (thanks Cyrus for the tips)
