### PR TITLE
default(string) is string!

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -114,7 +114,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConstantValue constantValue = this.FoldConstantConversion(syntax, source, conversion, destination, diagnostics);
             if (conversion.Kind == ConversionKind.DefaultOrNullLiteral && source.Kind == BoundKind.DefaultExpression)
             {
-                source = ((BoundDefaultExpression)source).Update(constantValue, destination);
+                var defaultExpression = (BoundDefaultExpression)source;
+                source = defaultExpression.Update(defaultExpression.IsNullable, constantValue, destination);
             }
 
             return new BoundConversion(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1126,8 +1126,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression BindDefaultExpression(DefaultExpressionSyntax node, DiagnosticBag diagnostics)
         {
-            TypeSymbol type = this.BindType(node.Type, diagnostics).TypeSymbol;
-            return new BoundDefaultExpression(node, type);
+            var typeWithAnnotations = this.BindType(node.Type, diagnostics);
+            var type = typeWithAnnotations.TypeSymbol;
+            var isNullable = typeWithAnnotations.IsNullable;
+            Debug.Assert(isNullable.HasValue);
+            return new BoundDefaultExpression(node, isNullable: isNullable.GetValueOrDefault(), constantValueOpt: type.GetDefaultValue(), type: type);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -224,6 +224,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.TupleLiteral:
                     return false;
                 case BoundKind.DefaultExpression:
+                    {
+                        var defaultExpression = (BoundDefaultExpression)expr;
+                        return ((object)defaultExpression.Type == null) ? (bool?)null : defaultExpression.IsNullable;
+                    }
                 case BoundKind.Literal:
                 case BoundKind.UnboundLambda:
                     break;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -520,6 +520,7 @@
   <Node Name="BoundDefaultExpression" Base="BoundExpression">
     <!-- Type is null in the case of a default literal, and non-null for default(T). -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>
+    <Field Name="IsNullable" Type="bool"/>
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -542,8 +542,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundDefaultExpression
     {
-        public BoundDefaultExpression(SyntaxNode syntax, TypeSymbol type, bool hasErrors = false)
-            : this(syntax, type.GetDefaultValue(), type, hasErrors)
+        public BoundDefaultExpression(SyntaxNode syntax, TypeSymbol type)
+            : this(syntax, type.GetDefaultValue(), type)
+        {
+        }
+
+        public BoundDefaultExpression(SyntaxNode syntax, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors = false)
+            : this(syntax, false, constantValueOpt, type, hasErrors)
         {
         }
     }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -12699,6 +12699,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating a null value of a non-nullable type..
+        /// </summary>
+        internal static string WRN_DefaultOfNonNullableType {
+            get {
+                return ResourceManager.GetString("WRN_DefaultOfNonNullableType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating a null value of a non-nullable type..
+        /// </summary>
+        internal static string WRN_DefaultOfNonNullableType_Title {
+            get {
+                return ResourceManager.GetString("WRN_DefaultOfNonNullableType_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The default value specified for parameter &apos;{0}&apos; will have no effect because it applies to a member that is used in contexts that do not allow optional arguments.
         /// </summary>
         internal static string WRN_DefaultValueForUnconsumedLocation {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5156,6 +5156,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureStaticNullChecking" xml:space="preserve">
     <value>static null checking</value>
   </data>
+  <data name="WRN_DefaultOfNonNullableType" xml:space="preserve">
+    <value>Creating a null value of a non-nullable type.</value>
+  </data>
+  <data name="WRN_DefaultOfNonNullableType_Title" xml:space="preserve">
+    <value>Creating a null value of a non-nullable type.</value>
+  </data>
   <data name="WRN_NullAsNonNullable" xml:space="preserve">
     <value>Cannot convert null to non-nullable reference.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1491,6 +1491,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_PatternWrongGenericTypeInVersion = 8314,
         ERR_AmbigBinaryOpsOnDefault = 8315,
 
+        WRN_DefaultOfNonNullableType = 8599,
         WRN_NullAsNonNullable = 8600,
         WRN_NullReferenceAssignment = 8601,
         WRN_NullReferenceReceiver = 8602,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -318,6 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AlignmentMagnitude:
                 case ErrorCode.WRN_AttributeIgnoredWhenPublicSigning:
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
+                case ErrorCode.WRN_DefaultOfNonNullableType:
                 case ErrorCode.WRN_NullAsNonNullable:
                 case ErrorCode.WRN_NullReferenceAssignment:
                 case ErrorCode.WRN_NullReferenceReceiver:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2288,9 +2288,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!IsConditionalState);
             if (this.State.Reachable)
             {
-                if ((object)node.Type != null && node.Type.IsReferenceType == true)
+                if ((object)node.Type != null && node.Type.IsReferenceType)
                 {
-                    this.State.ResultIsNotNull = false;
+                    bool isNotNull = node.Syntax.Kind() == SyntaxKind.DefaultExpression && !node.IsNullable;
+                    this.State.ResultIsNotNull = isNotNull;
+                    if (isNotNull && _includeNonNullableWarnings)
+                    {
+                        // Creating a null value of a non-nullable type.
+                        ReportStaticNullCheckingDiagnostics(ErrorCode.WRN_DefaultOfNonNullableType, node.Syntax);
+                    }
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1807,18 +1807,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDefaultExpression : BoundExpression
     {
-        public BoundDefaultExpression(SyntaxNode syntax, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors)
+        public BoundDefaultExpression(SyntaxNode syntax, bool isNullable, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors)
             : base(BoundKind.DefaultExpression, syntax, type, hasErrors)
         {
+            this.IsNullable = isNullable;
             this.ConstantValueOpt = constantValueOpt;
         }
 
-        public BoundDefaultExpression(SyntaxNode syntax, ConstantValue constantValueOpt, TypeSymbol type)
+        public BoundDefaultExpression(SyntaxNode syntax, bool isNullable, ConstantValue constantValueOpt, TypeSymbol type)
             : base(BoundKind.DefaultExpression, syntax, type)
         {
+            this.IsNullable = isNullable;
             this.ConstantValueOpt = constantValueOpt;
         }
 
+
+        public bool IsNullable { get; }
 
         public ConstantValue ConstantValueOpt { get; }
 
@@ -1827,11 +1831,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitDefaultExpression(this);
         }
 
-        public BoundDefaultExpression Update(ConstantValue constantValueOpt, TypeSymbol type)
+        public BoundDefaultExpression Update(bool isNullable, ConstantValue constantValueOpt, TypeSymbol type)
         {
-            if (constantValueOpt != this.ConstantValueOpt || type != this.Type)
+            if (isNullable != this.IsNullable || constantValueOpt != this.ConstantValueOpt || type != this.Type)
             {
-                var result = new BoundDefaultExpression(this.Syntax, constantValueOpt, type, this.HasErrors);
+                var result = new BoundDefaultExpression(this.Syntax, isNullable, constantValueOpt, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8786,7 +8790,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDefaultExpression(BoundDefaultExpression node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(node.ConstantValueOpt, type);
+            return node.Update(node.IsNullable, node.ConstantValueOpt, type);
         }
         public override BoundNode VisitIsOperator(BoundIsOperator node)
         {
@@ -9863,6 +9867,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new TreeDumperNode("defaultExpression", null, new TreeDumperNode[]
             {
+                new TreeDumperNode("isNullable", node.IsNullable, null),
                 new TreeDumperNode("constantValueOpt", node.ConstantValueOpt, null),
                 new TreeDumperNode("type", node.Type, null)
             }

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -175,6 +175,7 @@
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
+                case ErrorCode.WRN_DefaultOfNonNullableType:
                 case ErrorCode.WRN_NullAsNonNullable:
                 case ErrorCode.WRN_NullReferenceAssignment:
                 case ErrorCode.WRN_NullReferenceReceiver:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
-    public partial class StaticNullChecking : CSharpTestBase
+    public class StaticNullChecking : CSharpTestBase
     {
         private const string NullableAttributeDefinition = @"
 namespace System.Runtime.CompilerServices
@@ -3299,9 +3299,9 @@ struct S2
                 // (291,15): warning CS8602: Possible dereference of a null reference.
                 //         z30 = x30[y30];
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x30").WithLocation(291, 15),
-                // (296,15): warning CS8600: Cannot convert null to non-nullable reference.
+                // (296,15): warning CS8599: Creating a null value of a non-nullable type.
                 //         x31 = default(CL1);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(CL1)").WithLocation(296, 15),
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(CL1)").WithLocation(296, 15),
                 // (301,19): hidden CS8607: Expression is probably never null.
                 //         var y32 = new CL1() ?? x32;
                 Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "new CL1()").WithLocation(301, 19),
@@ -9112,9 +9112,9 @@ class C
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                // (10,14): warning CS8600: Cannot convert null to non-nullable reference.
+                // (10,14): warning CS8599: Creating a null value of a non-nullable type.
                 //         x1 = default(C);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(C)").WithLocation(10, 14)
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(C)").WithLocation(10, 14)
                 );
         }
 
@@ -15053,9 +15053,9 @@ class Program
                 // (16,22): warning CS8601: Possible null reference assignment.
                 //         p.LastName = null as string?;
                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "null as string?").WithLocation(16, 22),
-                // (17,22): warning CS8600: Cannot convert null to non-nullable reference.
+                // (17,22): warning CS8599: Creating a null value of a non-nullable type.
                 //         p.LastName = default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 22),
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(string)").WithLocation(17, 22),
                 // (18,22): warning CS8600: Cannot convert null to non-nullable reference.
                 //         p.LastName = default;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 22),
@@ -15134,9 +15134,9 @@ static class Extensions
                 // (15,10): warning CS8604: Possible null reference argument for parameter 's' in 'void Extensions.F(string s)'.
                 //         (null as string?).F();
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("s", "void Extensions.F(string s)").WithLocation(15, 10),
-                // (16,9): warning CS8600: Cannot convert null to non-nullable reference.
+                // (16,9): warning CS8599: Creating a null value of a non-nullable type.
                 //         default(string).F();
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(16, 9),
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(string)").WithLocation(16, 9),
                 // (17,11): hidden CS8605: Result of the comparison is possibly always true.
                 //         ((p != null) ? p.MiddleName : null).F();
                 Diagnostic(ErrorCode.HDN_NullCheckIsProbablyAlwaysTrue, "p != null").WithLocation(17, 11),
@@ -15217,9 +15217,9 @@ class Program
                 // (16,11): warning CS8604: Possible null reference argument for parameter 'name' in 'void Program.G(string name)'.
                 //         G(null as string?);
                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "null as string?").WithArguments("name", "void Program.G(string name)").WithLocation(16, 11),
-                // (17,11): warning CS8600: Cannot convert null to non-nullable reference.
+                // (17,11): warning CS8599: Creating a null value of a non-nullable type.
                 //         G(default(string));
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(17, 11),
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(string)").WithLocation(17, 11),
                 // (18,11): warning CS8600: Cannot convert null to non-nullable reference.
                 //         G(default);
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(18, 11),
@@ -15297,9 +15297,9 @@ class Program
                 // (14,27): warning CS8603: Possible null reference return.
                 //     static string F5() => null as string?;
                 Diagnostic(ErrorCode.WRN_NullReferenceReturn, "null as string?").WithLocation(14, 27),
-                // (15,27): warning CS8600: Cannot convert null to non-nullable reference.
+                // (15,27): warning CS8599: Creating a null value of a non-nullable type.
                 //     static string F6() => default(string);
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string)").WithLocation(15, 27),
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(string)").WithLocation(15, 27),
                 // (16,27): warning CS8600: Cannot convert null to non-nullable reference.
                 //     static string F7() => default;
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default").WithLocation(16, 27),
@@ -15315,7 +15315,7 @@ class Program
         }
 
         [Fact]
-        public void SuppressNullableWarning()
+        public void SuppressNullableWarning_01()
         {
             var source =
 @"class C
@@ -15324,7 +15324,7 @@ class Program
     {
         G(null!);
         G((null as string)!);
-        G(default(string)!);
+        G(default(string)!); // Cannot suppress warning from default(string)
         G(default!);
         G(s!);
     }
@@ -15344,7 +15344,7 @@ class Program
                 //         G((null as string)!);
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "(null as string)!").WithArguments("static null checking", "8.0").WithLocation(6, 11),
                 // (7,11): error CS8107: Feature 'static null checking' is not available in C# 7. Please use language version 8.0 or greater.
-                //         G(default(string)!);
+                //         G(default(string)!); // Cannot suppress warning from default(string)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "default(string)!").WithArguments("static null checking", "8.0").WithLocation(7, 11),
                 // (8,11): error CS8107: Feature 'static null checking' is not available in C# 7. Please use language version 8.0 or greater.
                 //         G(default!);
@@ -15362,7 +15362,32 @@ class Program
             comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,11): warning CS8599: Creating a null value of a non-nullable type.
+                //         G(default(string)!); // Cannot suppress warning from default(string)
+                Diagnostic(ErrorCode.WRN_DefaultOfNonNullableType, "default(string)").WithLocation(7, 11));
+        }
+
+        [Fact]
+        public void SuppressNullableWarning_02()
+        {
+            var source =
+@"class C
+{
+    static void F()
+    {
+        G(default(string?));
+        G(default(string?)!);
+    }
+    static void G(string s)
+    {
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,11): warning CS8600: Cannot convert null to non-nullable reference.
+                //         G(default(string?));
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "default(string?)").WithLocation(5, 11));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -259,6 +259,7 @@ class X
                         case ErrorCode.WRN_UnreferencedLocalFunction:
                             Assert.Equal(3, ErrorFacts.GetWarningLevel(errorCode));
                             break;
+                        case ErrorCode.WRN_DefaultOfNonNullableType:
                         case ErrorCode.WRN_NullAsNonNullable:
                         case ErrorCode.WRN_NullReferenceAssignment:
                         case ErrorCode.WRN_NullReferenceReceiver:


### PR DESCRIPTION
Treat `default(string)` as non-nullable `string`, but report warning for the `default(string)` expression: `Creating a null value of a non-nullable type`.