### PR TITLE
write exception message only to console from csi

### DIFF
--- a/src/Interactive/csi/Csi.cs
+++ b/src/Interactive/csi/Csi.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex.ToString());
+                Console.Error.WriteLine(ex.Message);
                 return 1;
             }
         }


### PR DESCRIPTION
**Customer scenario**

When using csi.exe to run build scripts, the exception stack trace is almost never useful. Usually only the message is useful. The stack trace only pollutes the console window, and typically causes the exception _message_ to scroll off the screen.
