### PR TITLE
Fixes for Microsoft.NETCore.Compilers package

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -7,6 +7,8 @@
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"
+             AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <PropertyGroup>
     <CSharpCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     <BasicCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.VisualBasic.Core.targets</BasicCoreTargetsPath>

--- a/build/NuGetAdditionalFiles/RunCsc.cmd
+++ b/build/NuGetAdditionalFiles/RunCsc.cmd
@@ -4,4 +4,4 @@ if defined DOTNET_HOST_PATH (
 ) else (
     set HOST_PATH=dotnet
 )
-%HOST_PATH% %~dp0\csc.dll %*
+"%HOST_PATH%" "%~dp0\csc.dll" %*

--- a/build/NuGetAdditionalFiles/RunVbc.cmd
+++ b/build/NuGetAdditionalFiles/RunVbc.cmd
@@ -4,4 +4,4 @@ if defined DOTNET_HOST_PATH (
 ) else (
     set HOST_PATH=dotnet
 )
-%HOST_PATH% %~dp0\vbc.dll %*
+"%HOST_PATH%" "%~dp0\vbc.dll" %*


### PR DESCRIPTION
When dogfooding I ran into a few bugs in the Microsoft.NETCore.Compilers package,
including

1. We need to override the CopyRefAssembly task
2. We need to surround the path components of the call with quotes