### PR TITLE
Ensure the RunCsc and RunVbc scripts use quoted paths.

### DIFF
--- a/build/NuGetAdditionalFiles/RunCsc.cmd
+++ b/build/NuGetAdditionalFiles/RunCsc.cmd
@@ -4,4 +4,4 @@ if defined DOTNET_HOST_PATH (
 ) else (
     set HOST_PATH=dotnet
 )
-%HOST_PATH% %~dp0\csc.dll %*
+"%HOST_PATH%" "%~dp0\csc.dll" %*

--- a/build/NuGetAdditionalFiles/RunVbc.cmd
+++ b/build/NuGetAdditionalFiles/RunVbc.cmd
@@ -4,4 +4,4 @@ if defined DOTNET_HOST_PATH (
 ) else (
     set HOST_PATH=dotnet
 )
-%HOST_PATH% %~dp0\vbc.dll %*
+"%HOST_PATH%" "%~dp0\vbc.dll" %*


### PR DESCRIPTION
When `%HOST_PATH%` contains a space, the call to the compiler fails.

Fix #23066

**Customer scenario**

When invoking RunCsc from a dotnet.exe that is installed to `C:\Program Files`, the call to the compiler fails because of the space in the path.

**Bugs this fixes:**

#23066

**Workarounds, if any**

Don't install .NET Core SDK to a path with a space in it.


**Risk**

Should be very low.  Just adding quotes around two paths in RunCsc and RunVbc.

**Performance impact**

No performance impact, as this is simply quoting two paths in two scripts.

**Is this a regression from a previous update?**

Yes, the scenario listed in the bug worked with earlier versions of the .NET Core SDK.

**Root cause analysis:**

> How did we miss it?  

Simple mistake when writing a script.

> What tests are we adding to guard against it in the future?

None as of now.  I'm not sure how to test these scripts in the repo, nor how to test them using a path to `dotnet.exe` with spaces in it.

**How was the bug found?**

Dogfooding in dotnet/corefxlab, which uses a specific version of the Microsoft.NETCore.Compilers package.  I updated to the latest .NET Core SDK, and my build started failing.

**Test documentation updated?**

N/A

/cc @khyperia 