### PR TITLE
Warn for uninitialized non-nullable fields

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Compilation.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(symbol);
             }
 
-            return symbol.Kind == SymbolKind.Parameter ? ((ParameterSymbol)symbol).Type : symbol.GetTypeOrReturnType();
+            return symbol.GetTypeOrReturnType();
         }
 
         private bool IsBindingModuleLevelAttribute()

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14705,6 +14705,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Non-nullable {0} &apos;{1}&apos; is uninitialized..
+        /// </summary>
+        internal static string WRN_UninitializedNonNullableField {
+            get {
+                return ResourceManager.GetString("WRN_UninitializedNonNullableField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-nullable field is uninitialized..
+        /// </summary>
+        internal static string WRN_UninitializedNonNullableField_Title {
+            get {
+                return ResourceManager.GetString("WRN_UninitializedNonNullableField_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to XML comment on &apos;{1}&apos; has a paramref tag for &apos;{0}&apos;, but there is no parameter by that name.
         /// </summary>
         internal static string WRN_UnmatchedParamRefTag {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5264,6 +5264,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation_Title" xml:space="preserve">
     <value>Nullability of reference types in type of parameter doesn't match implemented member.</value>
   </data>
+  <data name="WRN_UninitializedNonNullableField" xml:space="preserve">
+    <value>Non-nullable {0} '{1}' is uninitialized.</value>
+  </data>
+  <data name="WRN_UninitializedNonNullableField_Title" xml:space="preserve">
+    <value>Non-nullable field is uninitialized.</value>
+  </data>
   <data name="WRN_NullabilityMismatchInAssignment" xml:space="preserve">
     <value>Nullability of reference types in value of type '{0}' doesn't match target type '{1}'.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3097,7 +3097,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Nullable annotations on definition should be ignored
-            TypeSymbolWithAnnotations definitionType = definition.Kind == SymbolKind.Parameter ? ((ParameterSymbol)definition).Type : definition.GetTypeOrReturnType();
+            TypeSymbolWithAnnotations definitionType = definition.GetTypeOrReturnType();
             TypeSymbolWithAnnotations adjustedDefinitionType = definitionType.SetUnknownNullabilityForReferenceTypes();
 
             if ((object)definition == symbol)
@@ -3108,7 +3108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)definitionType == adjustedDefinitionType)
             {
                 // Adjustment has no effect
-                return symbol.Kind == SymbolKind.Parameter ? ((ParameterSymbol)symbol).Type : symbol.GetTypeOrReturnType();
+                return symbol.GetTypeOrReturnType();
             }
 
             // The original symbol was substituted, need to re-apply substitution to the adjusted type.   

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -943,6 +943,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     body = BindMethodBody(methodSymbol, compilationState, diagsForCurrentMethod, out importChain, out originalBodyNested);
 
+                    if (body != null && methodSymbol.MethodKind == MethodKind.Constructor)
+                    {
+                        UnassignedFieldsWalker.Analyze(_compilation, methodSymbol, body, diagsForCurrentMethod);
+                    }
+
                     // lower initializers just once. the lowered tree will be reused when emitting all constructors 
                     // with field initializers. Once lowered, these initializers will be stashed in processedInitializers.LoweredInitializers
                     // (see later in this method). Don't bother lowering _now_ if this particular ctor won't have the initializers 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -945,6 +945,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (body != null && methodSymbol.MethodKind == MethodKind.Constructor)
                     {
+                        // PROTOTYPE(NullableReferenceTypes): Consider moving analysis down to
+                        // FlowAnalysisPass below, so the initializers are included in the body.
                         UnassignedFieldsWalker.Analyze(_compilation, methodSymbol, body, diagsForCurrentMethod);
                     }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1509,7 +1509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_NullabilityMismatchInTypeOnExplicitImplementation = 8615,
         WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation = 8616,
         WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation = 8617,
-        // unused 8618
+        WRN_UninitializedNonNullableField = 8618,
         WRN_NullabilityMismatchInAssignment = 8619,
         WRN_NullabilityMismatchInArgument = 8620,
         WRN_NullabilityMismatchInReturnTypeOfTargetDelegate = 8621,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -333,6 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
+                case ErrorCode.WRN_UninitializedNonNullableField:
                 case ErrorCode.WRN_NullabilityMismatchInAssignment:
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Symbol member,
             BoundNode node,
             bool trackUnassignments = false,
-            bool trackClasses = false)
-            : base(compilation, member, node, trackClasses: trackClasses)
+            bool trackClassFields = false)
+            : base(compilation, member, node, trackClassFields: trackClassFields)
         {
             this.trackUnassignments = trackUnassignments;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -23,8 +23,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             CSharpCompilation compilation,
             Symbol member,
             BoundNode node,
-            bool trackUnassignments = false)
-            : base(compilation, member, node)
+            bool trackUnassignments = false,
+            bool trackClasses = false)
+            : base(compilation, member, node, trackClasses: trackClasses)
         {
             this.trackUnassignments = trackUnassignments;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -76,9 +76,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected readonly bool _trackExceptions;
 
         /// <summary>
-        /// Track classes in addition to structs.
+        /// Track fields of classes in addition to structs.
         /// </summary>
-        protected readonly bool _trackClasses;
+        protected readonly bool _trackClassFields;
 
         /// <summary>
         /// Pending escapes generated in the current scope (or more deeply nested scopes). When jump
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode lastInRegion = null,
             bool trackRegions = false,
             bool trackExceptions = false,
-            bool trackClasses = false)
+            bool trackClassFields = false)
         {
             Debug.Assert(node != null);
 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _loopHeadState = new Dictionary<BoundLoopStatement, LocalState>(ReferenceEqualityComparer.Instance);
             _trackRegions = trackRegions;
             _trackExceptions = trackExceptions;
-            _trackClasses = trackClasses;
+            _trackClassFields = trackClassFields;
         }
 
         protected abstract string Dump(LocalState state);
@@ -1914,7 +1914,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected bool MayRequireTrackingReceiverType(TypeSymbol type)
         {
             return (object)type != null &&
-                (_trackClasses || type.TypeKind == TypeKind.Struct);
+                (_trackClassFields || type.TypeKind == TypeKind.Struct);
         }
 
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -76,6 +76,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected readonly bool _trackExceptions;
 
         /// <summary>
+        /// Track classes in addition to structs.
+        /// </summary>
+        protected readonly bool _trackClasses;
+
+        /// <summary>
         /// Pending escapes generated in the current scope (or more deeply nested scopes). When jump
         /// statements (goto, break, continue, return) are processed, they are placed in the
         /// pendingBranches buffer to be processed later by the code handling the destination
@@ -159,7 +164,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode firstInRegion = null,
             BoundNode lastInRegion = null,
             bool trackRegions = false,
-            bool trackExceptions = false)
+            bool trackExceptions = false,
+            bool trackClasses = false)
         {
             Debug.Assert(node != null);
 
@@ -191,6 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _loopHeadState = new Dictionary<BoundLoopStatement, LocalState>(ReferenceEqualityComparer.Instance);
             _trackRegions = trackRegions;
             _trackExceptions = trackExceptions;
+            _trackClasses = trackClasses;
         }
 
         protected abstract string Dump(LocalState state);
