### PR TITLE
Fixes the issue #22955 related to attributes renaming.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             AssertIsForeground();
             VerifyNotDismissed();
-            this.ReplacementText = _renameInfo.GetFinalSymbolName(replacementText);
+            this.ReplacementText = replacementText;
 
             var asyncToken = _asyncListener.BeginAsyncOperation(nameof(ApplyReplacementText));
 


### PR DESCRIPTION
Fixes #22955 
As stated in the issue comments, wiping out a call to GetFinalSymbolName at [InlineRenameSession.cs, line 378](https://github.com/dotnet/roslyn/blob/878ffad23b8b06cb229c9ab31eada7634a473508/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs#L378) seems to solve the problem. 