### PR TITLE
Disable autosign of SWIX projects

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
@@ -24,4 +24,7 @@
   </ItemGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
+
+  <!-- Disable automatic signing. This will be signed in the batch phase -->
+  <Target Name="AddTargetPathToFilesToSign" />
 </Project>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
@@ -23,4 +23,7 @@
   </ItemGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
+
+  <!-- Disable automatic signing. This will be signed in the batch phase -->
+  <Target Name="AddTargetPathToFilesToSign" />
 </Project>


### PR DESCRIPTION
This disables the automatic signing of SWIX projects. Instead they are
signed as a part of our normal batch build.

