### PR TITLE
Guard from cancellation that could bring down VS.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
@@ -59,9 +59,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
             catch (Exception ex) when (ReportUnlessCanceled(ex, cancellationToken))
             {
-                // StreamJsonRpc will throw RemoteInvocationException for cancellation as its cancellation support.
-                // we asked servicehub team to throw cancellation token we gave in, but now, they don't. so here
-                // we translate RemoteInvocationException of our cancellation to our cancellation exception
+                // StreamJsonRpc throws RemoteInvocationException if the call is cancelled.
+                // Handle this case by throwing a proper cancellation exception instead.
+                // See https://github.com/Microsoft/vs-streamjsonrpc/issues/67
                 cancellationToken.ThrowIfCancellationRequested();
 
                 LogError($"exception: {ex.ToString()}");
@@ -82,9 +82,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
             catch (Exception ex) when (ReportUnlessCanceled(ex, cancellationToken))
             {
-                // StreamJsonRpc will throw RemoteInvocationException for cancellation as its cancellation support.
-                // we asked servicehub team to throw cancellation token we gave in, but now, they don't. so here
-                // we translate RemoteInvocationException of our cancellation to our cancellation exception
+                // StreamJsonRpc throws RemoteInvocationException if the call is cancelled.
+                // Handle this case by throwing a proper cancellation exception instead.
+                // See https://github.com/Microsoft/vs-streamjsonrpc/issues/67
                 cancellationToken.ThrowIfCancellationRequested();
 
                 LogError($"exception: {ex.ToString()}");
@@ -107,9 +107,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
             catch (Exception ex) // no when since Extensions.InvokeAsync already recorded it
             {
-                // StreamJsonRpc will throw RemoteInvocationException for cancellation as its cancellation support.
-                // we asked servicehub team to throw cancellation token we gave in, but now, they don't. so here
-                // we translate RemoteInvocationException of our cancellation to our cancellation exception
+                // StreamJsonRpc throws RemoteInvocationException if the call is cancelled.
+                // Handle this case by throwing a proper cancellation exception instead.
+                // See https://github.com/Microsoft/vs-streamjsonrpc/issues/67
                 cancellationToken.ThrowIfCancellationRequested();
 
                 LogError($"exception: {ex.ToString()}");
@@ -131,9 +131,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
             catch (Exception ex) // no when since Extensions.InvokeAsync already recorded it
             {
-                // StreamJsonRpc will throw RemoteInvocationException for cancellation as its cancellation support.
-                // we asked servicehub team to throw cancellation token we gave in, but now, they don't. so here
-                // we translate RemoteInvocationException of our cancellation to our cancellation exception
+                // StreamJsonRpc throws RemoteInvocationException if the call is cancelled.
+                // Handle this case by throwing a proper cancellation exception instead.
+                // See https://github.com/Microsoft/vs-streamjsonrpc/issues/67
                 cancellationToken.ThrowIfCancellationRequested();
 
                 LogError($"exception: {ex.ToString()}");

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
                         nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync), (object)checksums, cancellationToken).ConfigureAwait(false);
                 }
-                catch(RemoteHostClientExtensions.UnexpectedRemoteHostException)
+                catch(JsonRpcEx.UnexpectedRemoteHostException)
                 {
                     // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
                     // no one outside of engine should ever catch this exception or care about it.

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -196,10 +196,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var checksums = AddGlobalAssets(cancellationToken);
 
                 // send over global asset
-                await client.TryRunRemoteAsync(
-                    WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
-                    nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync),
-                    (object)checksums, cancellationToken).ConfigureAwait(false);
+                await client.IgnoreCancellationAsync(() =>
+                    client.TryRunRemoteAsync(
+                        WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
+                        nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync), (object)checksums, cancellationToken)).ConfigureAwait(false);
 
                 return client;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -206,7 +206,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
                 catch(RemoteHostClientExtensions.UnexpectedRemoteHostException)
                 {
-                    // ignore unexpected remote host failure
+                    // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
+                    // no one outside of engine should ever catch this exception or care about it.
+                    // we catch here so that we don't physically crash VS and give users time to save and exist VS
                 }
 
                 return client;

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -196,10 +196,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var checksums = AddGlobalAssets(cancellationToken);
 
                 // send over global asset
