### PR TITLE
Ensure CodeModel adds elastic trivia when setting names

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -879,6 +879,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 throw new ArgumentNullException(nameof(node));
             }
 
+            // In all cases, the resulting syntax for the new name has elastic trivia attached,
+            // whether via this call to SyntaxFactory.Identifier or via explicitly added elastic
+            // markers.
             SyntaxToken newIdentifier = SyntaxFactory.Identifier(name);
             switch (node.Kind())
             {
@@ -904,13 +907,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 case SyntaxKind.Parameter:
                     return ((ParameterSyntax)node).WithIdentifier(newIdentifier);
                 case SyntaxKind.NamespaceDeclaration:
-                    return ((NamespaceDeclarationSyntax)node).WithName(SyntaxFactory.IdentifierName(name));
+                    return ((NamespaceDeclarationSyntax)node).WithName(
+                        SyntaxFactory.ParseName(name)
+                            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
+                            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)));
                 case SyntaxKind.EnumMemberDeclaration:
                     return ((EnumMemberDeclarationSyntax)node).WithIdentifier(newIdentifier);
                 case SyntaxKind.VariableDeclarator:
                     return ((VariableDeclaratorSyntax)node).WithIdentifier(newIdentifier);
                 case SyntaxKind.Attribute:
-                    return ((AttributeSyntax)node).WithName(SyntaxFactory.IdentifierName(name));
+                    return ((AttributeSyntax)node).WithName(
+                        SyntaxFactory.ParseName(name)
+                            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker))
+                            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)));
                 case SyntaxKind.AttributeArgument:
                     return ((AttributeArgumentSyntax)node).WithNameEquals(SyntaxFactory.NameEquals(SyntaxFactory.IdentifierName(name)));
                 default:

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeNamespaceTests.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Overrides Function GetNameSetter(codeElement As EnvDTE.CodeNamespace) As Action(Of String)
-            Throw New NotImplementedException()
+            Return Sub(name) codeElement.Name = name
         End Function
 
         Protected Overrides Function GetParent(codeElement As EnvDTE.CodeNamespace) As Object

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -861,7 +861,7 @@ class CAttribute : Attribute { }
 
 #Region "Set Name tests"
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestSetName1() As Task
+        Public Async Function TestSetName_NewName() As Task
             Dim code =
 <Code>
 [$$Goo]