@@ -1892,7 +1899,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        protected static bool MayRequireTracking(BoundExpression receiverOpt, FieldSymbol fieldSymbol)
+        protected bool MayRequireTracking(BoundExpression receiverOpt, FieldSymbol fieldSymbol)
         {
             return
                 (object)fieldSymbol != null && //simplifies calling pattern for events
@@ -1900,9 +1907,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 !fieldSymbol.IsStatic &&
                 !fieldSymbol.IsFixed &&
                 receiverOpt.Kind != BoundKind.TypeExpression &&
-                receiverOpt.Type != null &&
-                receiverOpt.Type.IsStructType() &&
+                MayRequireTrackingReceiverType(receiverOpt.Type) &&
                 !receiverOpt.Type.IsPrimitiveRecursiveStruct();
+        }
+
+        protected bool MayRequireTrackingReceiverType(TypeSymbol type)
+        {
+            return (object)type != null &&
+                (_trackClasses || type.TypeKind == TypeKind.Struct);
         }
 
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -7,12 +7,15 @@ using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    // PROTOTYPE(NullableReferenceTypes): Should UnassignedFieldsWalker
+    // inherit from DataFlowPassBase<LocalState> directly since it has simpler
+    // requirements than DataFlowPass?
     internal sealed class UnassignedFieldsWalker : DataFlowPass
     {
         private readonly DiagnosticBag _diagnostics;
 
         private UnassignedFieldsWalker(CSharpCompilation compilation, MethodSymbol method, BoundNode node, DiagnosticBag diagnostics)
-            : base(compilation, method, node, trackClasses: true)
+            : base(compilation, method, node, trackClassFields: true)
         {
             _diagnostics = diagnostics;
         }
@@ -64,9 +67,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (member.Kind != SymbolKind.Field)
                 {
+                    // PROTOTYPE(NullableReferenceTypes): Handle events.
                     continue;
                 }
                 var field = (FieldSymbol)member;
+                // PROTOTYPE(NullableReferenceTypes): Can the HasInitializer
+                // call be removed, if the body already contains the initializers?
                 if (field.IsStatic || HasInitializer(field))
                 {
                     continue;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed class UnassignedFieldsWalker : DataFlowPass
+    {
+        private readonly DiagnosticBag _diagnostics;
+
+        private UnassignedFieldsWalker(CSharpCompilation compilation, MethodSymbol method, BoundNode node, DiagnosticBag diagnostics)
+            : base(compilation, method, node, trackClasses: true)
+        {
+            _diagnostics = diagnostics;
+        }
+
+        internal static void Analyze(CSharpCompilation compilation, MethodSymbol method, BoundNode node, DiagnosticBag diagnostics)
+        {
+            Debug.Assert(method.MethodKind == MethodKind.Constructor);
+
+            var flags = ((CSharpParseOptions)node.SyntaxTree.Options).GetNullableReferenceFlags();
+            if ((flags & NullableReferenceFlags.Enabled) == 0)
+            {
+                return;
+            }
+
+            var walker = new UnassignedFieldsWalker(compilation, method, node, diagnostics);
+            try
+            {
+                bool badRegion = false;
+                walker.Analyze(ref badRegion, null);
+            }
+            finally
+            {
+                walker.Free();
+            }
+        }
+
+        protected override ImmutableArray<PendingBranch> Scan(ref bool badRegion)
+        {
+            var result = base.Scan(ref badRegion);
+            ReportUninitializedNonNullableReferenceTypeFields();
+            return result;
+        }
+
+        private void ReportUninitializedNonNullableReferenceTypeFields()
+        {
+            var thisParameter = MethodThisParameter;
+            var location = thisParameter.ContainingSymbol.Locations.FirstOrDefault() ?? Location.None;
+
+            int thisSlot = VariableSlot(thisParameter);
+            if (thisSlot == -1)
+            {
+                return;
+            }
+
+            var thisType = thisParameter.Type.TypeSymbol;
+            Debug.Assert(thisType.IsDefinition);
+
+            foreach (var member in thisType.GetMembersUnordered())
+            {
+                if (member.Kind != SymbolKind.Field)
+                {
+                    continue;
+                }
+                var field = (FieldSymbol)member;
+                if (field.IsStatic || HasInitializer(field))
+                {
+                    continue;
+                }
+                var fieldType = field.Type;
+                if (!fieldType.IsReferenceType || fieldType.IsNullable != false)
+                {
+                    continue;
+                }
+                int fieldSlot = VariableSlot(field, thisSlot);
+                if (fieldSlot == -1 || !this.State.IsAssigned(fieldSlot))
+                {
+                    var symbol = (Symbol)(field.AssociatedSymbol as PropertySymbol) ?? field;
+                    _diagnostics.Add(ErrorCode.WRN_UninitializedNonNullableField, location, symbol.Kind.Localize(), symbol.Name);
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 bool badRegion = false;
-                walker.Analyze(ref badRegion, null);
+                walker.Analyze(ref badRegion, diagnostics: null);
             }
             finally
             {

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -190,6 +190,7 @@
                 case ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                 case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
+                case ErrorCode.WRN_UninitializedNonNullableField:
                 case ErrorCode.WRN_NullabilityMismatchInAssignment:
                 case ErrorCode.WRN_NullabilityMismatchInArgument:
                 case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -408,6 +408,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     returnType = local.Type;
                     refCustomModifiers = ImmutableArray<CustomModifier>.Empty;
                     break;
+                case SymbolKind.Parameter:
+                    ParameterSymbol parameter = (ParameterSymbol)symbol;
+                    refKind = parameter.RefKind;
+                    returnType = parameter.Type;
+                    refCustomModifiers = parameter.RefCustomModifiers;
+                    break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -1588,7 +1588,8 @@ class B2 : IB
         [Fact]
         public void Overriding_17()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 class C
 {
     public static void Main()
@@ -1683,7 +1684,8 @@ class B2 : A2
         [Fact]
         public void Overriding_22()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 class C
 {
     public static void Main()
@@ -1730,7 +1732,8 @@ class B1 : A1
         [Fact]
         public void Implementing_03()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 class C
 {
     public static void Main()
@@ -1820,7 +1823,8 @@ class B : IA, IA2
         [Fact]
         public void Implementing_04()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 class C
 {
     public static void Main()
@@ -2922,7 +2926,8 @@ class A
         [Fact()]
         public void Test1()
         {
-            CSharpCompilation c = CreateStandardCompilation(@"
+            CSharpCompilation c = CreateStandardCompilation(
+@"#pragma warning disable 8618
 class C
 {
     static void Main()
@@ -6291,7 +6296,8 @@ class CL0<T>
         [Fact]
         public void ObjectInitializer_01()
         {
-            CSharpCompilation c = CreateStandardCompilation(@"
+            CSharpCompilation c = CreateStandardCompilation(
+@"#pragma warning disable 8618
 class C
 {
     static void Main()
@@ -10395,7 +10401,8 @@ class CL1
         [Fact]
         public void IncrementOperator_02()
         {
-            CSharpCompilation c = CreateStandardCompilation(@"
+            CSharpCompilation c = CreateStandardCompilation(
+@"#pragma warning disable 8618
 class C
 {
     static void Main()
@@ -11111,7 +11118,8 @@ class Test
         [Fact]
         public void CompoundAssignment_06()
         {
-            CSharpCompilation c = CreateStandardCompilation(@"
+            CSharpCompilation c = CreateStandardCompilation(
+@"#pragma warning disable 8618
 class Test
 {
     static void Main()
@@ -11759,7 +11767,8 @@ class F : C<F?>, I1<C<B?>>, I2<C<B>?>
         [Fact]
         public void NullableAttribute_01()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 public abstract class B
 {
     public string? F1; 
@@ -11922,7 +11931,8 @@ class C
         [Fact]
         public void NullableAttribute_04()
         {
-            var source = @"
+            var source =
+@"#pragma warning disable 8618
 using System.Runtime.CompilerServices;
 
 public abstract class B
@@ -12238,7 +12248,8 @@ partial class C
 [module:System.Runtime.CompilerServices.NullableOptOut(true)]
 ";
 
-            string lib = @"
+            string lib =
+@"#pragma warning disable 8618
 using System;
 
 [System.Runtime.CompilerServices.NullableOptOut(true)]
@@ -12267,7 +12278,8 @@ public class CL0
 }
 ";
 
-            string source1 = @"
+            string source1 =
+@"#pragma warning disable 8618
 using System;
 
 
@@ -12302,7 +12314,8 @@ partial class C
 }
 ";
 
-            string source2 = @"
+            string source2 =
+@"#pragma warning disable 8618
 using System;
 
 [System.Runtime.CompilerServices.NullableOptOut(true)]
@@ -15046,7 +15059,8 @@ class C
         public void EmptyStructField()
         {
             var source =
-@"class A { }
+@"#pragma warning disable 8618
+class A { }
 struct B { }
 struct S
 {
@@ -15065,9 +15079,9 @@ struct S
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,26): warning CS8600: Cannot convert null to non-nullable reference.
+                // (8,26): warning CS8600: Cannot convert null to non-nullable reference.
                 //     public S(B b) : this(null, b)
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(7, 26));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(8, 26));
         }
 
         // PROTOTYPE(NullableReferenceTypes): Update other tests with WithNullCheckingFeature(NullableReferenceFlags.None) to verify expected changes.
@@ -15076,7 +15090,8 @@ struct S
         public void WarningOnConversion_Assignment()
         {
             var source =
-@"class Person
+@"#pragma warning disable 8618
+class Person
 {
     internal string FirstName { get; set; }
     internal string LastName { get; set; }
@@ -15102,57 +15117,58 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8.WithNullCheckingFeature(NullableReferenceFlags.AllowNullAsNonNull));
             comp.VerifyDiagnostics(
-                // (14,22): warning CS8601: Possible null reference assignment.
-                //         p.LastName = null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(14, 22),
                 // (15,22): warning CS8601: Possible null reference assignment.
+                //         p.LastName = null as string;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(15, 22),
+                // (16,22): warning CS8601: Possible null reference assignment.
                 //         p.LastName = null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(15, 22),
-                // (18,23): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(16, 22),
+                // (19,23): warning CS8601: Possible null reference assignment.
                 //         p.FirstName = p.MiddleName;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(18, 23),
-                // (19,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(19, 23),
+                // (20,22): warning CS8601: Possible null reference assignment.
                 //         p.LastName = p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(19, 22));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(20, 22));
 
             comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,22): warning CS8600: Cannot convert null to non-nullable reference.
-                //         p.LastName = null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 22),
                 // (12,22): warning CS8600: Cannot convert null to non-nullable reference.
-                //         p.LastName = (string)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(12, 22),
+                //         p.LastName = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 22),
                 // (13,22): warning CS8600: Cannot convert null to non-nullable reference.
+                //         p.LastName = (string)null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(13, 22),
+                // (14,22): warning CS8600: Cannot convert null to non-nullable reference.
                 //         p.LastName = (string?)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(13, 22),
-                // (14,22): warning CS8601: Possible null reference assignment.
-                //         p.LastName = null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(14, 22),
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(14, 22),
                 // (15,22): warning CS8601: Possible null reference assignment.
+                //         p.LastName = null as string;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string").WithLocation(15, 22),
+                // (16,22): warning CS8601: Possible null reference assignment.
                 //         p.LastName = null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(15, 22),
-                // (16,22): warning CS8600: Cannot convert null to non-nullable reference.
-                //         p.LastName = default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(16, 22),
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(16, 22),
                 // (17,22): warning CS8600: Cannot convert null to non-nullable reference.
+                //         p.LastName = default(string);
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 22),
+                // (18,22): warning CS8600: Cannot convert null to non-nullable reference.
                 //         p.LastName = default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(17, 22),
-                // (18,23): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 22),
+                // (19,23): warning CS8601: Possible null reference assignment.
                 //         p.FirstName = p.MiddleName;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(18, 23),
-                // (19,22): warning CS8601: Possible null reference assignment.
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName").WithLocation(19, 23),
+                // (20,22): warning CS8601: Possible null reference assignment.
                 //         p.LastName = p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(19, 22));
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "p.MiddleName ?? null").WithLocation(20, 22));
         }
 
         [Fact]
         public void WarningOnConversion_Receiver()
         {
             var source =
-@"class Person
+@"#pragma warning disable 8618
+class Person
 {
     internal string FirstName { get; set; }
     internal string LastName { get; set; }
@@ -15182,57 +15198,58 @@ static class Extensions
                 source,
                 parseOptions: TestOptions.Regular8.WithNullCheckingFeature(NullableReferenceFlags.AllowNullAsNonNull));
             comp.VerifyDiagnostics(
-                // (13,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
-                //         (null as string).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("s", "void Extensions.F(string s)").WithLocation(13, 10),
                 // (14,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
+                //         (null as string).F();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("s", "void Extensions.F(string s)").WithLocation(14, 10),
+                // (15,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (null as string?).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(14, 10),
-                // (16,11): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(15, 10),
+                // (17,11): hidden CS8605: Result of the comparison is possibly always true.
                 //         ((p != null) ? p.MiddleName : null).F();
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(16, 11),
-                // (16,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
-                //         ((p != null) ? p.MiddleName : null).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(16, 10),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 11),
                 // (17,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
+                //         ((p != null) ? p.MiddleName : null).F();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10),
+                // (18,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (p.MiddleName ?? null).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("s", "void Extensions.F(string s)").WithLocation(18, 10));
 
             comp = CreateCompilationWithMscorlib45(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,10): warning CS8600: Cannot convert null to non-nullable reference.
-                //         ((string)null).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(11, 10),
                 // (12,10): warning CS8600: Cannot convert null to non-nullable reference.
+                //         ((string)null).F();
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(12, 10),
+                // (13,10): warning CS8600: Cannot convert null to non-nullable reference.
                 //         ((string?)null).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(12, 10),
-                // (13,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
-                //         (null as string).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("s", "void Extensions.F(string s)").WithLocation(13, 10),
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(13, 10),
                 // (14,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
+                //         (null as string).F();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("s", "void Extensions.F(string s)").WithLocation(14, 10),
+                // (15,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (null as string?).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(14, 10),
-                // (15,9): warning CS8600: Cannot convert null to non-nullable reference.
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(15, 10),
+                // (16,9): warning CS8600: Cannot convert null to non-nullable reference.
                 //         default(string).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(15, 9),
-                // (16,11): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(16, 9),
+                // (17,11): hidden CS8605: Result of the comparison is possibly always true.
                 //         ((p != null) ? p.MiddleName : null).F();
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(16, 11),
-                // (16,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
-                //         ((p != null) ? p.MiddleName : null).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(16, 10),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 11),
                 // (17,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
+                //         ((p != null) ? p.MiddleName : null).F();
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10),
+                // (18,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (p.MiddleName ?? null).F();
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("s", "void Extensions.F(string s)").WithLocation(17, 10));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("s", "void Extensions.F(string s)").WithLocation(18, 10));
         }
 
         [Fact]
         public void WarningOnConversion_Argument()
         {
             var source =
-@"class Person
+@"#pragma warning disable 8618
+class Person
 {
     internal string FirstName { get; set; }
     internal string LastName { get; set; }
@@ -15261,63 +15278,64 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8.WithNullCheckingFeature(NullableReferenceFlags.AllowNullAsNonNull));
             comp.VerifyDiagnostics(
-                // (14,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
-                //         G(null as string);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("name", "void Program.G(string name)").WithLocation(14, 11),
                 // (15,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
+                //         G(null as string);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("name", "void Program.G(string name)").WithLocation(15, 11),
+                // (16,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(null as string?);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(15, 11),
-                // (18,12): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(16, 11),
+                // (19,12): hidden CS8605: Result of the comparison is possibly always true.
                 //         G((p != null) ? p.MiddleName : null);
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(18, 12),
-                // (18,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
-                //         G((p != null) ? p.MiddleName : null);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(18, 11),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(19, 12),
                 // (19,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
+                //         G((p != null) ? p.MiddleName : null);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11),
+                // (20,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(p.MiddleName ?? null);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("name", "void Program.G(string name)").WithLocation(20, 11));
 
             comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (11,11): warning CS8600: Cannot convert null to non-nullable reference.
-                //         G(null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(11, 11),
                 // (12,11): warning CS8600: Cannot convert null to non-nullable reference.
-                //         G((string)null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(12, 11),
+                //         G(null);
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(12, 11),
                 // (13,11): warning CS8600: Cannot convert null to non-nullable reference.
+                //         G((string)null);
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(13, 11),
+                // (14,11): warning CS8600: Cannot convert null to non-nullable reference.
                 //         G((string?)null);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(13, 11),
-                // (14,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
-                //         G(null as string);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("name", "void Program.G(string name)").WithLocation(14, 11),
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(14, 11),
                 // (15,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
+                //         G(null as string);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string").WithArguments("name", "void Program.G(string name)").WithLocation(15, 11),
+                // (16,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(null as string?);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(15, 11),
-                // (16,11): warning CS8600: Cannot convert null to non-nullable reference.
-                //         G(default(string));
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(16, 11),
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(16, 11),
                 // (17,11): warning CS8600: Cannot convert null to non-nullable reference.
+                //         G(default(string));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 11),
+                // (18,11): warning CS8600: Cannot convert null to non-nullable reference.
                 //         G(default);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(17, 11),
-                // (18,12): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 11),
+                // (19,12): hidden CS8605: Result of the comparison is possibly always true.
                 //         G((p != null) ? p.MiddleName : null);
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(18, 12),
-                // (18,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
-                //         G((p != null) ? p.MiddleName : null);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(18, 11),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(19, 12),
                 // (19,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
+                //         G((p != null) ? p.MiddleName : null);
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "(p != null) ? p.MiddleName : null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11),
+                // (20,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(p.MiddleName ?? null);
-                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("name", "void Program.G(string name)").WithLocation(19, 11));
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "p.MiddleName ?? null").WithArguments("name", "void Program.G(string name)").WithLocation(20, 11));
         }
 
         [Fact]
         public void WarningOnConversion_Return()
         {
             var source =
-@"class Person
+@"#pragma warning disable 8618
+class Person
 {
     internal string FirstName { get; set; }
     internal string LastName { get; set; }
@@ -15340,56 +15358,56 @@ class Program
                 source,
                 parseOptions: TestOptions.Regular8.WithNullCheckingFeature(NullableReferenceFlags.AllowNullAsNonNull));
             comp.VerifyDiagnostics(
-                // (12,27): warning CS8603: Possible null reference return.
-                //     static string F4() => null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(12, 27),
                 // (13,27): warning CS8603: Possible null reference return.
+                //     static string F4() => null as string;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(13, 27),
+                // (14,27): warning CS8603: Possible null reference return.
                 //     static string F5() => null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(13, 27),
-                // (16,36): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(14, 27),
+                // (17,36): hidden CS8605: Result of the comparison is possibly always true.
                 //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(16, 36),
-                // (16,35): warning CS8603: Possible null reference return.
-                //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(p != null) ? p.MiddleName : null").WithLocation(16, 35),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 36),
                 // (17,35): warning CS8603: Possible null reference return.
+                //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(p != null) ? p.MiddleName : null").WithLocation(17, 35),
+                // (18,35): warning CS8603: Possible null reference return.
                 //     static string F9(Person p) => p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "p.MiddleName ?? null").WithLocation(17, 35));
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "p.MiddleName ?? null").WithLocation(18, 35));
 
             comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,27): warning CS8600: Cannot convert null to non-nullable reference.
-                //     static string F1() => null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(9, 27),
                 // (10,27): warning CS8600: Cannot convert null to non-nullable reference.
-                //     static string F2() => (string)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(10, 27),
+                //     static string F1() => null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(10, 27),
                 // (11,27): warning CS8600: Cannot convert null to non-nullable reference.
+                //     static string F2() => (string)null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string)null").WithLocation(11, 27),
+                // (12,27): warning CS8600: Cannot convert null to non-nullable reference.
                 //     static string F3() => (string?)null;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(11, 27),
-                // (12,27): warning CS8603: Possible null reference return.
-                //     static string F4() => null as string;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(12, 27),
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "(string?)null").WithLocation(12, 27),
                 // (13,27): warning CS8603: Possible null reference return.
+                //     static string F4() => null as string;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string").WithLocation(13, 27),
+                // (14,27): warning CS8603: Possible null reference return.
                 //     static string F5() => null as string?;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(13, 27),
-                // (14,27): warning CS8600: Cannot convert null to non-nullable reference.
-                //     static string F6() => default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(14, 27),
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(14, 27),
                 // (15,27): warning CS8600: Cannot convert null to non-nullable reference.
+                //     static string F6() => default(string);
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(15, 27),
+                // (16,27): warning CS8600: Cannot convert null to non-nullable reference.
                 //     static string F7() => default;
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(15, 27),
-                // (16,36): hidden CS8605: Result of the comparison is possibly always true.
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(16, 27),
+                // (17,36): hidden CS8605: Result of the comparison is possibly always true.
                 //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
-                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(16, 36),
-                // (16,35): warning CS8603: Possible null reference return.
-                //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(p != null) ? p.MiddleName : null").WithLocation(16, 35),
+                Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 36),
                 // (17,35): warning CS8603: Possible null reference return.
+                //     static string F8(Person p) => (p != null) ? p.MiddleName : null;
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "(p != null) ? p.MiddleName : null").WithLocation(17, 35),
+                // (18,35): warning CS8603: Possible null reference return.
                 //     static string F9(Person p) => p.MiddleName ?? null;
-                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "p.MiddleName ?? null").WithLocation(17, 35));
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "p.MiddleName ?? null").WithLocation(18, 35));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
-    public partial class StaticNullChecking : CSharpTestBase
+    public class StaticNullChecking_Fields : CSharpTestBase
     {
         [Fact]
         public void NoNonNullWarnings_CSharp7()
@@ -602,7 +602,26 @@ class C
         [Fact]
         public void LocalFunction()
         {
-            // PROTOTYPE(NullableReferenceTypes):
+            var source =
+@"#pragma warning disable 0169
+class C
+{
+    private object F;
+    private object G;
+    C()
+    {
+        void L(object o)
+        {
+            F = o;
+        }
+        L(new object());
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,5): warning CS8618: Non-nullable field 'G' is uninitialized.
+                //     C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "G").WithLocation(6, 5));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
@@ -404,7 +404,7 @@ class C
         [Fact]
         public void Events_ExplicitConstructors()
         {
-            // PROTOTYPE(NullableReferenceTypes):
+            // PROTOTYPE(NullableReferenceTypes): Handle events.
         }
 
         [Fact]
@@ -459,6 +459,25 @@ class C
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void Tuple()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0649
+    internal readonly (object A, object B) F1;
+    internal readonly (object? A, object) F2;
+    internal readonly (object, object? B) F3;
+    internal readonly (object?, object?) F4;
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_Fields.cs
@@ -1,0 +1,608 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public partial class StaticNullChecking : CSharpTestBase
+    {
+        [Fact]
+        public void NoNonNullWarnings_CSharp7()
+        {
+            var source =
+@"class C
+{
+    internal object F;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7);
+            comp.VerifyDiagnostics(
+                // (3,21): warning CS0649: Field 'C.F' is never assigned to, and will always have its default value null
+                //     internal object F;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F").WithArguments("C.F", "null").WithLocation(3, 21));
+        }
+
+        [Fact]
+        public void ReadWriteFields_DefaultConstructor()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0169
+#pragma warning disable 0649
+    private object F1;
+    internal object? F2;
+    internal object?[] F3;
+    private object[]? F4;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                // class C
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(1, 7),
+                // (1,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                // class C
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(1, 7));
+        }
+
+        [Fact]
+        public void ReadWriteFields_ExplicitConstructors()
+        {
+            var source =
+@"class C
+{
+    internal object F1;
+    private object? F2;
+    private object?[] F3;
+    internal object[]? F4;
+    internal C()
+    {
+    }
+    internal C(object o)
+    {
+        F1 = o;
+        F3 = new[] { o, null };
+    }
+    internal C(object x, object y)
+    {
+        F2 = x;
+        F4 = new[] { x, y };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(7, 14),
+                // (7,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(7, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(15, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(15, 14));
+        }
+
+        [Fact]
+        public void ReadOnlyFields_DefaultConstructor()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0169
+#pragma warning disable 0649
+    private readonly object F1;
+    internal readonly object? F2;
+    internal readonly object?[] F3;
+    private readonly object[]? F4;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                // class C
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(1, 7),
+                // (1,7): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                // class C
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(1, 7));
+        }
+
+        [Fact]
+        public void ReadOnlyFields_ExplicitConstructors()
+        {
+            var source =
+@"class C
+{
+    internal readonly object F1;
+    private readonly object? F2;
+    private readonly object?[] F3;
+    internal readonly object[]? F4;
+    internal C()
+    {
+    }
+    internal C(object o)
+    {
+        F1 = o;
+        F3 = new[] { o, null };
+    }
+    internal C(object x, object y)
+    {
+        F2 = x;
+        F4 = new[] { x, y };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(7, 14),
+                // (7,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(7, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(15, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(15, 14));
+        }
+
+        [Fact]
+        public void FieldInitializers_DefaultConstructor()
+        {
+            var source =
+@"class C
+{
+    private object F1 = new object();
+    internal object? F2 = new object();
+    internal object?[] F3 = new [] { new object(), null };
+    private object[]? F4 = new [] { new object() };
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        // PROTOTYPE(NullableReferenceTypes): Report warnings for static fields.
+        [Fact(Skip = "Static fields")]
+        public void StaticFields_DefaultConstructor()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0169
+    private static object F1;
+    private static object F2 = new object();
+    private readonly static object F3;
+    private readonly static object F4 = new object();
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,12): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     static C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(8, 12),
+                // (8,12): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     static C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(8, 12));
+        }
+
+        // PROTOTYPE(NullableReferenceTypes): Report warnings for static fields.
+        [Fact(Skip = "Static fields")]
+        public void StaticFields_ExplicitConstructor()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0169
+    private static object F1;
+    private static object F2;
+    private readonly static object F3;
+    private readonly static object F4;
+    static C()
+    {
+        F2 = new object();
+        F4 = new object();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,12): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     static C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(8, 12),
+                // (8,12): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     static C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(8, 12));
+        }
+
+        // Each constructor is handled in isolation.
+        [Fact]
+        public void ChainedConstructors()
+        {
+            var source =
+@"class C
+{
+    private object F1;
+    private object F2;
+    private readonly object F3;
+    private object F4 = new object();
+    private C()
+    {
+        F1 = new object();
+    }
+    internal C(object x) : this()
+    {
+        F2 = x;
+    }
+    internal C(object x, object y) : this(x)
+    {
+        F3 = y;
+    }
+    internal C(object x, object y, object z) : this()
+    {
+        F3 = z;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,13): warning CS8618: Non-nullable field 'F2' is uninitialized.
+                //     private C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F2").WithLocation(7, 13),
+                // (7,13): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     private C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(7, 13),
+                // (11,14): warning CS8618: Non-nullable field 'F3' is uninitialized.
+                //     internal C(object x) : this()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F3").WithLocation(11, 14),
+                // (11,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C(object x) : this()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(11, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F2' is uninitialized.
+                //     internal C(object x, object y) : this(x)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F2").WithLocation(15, 14),
+                // (15,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C(object x, object y) : this(x)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(15, 14),
+                // (19,14): warning CS8618: Non-nullable field 'F2' is uninitialized.
+                //     internal C(object x, object y, object z) : this()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F2").WithLocation(19, 14),
+                // (19,14): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     internal C(object x, object y, object z) : this()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(19, 14));
+        }
+
+        [Fact]
+        public void ReadWriteAutoProperties_ExplicitConstructors()
+        {
+            var source =
+@"class C
+{
+    private object P1 { get; set; }
+    internal object? P2 { get; set; }
+    internal object?[] P3 { get; set; }
+    private object[]? P4 { get; set; }
+    internal C()
+    {
+    }
+    internal C(object o)
+    {
+        P1 = o;
+        P3 = new[] { o,  null };
+    }
+    internal C(object x, object y)
+    {
+        P2 = x;
+        P4 = new[] { x, y };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P3").WithLocation(7, 14),
+                // (7,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P1").WithLocation(7, 14),
+                // (15,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P3").WithLocation(15, 14),
+                // (15,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P1").WithLocation(15, 14));
+        }
+
+        [Fact]
+        public void ReadOnlyAutoProperties_ExplicitConstructors()
+        {
+            var source =
+@"class C
+{
+    private object P1 { get; }
+    internal object? P2 { get; }
+    internal object?[] P3 { get; }
+    private object[]? P4 { get; }
+    internal C()
+    {
+    }
+    internal C(object o)
+    {
+        P1 = o;
+        P3 = new[] { o,  null };
+    }
+    internal C(object x, object y)
+    {
+        P2 = x;
+        P4 = new[] { x, y };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P3").WithLocation(7, 14),
+                // (7,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
+                //     internal C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P1").WithLocation(7, 14),
+                // (15,14): warning CS8618: Non-nullable property 'P3' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P3").WithLocation(15, 14),
+                // (15,14): warning CS8618: Non-nullable property 'P1' is uninitialized.
+                //     internal C(object x, object y)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P1").WithLocation(15, 14));
+        }
+
+        [Fact]
+        public void AutoPropertyInitializers_DefaultConstructor()
+        {
+            var source =
+@"class C
+{
+    private object P1 { get; } = new object();
+    internal object P2 { get; set; } = new object();
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AutoPropertyInitializers_ExplicitConstructors()
+        {
+            var source =
+@"class C
+{
+    private object P1 { get; } = new object();
+    internal object?[] P2 { get; } = new object?[0];
+    internal object P3 { get; set; } = new object();
+    private object?[] P4 { get; set; } = new object?[0];
+    internal C(object o)
+    {
+        P1 = o;
+        P2 = new object?[] { o };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void Properties_ExplicitImplementations()
+        {
+            var source =
+@"using System;
+class C
+{
+    private object P1 { get { throw new NotImplementedException(); } }
+    private object P3 { set { } }
+    private object[] P2 { get { throw new NotImplementedException(); } set { } }
+    internal C()
+    {
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void Events_ExplicitConstructors()
+        {
+            // PROTOTYPE(NullableReferenceTypes):
+        }
+
+        [Fact]
+        public void GenericType()
+        {
+            var source =
+@"class C<T>
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private readonly T F2;
+    private C(T t)
+    {
+        F1 = t;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void GenericType_ClassConstraint()
+        {
+            var source =
+@"class C<T> where T : class
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private readonly T? F2;
+    private C()
+    {
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,13): warning CS8618: Non-nullable field 'F1' is uninitialized.
+                //     private C()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F1").WithLocation(6, 13));
+        }
+
+        [Fact]
+        public void GenericType_StructConstraint()
+        {
+            var source =
+@"class C<T> where T : struct
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private readonly T? F2;
+    private C()
+    {
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NotInitializedInAllPaths_Class()
+        {
+            var source =
+@"class C
+{
+#pragma warning disable 0169
+    private readonly string F;
+    private string[] P { get; }
+    internal C(string s)
+    {
+        if (s.Length > 0)
+            F = s;
+        else
+            P = new [] { s };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,14): warning CS8618: Non-nullable property 'P' is uninitialized.
+                //     internal C(string s)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("property", "P").WithLocation(6, 14),
+                // (6,14): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal C(string s)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "C").WithArguments("field", "F").WithLocation(6, 14));
+        }
+
+        [Fact]
+        public void NotInitializedInAllPaths_Struct()
+        {
+            var source =
+@"struct S
+{
+#pragma warning disable 0169
+    private readonly string F;
+    private string[] P { get; set; }
+    internal S(string s)
+    {
+        if (s.Length > 0)
+            F = s;
+        else
+            P = new [] { s };
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,14): error CS0843: Auto-implemented property 'S.P' must be fully assigned before control is returned to the caller.
+                //     internal S(string s)
+                Diagnostic(ErrorCode.ERR_UnassignedThisAutoProperty, "S").WithArguments("S.P").WithLocation(6, 14),
+                // (6,14): error CS0171: Field 'S.F' must be fully assigned before control is returned to the caller
+                //     internal S(string s)
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S").WithArguments("S.F").WithLocation(6, 14),
+                // (6,14): warning CS8618: Non-nullable property 'P' is uninitialized.
+                //     internal S(string s)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "S").WithArguments("property", "P").WithLocation(6, 14),
+                // (6,14): warning CS8618: Non-nullable field 'F' is uninitialized.
+                //     internal S(string s)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "S").WithArguments("field", "F").WithLocation(6, 14));
+        }
+
+        [Fact]
+        public void EmptyStruct()
+        {
+            var source =
+@"struct S
+{
+    S(object o)
+    {
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        // PROTOTYPE(NullableReferenceTypes): Struct assign `this`.
+        [Fact(Skip = "Assign this")]
+        public void StructAssignThis()
+        {
+            var source =
+@"struct S
+{
+#pragma warning disable 0169
+    private readonly string F;
+    private string[] P { get; set; }
+    internal S(S s)
+    {
+        this = s;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void StructObjectCreation()
+        {
+            var source =
+@"#pragma warning disable 0649
+struct S
+{
+    internal string F;
+    internal string G;
+}
+class C
+{
+    static void F(S s) { }
+    static void Main()
+    {
+        F(new S());
+        F(new S() { F = string.Empty });
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ValueTypeFields()
+        {
+            var source =
+@"#pragma warning disable 0169
+struct S { }
+class C
+{
+    private readonly S s;
+    private int i;
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TryCatch()
+        {
+            // PROTOTYPE(NullableReferenceTypes):
+        }
+
+        [Fact]
+        public void LocalFunction()
+        {
+            // PROTOTYPE(NullableReferenceTypes):
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -3230,9 +3230,9 @@ namespace N{0}
     }}
 }}
 ";
-
-            var tree1 = SyntaxFactory.ParseSyntaxTree(string.Format(sourceTemplate, 1), path: "a.cs");
-            var tree2 = SyntaxFactory.ParseSyntaxTree(string.Format(sourceTemplate, 2), path: "b.cs");
+            var parseOptions = TestOptions.Regular7;
+            var tree1 = SyntaxFactory.ParseSyntaxTree(string.Format(sourceTemplate, 1), parseOptions, path: "a.cs");
+            var tree2 = SyntaxFactory.ParseSyntaxTree(string.Format(sourceTemplate, 2), parseOptions, path: "b.cs");
             var comp = CreateStandardCompilation(new[] { tree1, tree2 });
 
             comp.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -274,6 +274,7 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation:
                         case ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation:
+                        case ErrorCode.WRN_UninitializedNonNullableField:
                         case ErrorCode.WRN_NullabilityMismatchInAssignment:
                         case ErrorCode.WRN_NullabilityMismatchInArgument:
                         case ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate:


### PR DESCRIPTION
Report warnings for uninitialized non-nullable fields with reference types.

Not handled:
- Static fields
- Events
- Struct `this` assignment
- Assignment in local functions

Also, each constructor is analyzed in isolation - initialization from chained constructors is not considered.