-                await client.IgnoreCancellationAsync(() =>
-                    client.TryRunRemoteAsync(
+                try
+                {
+                    // this only return false if OOP doesn't exist. otherwise, this will throw
+                    // as usual. 
+                    await client.TryRunRemoteAsync(
                         WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
-                        nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync), (object)checksums, cancellationToken)).ConfigureAwait(false);
+                        nameof(IRemoteHostService.SynchronizeGlobalAssetsAsync), (object)checksums, cancellationToken).ConfigureAwait(false);
+                }
+                catch(RemoteHostClientExtensions.UnexpectedRemoteHostException)
+                {
+                    // ignore unexpected remote host failure
+                }
 
                 return client;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
@@ -122,16 +122,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     // we catch here so that we don't physically crash VS and give users time to save and exist VS
                 }
             }
-        }
 
-        private static void CancelAndDispose(CancellationTokenSource cancellationSource)
-        {
-            // cancel running tasks
-            cancellationSource.Cancel();
+            private static void CancelAndDispose(CancellationTokenSource cancellationSource)
+            {
+                // cancel running tasks
+                cancellationSource.Cancel();
 
-            // dispose cancellation token source
-            cancellationSource.Dispose();
+                // dispose cancellation token source
+                cancellationSource.Dispose();
+            }
         }
     }
-}
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -88,7 +88,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
                 catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
                 {
-                    // don't crash on unexpected remote host exception.
+                    // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
+                    // no one outside of engine should ever catch this exception or care about it.
+                    // we catch here so that we don't physically crash VS and give users time to save and exist VS
                 }
             }
 
@@ -106,7 +108,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
                 catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
                 {
-                    // don't crash on unexpected remote host exception.
+                    // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
+                    // no one outside of engine should ever catch this exception or care about it.
+                    // we catch here so that we don't physically crash VS and give users time to save and exist VS
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         nameof(IRemoteHostService.RegisterPrimarySolutionId),
                         new object[] { solutionId, storageLocation }, CancellationToken.None).Wait(CancellationToken.None);
                 }
-                catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
+                catch (JsonRpcEx.UnexpectedRemoteHostException)
                 {
                     // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
                     // no one outside of engine should ever catch this exception or care about it.
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         new object[] { solutionId, synchronousShutdown },
                         CancellationToken.None).Wait(CancellationToken.None);
                 }
-                catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
+                catch (JsonRpcEx.UnexpectedRemoteHostException)
                 {
                     // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
                     // no one outside of engine should ever catch this exception or care about it.

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -80,14 +80,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 try
                 {
+                    // this will only return false if OOP doesn't exist. otherwise,
+                    // it will throw and handled as usual
                     _session.TryInvokeAsync(
                         nameof(IRemoteHostService.RegisterPrimarySolutionId),
                         new object[] { solutionId, storageLocation }, CancellationToken.None).Wait(CancellationToken.None);
                 }
-                catch (OperationCanceledException)
+                catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
                 {
-                    // in error case, we could get operation cancelled exception.
-                    // in that case, we already show info bar to users, so don't crash VS
+                    // don't crash on unexpected remote host exception.
                 }
             }
 
@@ -96,15 +97,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 try
                 {
+                    // this will only return false if OOP doesn't exist. otherwise,
+                    // it will throw and handled as usual
                     _session.TryInvokeAsync(
                         nameof(IRemoteHostService.UnregisterPrimarySolutionId),
                         new object[] { solutionId, synchronousShutdown },
                         CancellationToken.None).Wait(CancellationToken.None);
                 }
