### PR TITLE
 guard from cancellation that could bring down VS.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -177,10 +177,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var checksums = AddGlobalAssets(cancellationToken);
 
                 // send over global asset
-                await client.RunOnRemoteHostAsync(
-                    WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
-                    nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync),
-                    (object)checksums, cancellationToken).ConfigureAwait(false);
+                await client.IgnoreCancellationAsync(() =>
+                    client.RunOnRemoteHostAsync(
+                        WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
+                        nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync),
+                        (object)checksums, cancellationToken)).ConfigureAwait(false);
 
                 return client;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -122,9 +123,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     var solution = _service.Workspace.CurrentSolution;
                     var checksum = await solution.State.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
 
-                    await remoteHostClient.RunOnRemoteHostAsync(
-                        WellKnownRemoteHostServices.RemoteHostService, solution,
-                        nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync), checksum, cancellationToken).ConfigureAwait(false);
+                    await remoteHostClient.IgnoreCancellationAsync(() =>
+                        remoteHostClient.RunOnRemoteHostAsync(
+                            WellKnownRemoteHostServices.RemoteHostService, solution,
+                            nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync), checksum, cancellationToken)).ConfigureAwait(false);
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -176,5 +176,19 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunOnRemoteHostAsync<T>(client, WellKnownServiceHubServices.CodeAnalysisService, solution, targetName, arguments, cancellationToken);
         }
+
+        public static async Task IgnoreCancellationAsync(
+            this RemoteHostClient client, Func<Task> actionAsync)
+        {
+            try
+            {
+                await actionAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // in error case, we could get operation cancelled exception.
+                // in that case, we already show info bar to users, so don't crash VS
+            }
+        }
     }
 }


### PR DESCRIPTION
this is not generic ignore cancellation, but adding very specific places that we know we already show info bar to ignore cancellation or expect cancellation at specific situation as VS shutdown.

**Customer scenario**

Users is shutting down VS, and see VS get crashed. and restarted.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/476653?src=alerts&src-action=cta
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/479684

**Workarounds, if any**

there is no workaround. it doesn't happen all the time though, it only happen if VS is shutting down at unfortunate time where there is on going active connection with OOP.

**Risk**

this is very safe fix. 

**Performance impact**

N/A

**Is this a regression from a previous update?**

No

**Root cause analysis:**

most of Roslyn is guarded against cancellation, and these are some places related to OOP that is not guarded on cancellation exception.

**How was the bug found?**

customer feedback, dogfooding

