### PR TITLE
Don't crash calculating checksums when reading invalid PE image formats

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -290,22 +290,31 @@ namespace Microsoft.CodeAnalysis.Execution
                 return;
             }
 
-            if (metadata is AssemblyMetadata assemblyMetadata)
+            try
             {
-                writer.WriteInt32((int)assemblyMetadata.Kind);
-
-                var modules = assemblyMetadata.GetModules();
-                writer.WriteInt32(modules.Length);
-
-                foreach (var module in modules)
+                if (metadata is AssemblyMetadata assemblyMetadata)
                 {
-                    WriteMvidTo(module, writer, cancellationToken);
+                    writer.WriteInt32((int)assemblyMetadata.Kind);
+
+                    var modules = assemblyMetadata.GetModules();
+                    writer.WriteInt32(modules.Length);
+
+                    foreach (var module in modules)
+                    {
+                        WriteMvidTo(module, writer, cancellationToken);
+                    }
+
+                    return;
                 }
 
+                WriteMvidTo((ModuleMetadata)metadata, writer, cancellationToken);
+            }
+            catch (Exception e) when (e is BadImageFormatException || e is IOException)
+            {
+                // Handle error cases where we can't read the metadata or a PE image format is 
+                // invalid.
                 return;
             }
-
-            WriteMvidTo((ModuleMetadata)metadata, writer, cancellationToken);
         }
 
         private void WriteMvidTo(ModuleMetadata metadata, ObjectWriter writer, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=234447

Consumers of AssemblyMetadata.GetModules() are expected to handle
BadImageFormatExceptions and IOExceptions, which were both left
unhandled by the mvid writer in the ReferenceSerializationService.

**Customer scenario**

There is a referenced assembly with an invalid public key or public key token, and then calculating the referencing project's checksum crashes VS.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=234447

**Workarounds, if any**

No known workarounds

**Risk**

Low. Other pathways through this code have similar recovery logic, and there's already a similar failure mode in this code when the metadata for the reference can't be read at all. This case is now handled in the same way.

**Performance impact**

None.

**Is this a regression from a previous update?**

TODO: Unknown.

**Root cause analysis:**

TODO: How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Watson (3644 hits)