### PR TITLE
Fix PathMapping to a root directory

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1037,11 +1037,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         case "pathmap":
                             // "/pathmap:K1=V1,K2=V2..."
+                            unquoted = RemoveQuotesAndSlashes(value);
                             {
-                                if (value == null)
+                                if (unquoted == null)
                                     break;
 
-                                pathMap = pathMap.Concat(ParsePathMap(value, diagnostics));
+                                pathMap = pathMap.Concat(ParsePathMap(unquoted, diagnostics));
                             }
                             continue;
 

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1037,10 +1037,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         case "pathmap":
                             // "/pathmap:K1=V1,K2=V2..."
-                            unquoted = RemoveQuotesAndSlashes(value);
                             {
+                                unquoted = RemoveQuotesAndSlashes(value);
+
                                 if (unquoted == null)
+                                {
                                     break;
+                                }
 
                                 pathMap = pathMap.Concat(ParsePathMap(unquoted, diagnostics));
                             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9236,6 +9236,13 @@ class C {
                 var pdbPath = Path.Combine(dir.Path, "a.pdb");
                 AssertPdbEmit(dir, pdbPath, @"/a.pdb", $@"/pathmap:{dir.Path}=/");
             }
+
+            // Multi-specified path map with mixed slashes
+            using (var dir = new DisposableDirectory(Temp))
+            {
+                var pdbPath = Path.Combine(dir.Path, "a.pdb");
+                AssertPdbEmit(dir, pdbPath, "/goo/a.pdb", $"/pathmap:{dir.Path}=/goo,{dir.Path}{PathUtilities.DirectorySeparatorChar}=/bar");
+            }
         }
 
         [CompilerTrait(CompilerFeature.Determinism)]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9113,12 +9113,16 @@ class C {
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K1", "V1"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+
+            parsedArgs = DefaultParse(new[] { "/pathmap:C:\\goo\\=/", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(KeyValuePair.Create("C:\\goo\\", "/"), parsedArgs.PathMap[0]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:K1=V1,K2=V2", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify();
-            Assert.Equal(KeyValuePair.Create("K1", "V1"), parsedArgs.PathMap[0]);
-            Assert.Equal(KeyValuePair.Create("K2", "V2"), parsedArgs.PathMap[1]);
+            Assert.Equal(KeyValuePair.Create("K1\\", "V1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K2\\", "V2\\"), parsedArgs.PathMap[1]);
 
             parsedArgs = DefaultParse(new[] { "/pathmap:,,,", "a.cs" }, _baseDirectory);
             Assert.Equal(4, parsedArgs.Errors.Count());
@@ -9210,6 +9214,13 @@ class C {
             {
                 var pdbPath = Path.Combine(dir.Path, "a.pdb");
                 AssertPdbEmit(dir, pdbPath, @"a.pdb", $@"/features:pdb-path-determinism");
+            }
+
+            // Unix path map
+            using (var dir = new DisposableDirectory(Temp))
+            {
+                var pdbPath = Path.Combine(dir.Path, "a.pdb");
+                AssertPdbEmit(dir, pdbPath, @"/a.pdb", $@"/pathmap:{dir.Path}=/");
             }
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9139,6 +9139,20 @@ class C {
             parsedArgs = DefaultParse(new[] { "/pathmap:k=v=bad", "a.cs" }, _baseDirectory);
             Assert.Equal(1, parsedArgs.Errors.Count());
             Assert.Equal((int)ErrorCode.ERR_InvalidPathMap, parsedArgs.Errors[0].Code);
+
+            parsedArgs = DefaultParse(new[] { "/pathmap:\"supporting spaces=is hard\"", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(KeyValuePair.Create("supporting spaces\\", "is hard\\"), parsedArgs.PathMap[0]);
+
+            parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1=V 1\",\"K 2=V 2\"", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
+
+            parsedArgs = DefaultParse(new[] { "/pathmap:\"K 1\"=\"V 1\",\"K 2\"=\"V 2\"", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(KeyValuePair.Create("K 1\\", "V 1\\"), parsedArgs.PathMap[0]);
+            Assert.Equal(KeyValuePair.Create("K 2\\", "V 2\\"), parsedArgs.PathMap[1]);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2527,25 +2527,44 @@ class Program
         [Fact]
         public void PathMapKeepsCrossPlatformRoot()
         {
-            CSharpCommandLineArguments Parse(params string[] args)
+            CSharpCommandLineArguments parse(params string[] args)
             {
                 var parsedArgs = CSharpCommandLineParser.Default.Parse(args, TempRoot.Root, RuntimeEnvironment.GetRuntimeDirectory(), null);
                 parsedArgs.Errors.Verify();
                 return parsedArgs;
             }
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/"), Parse("/pathmap:C:\\=/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), Parse("/pathmap:C:\\=/temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), Parse("/pathmap:C:\\=/temp/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/"), Parse("/pathmap:C:\\temp\\=/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), Parse("/pathmap:C:\\temp=/temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), Parse("/pathmap:C:\\temp\\=/temp/", "a.cs").PathMap[0]);
 
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\"), Parse("/pathmap:/=C:\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), Parse("/pathmap:/=C:\\temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), Parse("/pathmap:/=C:\\temp\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\"), Parse("/pathmap:/temp/=C:\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), Parse("/pathmap:/temp=C:\\temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), Parse("/pathmap:/temp/=C:\\temp\\", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/"), parse("/pathmap:C:\\=/", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), parse("/pathmap:C:\\=/temp", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), parse("/pathmap:C:\\=/temp/", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/"), parse("/pathmap:C:\\temp\\=/", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), parse("/pathmap:C:\\temp=/temp", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), parse("/pathmap:C:\\temp\\=/temp/", "a.cs").PathMap[0]);
+
+            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\"), parse("/pathmap:/=C:\\", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), parse("/pathmap:/=C:\\temp", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), parse("/pathmap:/=C:\\temp\\", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\"), parse("/pathmap:/temp/=C:\\", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), parse("/pathmap:/temp=C:\\temp", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), parse("/pathmap:/temp/=C:\\temp\\", "a.cs").PathMap[0]);
+        }
+
+        [Fact]
+        public void PathMapInconsistentSlashes()
+        {
+            CSharpCommandLineArguments parse(params string[] args)
+            {
+                var parsedArgs = CSharpCommandLineParser.Default.Parse(args, TempRoot.Root, RuntimeEnvironment.GetRuntimeDirectory(), null);
+                parsedArgs.Errors.Verify();
+                return parsedArgs;
+            }
+
+            var sep = PathUtilities.DirectorySeparatorChar;
+            Assert.Equal(new KeyValuePair<string, string>("C:\\temp/goo" + sep, "/temp\\goo" + sep), parse("/pathmap:C:\\temp/goo=/temp\\goo", "a.cs").PathMap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("noslash" + sep, "withoutslash" + sep), parse("/pathmap:noslash=withoutslash", "a.cs").PathMap[0]);
+            var doublemap = parse("/pathmap:/temp=/goo,/temp/=/bar", "a.cs").PathMap;
+            Assert.Equal(new KeyValuePair<string, string>("/temp/", "/goo/"), doublemap[0]);
+            Assert.Equal(new KeyValuePair<string, string>("/temp/", "/bar/"), doublemap[1]);
         }
         #endregion
     }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -2524,29 +2524,20 @@ class Program
         #region PathMap Linux Tests
         // Like the above (CoreCLR Signing Tests), these aren't actually syntax tests, but this is in one of only two assemblies tested on linux
 
-        [Fact]
-        public void PathMapKeepsCrossPlatformRoot()
+        [Theory]
+        [InlineData("C:\\", "/", "C:\\", "/")]
+        [InlineData("C:\\temp\\", "/temp/", "C:\\temp", "/temp")]
+        [InlineData("C:\\temp\\", "/temp/", "C:\\temp\\", "/temp/")]
+        [InlineData("/", "C:\\", "/", "C:\\")]
+        [InlineData("/temp/", "C:\\temp\\", "/temp", "C:\\temp")]
+        [InlineData("/temp/", "C:\\temp\\", "/temp/", "C:\\temp\\")]
+        public void PathMapKeepsCrossPlatformRoot(string expectedFrom, string expectedTo, string sourceFrom, string sourceTo)
         {
-            CSharpCommandLineArguments parse(params string[] args)
-            {
-                var parsedArgs = CSharpCommandLineParser.Default.Parse(args, TempRoot.Root, RuntimeEnvironment.GetRuntimeDirectory(), null);
-                parsedArgs.Errors.Verify();
-                return parsedArgs;
-            }
-
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/"), parse("/pathmap:C:\\=/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), parse("/pathmap:C:\\=/temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\", "/temp/"), parse("/pathmap:C:\\=/temp/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/"), parse("/pathmap:C:\\temp\\=/", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), parse("/pathmap:C:\\temp=/temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("C:\\temp\\", "/temp/"), parse("/pathmap:C:\\temp\\=/temp/", "a.cs").PathMap[0]);
-
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\"), parse("/pathmap:/=C:\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), parse("/pathmap:/=C:\\temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/", "C:\\temp\\"), parse("/pathmap:/=C:\\temp\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\"), parse("/pathmap:/temp/=C:\\", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), parse("/pathmap:/temp=C:\\temp", "a.cs").PathMap[0]);
-            Assert.Equal(new KeyValuePair<string, string>("/temp/", "C:\\temp\\"), parse("/pathmap:/temp/=C:\\temp\\", "a.cs").PathMap[0]);
+            var pathmapArg = $"/pathmap:{sourceFrom}={sourceTo}";
+            var parsedArgs = CSharpCommandLineParser.Default.Parse(new[] { pathmapArg, "a.cs" }, TempRoot.Root, RuntimeEnvironment.GetRuntimeDirectory(), null);
+            parsedArgs.Errors.Verify();
+            var expected = new KeyValuePair<string, string>(expectedFrom, expectedTo);
+            Assert.Equal(expected, parsedArgs.PathMap[0]);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -875,15 +875,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A key in the pathMap ends with a path separator..
-        /// </summary>
-        internal static string KeyInPathMapEndsWithSeparator {
-            get {
-                return ResourceManager.GetString("KeyInPathMapEndsWithSeparator", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Metadata PE stream should not be given when emitting metadata only..
         /// </summary>
         internal static string MetadataPeStreamUnexpectedWhenEmittingMetadataOnly {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -225,9 +225,6 @@
   <data name="NullValueInPathMap" xml:space="preserve">
     <value>A value in the pathMap is null.</value>
   </data>
-  <data name="KeyInPathMapEndsWithSeparator" xml:space="preserve">
-    <value>A key in the pathMap ends with a path separator.</value>
-  </data>
   <data name="CompilationOptionsMustNotHaveErrors" xml:space="preserve">
     <value>Compilation options must not have errors.</value>
   </data>

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -214,8 +214,8 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    from = PathUtilities.AddTrailingSeparator(from);
-                    to = PathUtilities.AddTrailingSeparator(to);
+                    from = PathUtilities.EnsureTrailingSeparator(from);
+                    to = PathUtilities.EnsureTrailingSeparator(to);
                     pathMapBuilder.Add(new KeyValuePair<string, string>(from, to));
                 }
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -205,15 +205,17 @@ namespace Microsoft.CodeAnalysis
                     errors.Add(Diagnostic.Create(_messageProvider, _messageProvider.ERR_InvalidPathMap, kEqualsV));
                     continue;
                 }
-                var from = PathUtilities.TrimTrailingSeparators(kv[0]);
-                var to = PathUtilities.TrimTrailingSeparators(kv[1]);
+                var from = kv[0];
+                var to = kv[1];
 
-                if (from.Length == 0 || (to.Length == 0 && kv[1] != "/"))
+                if (from.Length == 0 || to.Length == 0)
                 {
                     errors.Add(Diagnostic.Create(_messageProvider, _messageProvider.ERR_InvalidPathMap, kEqualsV));
                 }
                 else
                 {
+                    from = PathUtilities.AddTrailingSeparator(from);
+                    to = PathUtilities.AddTrailingSeparator(to);
                     pathMapBuilder.Add(new KeyValuePair<string, string>(from, to));
                 }
             }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -60,7 +60,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Ensures a trailing directory separator character
         /// </summary>
-        public static string AddTrailingSeparator(string s)
+        public static string EnsureTrailingSeparator(string s)
         {
             if (s.Length == 0 || IsAnyDirectorySeparator(s[s.Length - 1]))
             {
@@ -80,7 +80,7 @@ namespace Roslyn.Utilities
             }
             else
             {
-                // If the slashes are not consistent, use the current platform's slash.
+                // If there are no slashes or they are inconsistent, use the current platform's slash.
                 return s + DirectorySeparatorChar;
             }
         }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -37,6 +37,10 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Removes trailing directory separator characters
         /// </summary>
+        /// <remarks>
+        /// This will trim the root directory separator:
+        /// "C:\" maps to "C:", and "/" maps to ""
+        /// </remarks>
         public static string TrimTrailingSeparators(string s)
         {
             int lastSeparator = s.Length;
@@ -51,6 +55,34 @@ namespace Roslyn.Utilities
             }
 
             return s;
+        }
+
+        /// <summary>
+        /// Ensures a trailing directory separator character
+        /// </summary>
+        public static string AddTrailingSeparator(string s)
+        {
+            if (s.Length == 0 || IsAnyDirectorySeparator(s[s.Length - 1]))
+            {
+                return s;
+            }
+
+            // Use the existing slashes in the path, if they're consistent
+            bool hasSlash = s.IndexOf('/') >= 0;
+            bool hasBackslash = s.IndexOf('\\') >= 0;
+            if (hasSlash && !hasBackslash)
+            {
+                return s + '/';
+            }
+            else if (!hasSlash && hasBackslash)
+            {
+                return s + '\\';
+            }
+            else
+            {
+                // If the slashes are not consistent, use the current platform's slash.
+                return s + DirectorySeparatorChar;
+            }
         }
 
         public static string GetExtension(string path)
@@ -625,14 +657,16 @@ namespace Roslyn.Utilities
                 return filePath;
             }
 
-            // find the first key in the path map that matches a prefix of the normalized path (followed by a path separator).
+            // find the first key in the path map that matches a prefix of the normalized path.
             // Note that we expect the client to use consistent capitalization; we use ordinal (case-sensitive) comparisons.
             foreach (var kv in pathMap)
             {
                 var oldPrefix = kv.Key;
                 if (!(oldPrefix?.Length > 0)) continue;
 
-                if (filePath.StartsWith(oldPrefix, StringComparison.Ordinal) && filePath.Length > oldPrefix.Length && IsAnyDirectorySeparator(filePath[oldPrefix.Length]))
+                // oldPrefix always ends with a path separator, so there's no need to check if it was a partial match
+                // e.g. for the map /goo=/bar and filename /goooo
+                if (filePath.StartsWith(oldPrefix, StringComparison.Ordinal))
                 {
                     var replacementPrefix = kv.Value;
 

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -72,8 +72,8 @@ namespace Microsoft.CodeAnalysis
                         throw new ArgumentException(CodeAnalysisResources.NullValueInPathMap, nameof(pathMap));
                     }
 
-                    var normalizedKey = PathUtilities.AddTrailingSeparator(key);
-                    var normalizedValue = PathUtilities.AddTrailingSeparator(value);
+                    var normalizedKey = PathUtilities.EnsureTrailingSeparator(key);
+                    var normalizedValue = PathUtilities.EnsureTrailingSeparator(value);
 
                     pathMapBuilder.Add(new KeyValuePair<string, string>(normalizedKey, normalizedValue));
                 }

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -47,11 +48,16 @@ namespace Microsoft.CodeAnalysis
 
             _baseDirectory = baseDirectory;
             _searchPaths = searchPaths;
-            _pathMap = pathMap.NullToEmpty();
 
-            // the keys in pathMap should not end with a path separator
+            // The previous public API required paths to not end with a path separator.
+            // This broke handling of root paths (e.g. "/" cannot be represented), so
+            // the new requirement is for paths to always end with a path separator.
+            // However, because this is a public API, both conventions must be allowed,
+            // so normalize the paths here (instead of enforcing end-with-sep).
             if (!pathMap.IsDefaultOrEmpty)
             {
+                var pathMapBuilder = ArrayBuilder<KeyValuePair<string, string>>.GetInstance(pathMap.Length);
+
                 foreach (var kv in pathMap)
                 {
                     var key = kv.Key;
@@ -66,11 +72,17 @@ namespace Microsoft.CodeAnalysis
                         throw new ArgumentException(CodeAnalysisResources.NullValueInPathMap, nameof(pathMap));
                     }
 
-                    if (PathUtilities.IsAnyDirectorySeparator(key[key.Length - 1]))
-                    {
-                        throw new ArgumentException(CodeAnalysisResources.KeyInPathMapEndsWithSeparator, nameof(pathMap));
-                    }
+                    var normalizedKey = PathUtilities.AddTrailingSeparator(key);
+                    var normalizedValue = PathUtilities.AddTrailingSeparator(value);
+
+                    pathMapBuilder.Add(new KeyValuePair<string, string>(normalizedKey, normalizedValue));
                 }
+
+                _pathMap = pathMapBuilder.ToImmutableAndFree();
+            }
+            else
+            {
+                _pathMap = ImmutableArray<KeyValuePair<string, string>>.Empty;
             }
         }
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1068,11 +1068,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         Case "pathmap"
                             ' "/pathmap:K1=V1,K2=V2..."
-                            If value = Nothing Then
+                            Dim unquoted = RemoveQuotesAndSlashes(value)
+                            If unquoted = Nothing Then
                                 Exit Select
                             End If
 
-                            pathMap = pathMap.Concat(ParsePathMap(value, diagnostics))
+                            pathMap = pathMap.Concat(ParsePathMap(unquoted, diagnostics))
                             Continue For
 
                         Case "reportanalyzer"

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3043,6 +3043,18 @@ End Module
                 Dim pePdbPath = Path.Combine(dir.Path, "a.pdb")
                 assertPdbEmit(dir, "a.pdb", {"/features:pdb-path-determinism"})
             End Using
+
+            ' Unix path map
+            Using dir As New DisposableDirectory(Temp)
+                Dim pdbPath = Path.Combine(dir.Path, "a.pdb")
+                assertPdbEmit(dir, "/a.pdb", {$"/pathmap:{dir.Path}=/"})
+            End Using
+
+            ' Multi-specified path map with mixed slashes
+            Using dir As New DisposableDirectory(Temp)
+                Dim pdbPath = Path.Combine(dir.Path, "a.pdb")
+                assertPdbEmit(dir, "/goo/a.pdb", {$"/pathmap:{dir.Path}=/goo,{dir.Path}{PathUtilities.DirectorySeparatorChar}=/bar"})
+            End Using
         End Sub
 
 


### PR DESCRIPTION
Fixes #22815

Fixes https://github.com/dotnet/roslyn/issues/21639

The convention is now to store PathMap entries ending with a path separator, instead of without.

Also, this properly unquotes PathMap command line parsing.