### PR TITLE
Disable 'Use 'throw' exception' refactoring for generic type parameter without constraint

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
@@ -454,5 +454,74 @@ class B
     }
 }");
         }
+
+        [WorkItem(22926, "https://github.com/dotnet/roslyn/issues/22926")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TestNotWhenUnconstrainedTypeParameter()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+class A<T>
+{
+    T x;
+    public A(T t)
+    {
+        if (t == null) [|throw|] new ArgumentNullException();
+        x = t;
+    }
+}");
+        }
+
+        [WorkItem(22926, "https://github.com/dotnet/roslyn/issues/22926")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TestWhenClassConstrainedTypeParameter()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class A<T> where T: class
+{
+    T x;
+    public A(T t)
+    {
+        if (t == null) [|throw|] new ArgumentNullException();
+        x = t;
+    }
+}",
+@"using System;
+class A<T> where T: class
+{
+    T x;
+    public A(T t)
+    {
+        x = t ?? throw new ArgumentNullException();
+    }
+}");
+        }
+
+        [WorkItem(22926, "https://github.com/dotnet/roslyn/issues/22926")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TestWhenStructConstrainedTypeParameter()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class A<T> where T: struct
+{
+    T? x;
+    public A(T? t)
+    {
+        if (t == null) [|throw|] new ArgumentNullException();
+        x = t;
+    }
+}",
+@"using System;
+class A<T> where T: struct
+{
+    T? x;
+    public A(T? t)
+    {
+        x = t ?? throw new ArgumentNullException();
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.UseThrowExpression
@@ -132,6 +133,11 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
 
             if (!TryFindAssignmentExpression(containingBlock, ifOperation, localOrParameter,
                     out var expressionStatement, out var assignmentExpression))
+            {
+                return;
+            }
+
+            if (!IsReferenceOrNullableType(localOrParameter))
             {
                 return;
             }
@@ -279,6 +285,22 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             }
 
             return false;
+        }
+
+        private bool IsReferenceOrNullableType(ISymbol symbol)
+        {
+            ITypeSymbol type = null;
+            if (symbol is ILocalSymbol local)
+            {
+                type = local.Type; 
+            }
+
+            if (symbol is IParameterSymbol parameter)
+            {
+                type = parameter.Type;
+            }
+
+            return type != null && (type.IsReferenceType || type.IsNullable());
         }
 
         private bool TryGetLocalOrParameterSymbol(

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 return;
             }
 
-            if (!IsReferenceOrNullableType(localOrParameter))
+            if (!localOrParameter.GetSymbolType().CanAddNullCheck())
             {
                 return;
             }
@@ -285,22 +285,6 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             }
 
             return false;
-        }
-
-        private bool IsReferenceOrNullableType(ISymbol symbol)
-        {
-            ITypeSymbol type = null;
-            if (symbol is ILocalSymbol local)
-            {
-                type = local.Type; 
-            }
-
-            if (symbol is IParameterSymbol parameter)
-            {
-                type = parameter.Type;
-            }
-
-            return type != null && (type.IsReferenceType || type.IsNullable());
         }
 
         private bool TryGetLocalOrParameterSymbol(


### PR DESCRIPTION
**Customer scenario**

IDE0016 provides invalid codefix on generic type without constraint

**Bugs this fixes:**

Fixes #22926

**Risk**

Low

**Performance impact**

Low

**Is this a regression from a previous update?**

**Root cause analysis:**

Missed check for parameter type.

**How was the bug found?**

customer reported
