### PR TITLE
Refactor CommonCompiler.RunCore

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxTree tree,
             SourceReferenceResolver resolver,
             OrderedSet<string> embeddedFiles,
-            IList<Diagnostic> diagnostics)
+            DiagnosticBag diagnostics)
         {
             foreach (LineDirectiveTriviaSyntax directive in tree.GetRoot().GetDirectives(
                 d => d.IsActive && !d.HasErrors && d.Kind() == SyntaxKind.LineDirectiveTrivia))

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2076,6 +2076,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal ImmutableArray<Diagnostic> GetDiagnostics(CompilationStage stage, bool includeEarlierStages, CancellationToken cancellationToken)
         {
+            var diagnostics = DiagnosticBag.GetInstance();
+            GetDiagnostics(stage, includeEarlierStages, diagnostics, cancellationToken);
+            return diagnostics.ToReadOnlyAndFree();
+        }
+
+        internal override void GetDiagnostics(CompilationStage stage, bool includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken = default)
+        {
             var builder = DiagnosticBag.GetInstance();
 
             if (stage == CompilationStage.Parse || (stage > CompilationStage.Parse && includeEarlierStages))
@@ -2153,9 +2160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Before returning diagnostics, we filter warnings
             // to honor the compiler options (e.g., /nowarn, /warnaserror and /warn) and the pragmas.
-            var result = DiagnosticBag.GetInstance();
-            FilterAndAppendAndFreeDiagnostics(result, ref builder);
-            return result.ToReadOnlyAndFree<Diagnostic>();
+            FilterAndAppendAndFreeDiagnostics(diagnostics, ref builder);
         }
 
         private static void AppendLoadDirectiveDiagnostics(DiagnosticBag builder, SyntaxAndDeclarationManager syntaxAndDeclarations, SyntaxTree syntaxTree, Func<IEnumerable<Diagnostic>, IEnumerable<Diagnostic>> locationFilterOpt = null)

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -693,6 +693,7 @@ namespace Microsoft.CodeAnalysis
                     WithOutputNameOverride(outputName).
                     WithPdbFilePath(PathUtilities.NormalizePathPrefix(finalPdbFilePath, Arguments.PathMap));
 
+                // TODO(https://github.com/dotnet/roslyn/issues/19592):
                 // This feature flag is being maintained until our next major release to avoid unnecessary 
                 // compat breaks with customers.
                 if (Arguments.ParseOptions.Features.ContainsKey("pdb-path-determinism") && !string.IsNullOrEmpty(emitOptions.PdbFilePath))

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -432,7 +432,6 @@ namespace Microsoft.CodeAnalysis
         private bool ReportErrors(DiagnosticBag diagnostics, TextWriter consoleOutput, ErrorLogger errorLoggerOpt)
             => ReportErrors(diagnostics.ToReadOnly(), consoleOutput, errorLoggerOpt);
 
-
         /// <summary>
         /// Returns true if the diagnostic is an error that should be reported.
         /// </summary>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1118,6 +1118,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public abstract ImmutableArray<Diagnostic> GetDiagnostics(CancellationToken cancellationToken = default(CancellationToken));
 
+        internal abstract void GetDiagnostics(CompilationStage stage, bool includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken = default);
+
         internal void EnsureCompilationEventQueueCompleted()
         {
             Debug.Assert(EventQueue != null);

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -225,13 +225,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Takes an exception produced while writing to a file stream and produces a diagnostic.
         /// </summary>
-        public void ReportStreamWriteException(Exception e, string filePath, TextWriter consoleOutput)
+        public void ReportStreamWriteException(Exception e, string filePath, DiagnosticBag diagnostics)
         {
-            if (consoleOutput != null)
-            {
-                var diagnostic = new DiagnosticInfo(this, ERR_OutputWriteFailed, filePath, e.Message);
-                consoleOutput.WriteLine(diagnostic.ToString(consoleOutput.FormatProvider));
-            }
+            diagnostics.Add(CreateDiagnostic(ERR_OutputWriteFailed, Location.None, filePath, e.Message));
         }
 
         public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);

--- a/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
@@ -17,7 +17,7 @@ namespace Roslyn.Utilities
     {
         private bool? _failed; // Nullable to assert that this is only checked after dispose
         private readonly string _filePath;
-        private readonly TextWriter _writer;
+        private readonly DiagnosticBag _diagnostics;
         private readonly CommonMessageProvider _messageProvider;
 
         /// <summary>
@@ -40,13 +40,13 @@ namespace Roslyn.Utilities
         public NoThrowStreamDisposer(
             Stream stream,
             string filePath,
-            TextWriter writer,
+            DiagnosticBag diagnostics,
             CommonMessageProvider messageProvider)
         {
             Stream = stream;
             _failed = null;
             _filePath = filePath;
-            _writer = writer;
+            _diagnostics = diagnostics;
             _messageProvider = messageProvider;
         }
 
@@ -63,7 +63,7 @@ namespace Roslyn.Utilities
             }
             catch (Exception e)
             {
-                _messageProvider.ReportStreamWriteException(e, _filePath, _writer);
+                _messageProvider.ReportStreamWriteException(e, _filePath, _diagnostics);
                 // Record if any exceptions are thrown during dispose
                 _failed = true;
             }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             tree As SyntaxTree,
             resolver As SourceReferenceResolver,
             embeddedFiles As OrderedSet(Of String),
-            diagnostics As IList(Of Diagnostic))
+            diagnostics As DiagnosticBag)
 
             For Each directive As ExternalSourceDirectiveTriviaSyntax In tree.GetRoot().GetDirectives(
                 Function(d) d.Kind() = SyntaxKind.ExternalSourceDirectiveTrivia)

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1913,6 +1913,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' should sort the errors as desired.
         ''' </returns>
         Friend Overloads Function GetDiagnostics(stage As CompilationStage, Optional includeEarlierStages As Boolean = True, Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of Diagnostic)
+            Dim diagnostics = DiagnosticBag.GetInstance()
+            GetDiagnostics(stage, includeEarlierStages, diagnostics, cancellationToken)
+            Return diagnostics.ToReadOnlyAndFree()
+        End Function
+
+        Friend Overrides Sub GetDiagnostics(stage As CompilationStage,
+                                             includeEarlierStages As Boolean,
+                                             diagnostics As DiagnosticBag,
+                                             Optional cancellationToken As CancellationToken = Nothing)
+
             Dim builder = DiagnosticBag.GetInstance()
 
             ' Add all parsing errors.
@@ -1971,10 +1981,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Before returning diagnostics, we filter some of them
             ' to honor the compiler options (e.g., /nowarn and /warnaserror)
-            Dim result = DiagnosticBag.GetInstance()
-            FilterAndAppendAndFreeDiagnostics(result, builder)
-            Return result.ToReadOnlyAndFree(Of Diagnostic)()
-        End Function
+            FilterAndAppendAndFreeDiagnostics(diagnostics, builder)
+        End Sub
 
         Private Function GetClsComplianceDiagnostics(cancellationToken As CancellationToken, Optional filterTree As SyntaxTree = Nothing, Optional filterSpanWithinTree As TextSpan? = Nothing) As ImmutableArray(Of Diagnostic)
             If filterTree IsNot Nothing Then
@@ -2161,7 +2169,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             additionalTypes As ImmutableArray(Of NamedTypeSymbol),
             cancellationToken As CancellationToken) As CommonPEModuleBuilder
 
-            Debug.Assert(diagnostics.IsEmptyWithoutResolution) ' True, but not required.
             Debug.Assert(Not IsSubmission OrElse HasCodeToEmit())
 
             ' Get the runtime metadata version from the cor library. If this fails we have no reasonable value to give.

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8577,7 +8577,7 @@ End Module
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
             Assert.Equal(1, csc.Run(outWriter))
-            Assert.Equal($"error BC2012: can't open '{xmlPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+            Assert.Equal($"vbc : error BC2012: can't open '{xmlPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
         End Sub
 
         <Theory>
@@ -8605,7 +8605,7 @@ End Module
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
             Assert.Equal(1, csc.Run(outWriter))
-            Assert.Equal($"error BC2012: can't open '{sourceLinkPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+            Assert.Equal($"vbc : error BC2012: can't open '{sourceLinkPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
         End Sub
 
         <Fact>


### PR DESCRIPTION
This is the monolith method for batch compilation in C# and VB.
It is large and confusing. I've tried to make it better by moving to a single
error reporting system for every piece of the pipeline (Diagnostics in DiagnosticBags).

It may be helpful to look at each commit separately.