### PR TITLE
EnC: LCS GetDistance optimization of large differences in sequence lengths

### DIFF
--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -164,11 +164,11 @@ namespace Microsoft.CodeAnalysis.Differencing
 
         /// <summary>
         /// Returns a distance [0..1] of the specified sequences.
-        /// The smaller distance the more of their elements match.
+        /// The smaller distance the more similar the sequences are.
         /// </summary>
         /// <summary>
         /// Returns a distance [0..1] of the specified sequences.
-        /// The smaller distance the more of their elements match.
+        /// The smaller distance the more similar the sequences are.
         /// </summary>
         protected double ComputeDistance(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
@@ -177,6 +177,15 @@ namespace Microsoft.CodeAnalysis.Differencing
             if (oldLength == 0 || newLength == 0)
             {
                 return (oldLength == newLength) ? 0.0 : 1.0;
+            }
+
+            // If the sequences differ significantly in size their distance will be very close to 1.0 
+            // (even if one is a strict subsequence of the other).
+            // Avoid running an expensive LCS algorithm on such sequences.
+            double lenghtRatio = (oldLength > newLength) ? oldLength / newLength : newLength / oldLength;
+            if (lenghtRatio > 100)
+            {
+                return 1.0;
             }
 
             int lcsLength = 0;

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.0);
+            Assert.Equal(0.0, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
         }
 
 
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
+            Assert.Equal(0.75, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
+            Assert.Equal(0.75, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
+            Assert.Equal(0.6, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.556, 3);
+            Assert.Equal(0.556, lcs.ComputeDistance(str1, str2), precision: 3);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
+            Assert.Equal(0.6, lcs.ComputeDistance(str1, str2));
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.429, 3);
+            Assert.Equal(0.429, lcs.ComputeDistance(str1, str2), precision: 3);
         }
 
         [Fact]
@@ -305,7 +305,39 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
+        }
+
+        [Fact]
+        public void LongString()
+        {
+            var s = "A";
+
+            var x9 = new string('x', 9);
+            var x10 = new string('x', 10);
+            var x99 = new string('x', 99);
+            var x100 = new string('x', 100);
+            var x1000 = new string('x', 1000);
+
+            var y1000 = new string('y', 1000);
+
+            var sx9 = s + x9;
+            var sx99 = s + x99;
+            var sx1000 = s + new string('x', 1000);
+            var sx100000000 = s + new string('x', 100000000);
+            
+            Assert.Equal(0.900, lcs.ComputeDistance(s, sx9), precision: 3);
+            Assert.Equal(0.990, lcs.ComputeDistance(s, sx99), precision: 3);
+            Assert.Equal(1.000, lcs.ComputeDistance(s, sx1000), precision: 3);
+            Assert.Equal(1.000, lcs.ComputeDistance(s, sx100000000), precision: 3);
+
+            Assert.Equal(0.900, lcs.ComputeDistance(sx9, s), precision: 3);
+            Assert.Equal(0.990, lcs.ComputeDistance(sx99, s), precision: 3);
+            Assert.Equal(1.000, lcs.ComputeDistance(sx1000, s), precision: 3);
+            Assert.Equal(1.000, lcs.ComputeDistance(sx100000000, s), precision: 3);
+
+            Assert.Equal(1.000, lcs.ComputeDistance(x10 + y1000, x10), precision: 3);
+            Assert.Equal(0.5, lcs.ComputeDistance(x1000 + y1000, x1000), precision: 3);
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

VS crashes when editing large methods (1000s of statements) during debugging.

**Bugs this fixes:**

VSO [517304](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/517304)

**Workarounds, if any**

Split the method into smaller methods.

**Risk**

Low.

**Performance impact**

Improves performance by short-circuiting comparison of code blocks that significantly differ in size.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The syntax diffing algorithm has space complexity O((N+M)*D) where N is size of first sequence, M size of other sequence, D is number of differences in between the sequences. If N >> M then D ~ N and thus the complexity degenerates to O(N^2). 

**How was the bug found?**

Customer reported.