@@ -875,6 +875,40 @@ class C { }
 </Code>
 
             Await TestSetName(code, expected, "Bar", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SimpleNameToDottedName() As Task
+            Dim code =
+<Code>
+[$$Goo]
+class C { }
+</Code>
+
+            Dim expected =
+<Code>
+[Bar.Baz]
+class C { }
+</Code>
+
+            Await TestSetName(code, expected, "Bar.Baz", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_DottedNameToSimpleName() As Task
+            Dim code =
+<Code>
+[$$Goo.Bar]
+class C { }
+</Code>
+
+            Dim expected =
+<Code>
+[Baz]
+class C { }
+</Code>
+
+            Await TestSetName(code, expected, "Baz", NoThrow(Of String)())
         End Function
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
@@ -389,6 +389,109 @@ namespace N1
 
 #End Region
 
+#Region "Set Name tests"
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SameName() As Task
+            Dim code =
+<Code><![CDATA[
+namespace N$$ 
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+namespace N
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Await TestSetName(code, expected, "N", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_NewName() As Task
+            Dim code =
+<Code><![CDATA[
+namespace N$$
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+namespace N2
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Await TestSetName(code, expected, "N2", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SimpleNameToDottedName() As Task
+            Dim code =
+<Code><![CDATA[
+namespace N1$$
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+namespace N2.N3
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Await TestSetName(code, expected, "N2.N3", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_DottedNameToSimpleName() As Task
+            Dim code =
+<Code><![CDATA[
+namespace N1.N2$$
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+namespace N3.N4
+{
+    class C
+    {
+    }
+}
+]]></Code>
+
+            Await TestSetName(code, expected, "N3.N4", NoThrow(Of String)())
+        End Function
+
+#End Region
+
 #Region "Remove tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeAttributeTests.vb
@@ -1065,7 +1065,7 @@ End Class
 
 #Region "Set Name tests"
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestSetName1() As Task
+        Public Async Function TestSetName_NewName() As Task
             Dim code =
 <Code><![CDATA[
 <$$Goo()>
@@ -1081,6 +1081,44 @@ End Class
 ]]></Code>
 
             Await TestSetName(code, expected, "Bar", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SimpleNameToDottedName() As Task
+            Dim code =
+<Code><![CDATA[
+<$$Goo()>
+Class C
+End Class
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+<Bar.Baz()>
+Class C
+End Class
+]]></Code>
+
+            Await TestSetName(code, expected, "Bar.Baz", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_DottedNameToSimpleName() As Task
+            Dim code =
+<Code><![CDATA[
+<$$Goo()>
+Class C
+End Class
+]]></Code>
+
+            Dim expected =
+<Code><![CDATA[
+<Bar.Baz()>
+Class C
+End Class
+]]></Code>
+
+            Await TestSetName(code, expected, "Bar.Baz", NoThrow(Of String)())
         End Function
 #End Region
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeNamespaceTests.vb
@@ -821,6 +821,94 @@ End Namespace
 
 #End Region
 
+#Region "Set Name tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SameName() As Task
+            Dim code =
+<Code>
+Namespace N$$
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Await TestSetName(code, expected, "N", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_NewName() As Task
+            Dim code =
+<Code>
+Namespace N$$
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N2
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Await TestSetName(code, expected, "N2", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_SimpleNameToDottedName() As Task
+            Dim code =
+<Code>
+Namespace N1$$
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N2.N3
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Await TestSetName(code, expected, "N2.N3", NoThrow(Of String)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetName_DottedNameToDottedName() As Task
+            Dim code =
+<Code>
+Namespace N1.N2$$
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N3.N4
+    Class C
+    End Class
+End Namespace
+</Code>
+
+            Await TestSetName(code, expected, "N3.N4", NoThrow(Of String)())
+        End Function
+
+#End Region
+
 #Region "Remove tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -941,11 +941,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Throw New ArgumentNullException(NameOf(node))
             End If
 
+            ' In all cases, the resulting syntax for the new name has elastic trivia attached,
+            ' whether via this call to SyntaxFactory.Identifier or via explicitly added elastic
+            ' markers.
             Dim identifier As SyntaxToken = SyntaxFactory.Identifier(name)
 
             Select Case node.Kind
                 Case SyntaxKind.Attribute
-                    Return DirectCast(node, AttributeSyntax).WithName(SyntaxFactory.ParseTypeName(name))
+                    Return DirectCast(node, AttributeSyntax).WithName(
+                        SyntaxFactory.ParseTypeName(name) _
+                            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)) _
+                            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)))
                 Case SyntaxKind.ClassStatement
                     Return DirectCast(node, ClassStatementSyntax).WithIdentifier(identifier)
                 Case SyntaxKind.InterfaceStatement
@@ -960,7 +966,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                      SyntaxKind.DelegateSubStatement
                     Return DirectCast(node, DelegateStatementSyntax).WithIdentifier(identifier)
                 Case SyntaxKind.NamespaceStatement
-                    Return DirectCast(node, NamespaceStatementSyntax).WithName(SyntaxFactory.ParseName(name))
+                    Return DirectCast(node, NamespaceStatementSyntax).WithName(
+                        SyntaxFactory.ParseName(name) _
+                            .WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)) _
+                            .WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.ElasticMarker)))
                 Case SyntaxKind.SubStatement,
                      SyntaxKind.FunctionStatement,
                      SyntaxKind.SubNewStatement


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/512823
https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/524726

In VB Code Model, we use SyntaxFactory.ParseTypeName/ParseName when setting the name of an attribute or namespace. Doing this fails to add elastic trivia the way it is added in all other cases, so setting the name of a namespace (for example) would remove the newline, creating broken code. To fix this, we now manually add elastic trivia in these cases.

C# was already functioning correctly, but it was using ".IdentifierName()" to parse dotted names, which isn't advised. This change also updates the C# side accordingly.

Escrow
--------

**Customer scenario**: In Visual Basic, every save from an XSD designer with a Custom Tool Namespace set  will update the backing dataset .vb file to contain incorrect code (whether it has been changed or not), breaking subsequent builds until it is manually fixed up.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/512823

**Workarounds, if any**: After any such save of an XSD file, the user can open and manually clean up the data set code before building.

**Risk**: Very low. This is a seldom used API in VB that we haven't heard reports of before.

**Performance impact**: None, this merely changes the way syntax is built to include elastic trivia and that is only done in CodeModel scenarios.

**Is this a regression from a previous update?** No

**Root cause analysis:** The API is not often used and so far I don't see tests for how trivia is handled in `SetName`. Tests have been added.

**How was the bug found?** Customer reported (DTS)