### PR TITLE
Updating nullable refs branch for preview release

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -9,9 +9,11 @@
 
   <PropertyGroup>
     <!-- This is the assembly version of Roslyn from the .NET assembly perspective. It should only be revved during significant point releases. -->
-    <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.6.0</RoslynAssemblyVersionBase>
+    <!-- PROTOTYPE(NullableReferenceTypes): Revert before merging to master. -->
+    <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.6.1</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
-    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.6.0</RoslynFileVersionBase>
+    <!-- PROTOTYPE(NullableReferenceTypes): Revert before merging to master. -->
+    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.6.1</RoslynFileVersionBase>
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>

--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="f6d4ae9d-5ca3-4e0b-9035-9457cccf53fa" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Roslyn Insiders (Without Tool Window)</DisplayName>
-    <Description>Pre-release build of Roslyn compilers and language services.</Description>
+    <DisplayName>Roslyn Nullable Reference Types Preview</DisplayName>
+    <Description>Pre-release build of Roslyn compilers and language services with support for nullable reference types.</Description>
   </Metadata>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />

--- a/src/Setup/Vsix/myget_org-extensions.config
+++ b/src/Setup/Vsix/myget_org-extensions.config
@@ -4,7 +4,5 @@
   we run after every signed build uploads all shipped extensions in the VSIX folder to myget.org
  -->
 <extensions>
-  <extension id="Microsoft.VisualStudio.IntegrationTest.Setup" path="Vsix\VisualStudioIntegrationTestSetup" />
-  <extension id="Roslyn.Deployment.Full" path="Vsix\Roslyn.Deployment.Full" />
-  <extension id="Roslyn.Deployment.Full.Next" path="Vsix\Roslyn.Deployment.Full.Next" />
+  <extension id="RoslynDeployment" path="Vsix\Roslyn" />
 </extensions>


### PR DESCRIPTION
- Updating the version number to be greater than 2.6.1
- Changed VSIX manifest wording
- Changed publish script to only publish RoslynDeployment.vsix
