### PR TITLE
Ensure that we track additional member symbols in the VB binder conte…

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1207,14 +1207,14 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IPropertyInitializerOperation CreateBoundPropertyEqualsValueOperation(BoundPropertyEqualsValue boundPropertyEqualsValue)
         {
-            IPropertySymbol initializedProperty = boundPropertyEqualsValue.Property;
+            ImmutableArray<IPropertySymbol> initializedProperties = ImmutableArray.Create<IPropertySymbol>(boundPropertyEqualsValue.Property);
             Lazy<IOperation> value = new Lazy<IOperation>(() => Create(boundPropertyEqualsValue.Value));
             OperationKind kind = OperationKind.PropertyInitializer;
             SyntaxNode syntax = boundPropertyEqualsValue.Syntax;
             ITypeSymbol type = null;
             Optional<object> constantValue = default(Optional<object>);
             bool isImplicit = boundPropertyEqualsValue.WasCompilerGenerated;
-            return new LazyPropertyInitializer(initializedProperty, value, kind, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new LazyPropertyInitializer(initializedProperties, value, kind, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
         private IParameterInitializerOperation CreateBoundParameterEqualsValueOperation(BoundParameterEqualsValue boundParameterEqualsValue)

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -4046,15 +4046,15 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal abstract partial class BasePropertyInitializer : SymbolInitializer, IPropertyInitializerOperation
     {
-        public BasePropertyInitializer(IPropertySymbol initializedProperty, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        public BasePropertyInitializer(ImmutableArray<IPropertySymbol> initializedProperties, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            InitializedProperty = initializedProperty;
+            InitializedProperties = initializedProperties;
         }
         /// <summary>
-        /// Set method used to initialize the property.
+        /// Initialized properties. There can be multiple properties for Visual Basic 'WithEvents' declaration with AsNew clause.
         /// </summary>
-        public IPropertySymbol InitializedProperty { get; }
+        public ImmutableArray<IPropertySymbol> InitializedProperties { get; }
         public override IEnumerable<IOperation> Children
         {
             get
@@ -4081,8 +4081,8 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal sealed partial class PropertyInitializer : BasePropertyInitializer, IPropertyInitializerOperation
     {
-        public PropertyInitializer(IPropertySymbol initializedProperty, IOperation value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-            base(initializedProperty, kind, semanticModel, syntax, type, constantValue, isImplicit)
+        public PropertyInitializer(ImmutableArray<IPropertySymbol> initializedProperties, IOperation value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(initializedProperties, kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
             ValueImpl = value;
         }
@@ -4096,8 +4096,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyValue;
 
-        public LazyPropertyInitializer(IPropertySymbol initializedProperty, Lazy<IOperation> value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-            base(initializedProperty, kind, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyPropertyInitializer(ImmutableArray<IPropertySymbol> initializedProperties, Lazy<IOperation> value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(initializedProperties, kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }

--- a/src/Compilers/Core/Portable/Operations/IFieldInitializerOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IFieldInitializerOperation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IFieldInitializerOperation : ISymbolInitializerOperation
     {
         /// <summary>
-        /// Initialized fields. There can be multiple fields for Visual Basic fields declared with As New.
+        /// Initialized fields. There can be multiple fields for Visual Basic fields declared with AsNew clause.
         /// </summary>
         ImmutableArray<IFieldSymbol> InitializedFields { get; }
     }

--- a/src/Compilers/Core/Portable/Operations/IPropertyInitializerOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IPropertyInitializerOperation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.CodeAnalysis.Operations
 {
     /// <summary>
@@ -7,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// <para>
     /// Current usage:
     ///  (1) C# property initializer with equals value clause.
-    ///  (2) VB property initializer with equals value clause or AsNew clause.
+    ///  (2) VB property initializer with equals value clause or AsNew clause. Multiple properties can be initialized with 'WithEvents' declaration with AsNew clause in VB.
     /// </para>
     /// </summary>
     /// <remarks>
@@ -17,9 +19,9 @@ namespace Microsoft.CodeAnalysis.Operations
     public interface IPropertyInitializerOperation : ISymbolInitializerOperation
     {
         /// <summary>
-        /// Set method used to initialize the property.
+        /// Initialized properties. There can be multiple properties for Visual Basic 'WithEvents' declaration with AsNew clause.
         /// </summary>
-        IPropertySymbol InitializedProperty { get; }
+        ImmutableArray<IPropertySymbol> InitializedProperties { get; }
     }
 }
 

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         public override IOperation VisitPropertyInitializer(IPropertyInitializerOperation operation, object argument)
         {
-            return new PropertyInitializer(operation.InitializedProperty, Visit(operation.Value), operation.Kind, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+            return new PropertyInitializer(operation.InitializedProperties, Visit(operation.Value), operation.Kind, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
         }
 
         public override IOperation VisitParameterInitializer(IParameterInitializerOperation operation, object argument)

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -394,7 +394,7 @@ Microsoft.CodeAnalysis.Operations.IPatternCaseClauseOperation.Label.get -> Micro
 Microsoft.CodeAnalysis.Operations.IPatternCaseClauseOperation.Pattern.get -> Microsoft.CodeAnalysis.Operations.IPatternOperation
 Microsoft.CodeAnalysis.Operations.IPatternOperation
 Microsoft.CodeAnalysis.Operations.IPropertyInitializerOperation
-Microsoft.CodeAnalysis.Operations.IPropertyInitializerOperation.InitializedProperty.get -> Microsoft.CodeAnalysis.IPropertySymbol
+Microsoft.CodeAnalysis.Operations.IPropertyInitializerOperation.InitializedProperties.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IPropertySymbol>
 Microsoft.CodeAnalysis.Operations.IPropertyReferenceOperation
 Microsoft.CodeAnalysis.Operations.IPropertyReferenceOperation.Arguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Operations.IArgumentOperation>
 Microsoft.CodeAnalysis.Operations.IPropertyReferenceOperation.Property.get -> Microsoft.CodeAnalysis.IPropertySymbol

--- a/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
@@ -62,6 +62,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Throw ExceptionUtilities.Unreachable
+            End Get
+        End Property
+
         Public Overrides ReadOnly Property IsInQuery As Boolean
             Get
                 ' we should stop at the method or type binder.

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -327,6 +327,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        ''' <summary>
+        ''' Additional members associated with the binding context
+        ''' Currently, this field is only used for multiple field symbols initialized by an AsNew field initializer, e.g. "Dim x, y As New Integer"
+        ''' </summary>
+        Public Overridable ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return m_containingBinder.AdditionalContainingMembers
+            End Get
+        End Property
+
         Friend ReadOnly Property ContainingModule As ModuleSymbol
             Get
                 ' If there's a containing member, it either is or has a containing module.

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -329,7 +329,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ''' <summary>
         ''' Additional members associated with the binding context
-        ''' Currently, this field is only used for multiple field symbols initialized by an AsNew field initializer, e.g. "Dim x, y As New Integer"
+        ''' Currently, this field is only used for multiple field/property symbols initialized by an AsNew initializer, e.g. "Dim x, y As New Integer" or "WithEvents x, y as New Object"
         ''' </summary>
         Public Overridable ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
             Get

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderBuilder.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
@@ -321,7 +322,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                containingType)
             End If
 
-            Return New DeclarationInitializerBinder(parameterSymbol, containingBinder, node)
+            Return New DeclarationInitializerBinder(parameterSymbol, ImmutableArray(Of Symbol).Empty, containingBinder, node)
         End Function
 
         ''' <summary>
@@ -334,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 containingBinder = BinderBuilder.CreateBinderForMethodDeclaration(methodSymbol, containingBinder)
             End If
 
-            Return New DeclarationInitializerBinder(parameterSymbol, containingBinder, node)
+            Return New DeclarationInitializerBinder(parameterSymbol, ImmutableArray(Of Symbol).Empty, containingBinder, node)
         End Function
 
         ''' <summary>
@@ -415,9 +416,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Shared Function CreateBinderForInitializer(containingBinder As Binder,
-                                                          fieldOrProperty As Symbol) As Binder
+                                                          fieldOrProperty As Symbol,
+                                                          additionalFieldsOrProperties As ImmutableArray(Of Symbol)) As Binder
 
             Debug.Assert((fieldOrProperty.Kind = SymbolKind.Field) OrElse (fieldOrProperty.Kind = SymbolKind.Property))
+            Debug.Assert(additionalFieldsOrProperties.All(Function(s) s.Kind = SymbolKind.Field OrElse s.Kind = SymbolKind.Property))
             Debug.Assert(containingBinder IsNot Nothing)
 
             Dim declarationSyntax As VisualBasicSyntaxNode
@@ -428,7 +431,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 declarationSyntax = DirectCast(fieldOrProperty, SourcePropertySymbol).DeclarationSyntax
             End If
 
-            Return New DeclarationInitializerBinder(fieldOrProperty, containingBinder, declarationSyntax)
+            Return New DeclarationInitializerBinder(fieldOrProperty, additionalFieldsOrProperties, containingBinder, declarationSyntax)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -273,7 +273,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim declarator = DirectCast(node, VariableDeclaratorSyntax)
                             ' Declaration should have initializer or AsNew.
                             Debug.Assert(declarator.Initializer IsNot Nothing OrElse TryCast(declarator.AsClause, AsNewClauseSyntax) IsNot Nothing)
-                            ' more than one name may happen if there is a syntax error or AsNew clause with multiple fields
+                            ' more than one name may happen if there is a syntax error or AsNew clause with multiple fields/properties
                             Debug.Assert(declarator.Names.Count > 0)
 
                             containingNamedTypeBinder = GetContainingNamedTypeBinderForMemberNode(node.Parent.Parent, containingBinder)
@@ -284,13 +284,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim identifier = declarator.Names(0).Identifier
                             fieldOrProperty = containingNamedTypeBinder.ContainingType.FindFieldOrProperty(identifier.ValueText, identifier.Span, _tree)
 
-                            ' Handle multiple fields initialized with AsNew clause
+                            ' Handle multiple fields/properties initialized with AsNew clause
                             If declarator.Names.Count > 1 Then
                                 Dim builder = ArrayBuilder(Of Symbol).GetInstance
                                 For Each name In declarator.Names.Skip(1)
                                     identifier = name.Identifier
-                                    Dim additionalField As Symbol = containingNamedTypeBinder.ContainingType.FindFieldOrProperty(identifier.ValueText, identifier.Span, _tree)
-                                    builder.Add(additionalField)
+                                    Dim additionalFieldOrProperty As Symbol = containingNamedTypeBinder.ContainingType.FindFieldOrProperty(identifier.ValueText, identifier.Span, _tree)
+                                    builder.Add(additionalFieldOrProperty)
                                 Next
                                 additionalFieldsOrProperties = builder.ToImmutableAndFree
                             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
@@ -264,14 +265,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Case NodeUsage.FieldOrPropertyInitializer
                     Dim fieldOrProperty As Symbol = Nothing
+                    Dim additionalFieldsOrProperties = ImmutableArray(Of Symbol).Empty
                     Dim containingNamedTypeBinder As NamedTypeBinder
 
                     Select Case node.Kind
                         Case SyntaxKind.VariableDeclarator
                             Dim declarator = DirectCast(node, VariableDeclaratorSyntax)
-                            ' Declaration should have initializer or AsNew and exactly one variable name.
+                            ' Declaration should have initializer or AsNew.
                             Debug.Assert(declarator.Initializer IsNot Nothing OrElse TryCast(declarator.AsClause, AsNewClauseSyntax) IsNot Nothing)
-                            ' more than one name may happen if there is a syntax error
+                            ' more than one name may happen if there is a syntax error or AsNew clause with multiple fields
                             Debug.Assert(declarator.Names.Count > 0)
 
                             containingNamedTypeBinder = GetContainingNamedTypeBinderForMemberNode(node.Parent.Parent, containingBinder)
@@ -281,6 +283,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                             Dim identifier = declarator.Names(0).Identifier
                             fieldOrProperty = containingNamedTypeBinder.ContainingType.FindFieldOrProperty(identifier.ValueText, identifier.Span, _tree)
+
+                            ' Handle multiple fields initialized with AsNew clause
+                            If declarator.Names.Count > 1 Then
+                                Dim builder = ArrayBuilder(Of Symbol).GetInstance
+                                For Each name In declarator.Names.Skip(1)
+                                    identifier = name.Identifier
+                                    Dim additionalField As Symbol = containingNamedTypeBinder.ContainingType.FindFieldOrProperty(identifier.ValueText, identifier.Span, _tree)
+                                    builder.Add(additionalField)
+                                Next
+                                additionalFieldsOrProperties = builder.ToImmutableAndFree
+                            End If
 
                         Case SyntaxKind.EnumMemberDeclaration
                             Dim enumDeclaration = DirectCast(node, EnumMemberDeclarationSyntax)
@@ -309,7 +322,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End Select
 
                     If fieldOrProperty IsNot Nothing Then
-                        Return BuildInitializerBinder(containingNamedTypeBinder, fieldOrProperty)
+                        Return BuildInitializerBinder(containingNamedTypeBinder, fieldOrProperty, additionalFieldsOrProperties)
                     End If
 
                     Return Nothing
@@ -323,7 +336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim identifier = modifiedIdentifier.Identifier
                         Dim field = containingType.FindMember(identifier.ValueText, SymbolKind.Field, identifier.Span, _tree)
                         If field IsNot Nothing Then
-                            Return BuildInitializerBinder(containingNamedTypeBinder, field)
+                            Return BuildInitializerBinder(containingNamedTypeBinder, field, ImmutableArray(Of Symbol).Empty)
                         End If
                     End If
 
@@ -630,8 +643,8 @@ lAgain:
             End If
         End Function
 
-        Private Function BuildInitializerBinder(containingBinder As Binder, fieldOrProperty As Symbol) As Binder
-            Return BinderBuilder.CreateBinderForInitializer(containingBinder, fieldOrProperty)
+        Private Function BuildInitializerBinder(containingBinder As Binder, fieldOrProperty As Symbol, additionalFieldsOrProperties As ImmutableArray(Of Symbol)) As Binder
+            Return BinderBuilder.CreateBinderForInitializer(containingBinder, fieldOrProperty, additionalFieldsOrProperties)
         End Function
 
         Private Function BuildAttributeBinder(containingBinder As Binder, node As VisualBasicSyntaxNode) As Binder

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
@@ -132,7 +132,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     Dim firstFieldOrProperty = initializer.FieldsOrProperties.First
-                    Dim initializerBinder = BinderBuilder.CreateBinderForInitializer(parentBinder, firstFieldOrProperty)
+                    Dim additionalSymbols = If(initializer.FieldsOrProperties.Length > 1, initializer.FieldsOrProperties.RemoveAt(0), ImmutableArray(Of Symbol).Empty)
+                    Dim initializerBinder = BinderBuilder.CreateBinderForInitializer(parentBinder, firstFieldOrProperty, additionalSymbols)
                     If initializerNode.Kind = SyntaxKind.ModifiedIdentifier Then
                         ' Array field with no explicit initializer.
                         Debug.Assert(initializer.FieldsOrProperties.Length = 1)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Query.vb
@@ -2736,6 +2736,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Get
             End Property
 
+            Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+                Get
+                    Return ImmutableArray(Of Symbol).Empty
+                End Get
+            End Property
+
             Public ReadOnly Property LambdaSymbol As LambdaSymbol
                 Get
                     Return _lambdaSymbol

--- a/src/Compilers/VisualBasic/Portable/Binding/ConstantFieldsInProgressBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ConstantFieldsInProgressBinder.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -31,6 +32,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return _field
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
@@ -36,7 +36,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Sub New(symbol As Symbol, additionalSymbols As ImmutableArray(Of Symbol), [next] As Binder, root As VisualBasicSyntaxNode)
             MyBase.New([next])
             Debug.Assert((symbol.Kind = SymbolKind.Field) OrElse (symbol.Kind = SymbolKind.Property) OrElse (symbol.Kind = SymbolKind.Parameter))
-            Debug.Assert(additionalSymbols.All(Function(s) s.Kind = SymbolKind.Field OrElse s.Kind = SymbolKind.Property))
+            Debug.Assert(additionalSymbols.All(Function(s) s.Kind = symbol.Kind AndAlso (s.Kind = SymbolKind.Field OrElse s.Kind = SymbolKind.Property)))
+            Debug.Assert(symbol.Kind <> SymbolKind.Parameter OrElse additionalSymbols.IsEmpty)
             Me._symbol = symbol
             Me._additionalSymbols = additionalSymbols
             Debug.Assert(root IsNot Nothing)
@@ -56,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ''' <summary>
         ''' Additional members associated with the binding context
-        ''' Currently, this field is only used for multiple field symbols initialized by an AsNew field initializer, e.g. "Dim x, y As New Integer"
+        ''' Currently, this field is only used for multiple field/property symbols initialized by an AsNew initializer, e.g. "Dim x, y As New Integer" or "WithEvents x, y as New Object"
         ''' </summary>
         Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
             Get

--- a/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DeclarationInitializerBinder.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -17,6 +18,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private ReadOnly _symbol As Symbol
 
+        ''' <summary>
+        ''' Backing field for the AdditionalContainingMembers property
+        ''' </summary>
+        Private ReadOnly _additionalSymbols As ImmutableArray(Of Symbol)
+
         ''' <summary> Root syntax node </summary>
         Private ReadOnly _root As VisualBasicSyntaxNode
 
@@ -24,12 +30,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Initializes a new instance of the <see cref="DeclarationInitializerBinder"/> class.
         ''' </summary>
         ''' <param name="symbol">The field, property or parameter symbol with an initializer or default value.</param>
+        ''' <param name="additionalSymbols">Additional field for property symbols initialized with the initializer.</param>
         ''' <param name="next">The next binder.</param>
         ''' <param name="root">Root syntax node</param>
-        Public Sub New(symbol As Symbol, [next] As Binder, root As VisualBasicSyntaxNode)
+        Public Sub New(symbol As Symbol, additionalSymbols As ImmutableArray(Of Symbol), [next] As Binder, root As VisualBasicSyntaxNode)
             MyBase.New([next])
             Debug.Assert((symbol.Kind = SymbolKind.Field) OrElse (symbol.Kind = SymbolKind.Property) OrElse (symbol.Kind = SymbolKind.Parameter))
+            Debug.Assert(additionalSymbols.All(Function(s) s.Kind = SymbolKind.Field OrElse s.Kind = SymbolKind.Property))
             Me._symbol = symbol
+            Me._additionalSymbols = additionalSymbols
             Debug.Assert(root IsNot Nothing)
             _root = root
         End Sub
@@ -42,6 +51,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return Me._symbol
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Additional members associated with the binding context
+        ''' Currently, this field is only used for multiple field symbols initialized by an AsNew field initializer, e.g. "Dim x, y As New Integer"
+        ''' </summary>
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return Me._additionalSymbols
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.RuntimeMembers
@@ -29,6 +30,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return If(_owner, MyBase.ContainingMember)
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.RuntimeMembers
@@ -73,6 +74,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return Me.Compilation.SourceModule
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
@@ -90,8 +90,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Iterator Function GetInitializedFieldsOrProperties(binder As Binder) As IEnumerable(Of Symbol)
             Yield Me.MemberSymbol
 
-            For Each additionalField In binder.AdditionalContainingMembers
-                Yield additionalField
+            For Each additionalSymbol In binder.AdditionalContainingMembers
+                Yield additionalSymbol
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
@@ -87,6 +87,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
+        Private Iterator Function GetInitializedFieldsOrProperties(binder As Binder) As IEnumerable(Of Symbol)
+            Yield Me.MemberSymbol
+
+            For Each additionalField In binder.AdditionalContainingMembers
+                Yield additionalField
+            Next
+        End Function
+
         Private Function BindInitializer(binder As Binder, initializer As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
             Dim boundInitializer As BoundNode = Nothing
 
@@ -106,7 +114,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim boundInitializers = ArrayBuilder(Of BoundInitializer).GetInstance
                         If initializer IsNot Nothing Then
                             ' bind const and non const field initializers the same to get a bound expression back and not a constant value.
-                            binder.BindFieldInitializer(ImmutableArray.Create(Of FieldSymbol)(fieldSymbol), initializer, boundInitializers, diagnostics, bindingForSemanticModel:=True)
+                            Dim fields = ImmutableArray.CreateRange(GetInitializedFieldsOrProperties(binder).Cast(Of FieldSymbol))
+                            binder.BindFieldInitializer(fields, initializer, boundInitializers, diagnostics, bindingForSemanticModel:=True)
                         Else
                             binder.BindArrayFieldImplicitInitializer(fieldSymbol, boundInitializers, diagnostics)
                         End If
@@ -122,15 +131,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Case SymbolKind.Property
                     '  get property symbol
-                    Dim propertySymbol = DirectCast(Me.MemberSymbol, PropertySymbol)
+                    Dim propertySymbols = ImmutableArray.CreateRange(GetInitializedFieldsOrProperties(binder).Cast(Of PropertySymbol))
                     Dim boundInitializers = ArrayBuilder(Of BoundInitializer).GetInstance
-                    binder.BindPropertyInitializer(ImmutableArray.Create(propertySymbol), initializer, boundInitializers, diagnostics)
+                    binder.BindPropertyInitializer(propertySymbols, initializer, boundInitializers, diagnostics)
                     boundInitializer = boundInitializers.First
                     boundInitializers.Free()
 
                     Dim expressionInitializer = TryCast(boundInitializer, BoundExpression)
                     If expressionInitializer IsNot Nothing Then
-                        Return New BoundPropertyInitializer(initializer, ImmutableArray.Create(propertySymbol), Nothing, expressionInitializer)
+                        Return New BoundPropertyInitializer(initializer, propertySymbols, Nothing, expressionInitializer)
                     End If
 
                 Case SymbolKind.Parameter

--- a/src/Compilers/VisualBasic/Portable/Binding/LocationSpecificBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LocationSpecificBinder.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.RuntimeMembers
@@ -42,6 +43,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return If(_owner, MyBase.ContainingMember)
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.PooledObjects
@@ -163,6 +164,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return _typeSymbol
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Binding/NamespaceBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/NamespaceBinder.vb
@@ -2,6 +2,7 @@
 
 Imports System.Collections.Concurrent
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.PooledObjects
@@ -49,6 +50,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Overrides ReadOnly Property ContainingMember As Symbol
             Get
                 Return _nsSymbol
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
@@ -48,6 +48,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
+            End Get
+        End Property
+
         Public MustOverride Overrides Function GetLocalForFunctionValue() As LocalSymbol
 
         Friend Overrides Sub LookupInSingleBinder(lookupResult As LookupResult,

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -907,7 +907,7 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundFieldInitializerOperation(boundFieldInitializer As BoundFieldInitializer) As IFieldInitializerOperation
-            Dim initializedFields As ImmutableArray(Of IFieldSymbol) = ImmutableArray(Of IFieldSymbol).CastUp(boundFieldInitializer.InitializedFields)
+            Dim initializedFields As ImmutableArray(Of IFieldSymbol) = boundFieldInitializer.InitializedFields.As(Of IFieldSymbol)
             Dim value As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundFieldInitializer.InitialValue))
             Dim kind As OperationKind = OperationKind.FieldInitializer
             Dim syntax As SyntaxNode = boundFieldInitializer.Syntax

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -918,14 +918,14 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundPropertyInitializerOperation(boundPropertyInitializer As BoundPropertyInitializer) As IPropertyInitializerOperation
-            Dim initializedProperty As IPropertySymbol = boundPropertyInitializer.InitializedProperties.FirstOrDefault()
+            Dim initializedProperties As ImmutableArray(Of IPropertySymbol) = boundPropertyInitializer.InitializedProperties.As(Of IPropertySymbol)
             Dim value As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundPropertyInitializer.InitialValue))
             Dim kind As OperationKind = OperationKind.PropertyInitializer
             Dim syntax As SyntaxNode = boundPropertyInitializer.Syntax
             Dim type As ITypeSymbol = Nothing
             Dim constantValue As [Optional](Of Object) = New [Optional](Of Object)()
             Dim isImplicit As Boolean = boundPropertyInitializer.WasCompilerGenerated
-            Return New LazyPropertyInitializer(initializedProperty, value, kind, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New LazyPropertyInitializer(initializedProperties, value, kind, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
         Private Function CreateBoundParameterEqualsValueOperation(boundParameterEqualsValue As BoundParameterEqualsValue) As IParameterInitializerOperation

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
@@ -192,6 +192,34 @@ IFieldInitializerOperation (2 initialized fields) (OperationKind.FieldInitialize
 
         <CompilerTrait(CompilerFeature.IOperation)>
         <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
+        Public Sub SingleFieldInitializerErrorCase()
+            Dim source = <![CDATA[
+Class C1
+    Dim x, y As Object = Me'BIND:"= Me"
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IFieldInitializerOperation (2 initialized fields) (OperationKind.FieldInitializer, Type: null, IsInvalid) (Syntax: '= Me')
+  Field_1: C1.x As System.Object
+  Field_2: C1.y As System.Object
+  IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsInvalid, IsImplicit) (Syntax: 'Me')
+    Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+    Operand: 
+      IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C1, IsInvalid) (Syntax: 'Me')
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30671: Explicit initialization is not permitted with multiple variables declared with a single type specifier.
+    Dim x, y As Object = Me'BIND:"= Me"
+        ~~~~~~~~~~~~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of EqualsValueSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
         Public Sub MultipleWithEventsInitializers()
             Dim source = <![CDATA[
 Class C1
@@ -223,7 +251,7 @@ IPropertyInitializerOperation (2 initialized properties) (OperationKind.Property
 
         <CompilerTrait(CompilerFeature.IOperation)>
         <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
-        Public Sub SingleWithEventsInitializers()
+        Public Sub SingleWithEventsInitializersErrorCase()
             Dim source = <![CDATA[
 Class C1
     Public Sub New(c As C1)

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
@@ -168,7 +168,7 @@ IFieldInitializerOperation (Field: C.x As System.Object) (OperationKind.FieldIni
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17813"), WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
+        <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
         Public Sub MultipleFieldInitializers()
             Dim source = <![CDATA[
 Class C
@@ -176,15 +176,76 @@ Class C
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IFieldInitializer (2 initialized fields) (OperationKind.FieldInitializer)  (Syntax: 'As New Object')
+IFieldInitializerOperation (2 initialized fields) (OperationKind.FieldInitializer, Type: null) (Syntax: 'As New Object')
   Field_1: C.x As System.Object
   Field_2: C.y As System.Object
-  IObjectCreationExpression (Constructor: Sub System.Object..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Object) (Syntax: 'New Object')
+  IObjectCreationOperation (Constructor: Sub System.Object..ctor()) (OperationKind.ObjectCreation, Type: System.Object) (Syntax: 'New Object')
+    Arguments(0)
+    Initializer: 
+      null
 ]]>.Value
 
             Dim expectedDiagnostics = String.Empty
 
             VerifyOperationTreeAndDiagnosticsForTest(Of AsNewClauseSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
+        Public Sub MultipleWithEventsInitializers()
+            Dim source = <![CDATA[
+Class C1
+    Public Sub New(c As C1)
+    End Sub
+
+    WithEvents e, f As New C1(Me)'BIND:"As New C1(Me)"
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IPropertyInitializerOperation (2 initialized properties) (OperationKind.PropertyInitializer, Type: null) (Syntax: 'As New C1(Me)')
+  Property_1: WithEvents C1.e As C1
+  Property_2: WithEvents C1.f As C1
+  IObjectCreationOperation (Constructor: Sub C1..ctor(c As C1)) (OperationKind.ObjectCreation, Type: C1) (Syntax: 'New C1(Me)')
+    Arguments(1):
+        IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: c) (OperationKind.Argument, Type: null) (Syntax: 'Me')
+          IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C1) (Syntax: 'Me')
+          InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+    Initializer: 
+      null
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of AsNewClauseSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact, WorkItem(17813, "https://github.com/dotnet/roslyn/issues/17813")>
+        Public Sub SingleWithEventsInitializers()
+            Dim source = <![CDATA[
+Class C1
+    Public Sub New(c As C1)
+    End Sub
+    WithEvents e, f As C1 = Me'BIND:"= Me"
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IPropertyInitializerOperation (2 initialized properties) (OperationKind.PropertyInitializer, Type: null, IsInvalid) (Syntax: '= Me')
+  Property_1: WithEvents C1.e As C1
+  Property_2: WithEvents C1.f As C1
+  IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C1, IsInvalid) (Syntax: 'Me')
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30671: Explicit initialization is not permitted with multiple variables declared with a single type specifier.
+    WithEvents e, f As C1 = Me'BIND:"= Me"
+               ~~~~~~~~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of EqualsValueSyntax)(source, expectedOperationTree, expectedDiagnostics)
         End Sub
 
         <CompilerTrait(CompilerFeature.IOperation)>
@@ -199,7 +260,7 @@ Class C
     End Function
 End Class]]>.Value
 
-Dim expectedOperationTree = <![CDATA[
+            Dim expectedOperationTree = <![CDATA[
 IFieldInitializerOperation (Field: C.s1 As System.Int32) (OperationKind.FieldInitializer, Type: null) (Syntax: '= 1 + F()')
   IBinaryOperation (BinaryOperatorKind.Add, Checked) (OperationKind.BinaryOperator, Type: System.Int32) (Syntax: '1 + F()')
     Left: 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -34,6 +34,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
+            End Get
+        End Property
+
         Friend Overrides Sub LookupInSingleBinder(
                 lookupResult As LookupResult,
                 name As String, arity As Integer,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
@@ -51,6 +51,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
+        Public Overrides ReadOnly Property AdditionalContainingMembers As ImmutableArray(Of Symbol)
+            Get
+                Return ImmutableArray(Of Symbol).Empty
+            End Get
+        End Property
+
         Public Overrides ReadOnly Property ContainingNamespaceOrType As NamespaceOrTypeSymbol
             Get
                 Return _substitutedSourceMethod.ContainingNamespaceOrType

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1196,10 +1196,34 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitPropertyInitializer(IPropertyInitializerOperation operation)
         {
             LogString(nameof(IPropertyInitializerOperation));
-            LogSymbol(operation.InitializedProperty, header: " (Property");
-            LogString(")");
-            LogCommonPropertiesAndNewLine(operation);
 
+            if (operation.InitializedProperties.Length <= 1)
+            {
+                if (operation.InitializedProperties.Length == 1)
+                {
+                    LogSymbol(operation.InitializedProperties[0], header: " (Property");
+                    LogString(")");
+                }
+
+                LogCommonPropertiesAndNewLine(operation);
+            }
+            else
+            {
+                LogString($" ({operation.InitializedProperties.Length} initialized properties)");
+                LogCommonPropertiesAndNewLine(operation);
+
+                Indent();
+
+                int index = 1;
+                foreach (var property in operation.InitializedProperties)
+                {
+                    LogSymbol(property, header: $"Property_{index++}");
+                    LogNewLine();
+                }
+
+                Unindent();
+            }
+            
             base.VisitPropertyInitializer(operation);
         }
 

--- a/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public override void VisitPropertyInitializer(IPropertyInitializerOperation operation)
         {
-            var initializedProperty = operation.InitializedProperty;
+            var initializedProperty = operation.InitializedProperties;
 
             base.VisitPropertyInitializer(operation);
         }


### PR DESCRIPTION
…xt and populate the additional field/property symbols initialized by VB AsNew clause that initializes more than one field/property

Note: This change also includes an API change to `IPropertyInitializer` as VB WithEvents declaration with AsNew clause initializer can initialize multiple properties.
Fixes #17813 
vso :https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/521939