### PR TITLE
Further simplify how SWIX are produced

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
@@ -12,7 +12,7 @@
     <OutputType>vsix</OutputType>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.props" />
 
   <PropertyGroup>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(VsixVersion);OutputPath=$(RoslynOutputPath);RepoRoot=$(RepoRoot)</PackagePreprocessorDefinitions>
@@ -23,8 +23,5 @@
     <Package Include="Microsoft.CodeAnalysis.Compilers.swr" />
   </ItemGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
-
-  <!-- Disable automatic signing. This will be signed in the batch phase -->
-  <Target Name="AddTargetPathToFilesToSign" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.targets" />
 </Project>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
@@ -12,8 +12,7 @@
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.props" />
 
   <Target Name="BeforeBuild">
     <MSBuild Projects="Microsoft.CodeAnalysis.Compilers.swixproj" Targets="Build" />
@@ -23,8 +22,5 @@
     <MergeManifest Include="$(OutputPath)\Microsoft.CodeAnalysis.Compilers.json" />
   </ItemGroup>
 
-  <Target Name="ValidateManifest" />
-
-  <!-- Disable automatic signing. This will be signed in the batch phase -->
-  <Target Name="AddTargetPathToFilesToSign" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.targets" />
 </Project>

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
@@ -12,8 +12,7 @@
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.props" />
 
   <ItemGroup>
     <MergeManifest Include="$(OutputPath)\..\ExpressionEvaluatorPackage\Microsoft.CodeAnalysis.ExpressionEvaluator.json" />
@@ -24,6 +23,5 @@
 
   <Target Name="ValidateManifest" />
 
-  <!-- Disable automatic signing. This will be signed in the batch phase -->
-  <Target Name="AddTargetPathToFilesToSign" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.targets" />
 </Project>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
@@ -11,7 +11,7 @@
     <OutputType>vsix</OutputType>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.props" />
 
   <PropertyGroup>
     <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);NuGetPackageRoot=$(NuGetPackageRoot)</PackagePreprocessorDefinitions>
@@ -22,8 +22,5 @@
     <Package Include="PortableFacades.swr" />
   </ItemGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
-
-  <!-- Disable automatic signing. This will be signed in the batch phase -->
-  <Target Name="AddTargetPathToFilesToSign" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.targets" />
 </Project>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
@@ -12,8 +12,7 @@
     <ValidateManifest>false</ValidateManifest>
   </PropertyGroup>
 
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
-  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.props" />
 
   <Target Name="BeforeBuild">
     <MSBuild Projects="PortableFacades.swixproj" Targets="Build" />
@@ -25,6 +24,5 @@
 
   <Target Name="ValidateManifest" />
 
-  <!-- Disable automatic signing. This will be signed in the batch phase -->
-  <Target Name="AddTargetPathToFilesToSign" />
+  <Import Project="$(NuGetPackageRoot)\microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\build\MicroBuild.Plugins.*.targets" />
 </Project>


### PR DESCRIPTION
This changes the SWIX builds to use the SWIX props / targets files
by directly importing them rather than indirectly importing them via the
Microbuild props / targets.

This has a couple of advantages:

1. Simplifies the files. No longer have to suppress the signing that
Microbuild was adding.
1. Makes the build more robust. We will no longer get bitten by the
build errors that occur when more than one version of the SWIX NuGet
package is installed.

