### PR TITLE
Add the Roslyn version string into Help > About

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.LanguageServices.Utilities;
 
 // NOTE(DustinCa): The EditorFactory registration is in VisualStudioComponents\CSharpPackageRegistration.pkgdef.
 // The reason for this is because the ProvideEditorLogicalView does not allow a name value to specified in addition to
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     // (See vsproject\cool\coolpkg\pkg\VCSharp_Proj_System_Reg.pkgdef for an example).
     [Guid(Guids.CSharpPackageIdString)]
     [PackageRegistration(UseManagedResourcesOnly = true)]
+    [ProvideRoslynVersionRegistration(Guids.CSharpPackageIdString, "Microsoft Visual C#", productNameResourceID: 116, detailsResourceID: 117)]
     [ProvideLanguageExtension(typeof(CSharpLanguageService), ".cs")]
     [ProvideLanguageService(Guids.CSharpLanguageServiceIdString, "CSharp", languageResourceID: 101, RequestStockColors = true, ShowDropDownOptions = true)]
 

--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -215,4 +215,12 @@
     <value>Naming Style;Name Styles;Naming Rule;Naming Conventions</value>
     <comment>C# Naming Style options page keywords</comment>
   </data>
+  <data name="116" xml:space="preserve">
+    <value>C# Tools</value>
+    <comment>Help &gt; About</comment>
+  </data>
+  <data name="117" xml:space="preserve">
+    <value>C# components used in the IDE. Depending on your project type and settings, a different version of the compiler may be used.</value>
+    <comment>Help &gt; About</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/Utilities/ProvideRoslynVersionRegistration.cs
+++ b/src/VisualStudio/Core/Def/Utilities/ProvideRoslynVersionRegistration.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.Utilities
+{
+    /// <summary>
+    /// Adds information to Help &gt; About screen showing the version of the Roslyn package.
+    /// </summary>
+    internal sealed class ProvideRoslynVersionRegistration : RegistrationAttribute
+    {
+        private readonly string _packageGuidString;
+        private readonly string _productName;
+        private readonly int _productNameResourceID;
+        private readonly int _detailsResourceID;
+
+        public ProvideRoslynVersionRegistration(string packageGuidString, string productName, int productNameResourceID, int detailsResourceID)
+        {
+            _packageGuidString = packageGuidString;
+            _productName = productName;
+            _productNameResourceID = productNameResourceID;
+            _detailsResourceID = detailsResourceID;
+        }
+
+        private string GetKeyName()
+        {
+            return "InstalledProducts\\" + _productName;
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            // Fetch the version of this build. As a reminder, this code runs during the build process, not at runtime -- it's
+            // ran by the CreatPkgDef.exe tool by reflecting over built assembly and invoking this method.
+            var version = FileVersionInfo.GetVersionInfo(typeof(ProvideRoslynVersionRegistration).Assembly.Location);
+
+            using (var key = context.CreateKey(GetKeyName()))
+            {
+                key.SetValue(null, "#" + _productNameResourceID);
+                key.SetValue("Package", Guid.Parse(_packageGuidString).ToString("B"));
+                key.SetValue("PID", version.ProductVersion);
+                key.SetValue("ProductDetails", "#" + _detailsResourceID);
+                key.SetValue("UseInterface", false);
+                key.SetValue("UseVSProductID", false);
+            }
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            context.RemoveKey(GetKeyName());
+        }
+    }
+}

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -9,6 +9,7 @@ Imports Microsoft.VisualStudio.LanguageServices.CSharp.Options.Formatting
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
@@ -38,6 +39,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
     <Guid(Guids.VisualBasicPackageIdString)>
     <PackageRegistration(UseManagedResourcesOnly:=True)>
+    <ProvideRoslynVersionRegistration(Guids.VisualBasicPackageIdString, "Microsoft Visual Basic", 113, 114)>
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".bas")>
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".cls")>
     <ProvideLanguageExtension(GetType(VisualBasicLanguageService), ".ctl")>

--- a/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
+++ b/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
@@ -186,4 +186,12 @@
     <value>Change completion list settings;Pre-select most recently used member</value>
     <comment>IntelliSense options page keywords</comment>
   </data>
+  <data name="114" xml:space="preserve">
+    <value>Visual Basic components used in the IDE. Depending on your project type and settings, a different version of the compiler may be used.</value>
+    <comment>Help &gt; About</comment>
+  </data>
+  <data name="113" xml:space="preserve">
+    <value>Visual Basic Tools</value>
+    <comment>Help &gt; About</comment>
+  </data>
 </root>


### PR DESCRIPTION
This shows our informational version in Help > About instead of a
useless ProductID GUID.

Fixes dotnet/roslyn#17038.

Before:

![image](https://user-images.githubusercontent.com/201340/32678454-3ca70500-c617-11e7-8c9c-8a779b4f2aa7.png)

After:

![image](https://user-images.githubusercontent.com/201340/32678494-6a727bf4-c617-11e7-980d-35e4219b5673.png)