-                catch (OperationCanceledException)
+                catch (RemoteHostClientExtensions.UnexpectedRemoteHostException)
                 {
-                    // in error case, we could get operation cancelled exception.
-                    // in that case, we already show info bar to users, so don't crash VS
+                    // don't crash on unexpected remote host exception.
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -230,21 +230,9 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var checksum = await solution.State.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
 
-                try
-                {
-                    // this will return false only if OOP doesn't exist. 
-                    // otherwise, it will throw and handled as usual. here we don't care about return value
-                    // since if OOP doesn't exist, this call is NOOP and don't have any meaning.
-                    await remoteHostClient.TryRunRemoteAsync(
-                        WellKnownRemoteHostServices.RemoteHostService, solution,
-                        nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync), checksum, cancellationToken).ConfigureAwait(false);
-                }
-                catch (UnexpectedRemoteHostException)
-                {
-                    // ignore unexpected remote host exception. it is allowed here since it is part of OOP engine.
-                    // no one outside of engine should ever catch this exception or care about it.
-                    // we catch here so that we don't physically crash VS and give users time to save and exist VS
-                }
+                await remoteHostClient.TryRunRemoteAsync(
+                    WellKnownRemoteHostServices.RemoteHostService, solution,
+                    nameof(IRemoteHostService.SynchronizePrimaryWorkspaceAsync), checksum, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -316,37 +304,6 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
 
                 return await session.InvokeAsync<T>(targetName, arguments, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
-        /// this is a workaround to not crash host when remote call is failed for a reason not
-        /// related to us. example will be extension manager failure, connection creation failure
-        /// and etc. this is a special exception that should be only used in very specific cases.
-        /// 
-        /// no one except code related to OOP engine should care about this exception. 
-        /// if this is fired, then VS is practicially in corrupted/crashed mode. we just didn't
-        /// physically crashed VS due to feedbacks that want to give users time to save their works.
-        /// when this is fired, VS clearly shows users to save works and restart VS since VS is crashed.
-        /// 
-        /// so no one should ever, outside of OOP engine, try to catch this exception and try to recover.
-        /// 
-        /// that facts this inherits cancellation exception is an implementation detail to make VS not physically crash.
-        /// it doesn't mean one should try to recover from it or treat it as cancellation exception.
-        /// 
-        /// we choose cancellation exception since we didn't want this workaround to be too intrusive.
-        /// on our code. we already handle cancellation gracefully and recover properly in most of cases.
-        /// but that doesn't mean we want to let users to keep use VS. like I stated above, once this is
-        /// fired, VS is logically crashed. we just want VS to be stable enough until users save and exist VS.
-        /// 
-        /// this is a workaround since we would like to go back to normal crash behavior
-        /// if enough of the above issues are fixed or we implements official NFW framework in Roslyn
-        /// </summary>
-        public class UnexpectedRemoteHostException : OperationCanceledException
-        {
-            public UnexpectedRemoteHostException() :
-                base("unexpected remote host exception", CancellationToken.None)
-            {
             }
         }
     }


### PR DESCRIPTION
created separate PR since there was some change around how cancellation works between 15.4 and 15.5 (Roslyn moved to new cancellation API supported by StreamJsonRpc)

**Customer scenario**

Users is shutting down VS, and see VS get crashed. and restarted.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/476653?src=alerts&src-action=cta
https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/518997

**Workarounds, if any**

there is no workaround. it doesn't happen all the time though, it only happen if VS is shutting down at unfortunate time where there is on going active connection with OOP.

**Risk**

this is very safe fix. 

**Performance impact**

N/A

**Is this a regression from a previous update?**

No

**Root cause analysis:**

most of Roslyn is guarded against cancellation, and these are some places related to OOP that is not guarded on cancellation exception.

**How was the bug found?**

customer feedback, dogfooding

