### PR TITLE
Reduce the use of the preprocessor

### DIFF
--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -36,6 +36,9 @@
     <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
       <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\CoreClrShim.cs">
+      <Link>CoreClrShim.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\DesktopBuildClient.cs">
       <Link>DesktopBuildClient.cs</Link>
     </Compile>

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -36,11 +36,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             // VBCSCompiler is installed in the same directory as csc.exe and vbc.exe which is also the 
             // location of the response files.
             var clientDirectory = AppDomain.CurrentDomain.BaseDirectory;
-#if NET46
-            var sdkDirectory = RuntimeEnvironment.GetRuntimeDirectory();
-#else
-            var sdkDirectory = (string)null;
-#endif
+            var sdkDirectory = BuildClient.GetSystemSdkDirectory();
+
             return new DesktopCompilerServerHost(clientDirectory, sdkDirectory);
         }
 

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-    <Reference Include="System.Configuration"  Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
+    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netcoreapp2.0'" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>
@@ -36,6 +36,9 @@
     </Compile>
     <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
       <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Shared\CoreClrShim.cs">
+      <Link>CoreClrShim.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\DesktopAnalyzerAssemblyLoader.cs">
       <Link>DesktopAnalyzerAssemblyLoader.cs</Link>

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -198,11 +198,7 @@ End Module")
             var client = ServerUtil.CreateBuildClient(language);
             client.TimeoutOverride = Timeout.Infinite;
 
-#if NET461
-            var sdkDir = RuntimeEnvironment.GetRuntimeDirectory();
-#else
-            string sdkDir = null;
-#endif
+            var sdkDir = ServerUtil.DefaultSdkDirectory;
 
             var buildPaths = new BuildPaths(
                 clientDir: Path.GetDirectoryName(typeof(CommonCompiler).Assembly.Location),
@@ -222,10 +218,11 @@ End Module")
 
         private static void RunCompilerOutput(TempFile file, string expectedOutput)
         {
-#if NET461
-            var result = ProcessUtilities.Run(file.Path, "", Path.GetDirectoryName(file.Path));
-            Assert.Equal(expectedOutput.Trim(), result.Output.Trim());
-#endif
+            if (!CoreClrShim.IsRunningOnCoreClr)
+            {
+                var result = ProcessUtilities.Run(file.Path, "", Path.GetDirectoryName(file.Path));
+                Assert.Equal(expectedOutput.Trim(), result.Output.Trim());
+            }
         }
 
         private static void VerifyResult((int ExitCode, string Output) result)

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -69,11 +69,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
     internal static class ServerUtil
     {
         internal static string DefaultClientDirectory { get; } = Path.GetDirectoryName(typeof(DesktopBuildClientTests).Assembly.Location);
-#if NET461
-        internal static string DefaultSdkDirectory { get; } = RuntimeEnvironment.GetRuntimeDirectory();
-#else
-        internal static string DefaultSdkDirectory { get; } = null;
-#endif
+        internal static string DefaultSdkDirectory { get; } = BuildClient.GetSystemSdkDirectory();
 
         internal static BuildPaths CreateBuildPaths(string workingDir, string tempDir)
         {

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -40,6 +40,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
     {
         protected static bool IsRunningOnWindows => Path.DirectorySeparatorChar == '\\';
 
+        /// <summary>
+        /// Returns the directory that contains mscorlib, or null when running on CoreCLR.
+        /// </summary>
         public static string GetSystemSdkDirectory()
         {
             if (CoreClrShim.IsRunningOnCoreClr)

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -40,6 +40,18 @@ namespace Microsoft.CodeAnalysis.CommandLine
     {
         protected static bool IsRunningOnWindows => Path.DirectorySeparatorChar == '\\';
 
+        public static string GetSystemSdkDirectory()
+        {
+            if (CoreClrShim.IsRunningOnCoreClr)
+            {
+                return null;
+            }
+            else
+            {
+                return RuntimeEnvironment.GetRuntimeDirectory();
+            }
+        }
+
         /// <summary>
         /// Run a compilation through the compiler server and print the output
         /// to the console. If the compiler server fails, run the fallback
@@ -191,15 +203,16 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return false;
             }
 
-#if NET46
+            if (CoreClrShim.IsRunningOnCoreClr)
+            {
+                // The native invoke ends up giving us both CoreRun and the exe file.
+                // We've decided to ignore backcompat for CoreCLR,
+                // and use the Main()-provided arguments
+                // https://github.com/dotnet/roslyn/issues/6677
+                return false;
+            }
+
             return true;
-#else
-            // (Not NET46 -> on CoreCLR)
-            // The native invoke ends up giving us both CoreRun and the exe file.
-            // Need to find a good way to remove the host as well as the EXE argument.
-            // https://github.com/dotnet/roslyn/issues/6677
-            return false;
-#endif
         }
 
         /// <summary>

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -341,13 +341,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static bool TryCreateServerCore(string clientDir, string pipeName)
         {
-#if NETSTANDARD1_3
             bool isRunningOnCoreClr = CoreClrShim.IsRunningOnCoreClr;
-#elif NET46
-            bool isRunningOnCoreClr = false;
-#elif NETCOREAPP2_0
-            bool isRunningOnCoreClr = true;
-#endif
             string expectedPath;
             string processArguments;
             if (isRunningOnCoreClr)

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -3,11 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -31,15 +28,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static int Run(IEnumerable<string> arguments, RequestLanguage language, CompileFunc compileFunc, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
         {
-#if NET46
-            var sdkDir = RuntimeEnvironment.GetRuntimeDirectory();
-#else
-            string sdkDir = null;
+            var sdkDir = GetSystemSdkDirectory();
+            if (CoreClrShim.IsRunningOnCoreClr)
+            {
+                // Register encodings for console
+                // https://github.com/dotnet/roslyn/issues/10785
+                System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+            }
 
-            // Register encodings for console
-            // https://github.com/dotnet/roslyn/issues/10785 
-            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
-#endif
             var client = new DesktopBuildClient(language, compileFunc, analyzerAssemblyLoader);
             var clientDir = AppContext.BaseDirectory;
             var workingDir = Directory.GetCurrentDirectory();

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -35,6 +35,9 @@
     <Compile Include="..\..\Shared\CoreClrAnalyzerAssemblyLoader.cs">
       <Link>CoreClrAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\CoreClrShim.cs">
+      <Link>CoreClrShim.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\DesktopBuildClient.cs">
       <Link>DesktopBuildClient.cs</Link>
     </Compile>


### PR DESCRIPTION
Prefer to use runtime checks instead. Only use a the preprocessor where an API actually matters at compile-time.

Remaining preprocessor checks:

* `DesktopAnalyzerAssemblyLoader`/`CoreClrAnalyzerAssemblyLoader`/`ShadowCopyAnalyzerAssemblyLoader`: preprocessor needed for badly-structured inherentence for `ShadowCopy`, and for the API `AssemblyLoadContext`.
* `NamedPipeClientConnection.cs` `NamedPipeServerStream` constructor (the `WRITE_DAC` stuff)
* `BuildServerConnection.cs` `CheckIdentityUnix` - private reflection not available on netstandard (for authentication of pipes). (However, it doesn't matter, since the only netstandard project here is clientside, not serverside)
* `BuildServerConnection.cs` `GetPipeSecurity` - `PipeStream.GetAccessControl` not available on netstandard (preprocessor changes it to reflection).
* Bunches of tests.