### PR TITLE
Avoid GetEnumerator call in SourceMemberContainerSymbol.GetSimpleNonTypeMembers

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return StaticCast<Declaration>.From(this.Children);
         }
 
-        public IEnumerable<string> MemberNames
+        public ICollection<string> MemberNames
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1219,7 +1219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<Symbol> GetSimpleNonTypeMembers(string name)
         {
-            if (_lazyMembersDictionary != null || MemberNames.Contains(name))
+            if (_lazyMembersDictionary != null || declaration.MemberNames.Contains(name))
             {
                 return GetMembers(name);
             }


### PR DESCRIPTION
**Customer scenario**

`GetSymbolInfo()` call results in unnecessary allocations due to a call to `GetEnumerator()` for merged type declaration.

**Bugs this fixes:**

Item 2 of #22908

**Workarounds, if any**

None.

**Risk**

Low

**Performance impact**

See #22908

**Is this a regression from a previous update?**

No

**How was the bug found?**

External customer

:link: https://developercommunity.visualstudio.com/content/problem/136590/intellisense-issues-1.html