### PR TITLE
scripting hosts: print the submission stack trace only to the console

### DIFF
--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -141,9 +141,9 @@ throw new Exception(""Error!"");
 
             Assert.True(result.ContainsErrors);
             AssertEx.AssertEqualToleratingWhitespaceDifferences("OK", result.Output);
-            AssertEx.AssertStartsWithToleratingWhitespaceDifferences($@"
-System.Exception: Error!
-   at Submission#0.<<Initialize>>d__0.MoveNext() in {cwd}{Path.DirectorySeparatorChar}a.csx:line 2
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
+Error!
+   + <Initialize>.MoveNext() at {cwd}{Path.DirectorySeparatorChar}a.csx : 2
 ", result.Errors);
         }
     }

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -192,6 +192,11 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 _compiler.ReportErrors(e.Diagnostics, _console.Error, errorLogger);
                 return CommonCompiler.Failed;
             }
+            catch (Exception e)
+            {
+                DisplayException(e);
+                return e.HResult;
+            }
         }
 
         private void RunInteractiveLoop(ScriptOptions options, string initialScriptCodeOpt, CancellationToken cancellationToken)

--- a/src/Scripting/Core/Hosting/CommonMemberFilter.cs
+++ b/src/Scripting/Core/Hosting/CommonMemberFilter.cs
@@ -14,6 +14,13 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         public override bool Include(StackFrame frame)
         {
             var method = frame.GetMethod();
+
+            // TODO (https://github.com/dotnet/roslyn/issues/23101): investigate which submission frames *can* be excluded
+            if (method.DeclaringType?.FullName.StartsWith("Submission#0").ToThreeState() == ThreeState.True)
+            {
+                return true;
+            }
+
             if (IsHiddenMember(method))
             {
                 return false;


### PR DESCRIPTION
If a script contains just `throw new Exception("hello world");` then csi outputs this to the console:

```
System.Exception: hello world
   at Submission#0.<<Initialize>>d__0.MoveNext() in c:\code\foo.csx:line 1
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.<RunSubmissionsAsync>d__9`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Scripting.Script`1.<RunSubmissionsAsync>d__21.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunScript(ScriptOptions options, SourceText code, ErrorLogger errorLogger, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunInteractiveCore(ErrorLogger errorLogger)
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunInteractive()
   at Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.Csi.Main(String[] args) in C:\code\dotnet\roslyn\src\Interactive\csi\Csi.cs:line 40
```

The only useful part of this is:

```
System.Exception: hello world
   at Submission#0.<<Initialize>>d__0.MoveNext() in c:\code\foo.csx:line 1
```