### PR TITLE
Add support for recursive patterns in `is`

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2682,7 +2682,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var boundConstantPattern = BindConstantPattern(
-                    node.Right, operand.Type, node.Right, node.Right.HasErrors, isPatternDiagnostics, out wasExpression, wasSwitchCase: false);
+                    node.Right, operand.Type, node.Right, node.Right.HasErrors, isPatternDiagnostics, out wasExpression);
                 if (wasExpression)
                 {
                     isTypeDiagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1,0 +1,409 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal class DecisionDagBuilder
+    {
+        private readonly Conversions Conversions;
+        private readonly TypeSymbol BooleanType;
+        private readonly TypeSymbol ObjectType;
+
+        internal DecisionDagBuilder(CSharpCompilation compilation)
+        {
+            this.Conversions = compilation.Conversions;
+            this.BooleanType = compilation.GetSpecialType(SpecialType.System_Boolean);
+            this.ObjectType = compilation.GetSpecialType(SpecialType.System_Object);
+        }
+
+        public BoundDecisionDag CreateDecisionDag(BoundPatternSwitchStatement statement)
+        {
+            ImmutableArray<PartialCaseDecision> cases = MakeCases(statement);
+            BoundDecisionDag dag = MakeDecisionDag(cases);
+            return dag;
+        }
+
+        public BoundDagTemp LowerPattern(
+            BoundExpression input,
+            BoundPattern pattern,
+            out ImmutableArray<BoundDagDecision> decisions,
+            out ImmutableArray<(BoundExpression, BoundDagTemp)> bindings)
+        {
+            var rootIdentifier = new BoundDagTemp(input.Syntax, input.Type, null, 0);
+            MakeAndSimplifyDecisionsAndBindings(rootIdentifier, pattern, out decisions, out bindings);
+            return rootIdentifier;
+        }
+
+        private ImmutableArray<PartialCaseDecision> MakeCases(BoundPatternSwitchStatement statement)
+        {
+            var rootIdentifier = new BoundDagTemp(statement.Expression.Syntax, statement.Expression.Type, null, 0);
+            int i = 0;
+            var builder = ArrayBuilder<PartialCaseDecision>.GetInstance();
+            foreach (var section in statement.SwitchSections)
+            {
+                foreach (var label in section.SwitchLabels)
+                {
+                    builder.Add(MakePartialCaseDecision(++i, rootIdentifier, label));
+                }
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        private PartialCaseDecision MakePartialCaseDecision(int index, BoundDagTemp input, BoundPatternSwitchLabel label)
+        {
+            MakeAndSimplifyDecisionsAndBindings(input, label.Pattern, out var decisions, out var bindings);
+            return new PartialCaseDecision(index, decisions, bindings, label.Guard, label.Label);
+        }
+
+        private void MakeAndSimplifyDecisionsAndBindings(
+            BoundDagTemp input,
+            BoundPattern pattern,
+            out ImmutableArray<BoundDagDecision> decisions,
+            out ImmutableArray<(BoundExpression, BoundDagTemp)> bindings)
+        {
+            var decisionsBuilder = ArrayBuilder<BoundDagDecision>.GetInstance();
+            var bindingsBuilder = ArrayBuilder<(BoundExpression, BoundDagTemp)>.GetInstance();
+            // use site diagnostics will have been produced during binding of the patterns, so can be discarded here
+            HashSet<DiagnosticInfo> discardedUseSiteDiagnostics = null;
+            MakeDecisionsAndBindings(input, pattern, decisionsBuilder, bindingsBuilder, ref discardedUseSiteDiagnostics);
+
+            // Now simplify the decisions and bindings. We don't need anything in decisions that does not
+            // contribute to the result. This will, for example, permit us to match `(2, 3) is (2, _)` without
+            // fetching `Item2` from the input.
+            var usedValues = PooledHashSet<BoundDagEvaluation>.GetInstance();
+            foreach (var (_, temp) in bindingsBuilder)
+            {
+                if (temp.Source != (object)null)
+                {
+                    usedValues.Add(temp.Source);
+                }
+            }
+            for (int i = decisionsBuilder.Count - 1; i >= 0; i--)
+            {
+                switch (decisionsBuilder[i])
+                {
+                    case BoundDagEvaluation e:
+                        {
+                            if (usedValues.Contains(e))
+                            {
+                                if (e.Input.Source != (object)null)
+                                {
+                                    usedValues.Add(e.Input.Source);
+                                }
+                            }
+                            else
+                            {
+                                decisionsBuilder.RemoveAt(i);
+                            }
+                        }
+                        break;
+                    case BoundDagDecision d:
+                        {
+                            usedValues.Add(d.Input.Source);
+                        }
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(decisionsBuilder[i]);
+                }
+            }
+
+            // We also do not need to compute any result more than once. This will permit us to fetch
+            // a property once even if it is used more than once, e.g. `o is { X: P1, X: P2 }`
+            usedValues.Clear();
+            usedValues.Add(input.Source);
+            for (int i = 0; i < decisionsBuilder.Count; i++)
+            {
+                switch (decisionsBuilder[i])
+                {
+                    case BoundDagEvaluation e:
+                        if (usedValues.Contains(e))
+                        {
+                            decisionsBuilder.RemoveAt(i);
+                            i--;
+                        }
+                        else
+                        {
+                            usedValues.Add(e);
+                        }
+                        break;
+                }
+            }
+
+            usedValues.Free();
+            decisions = decisionsBuilder.ToImmutableAndFree();
+            bindings = bindingsBuilder.ToImmutableAndFree();
+        }
+
+        private void MakeDecisionsAndBindings(
+                BoundDagTemp input,
+                BoundPattern pattern,
+                ArrayBuilder<BoundDagDecision> decisions,
+                ArrayBuilder<(BoundExpression, BoundDagTemp)> bindings,
+                ref HashSet<DiagnosticInfo> discardedUseSiteDiagnostics)
+        {
+            switch (pattern)
+            {
+                case BoundDeclarationPattern declaration:
+                    MakeDecisionsAndBindings(input, declaration, decisions, bindings, ref discardedUseSiteDiagnostics);
+                    break;
+                case BoundConstantPattern constant:
+                    MakeDecisionsAndBindings(input, constant, decisions, bindings, ref discardedUseSiteDiagnostics);
+                    break;
+                case BoundDiscardPattern wildcard:
+                    // Nothing to do. It always matches.
+                    break;
+                case BoundRecursivePattern recursive:
+                    MakeDecisionsAndBindings(input, recursive, decisions, bindings, ref discardedUseSiteDiagnostics);
+                    break;
+                default:
+                    throw new NotImplementedException(pattern.Kind.ToString());
+            }
+        }
+
+        private void MakeDecisionsAndBindings(
+            BoundDagTemp input,
+            BoundDeclarationPattern declaration,
+            ArrayBuilder<BoundDagDecision> decisions,
+            ArrayBuilder<(BoundExpression, BoundDagTemp)> bindings,
+            ref HashSet<DiagnosticInfo> discardedUseSiteDiagnostics)
+        {
+            var type = declaration.DeclaredType.Type;
+            var syntax = declaration.Syntax;
+
+            // Add a null and type test if needed.
+            if (!declaration.IsVar)
+            {
+                NullCheck(input, declaration.Syntax, decisions);
+                input = ConvertToType(input, declaration.Syntax, type, decisions, ref discardedUseSiteDiagnostics);
+            }
+
+            var left = declaration.VariableAccess;
+            if (left != null)
+            {
+                Debug.Assert(left.Type == input.Type);
+                bindings.Add((left, input));
+            }
+            else
+            {
+                Debug.Assert(declaration.Variable == null);
+            }
+        }
+
+        private void NullCheck(
+            BoundDagTemp input,
+            SyntaxNode syntax,
+            ArrayBuilder<BoundDagDecision> decisions)
+        {
+            if (input.Type.CanContainNull())
+            {
+                // Add a null test
+                decisions.Add(new BoundNonNullDecision(syntax, input));
+            }
+        }
+
+        private BoundDagTemp ConvertToType(
+            BoundDagTemp input,
+            SyntaxNode syntax,
+            TypeSymbol type,
+            ArrayBuilder<BoundDagDecision> decisions,
+            ref HashSet<DiagnosticInfo> discardedUseSiteDiagnostics)
+        {
+            if (input.Type != type)
+            {
+                var inputType = input.Type.StrippedType(); // since a null check has already been done
+                var conversion = Conversions.ClassifyBuiltInConversion(inputType, type, ref discardedUseSiteDiagnostics);
+                if (input.Type.IsDynamic() ? type.SpecialType == SpecialType.System_Object : conversion.IsImplicit)
+                {
+                    // type test not needed, only the type cast
+                }
+                else
+                {
+                    // both type test and cast needed
+                    decisions.Add(new BoundTypeDecision(syntax, type, input));
+                }
+
+                var evaluation = new BoundDagTypeEvaluation(syntax, type, type, input);
+                input = new BoundDagTemp(syntax, type, evaluation, 0);
+                decisions.Add(evaluation);
+            }
+
+            return input;
+        }
+
+        private void MakeDecisionsAndBindings(
+            BoundDagTemp input,
+            BoundConstantPattern constant,
+            ArrayBuilder<BoundDagDecision> decisions,
+            ArrayBuilder<(BoundExpression, BoundDagTemp)> bindings,
+            ref HashSet<DiagnosticInfo> discardedUseSiteDiagnostics)
+        {
+            input = ConvertToType(input, constant.Syntax, constant.Value.Type, decisions, ref discardedUseSiteDiagnostics);
+            decisions.Add(new BoundValueDecision(constant.Syntax, constant.ConstantValue, input));
+        }
+
+        private void MakeDecisionsAndBindings(
+            BoundDagTemp input,
+            BoundRecursivePattern recursive,
+            ArrayBuilder<BoundDagDecision> decisions,
+            ArrayBuilder<(BoundExpression, BoundDagTemp)> bindings,
+            ref HashSet<DiagnosticInfo> discardedUseSiteDiagnostics)
+        {
+            Debug.Assert(input.Type == recursive.InputType);
+            NullCheck(input, recursive.Syntax, decisions);
+            if (recursive.DeclaredType != null && recursive.DeclaredType.Type != input.Type)
+            {
+                input = ConvertToType(input, recursive.Syntax, recursive.DeclaredType.Type, decisions, ref discardedUseSiteDiagnostics);
+            }
+
+            if (!recursive.Deconstruction.IsDefault)
+            {
+                // we have a "deconstruction" form, which is either an invocation of a Deconstruct method, or a disassembly of a tuple
+                if (recursive.DeconstructMethodOpt != null)
+                {
+                    var method = recursive.DeconstructMethodOpt;
+                    var evaluation = new BoundDagDeconstructEvaluation(recursive.Syntax, method, method, input);
+                    decisions.Add(evaluation);
+                    int extensionExtra = method.IsStatic ? 1 : 0;
+                    int count = Math.Min(method.ParameterCount - extensionExtra, recursive.Deconstruction.Length);
+                    for (int i = 0; i < count; i++)
+                    {
+                        var pattern = recursive.Deconstruction[i];
+                        var syntax = pattern.Syntax;
+                        var output = new BoundDagTemp(syntax, method.Parameters[i + extensionExtra].Type, evaluation, i);
+                        MakeDecisionsAndBindings(output, pattern, decisions, bindings, ref discardedUseSiteDiagnostics);
+                    }
+                }
+                else if (input.Type.IsTupleType)
+                {
+                    var elements = input.Type.TupleElements;
+                    var elementTypes = input.Type.TupleElementTypes;
+                    int count = Math.Min(elementTypes.Length, recursive.Deconstruction.Length);
+                    for (int i = 0; i < count; i++)
+                    {
+                        var pattern = recursive.Deconstruction[i];
+                        var syntax = pattern.Syntax;
+                        var field = elements[i];
+                        var evaluation = new BoundDagFieldEvaluation(syntax, field, field, input); // fetch the ItemN field
+                        decisions.Add(evaluation);
+                        var output = new BoundDagTemp(syntax, field.Type, evaluation, 0);
+                        MakeDecisionsAndBindings(output, pattern, decisions, bindings, ref discardedUseSiteDiagnostics);
+                    }
+                }
+                else
+                {
+                    // TODO(patterns2): This should not occur except in error cases. Perhaps this will be used to handle the ITuple case.
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (recursive.PropertiesOpt != null)
+            {
+                // we have a "property" form
+                for (int i = 0; i < recursive.PropertiesOpt.Length; i++)
+                {
+                    var prop = recursive.PropertiesOpt[i];
+                    var symbol = prop.symbol;
+                    BoundDagEvaluation evaluation;
+                    switch (symbol)
+                    {
+                        case PropertySymbol property:
+                            evaluation = new BoundDagPropertyEvaluation(prop.pattern.Syntax, property, property, input);
+                            break;
+                        case FieldSymbol field:
+                            evaluation = new BoundDagFieldEvaluation(prop.pattern.Syntax, field, field, input);
+                            break;
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+                    }
+                    decisions.Add(evaluation);
+                    var output = new BoundDagTemp(prop.pattern.Syntax, prop.symbol.GetTypeOrReturnType(), evaluation, 0);
+                    MakeDecisionsAndBindings(output, prop.pattern, decisions, bindings, ref discardedUseSiteDiagnostics);
+                }
+            }
+
+            if (recursive.VariableAccess != null)
+            {
+                // we have a "variable" declaration
+                bindings.Add((recursive.VariableAccess, input));
+            }
+        }
+
+        private static BoundDecisionDag MakeDecisionDag(ImmutableArray<PartialCaseDecision> cases)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class PartialCaseDecision
+    {
+        public readonly int Index;
+        public readonly ImmutableArray<BoundDagDecision> Decisions;
+        public readonly ImmutableArray<(BoundExpression, BoundDagTemp)> Bindings;
+        public readonly BoundExpression WhereClause;
+        public readonly LabelSymbol CaseLabel;
+        public PartialCaseDecision(
+            int Index,
+            ImmutableArray<BoundDagDecision> Decisions,
+            ImmutableArray<(BoundExpression, BoundDagTemp)> Bindings,
+            BoundExpression WhereClause,
+            LabelSymbol CaseLabel)
+        {
+            this.Index = Index;
+            this.Decisions = Decisions;
+            this.Bindings = Bindings;
+            this.WhereClause = WhereClause;
+            this.CaseLabel = CaseLabel;
+        }
+    }
+
+    partial class BoundDagEvaluation
+    {
+        public override bool Equals(object obj) => obj is BoundDagEvaluation other && this.Equals(other);
+        public bool Equals(BoundDagEvaluation other)
+        {
+            return other != (object)null && this.Kind == other.Kind && this.Input.Equals(other.Input) && this.Symbol == other.Symbol;
+        }
+        public override int GetHashCode()
+        {
+            return this.Input.GetHashCode() ^ (this.Symbol?.GetHashCode() ?? 0);
+        }
+        public static bool operator ==(BoundDagEvaluation left, BoundDagEvaluation right)
+        {
+            return (left == (object)null) ? right == (object)null : left.Equals(right);
+        }
+        public static bool operator !=(BoundDagEvaluation left, BoundDagEvaluation right)
+        {
+            return !left.Equals(right);
+        }
+    }
+
+    partial class BoundDagTemp
+    {
+        public override bool Equals(object obj) => obj is BoundDagTemp other && this.Equals(other);
+        public bool Equals(BoundDagTemp other)
+        {
+            return other != (object)null && this.Type == other.Type && object.Equals(this.Source, other.Source) && this.Index == other.Index;
+        }
+        public override int GetHashCode()
+        {
+            return this.Type.GetHashCode() ^ (this.Source?.GetHashCode() ?? 0) ^ this.Index;
+        }
+        public static bool operator ==(BoundDagTemp left, BoundDagTemp right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(BoundDagTemp left, BoundDagTemp right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     decisions.Add(new BoundTypeDecision(syntax, type, input));
                 }
 
-                var evaluation = new BoundDagTypeEvaluation(syntax, type, type, input);
+                var evaluation = new BoundDagTypeEvaluation(syntax, type, input);
                 input = new BoundDagTemp(syntax, type, evaluation, 0);
                 decisions.Add(evaluation);
             }
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (recursive.DeconstructMethodOpt != null)
                 {
                     var method = recursive.DeconstructMethodOpt;
-                    var evaluation = new BoundDagDeconstructEvaluation(recursive.Syntax, method, method, input);
+                    var evaluation = new BoundDagDeconstructEvaluation(recursive.Syntax, method, input);
                     decisions.Add(evaluation);
                     int extensionExtra = method.IsStatic ? 1 : 0;
                     int count = Math.Min(method.ParameterCount - extensionExtra, recursive.Deconstruction.Length);
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var pattern = recursive.Deconstruction[i];
                         var syntax = pattern.Syntax;
                         var field = elements[i];
-                        var evaluation = new BoundDagFieldEvaluation(syntax, field, field, input); // fetch the ItemN field
+                        var evaluation = new BoundDagFieldEvaluation(syntax, field, input); // fetch the ItemN field
                         decisions.Add(evaluation);
                         var output = new BoundDagTemp(syntax, field.Type, evaluation, 0);
                         MakeDecisionsAndBindings(output, pattern, decisions, bindings, ref discardedUseSiteDiagnostics);
@@ -316,10 +316,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     switch (symbol)
                     {
                         case PropertySymbol property:
-                            evaluation = new BoundDagPropertyEvaluation(prop.pattern.Syntax, property, property, input);
+                            evaluation = new BoundDagPropertyEvaluation(prop.pattern.Syntax, property, input);
                             break;
                         case FieldSymbol field:
-                            evaluation = new BoundDagFieldEvaluation(prop.pattern.Syntax, field, field, input);
+                            evaluation = new BoundDagFieldEvaluation(prop.pattern.Syntax, field, input);
                             break;
                         default:
                             throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
@@ -371,6 +371,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool Equals(BoundDagEvaluation other)
         {
             return other != (object)null && this.Kind == other.Kind && this.Input.Equals(other.Input) && this.Symbol == other.Symbol;
+        }
+        private Symbol Symbol
+        {
+            get
+            {
+                switch (this)
+                {
+                    case BoundDagFieldEvaluation e: return e.Field;
+                    case BoundDagPropertyEvaluation e: return e.Property;
+                    case BoundDagTypeEvaluation e: return e.Type;
+                    case BoundDagDeconstructEvaluation e: return e.DeconstructMethod;
+                    default: throw ExceptionUtilities.UnexpectedValue(this.Kind);
+                }
+            }
         }
         public override int GetHashCode()
         {

--- a/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder2.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternSwitchBinder2.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     // We use a subclass of SwitchBinder for the pattern-matching switch statement until we have completed
     // a totally compatible implementation of switch that also accepts pattern-matching constructs.
-    internal partial class PatternSwitchBinder : SwitchBinder
+    internal partial class PatternSwitchBinder2 : SwitchBinder
     {
-        internal PatternSwitchBinder(Binder next, SwitchStatementSyntax switchSyntax) : base(next, switchSyntax)
+        internal PatternSwitchBinder2(Binder next, SwitchStatementSyntax switchSyntax) : base(next, switchSyntax)
         {
         }
 
@@ -25,13 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// However, until we have edit-and-continue working, we continue using the old binder
         /// when we can.
         /// </summary>
-        private bool UseV7SwitchBinder
+        private bool UseV8SwitchBinder
         {
             get
             {
                     var parseOptions = SwitchSyntax?.SyntaxTree?.Options as CSharpParseOptions;
                     return
-                        parseOptions?.Features.ContainsKey("testV7SwitchBinder") == true ||
+                        parseOptions?.Features.ContainsKey("testV8SwitchBinder") == true ||
                         HasPatternSwitchSyntax(SwitchSyntax) ||
                         !SwitchGoverningType.IsValidV6SwitchGoverningType();
             }
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override BoundStatement BindSwitchExpressionAndSections(SwitchStatementSyntax node, Binder originalBinder, DiagnosticBag diagnostics)
         {
             // If it is a valid C# 6 switch statement, we use the old binder to bind it.
-            if (!UseV7SwitchBinder) return base.BindSwitchExpressionAndSections(node, originalBinder, diagnostics);
+            if (!UseV8SwitchBinder) return base.BindSwitchExpressionAndSections(node, originalBinder, diagnostics);
 
             Debug.Assert(SwitchSyntax.Equals(node));
 
@@ -54,10 +54,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BindPatternSwitchSections(originalBinder, out defaultLabel, out isComplete, out var someCaseMatches, diagnostics);
             var locals = GetDeclaredLocalsForScope(node);
             var functions = GetDeclaredLocalFunctionsForScope(node);
-            BoundDecisionDag decisionDag = null; // not relevant to the C# 7 pattern binder
+            BoundDecisionDag decisionDag = null; // we'll compute it later
             return new BoundPatternSwitchStatement(
-                node, boundSwitchExpression, someCaseMatches,
-                locals, functions, switchSections, defaultLabel, this.BreakLabel, decisionDag, isComplete);
+                syntax: node,
+                expression: boundSwitchExpression,
+                someLabelAlwaysMatches: someCaseMatches,
+                innerLocals: locals,
+                innerLocalFunctions: functions,
+                switchSections: switchSections,
+                defaultLabel: defaultLabel,
+                breakLabel: this.BreakLabel,
+                decisionDag: decisionDag,
+                isComplete: isComplete);
         }
 
         /// <summary>
@@ -136,56 +144,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sectionBinder != null);
             var labelsByNode = LabelsByNode;
 
-            bool? inputMatchesType(TypeSymbol patternType)
-            {
-                // use-site diagnostics will have been reported previously.
-                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                return ExpressionOfTypeMatchesPatternType(Conversions, SwitchGoverningType, patternType, ref useSiteDiagnostics, out _, SwitchGoverningExpression.ConstantValue, true);
-            }
-
             foreach (var labelSyntax in node.Labels)
             {
                 LabelSymbol label = labelsByNode[labelSyntax];
                 BoundPatternSwitchLabel boundLabel = BindPatternSwitchSectionLabel(sectionBinder, labelSyntax, label, ref defaultLabel, diagnostics);
-                bool isNotSubsumed = subsumption.AddLabel(boundLabel, diagnostics);
-                bool guardAlwaysSatisfied = boundLabel.Guard == null || boundLabel.Guard.ConstantValue == ConstantValue.True;
-
-                // patternMatches is true if the input expression is unconditionally matched by the pattern, false if it never matches, null otherwise.
-                // While subsumption would produce an error for an unreachable pattern based on the input's type, this is used for reachability (warnings),
-                // and takes the input value into account.
-                bool? patternMatches;
-                if (labelSyntax.Kind() == SyntaxKind.DefaultSwitchLabel)
-                {
-                    patternMatches = null;
-                }
-                else if (boundLabel.Pattern.Kind == BoundKind.DiscardPattern)
-                {
-                    // wildcard pattern matches anything
-                    patternMatches = true;
-                }
-                else if (boundLabel.Pattern is BoundDeclarationPattern d)
-                {
-                    // `var x` matches anything
-                    // `Type x` matches anything of a subtype of `Type` except null
-                    patternMatches = d.IsVar ? true : inputMatchesType(d.DeclaredType.Type);
-                }
-                else if (boundLabel.Pattern is BoundConstantPattern p)
-                {
-                    // `case 2` matches the input `2`
-                    patternMatches = SwitchGoverningExpression.ConstantValue?.Equals(p.ConstantValue);
-                }
-                else
-                {
-                    patternMatches = null;
-                }
-
-                bool labelIsReachable = isNotSubsumed && !someCaseMatches && patternMatches != false;
-                boundLabel = boundLabel.Update(boundLabel.Label, boundLabel.Pattern, boundLabel.Guard, labelIsReachable);
                 boundLabelsBuilder.Add(boundLabel);
-
-                // labelWouldMatch is true if we find an unconditional (no `when` clause restriction) label that matches the input expression
-                bool labelWouldMatch = guardAlwaysSatisfied && patternMatches == true;
-                someCaseMatches |= labelWouldMatch;
             }
 
             // Bind switch section statements
@@ -205,6 +168,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ref BoundPatternSwitchLabel defaultLabel,
             DiagnosticBag diagnostics)
         {
+            // Until we've determined whether or not the switch label is reachable, we assume it
+            // is. The caller updates isReachable after determining if the label is subsumed.
+            const bool isReachable = true;
+
             switch (node.Kind())
             {
                 case SyntaxKind.CaseSwitchLabel:
@@ -229,9 +196,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             diagnostics.Add(ErrorCode.WRN_DefaultInSwitch, caseLabelSyntax.Value.Location);
                         }
 
-                        // Until we've determined whether or not the switch label is reachable, we assume it
-                        // is. The caller updates isReachable after determining if the label is subsumed.
-                        const bool isReachable = true;
                         return new BoundPatternSwitchLabel(node, label, pattern, null, isReachable, hasErrors);
                     }
 
@@ -246,9 +210,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             hasErrors = true;
                         }
 
-                        // We always treat the default label as reachable, even if the switch is complete.
-                        const bool isReachable = true;
-
                         // Note that this is semantically last! The caller will place it in the decision tree
                         // in the final position.
                         defaultLabel = new BoundPatternSwitchLabel(node, label, pattern, null, isReachable, hasErrors);
@@ -262,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             matchLabelSyntax.Pattern, SwitchGoverningType, node.HasErrors, diagnostics);
                         return new BoundPatternSwitchLabel(node, label, pattern,
                             matchLabelSyntax.WhenClause != null ? sectionBinder.BindBooleanExpression(matchLabelSyntax.WhenClause.Condition, diagnostics) : null,
-                            true, node.HasErrors);
+                            isReachable, node.HasErrors);
                     }
 
                 default:

--- a/src/Compilers/CSharp/Portable/Binder/SubsumptionDiagnosticBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SubsumptionDiagnosticBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // For the purpose of computing subsumption, we ignore the input expression's constant
             // value. Therefore we create a fake expression here that doesn't contain the value.
-            var placeholderExpression = new BoundDup(syntax, RefKind.None, switchGoverningType);
+            var placeholderExpression = new BoundImplicitReceiver(syntax, switchGoverningType);
             _subsumptionTree = CreateEmptyDecisionTree(placeholderExpression);
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 throw ExceptionUtilities.UnexpectedValue(decisionTree.Kind);
                         }
                     }
-                case BoundKind.WildcardPattern:
+                case BoundKind.DiscardPattern:
                     // because we always handle `default:` last, and that is the only way to get a wildcard pattern,
                     // we should never need to see if it subsumes something else.
                     throw ExceptionUtilities.UnexpectedValue(decisionTree.Kind);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -40,8 +40,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (parseOptions?.IsFeatureEnabled(MessageID.IDS_FeaturePatternMatching) != false ||
                  parseOptions?.Features.ContainsKey("testV7SwitchBinder") != false ||
                  switchSyntax.HasErrors && HasPatternSwitchSyntax(switchSyntax))
-                ? new PatternSwitchBinder(next, switchSyntax)
+                ? ( HasRecursivePatternSwitchSyntax(switchSyntax)
+                        ? new PatternSwitchBinder2(next, switchSyntax)
+                        : (SwitchBinder)new PatternSwitchBinder(next, switchSyntax))
                 : new SwitchBinder(next, switchSyntax);
+        }
+
+        private static bool HasRecursivePatternSwitchSyntax(SwitchStatementSyntax switchSyntax)
+        {
+            foreach (var section in switchSyntax.Sections)
+            {
+                foreach (var label in section.Labels)
+                {
+                    if (label is CasePatternSwitchLabelSyntax s)
+                    {
+                        switch (s.Pattern.Kind())
+                        {
+                            case SyntaxKind.DeconstructionPattern:
+                            case SyntaxKind.PropertyPattern:
+                            case SyntaxKind.DiscardPattern:
+                                return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal static bool HasPatternSwitchSyntax(SwitchStatementSyntax switchSyntax)
@@ -242,7 +266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // bind the pattern, to cause its pattern variables to be inferred if necessary
                         var matchLabel = (CasePatternSwitchLabelSyntax)labelSyntax;
                         var pattern = sectionBinder.BindPattern(
-                            matchLabel.Pattern, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag, wasSwitchCase: true);
+                            matchLabel.Pattern, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -799,14 +799,76 @@
     <Field Name="SwitchSections" Type="ImmutableArray&lt;BoundPatternSwitchSection&gt;"/>
     <Field Name="DefaultLabel" Type="BoundPatternSwitchLabel" Null="allow"/>
     <Field Name="BreakLabel" Type="GeneratedLabelSymbol"/>
-    
-    <!-- We store the pattern switch binder so we can perform some binding-like
-         operations during control flow analysis. -->
-    <Field Name="Binder" Type="PatternSwitchBinder"/>
+
+    <!-- A directed acyclic decision graph for the switch statement. It can be traversed
+    to determine if all labels are reachable, and if every input is handled. -->
+    <Field Name="DecisionDag" Type="BoundDecisionDag" Null="allow"/>
     <!-- A switch is considered complete if every value of the switch expression's
          type is handled by some switch label that is either not guarded by a when
          clause, or for which the when clause expression has the constant value true. -->
     <Field Name="IsComplete" Type="bool"/>
+  </Node>
+
+  <AbstractNode Name="BoundDecisionDag" Base="BoundNode">
+    <Field Name="Label" Type="LabelSymbol"/>
+  </AbstractNode>
+  <!-- This node is used to indicate a point in the decision dag where an evaluation is performed, such as invoking Deconstruct. -->
+  <Node Name="BoundEvaluationPoint" Base="BoundDecisionDag">
+    <Field Name="Evaluation" Type="BoundDagEvaluation" Null="disallow"/>
+    <Field Name="Next" Type="BoundDecisionDag" Null="disallow"/>
+  </Node>
+  <!-- This node is used to indicate a point in the decision dag where a test may change the path of the decision dag. -->
+  <Node Name="BoundDecisionPoint" Base="BoundDecisionDag">
+    <Field Name="Decision" Type="BoundDagDecision" Null="disallow"/>
+    <Field Name="WhenTrue" Type="BoundDecisionDag" Null="disallow"/>
+    <Field Name="WhenFalse" Type="BoundDecisionDag" Null="disallow"/>
+  </Node>
+  <Node Name="BoundWhereClause" Base="BoundDecisionDag">
+    <Field Name="Bindings" Type="ImmutableArray&lt;(BoundExpression,BoundDagTemp)&gt;" Null="disallow"/>
+    <Field Name="Where" Type="BoundExpression" Null="allow"/>
+    <Field Name="WhenTrue" Type="BoundDecisionDag" Null="disallow"/>
+    <Field Name="WhenFalse" Type="BoundDecisionDag" Null="allow"/>
+  </Node>
+  <!-- This node is used to indicate a point in the decision dag where the decision has been completed. -->
+  <Node Name="BoundDecision" Base="BoundDecisionDag">
+  </Node>
+
+  <AbstractNode Name="BoundDagDecision" Base="BoundNode">
+     Input is the input to the decision point. 
+    <Field Name="Input" Type="BoundDagTemp"/>
+  </AbstractNode>
+  <Node Name="BoundDagTemp" Base="BoundNode">
+    <Field Name="Type" Type="TypeSymbol" Null="allow"/>
+    <Field Name="Source" Type="BoundDagEvaluation" Null="allow"/>
+    <Field Name="Index" Type="int"/>
+  </Node>
+  <Node Name="BoundNonNullDecision" Base="BoundDagDecision">
+     <!--Check that the input is not null.--> 
+  </Node>
+  <Node Name="BoundTypeDecision" Base="BoundDagDecision">
+     <!--Check that the input is of the given type. Null check is separate.--> 
+    <Field Name="Type" Type="TypeSymbol" Null="disallow"/>
+  </Node>
+  <Node Name="BoundValueDecision" Base="BoundDagDecision">
+     <!--Check that the input is the same as the given constant value.--> 
+    <Field Name="Value" Type="ConstantValue" Null="disallow"/>
+  </Node>
+  <!-- As a decision, an evaluation is considered to always succeed. -->
+  <AbstractNode Name="BoundDagEvaluation" Base="BoundDagDecision">
+    <Field Name="Symbol" Type="Symbol" Null="disallow"/>
+  </AbstractNode>
+  <Node Name="BoundDagDeconstructEvaluation" Base="BoundDagEvaluation">
+    <Field Name="DeconstructMethod" Type="MethodSymbol" Null="disallow"/>
+  </Node>
+  <Node Name="BoundDagTypeEvaluation" Base="BoundDagEvaluation">
+   <!--Cast to the given type, assumed to be used after a successful type check.--> 
+    <Field Name="Type" Type="TypeSymbol" Null="disallow"/>
+  </Node>
+  <Node Name="BoundDagFieldEvaluation" Base="BoundDagEvaluation">
+    <Field Name="Field" Type="FieldSymbol" Null="disallow"/>
+  </Node>
+  <Node Name="BoundDagPropertyEvaluation" Base="BoundDagEvaluation">
+    <Field Name="Property" Type="PropertySymbol" Null="disallow"/>
   </Node>
 
   <Node Name="BoundPatternSwitchSection" Base="BoundStatementList">
@@ -1588,6 +1650,14 @@
     <!-- CONSIDER: we might benefit from recording the input (matched value) type in the bound pattern. -->
   </AbstractNode>
 
+  <Node Name="BoundConstantPattern" Base="BoundPattern">
+    <Field Name="Value" Type="BoundExpression"/>
+    <Field Name="ConstantValue" Type="ConstantValue" Null="allow"/>
+  </Node>
+
+  <Node Name="BoundDiscardPattern" Base="BoundPattern">
+  </Node>
+
   <Node Name="BoundDeclarationPattern" Base="BoundPattern">
     <!-- Variable is a local symbol, or in the case of top-level code in scripts and interactive,
          a field that is a member of the script class. Variable is null if `_` is used. -->
@@ -1599,17 +1669,28 @@
          free. The necessity of this member is a consequence of a design issue documented in
          https://github.com/dotnet/roslyn/issues/13960 . When that is fixed this field can be
          removed. -->
-    <Field Name="VariableAccess" Type="BoundExpression" Null="disallow"/>
+    <Field Name="VariableAccess" Type="BoundExpression" Null="allow"/>
     <Field Name="DeclaredType" Type="BoundTypeExpression" Null="allow"/>
     <Field Name="IsVar" Type="bool"/>
   </Node>
 
-  <Node Name="BoundConstantPattern" Base="BoundPattern">
-    <Field Name="Value" Type="BoundExpression"/>
-    <Field Name="ConstantValue" Type="ConstantValue" Null="allow"/>
-  </Node>
-
-  <Node Name="BoundWildcardPattern" Base="BoundPattern">
+  <Node Name="BoundRecursivePattern" Base="BoundPattern">
+    <Field Name="DeclaredType" Type="BoundTypeExpression" Null="allow"/>
+    <Field Name="InputType" Type="TypeSymbol"/>
+    <Field Name="DeconstructMethodOpt" Type="MethodSymbol" Null="allow"/>
+    <Field Name="Deconstruction" Type="ImmutableArray&lt;BoundPattern&gt;" Null="allow"/>
+    <Field Name="PropertiesOpt" Type="ImmutableArray&lt;(Symbol symbol, BoundPattern pattern)&gt;" Null="allow"/>
+    <!-- Variable is a local symbol, or in the case of top-level code in scripts and interactive,
+         a field that is a member of the script class. Variable is null if `_` is used or if the identifier is omitted. -->
+    <Field Name="Variable" Type="Symbol" Null="allow"/>
+    <!-- VariableAccess is an access to the declared variable, suitable for use
+         in the lowered form in either an lvalue or rvalue position. We maintain it separately
+         from the Symbol to facilitate lowerings in which the variable is no longer a simple
+         variable access (e.g. in the expression evaluator). It is expected to be logically side-effect
+         free. The necessity of this member is a consequence of a design issue documented in
+         https://github.com/dotnet/roslyn/issues/13960 . When that is fixed this field can be
+         removed. -->
+    <Field Name="VariableAccess" Type="BoundExpression" Null="allow"/>
   </Node>
 
   <Node Name="BoundDiscardExpression" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -838,7 +838,7 @@
     <Field Name="Input" Type="BoundDagTemp"/>
   </AbstractNode>
   <Node Name="BoundDagTemp" Base="BoundNode">
-    <Field Name="Type" Type="TypeSymbol" Null="allow"/>
+    <Field Name="Type" Type="TypeSymbol" Null="disallow"/>
     <Field Name="Source" Type="BoundDagEvaluation" Null="allow"/>
     <Field Name="Index" Type="int"/>
   </Node>
@@ -855,7 +855,6 @@
   </Node>
   <!-- As a decision, an evaluation is considered to always succeed. -->
   <AbstractNode Name="BoundDagEvaluation" Base="BoundDagDecision">
-    <Field Name="Symbol" Type="Symbol" Null="disallow"/>
   </AbstractNode>
   <Node Name="BoundDagDeconstructEvaluation" Base="BoundDagEvaluation">
     <Field Name="DeconstructMethod" Type="MethodSymbol" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -555,12 +555,4 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
     }
-
-    internal partial class BoundDeclarationPattern
-    {
-        public BoundDeclarationPattern(SyntaxNode syntax, LocalSymbol localSymbol, BoundTypeExpression declaredType, bool isVar, bool hasErrors = false)
-            : this(syntax, localSymbol, localSymbol == null ? new BoundDiscardExpression(syntax, declaredType.Type) : (BoundExpression)new BoundLocal(syntax, localSymbol, null, declaredType.Type), declaredType, isVar, hasErrors)
-        {
-        }
-    }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTreeBuilder.cs
@@ -116,7 +116,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var declarationPattern = (BoundDeclarationPattern)pattern;
                         DecisionMaker maker =
-                            (e, t) => new DecisionTree.Guarded(e, t, ImmutableArray.Create(new KeyValuePair<BoundExpression, BoundExpression>(e, declarationPattern.VariableAccess)), sectionSyntax, guard, label);
+                            (e, t) => new DecisionTree.Guarded(
+                                        e, t,
+                                        (declarationPattern.VariableAccess == null)
+                                            ? ImmutableArray<KeyValuePair<BoundExpression, BoundExpression>>.Empty
+                                            : ImmutableArray.Create(new KeyValuePair<BoundExpression, BoundExpression>(e, declarationPattern.VariableAccess)),
+                                        sectionSyntax, guard, label);
                         if (declarationPattern.IsVar)
                         {
                             return Add(decisionTree, maker);
@@ -126,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return AddByType(decisionTree, declarationPattern.DeclaredType.Type, maker);
                         }
                     }
-                case BoundKind.WildcardPattern:
+                case BoundKind.DiscardPattern:
                 // We do not yet support a wildcard pattern syntax. It is used exclusively
                 // to model the "default:" case, which is handled specially in the caller.
                 default:

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5417,6 +5417,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type &apos;var&apos; is not permitted in recursive patterns. If you want the type inferred, just omit it..
+        /// </summary>
+        internal static string ERR_InferredRecursivePatternType {
+            get {
+                return ResourceManager.GetString("ERR_InferredRecursivePatternType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot initialize a by-reference variable with a value.
         /// </summary>
         internal static string ERR_InitializeByReferenceVariableWithValue {
@@ -7982,6 +7991,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A property subpattern requires a reference to the property or field to be matched, e.g. &apos;{{ Name: {0}}}&apos;.
+        /// </summary>
+        internal static string ERR_PropertyPatternNameMissing {
+            get {
+                return ResourceManager.GetString("ERR_PropertyPatternNameMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: property or indexer must have at least one accessor.
         /// </summary>
         internal static string ERR_PropertyWithNoAccessors {
@@ -9958,6 +9976,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_WinRtEventPassedByRef {
             get {
                 return ResourceManager.GetString("ERR_WinRtEventPassedByRef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Matching the tuple type &apos;{0}&apos; requires &apos;{1}&apos; subpatterns, but &apos;{2}&apos; subpatterns are present..
+        /// </summary>
+        internal static string ERR_WrongNumberOfSubpatterns {
+            get {
+                return ResourceManager.GetString("ERR_WrongNumberOfSubpatterns", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5216,4 +5216,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureRecursivePatterns" xml:space="preserve">
     <value>recursive patterns</value>
   </data>
+  <data name="ERR_InferredRecursivePatternType" xml:space="preserve">
+    <value>The type 'var' is not permitted in recursive patterns. If you want the type inferred, just omit it.</value>
+  </data>
+  <data name="ERR_WrongNumberOfSubpatterns" xml:space="preserve">
+    <value>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</value>
+  </data>
+  <data name="ERR_PropertyPatternNameMissing" xml:space="preserve">
+    <value>A property subpattern requires a reference to the property or field to be matched, e.g. '{{ Name: {0}}}'</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1541,6 +1541,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics introduced for recursive patterns
         // PROTOTYPE(patterns2): renumber these before committing
         ERR_MissingPattern = 8500,
+        ERR_InferredRecursivePatternType = 8501,
+        ERR_WrongNumberOfSubpatterns = 8502,
+        ERR_PropertyPatternNameMissing = 8503,
+        //ERR_FeatureIsUnimplemented = 8504,
         #endregion diagnostics introduced for recursive patterns
 
     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
@@ -109,6 +109,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return ((BoundDeclarationPattern)node).Variable as LocalSymbol;
                         }
 
+                    case BoundKind.RecursivePattern:
+                        {
+                            return ((BoundRecursivePattern)node).Variable as LocalSymbol;
+                        }
+
                     case BoundKind.FieldAccess:
                         {
                             var fieldAccess = (BoundFieldAccess)node;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -64,15 +64,29 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void NoteDeclaredPatternVariables(BoundPattern pattern)
         {
-            if (IsInside && pattern.Kind == BoundKind.DeclarationPattern)
+            if (IsInside)
             {
-                var decl = (BoundDeclarationPattern)pattern;
-                // The variable may be null if it is a discard designation `_`.
-                if (decl.Variable?.Kind == SymbolKind.Local)
+                switch (pattern)
                 {
-                    // Because this API only returns local symbols and parameters,
-                    // we exclude pattern variables that have become fields in scripts.
-                    _variablesDeclared.Add(decl.Variable);
+                    case BoundDeclarationPattern decl:
+                        {
+                            // The variable may be null if it is a discard designation `_`.
+                            if (decl.Variable?.Kind == SymbolKind.Local)
+                            {
+                                // Because this API only returns local symbols and parameters,
+                                // we exclude pattern variables that have become fields in scripts.
+                                _variablesDeclared.Add(decl.Variable);
+                            }
+                        }
+                        break;
+                    case BoundRecursivePattern recur:
+                        {
+                            if (recur.Variable?.Kind == SymbolKind.Local)
+                            {
+                                _variablesDeclared.Add(recur.Variable);
+                            }
+                        }
+                        break;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3077,6 +3077,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundDagTemp(SyntaxNode syntax, TypeSymbol type, BoundDagEvaluation source, int index, bool hasErrors = false)
             : base(BoundKind.DagTemp, syntax, hasErrors || source.HasErrors())
         {
+
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
             this.Type = type;
             this.Source = source;
             this.Index = index;
@@ -3200,28 +3203,23 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal abstract partial class BoundDagEvaluation : BoundDagDecision
     {
-        protected BoundDagEvaluation(BoundKind kind, SyntaxNode syntax, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+        protected BoundDagEvaluation(BoundKind kind, SyntaxNode syntax, BoundDagTemp input, bool hasErrors = false)
             : base(kind, syntax, input, hasErrors)
         {
 
-            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
-            this.Symbol = symbol;
         }
 
-
-        public Symbol Symbol { get; }
     }
 
     internal sealed partial class BoundDagDeconstructEvaluation : BoundDagEvaluation
     {
-        public BoundDagDeconstructEvaluation(SyntaxNode syntax, MethodSymbol deconstructMethod, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
-            : base(BoundKind.DagDeconstructEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        public BoundDagDeconstructEvaluation(SyntaxNode syntax, MethodSymbol deconstructMethod, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagDeconstructEvaluation, syntax, input, hasErrors || input.HasErrors())
         {
 
             Debug.Assert(deconstructMethod != null, "Field 'deconstructMethod' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.DeconstructMethod = deconstructMethod;
@@ -3235,11 +3233,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitDagDeconstructEvaluation(this);
         }
 
-        public BoundDagDeconstructEvaluation Update(MethodSymbol deconstructMethod, Symbol symbol, BoundDagTemp input)
+        public BoundDagDeconstructEvaluation Update(MethodSymbol deconstructMethod, BoundDagTemp input)
         {
-            if (deconstructMethod != this.DeconstructMethod || symbol != this.Symbol || input != this.Input)
+            if (deconstructMethod != this.DeconstructMethod || input != this.Input)
             {
-                var result = new BoundDagDeconstructEvaluation(this.Syntax, deconstructMethod, symbol, input, this.HasErrors);
+                var result = new BoundDagDeconstructEvaluation(this.Syntax, deconstructMethod, input, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -3249,12 +3247,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDagTypeEvaluation : BoundDagEvaluation
     {
-        public BoundDagTypeEvaluation(SyntaxNode syntax, TypeSymbol type, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
-            : base(BoundKind.DagTypeEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        public BoundDagTypeEvaluation(SyntaxNode syntax, TypeSymbol type, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagTypeEvaluation, syntax, input, hasErrors || input.HasErrors())
         {
 
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Type = type;
@@ -3268,11 +3265,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitDagTypeEvaluation(this);
         }
 
-        public BoundDagTypeEvaluation Update(TypeSymbol type, Symbol symbol, BoundDagTemp input)
+        public BoundDagTypeEvaluation Update(TypeSymbol type, BoundDagTemp input)
         {
-            if (type != this.Type || symbol != this.Symbol || input != this.Input)
+            if (type != this.Type || input != this.Input)
             {
-                var result = new BoundDagTypeEvaluation(this.Syntax, type, symbol, input, this.HasErrors);
+                var result = new BoundDagTypeEvaluation(this.Syntax, type, input, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -3282,12 +3279,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDagFieldEvaluation : BoundDagEvaluation
     {
-        public BoundDagFieldEvaluation(SyntaxNode syntax, FieldSymbol field, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
-            : base(BoundKind.DagFieldEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        public BoundDagFieldEvaluation(SyntaxNode syntax, FieldSymbol field, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagFieldEvaluation, syntax, input, hasErrors || input.HasErrors())
         {
 
             Debug.Assert(field != null, "Field 'field' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Field = field;
@@ -3301,11 +3297,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitDagFieldEvaluation(this);
         }
 
-        public BoundDagFieldEvaluation Update(FieldSymbol field, Symbol symbol, BoundDagTemp input)
+        public BoundDagFieldEvaluation Update(FieldSymbol field, BoundDagTemp input)
         {
-            if (field != this.Field || symbol != this.Symbol || input != this.Input)
+            if (field != this.Field || input != this.Input)
             {
-                var result = new BoundDagFieldEvaluation(this.Syntax, field, symbol, input, this.HasErrors);
+                var result = new BoundDagFieldEvaluation(this.Syntax, field, input, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -3315,12 +3311,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundDagPropertyEvaluation : BoundDagEvaluation
     {
-        public BoundDagPropertyEvaluation(SyntaxNode syntax, PropertySymbol property, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
-            : base(BoundKind.DagPropertyEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        public BoundDagPropertyEvaluation(SyntaxNode syntax, PropertySymbol property, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagPropertyEvaluation, syntax, input, hasErrors || input.HasErrors())
         {
 
             Debug.Assert(property != null, "Field 'property' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Property = property;
@@ -3334,11 +3329,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitDagPropertyEvaluation(this);
         }
 
-        public BoundDagPropertyEvaluation Update(PropertySymbol property, Symbol symbol, BoundDagTemp input)
+        public BoundDagPropertyEvaluation Update(PropertySymbol property, BoundDagTemp input)
         {
-            if (property != this.Property || symbol != this.Symbol || input != this.Input)
+            if (property != this.Property || input != this.Input)
             {
-                var result = new BoundDagPropertyEvaluation(this.Syntax, property, symbol, input, this.HasErrors);
+                var result = new BoundDagPropertyEvaluation(this.Syntax, property, input, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -9617,23 +9612,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.DeconstructMethod, node.Symbol, input);
+            return node.Update(node.DeconstructMethod, input);
         }
         public override BoundNode VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(type, node.Symbol, input);
+            return node.Update(type, input);
         }
         public override BoundNode VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.Field, node.Symbol, input);
+            return node.Update(node.Field, input);
         }
         public override BoundNode VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
         {
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(node.Property, node.Symbol, input);
+            return node.Update(node.Property, input);
         }
         public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
         {
@@ -10911,7 +10906,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("dagDeconstructEvaluation", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("deconstructMethod", node.DeconstructMethod, null),
-                new TreeDumperNode("symbol", node.Symbol, null),
                 new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
             }
             );
@@ -10921,7 +10915,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("dagTypeEvaluation", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("type", node.Type, null),
-                new TreeDumperNode("symbol", node.Symbol, null),
                 new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
             }
             );
@@ -10931,7 +10924,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("dagFieldEvaluation", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("field", node.Field, null),
-                new TreeDumperNode("symbol", node.Symbol, null),
                 new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
             }
             );
@@ -10941,7 +10933,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("dagPropertyEvaluation", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("property", node.Property, null),
-                new TreeDumperNode("symbol", node.Symbol, null),
                 new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
             }
             );

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -89,6 +89,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         BreakStatement,
         ContinueStatement,
         PatternSwitchStatement,
+        EvaluationPoint,
+        DecisionPoint,
+        WhereClause,
+        Decision,
+        DagTemp,
+        NonNullDecision,
+        TypeDecision,
+        ValueDecision,
+        DagDeconstructEvaluation,
+        DagTypeEvaluation,
+        DagFieldEvaluation,
+        DagPropertyEvaluation,
         PatternSwitchSection,
         PatternSwitchLabel,
         IfStatement,
@@ -162,9 +174,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         InterpolatedString,
         StringInsert,
         IsPatternExpression,
-        DeclarationPattern,
         ConstantPattern,
-        WildcardPattern,
+        DiscardPattern,
+        DeclarationPattern,
+        RecursivePattern,
         DiscardExpression,
         ThrowExpression,
         OutVariablePendingInference,
@@ -2809,8 +2822,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundPatternSwitchStatement : BoundStatement
     {
-        public BoundPatternSwitchStatement(SyntaxNode syntax, BoundExpression expression, bool someLabelAlwaysMatches, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, PatternSwitchBinder binder, bool isComplete, bool hasErrors = false)
-            : base(BoundKind.PatternSwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || defaultLabel.HasErrors())
+        public BoundPatternSwitchStatement(SyntaxNode syntax, BoundExpression expression, bool someLabelAlwaysMatches, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, BoundDecisionDag decisionDag, bool isComplete, bool hasErrors = false)
+            : base(BoundKind.PatternSwitchStatement, syntax, hasErrors || expression.HasErrors() || switchSections.HasErrors() || defaultLabel.HasErrors() || decisionDag.HasErrors())
         {
 
             Debug.Assert(expression != null, "Field 'expression' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
@@ -2818,7 +2831,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!innerLocalFunctions.IsDefault, "Field 'innerLocalFunctions' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(!switchSections.IsDefault, "Field 'switchSections' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(breakLabel != null, "Field 'breakLabel' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-            Debug.Assert(binder != null, "Field 'binder' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Expression = expression;
             this.SomeLabelAlwaysMatches = someLabelAlwaysMatches;
@@ -2827,7 +2839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.SwitchSections = switchSections;
             this.DefaultLabel = defaultLabel;
             this.BreakLabel = breakLabel;
-            this.Binder = binder;
+            this.DecisionDag = decisionDag;
             this.IsComplete = isComplete;
         }
 
@@ -2846,7 +2858,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public GeneratedLabelSymbol BreakLabel { get; }
 
-        public PatternSwitchBinder Binder { get; }
+        public BoundDecisionDag DecisionDag { get; }
 
         public bool IsComplete { get; }
 
@@ -2855,11 +2867,478 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitPatternSwitchStatement(this);
         }
 
-        public BoundPatternSwitchStatement Update(BoundExpression expression, bool someLabelAlwaysMatches, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, PatternSwitchBinder binder, bool isComplete)
+        public BoundPatternSwitchStatement Update(BoundExpression expression, bool someLabelAlwaysMatches, ImmutableArray<LocalSymbol> innerLocals, ImmutableArray<LocalFunctionSymbol> innerLocalFunctions, ImmutableArray<BoundPatternSwitchSection> switchSections, BoundPatternSwitchLabel defaultLabel, GeneratedLabelSymbol breakLabel, BoundDecisionDag decisionDag, bool isComplete)
         {
-            if (expression != this.Expression || someLabelAlwaysMatches != this.SomeLabelAlwaysMatches || innerLocals != this.InnerLocals || innerLocalFunctions != this.InnerLocalFunctions || switchSections != this.SwitchSections || defaultLabel != this.DefaultLabel || breakLabel != this.BreakLabel || binder != this.Binder || isComplete != this.IsComplete)
+            if (expression != this.Expression || someLabelAlwaysMatches != this.SomeLabelAlwaysMatches || innerLocals != this.InnerLocals || innerLocalFunctions != this.InnerLocalFunctions || switchSections != this.SwitchSections || defaultLabel != this.DefaultLabel || breakLabel != this.BreakLabel || decisionDag != this.DecisionDag || isComplete != this.IsComplete)
             {
-                var result = new BoundPatternSwitchStatement(this.Syntax, expression, someLabelAlwaysMatches, innerLocals, innerLocalFunctions, switchSections, defaultLabel, breakLabel, binder, isComplete, this.HasErrors);
+                var result = new BoundPatternSwitchStatement(this.Syntax, expression, someLabelAlwaysMatches, innerLocals, innerLocalFunctions, switchSections, defaultLabel, breakLabel, decisionDag, isComplete, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal abstract partial class BoundDecisionDag : BoundNode
+    {
+        protected BoundDecisionDag(BoundKind kind, SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+            : base(kind, syntax, hasErrors)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Label = label;
+        }
+
+        protected BoundDecisionDag(BoundKind kind, SyntaxNode syntax, LabelSymbol label)
+            : base(kind, syntax)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Label = label;
+        }
+
+
+        public LabelSymbol Label { get; }
+    }
+
+    internal sealed partial class BoundEvaluationPoint : BoundDecisionDag
+    {
+        public BoundEvaluationPoint(SyntaxNode syntax, BoundDagEvaluation evaluation, BoundDecisionDag next, LabelSymbol label, bool hasErrors = false)
+            : base(BoundKind.EvaluationPoint, syntax, label, hasErrors || evaluation.HasErrors() || next.HasErrors())
+        {
+
+            Debug.Assert(evaluation != null, "Field 'evaluation' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(next != null, "Field 'next' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Evaluation = evaluation;
+            this.Next = next;
+        }
+
+
+        public BoundDagEvaluation Evaluation { get; }
+
+        public BoundDecisionDag Next { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitEvaluationPoint(this);
+        }
+
+        public BoundEvaluationPoint Update(BoundDagEvaluation evaluation, BoundDecisionDag next, LabelSymbol label)
+        {
+            if (evaluation != this.Evaluation || next != this.Next || label != this.Label)
+            {
+                var result = new BoundEvaluationPoint(this.Syntax, evaluation, next, label, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDecisionPoint : BoundDecisionDag
+    {
+        public BoundDecisionPoint(SyntaxNode syntax, BoundDagDecision decision, BoundDecisionDag whenTrue, BoundDecisionDag whenFalse, LabelSymbol label, bool hasErrors = false)
+            : base(BoundKind.DecisionPoint, syntax, label, hasErrors || decision.HasErrors() || whenTrue.HasErrors() || whenFalse.HasErrors())
+        {
+
+            Debug.Assert(decision != null, "Field 'decision' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(whenTrue != null, "Field 'whenTrue' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(whenFalse != null, "Field 'whenFalse' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Decision = decision;
+            this.WhenTrue = whenTrue;
+            this.WhenFalse = whenFalse;
+        }
+
+
+        public BoundDagDecision Decision { get; }
+
+        public BoundDecisionDag WhenTrue { get; }
+
+        public BoundDecisionDag WhenFalse { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDecisionPoint(this);
+        }
+
+        public BoundDecisionPoint Update(BoundDagDecision decision, BoundDecisionDag whenTrue, BoundDecisionDag whenFalse, LabelSymbol label)
+        {
+            if (decision != this.Decision || whenTrue != this.WhenTrue || whenFalse != this.WhenFalse || label != this.Label)
+            {
+                var result = new BoundDecisionPoint(this.Syntax, decision, whenTrue, whenFalse, label, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundWhereClause : BoundDecisionDag
+    {
+        public BoundWhereClause(SyntaxNode syntax, ImmutableArray<(BoundExpression,BoundDagTemp)> bindings, BoundExpression @where, BoundDecisionDag whenTrue, BoundDecisionDag whenFalse, LabelSymbol label, bool hasErrors = false)
+            : base(BoundKind.WhereClause, syntax, label, hasErrors || @where.HasErrors() || whenTrue.HasErrors() || whenFalse.HasErrors())
+        {
+
+            Debug.Assert(!bindings.IsDefault, "Field 'bindings' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(whenTrue != null, "Field 'whenTrue' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Bindings = bindings;
+            this.Where = @where;
+            this.WhenTrue = whenTrue;
+            this.WhenFalse = whenFalse;
+        }
+
+
+        public ImmutableArray<(BoundExpression,BoundDagTemp)> Bindings { get; }
+
+        public BoundExpression Where { get; }
+
+        public BoundDecisionDag WhenTrue { get; }
+
+        public BoundDecisionDag WhenFalse { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitWhereClause(this);
+        }
+
+        public BoundWhereClause Update(ImmutableArray<(BoundExpression,BoundDagTemp)> bindings, BoundExpression @where, BoundDecisionDag whenTrue, BoundDecisionDag whenFalse, LabelSymbol label)
+        {
+            if (bindings != this.Bindings || @where != this.Where || whenTrue != this.WhenTrue || whenFalse != this.WhenFalse || label != this.Label)
+            {
+                var result = new BoundWhereClause(this.Syntax, bindings, @where, whenTrue, whenFalse, label, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDecision : BoundDecisionDag
+    {
+        public BoundDecision(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+            : base(BoundKind.Decision, syntax, label, hasErrors)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+        }
+
+        public BoundDecision(SyntaxNode syntax, LabelSymbol label)
+            : base(BoundKind.Decision, syntax, label)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+        }
+
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDecision(this);
+        }
+
+        public BoundDecision Update(LabelSymbol label)
+        {
+            if (label != this.Label)
+            {
+                var result = new BoundDecision(this.Syntax, label, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal abstract partial class BoundDagDecision : BoundNode
+    {
+        protected BoundDagDecision(BoundKind kind, SyntaxNode syntax, BoundDagTemp input, bool hasErrors = false)
+            : base(kind, syntax, hasErrors)
+        {
+
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Input = input;
+        }
+
+
+        public BoundDagTemp Input { get; }
+    }
+
+    internal sealed partial class BoundDagTemp : BoundNode
+    {
+        public BoundDagTemp(SyntaxNode syntax, TypeSymbol type, BoundDagEvaluation source, int index, bool hasErrors = false)
+            : base(BoundKind.DagTemp, syntax, hasErrors || source.HasErrors())
+        {
+            this.Type = type;
+            this.Source = source;
+            this.Index = index;
+        }
+
+
+        public TypeSymbol Type { get; }
+
+        public BoundDagEvaluation Source { get; }
+
+        public int Index { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDagTemp(this);
+        }
+
+        public BoundDagTemp Update(TypeSymbol type, BoundDagEvaluation source, int index)
+        {
+            if (type != this.Type || source != this.Source || index != this.Index)
+            {
+                var result = new BoundDagTemp(this.Syntax, type, source, index, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundNonNullDecision : BoundDagDecision
+    {
+        public BoundNonNullDecision(SyntaxNode syntax, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.NonNullDecision, syntax, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+        }
+
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitNonNullDecision(this);
+        }
+
+        public BoundNonNullDecision Update(BoundDagTemp input)
+        {
+            if (input != this.Input)
+            {
+                var result = new BoundNonNullDecision(this.Syntax, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundTypeDecision : BoundDagDecision
+    {
+        public BoundTypeDecision(SyntaxNode syntax, TypeSymbol type, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.TypeDecision, syntax, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Type = type;
+        }
+
+
+        public TypeSymbol Type { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitTypeDecision(this);
+        }
+
+        public BoundTypeDecision Update(TypeSymbol type, BoundDagTemp input)
+        {
+            if (type != this.Type || input != this.Input)
+            {
+                var result = new BoundTypeDecision(this.Syntax, type, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundValueDecision : BoundDagDecision
+    {
+        public BoundValueDecision(SyntaxNode syntax, ConstantValue value, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.ValueDecision, syntax, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(value != null, "Field 'value' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Value = value;
+        }
+
+
+        public ConstantValue Value { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitValueDecision(this);
+        }
+
+        public BoundValueDecision Update(ConstantValue value, BoundDagTemp input)
+        {
+            if (value != this.Value || input != this.Input)
+            {
+                var result = new BoundValueDecision(this.Syntax, value, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal abstract partial class BoundDagEvaluation : BoundDagDecision
+    {
+        protected BoundDagEvaluation(BoundKind kind, SyntaxNode syntax, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+            : base(kind, syntax, input, hasErrors)
+        {
+
+            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Symbol = symbol;
+        }
+
+
+        public Symbol Symbol { get; }
+    }
+
+    internal sealed partial class BoundDagDeconstructEvaluation : BoundDagEvaluation
+    {
+        public BoundDagDeconstructEvaluation(SyntaxNode syntax, MethodSymbol deconstructMethod, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagDeconstructEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(deconstructMethod != null, "Field 'deconstructMethod' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.DeconstructMethod = deconstructMethod;
+        }
+
+
+        public MethodSymbol DeconstructMethod { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDagDeconstructEvaluation(this);
+        }
+
+        public BoundDagDeconstructEvaluation Update(MethodSymbol deconstructMethod, Symbol symbol, BoundDagTemp input)
+        {
+            if (deconstructMethod != this.DeconstructMethod || symbol != this.Symbol || input != this.Input)
+            {
+                var result = new BoundDagDeconstructEvaluation(this.Syntax, deconstructMethod, symbol, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDagTypeEvaluation : BoundDagEvaluation
+    {
+        public BoundDagTypeEvaluation(SyntaxNode syntax, TypeSymbol type, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagTypeEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Type = type;
+        }
+
+
+        public TypeSymbol Type { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDagTypeEvaluation(this);
+        }
+
+        public BoundDagTypeEvaluation Update(TypeSymbol type, Symbol symbol, BoundDagTemp input)
+        {
+            if (type != this.Type || symbol != this.Symbol || input != this.Input)
+            {
+                var result = new BoundDagTypeEvaluation(this.Syntax, type, symbol, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDagFieldEvaluation : BoundDagEvaluation
+    {
+        public BoundDagFieldEvaluation(SyntaxNode syntax, FieldSymbol field, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagFieldEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(field != null, "Field 'field' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Field = field;
+        }
+
+
+        public FieldSymbol Field { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDagFieldEvaluation(this);
+        }
+
+        public BoundDagFieldEvaluation Update(FieldSymbol field, Symbol symbol, BoundDagTemp input)
+        {
+            if (field != this.Field || symbol != this.Symbol || input != this.Input)
+            {
+                var result = new BoundDagFieldEvaluation(this.Syntax, field, symbol, input, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDagPropertyEvaluation : BoundDagEvaluation
+    {
+        public BoundDagPropertyEvaluation(SyntaxNode syntax, PropertySymbol property, Symbol symbol, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagPropertyEvaluation, syntax, symbol, input, hasErrors || input.HasErrors())
+        {
+
+            Debug.Assert(property != null, "Field 'property' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(symbol != null, "Field 'symbol' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(input != null, "Field 'input' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Property = property;
+        }
+
+
+        public PropertySymbol Property { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDagPropertyEvaluation(this);
+        }
+
+        public BoundDagPropertyEvaluation Update(PropertySymbol property, Symbol symbol, BoundDagTemp input)
+        {
+            if (property != this.Property || symbol != this.Symbol || input != this.Input)
+            {
+                var result = new BoundDagPropertyEvaluation(this.Syntax, property, symbol, input, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -5896,46 +6375,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     }
 
-    internal sealed partial class BoundDeclarationPattern : BoundPattern
-    {
-        public BoundDeclarationPattern(SyntaxNode syntax, Symbol variable, BoundExpression variableAccess, BoundTypeExpression declaredType, bool isVar, bool hasErrors = false)
-            : base(BoundKind.DeclarationPattern, syntax, hasErrors || variableAccess.HasErrors() || declaredType.HasErrors())
-        {
-
-            Debug.Assert(variableAccess != null, "Field 'variableAccess' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
-
-            this.Variable = variable;
-            this.VariableAccess = variableAccess;
-            this.DeclaredType = declaredType;
-            this.IsVar = isVar;
-        }
-
-
-        public Symbol Variable { get; }
-
-        public BoundExpression VariableAccess { get; }
-
-        public BoundTypeExpression DeclaredType { get; }
-
-        public bool IsVar { get; }
-
-        public override BoundNode Accept(BoundTreeVisitor visitor)
-        {
-            return visitor.VisitDeclarationPattern(this);
-        }
-
-        public BoundDeclarationPattern Update(Symbol variable, BoundExpression variableAccess, BoundTypeExpression declaredType, bool isVar)
-        {
-            if (variable != this.Variable || variableAccess != this.VariableAccess || declaredType != this.DeclaredType || isVar != this.IsVar)
-            {
-                var result = new BoundDeclarationPattern(this.Syntax, variable, variableAccess, declaredType, isVar, this.HasErrors);
-                result.WasCompilerGenerated = this.WasCompilerGenerated;
-                return result;
-            }
-            return this;
-        }
-    }
-
     internal sealed partial class BoundConstantPattern : BoundPattern
     {
         public BoundConstantPattern(SyntaxNode syntax, BoundExpression value, ConstantValue constantValue, bool hasErrors = false)
@@ -5970,22 +6409,108 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundWildcardPattern : BoundPattern
+    internal sealed partial class BoundDiscardPattern : BoundPattern
     {
-        public BoundWildcardPattern(SyntaxNode syntax, bool hasErrors)
-            : base(BoundKind.WildcardPattern, syntax, hasErrors)
+        public BoundDiscardPattern(SyntaxNode syntax, bool hasErrors)
+            : base(BoundKind.DiscardPattern, syntax, hasErrors)
         {
         }
 
-        public BoundWildcardPattern(SyntaxNode syntax)
-            : base(BoundKind.WildcardPattern, syntax)
+        public BoundDiscardPattern(SyntaxNode syntax)
+            : base(BoundKind.DiscardPattern, syntax)
         {
         }
 
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
-            return visitor.VisitWildcardPattern(this);
+            return visitor.VisitDiscardPattern(this);
+        }
+    }
+
+    internal sealed partial class BoundDeclarationPattern : BoundPattern
+    {
+        public BoundDeclarationPattern(SyntaxNode syntax, Symbol variable, BoundExpression variableAccess, BoundTypeExpression declaredType, bool isVar, bool hasErrors = false)
+            : base(BoundKind.DeclarationPattern, syntax, hasErrors || variableAccess.HasErrors() || declaredType.HasErrors())
+        {
+            this.Variable = variable;
+            this.VariableAccess = variableAccess;
+            this.DeclaredType = declaredType;
+            this.IsVar = isVar;
+        }
+
+
+        public Symbol Variable { get; }
+
+        public BoundExpression VariableAccess { get; }
+
+        public BoundTypeExpression DeclaredType { get; }
+
+        public bool IsVar { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitDeclarationPattern(this);
+        }
+
+        public BoundDeclarationPattern Update(Symbol variable, BoundExpression variableAccess, BoundTypeExpression declaredType, bool isVar)
+        {
+            if (variable != this.Variable || variableAccess != this.VariableAccess || declaredType != this.DeclaredType || isVar != this.IsVar)
+            {
+                var result = new BoundDeclarationPattern(this.Syntax, variable, variableAccess, declaredType, isVar, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundRecursivePattern : BoundPattern
+    {
+        public BoundRecursivePattern(SyntaxNode syntax, BoundTypeExpression declaredType, TypeSymbol inputType, MethodSymbol deconstructMethodOpt, ImmutableArray<BoundPattern> deconstruction, ImmutableArray<(Symbol symbol, BoundPattern pattern)> propertiesOpt, Symbol variable, BoundExpression variableAccess, bool hasErrors = false)
+            : base(BoundKind.RecursivePattern, syntax, hasErrors || declaredType.HasErrors() || deconstruction.HasErrors() || variableAccess.HasErrors())
+        {
+
+            Debug.Assert(inputType != null, "Field 'inputType' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.DeclaredType = declaredType;
+            this.InputType = inputType;
+            this.DeconstructMethodOpt = deconstructMethodOpt;
+            this.Deconstruction = deconstruction;
+            this.PropertiesOpt = propertiesOpt;
+            this.Variable = variable;
+            this.VariableAccess = variableAccess;
+        }
+
+
+        public BoundTypeExpression DeclaredType { get; }
+
+        public TypeSymbol InputType { get; }
+
+        public MethodSymbol DeconstructMethodOpt { get; }
+
+        public ImmutableArray<BoundPattern> Deconstruction { get; }
+
+        public ImmutableArray<(Symbol symbol, BoundPattern pattern)> PropertiesOpt { get; }
+
+        public Symbol Variable { get; }
+
+        public BoundExpression VariableAccess { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitRecursivePattern(this);
+        }
+
+        public BoundRecursivePattern Update(BoundTypeExpression declaredType, TypeSymbol inputType, MethodSymbol deconstructMethodOpt, ImmutableArray<BoundPattern> deconstruction, ImmutableArray<(Symbol symbol, BoundPattern pattern)> propertiesOpt, Symbol variable, BoundExpression variableAccess)
+        {
+            if (declaredType != this.DeclaredType || inputType != this.InputType || deconstructMethodOpt != this.DeconstructMethodOpt || deconstruction != this.Deconstruction || propertiesOpt != this.PropertiesOpt || variable != this.Variable || variableAccess != this.VariableAccess)
+            {
+                var result = new BoundRecursivePattern(this.Syntax, declaredType, inputType, deconstructMethodOpt, deconstruction, propertiesOpt, variable, variableAccess, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
         }
     }
 
@@ -6294,6 +6819,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitContinueStatement(node as BoundContinueStatement, arg);
                 case BoundKind.PatternSwitchStatement: 
                     return VisitPatternSwitchStatement(node as BoundPatternSwitchStatement, arg);
+                case BoundKind.EvaluationPoint: 
+                    return VisitEvaluationPoint(node as BoundEvaluationPoint, arg);
+                case BoundKind.DecisionPoint: 
+                    return VisitDecisionPoint(node as BoundDecisionPoint, arg);
+                case BoundKind.WhereClause: 
+                    return VisitWhereClause(node as BoundWhereClause, arg);
+                case BoundKind.Decision: 
+                    return VisitDecision(node as BoundDecision, arg);
+                case BoundKind.DagTemp: 
+                    return VisitDagTemp(node as BoundDagTemp, arg);
+                case BoundKind.NonNullDecision: 
+                    return VisitNonNullDecision(node as BoundNonNullDecision, arg);
+                case BoundKind.TypeDecision: 
+                    return VisitTypeDecision(node as BoundTypeDecision, arg);
+                case BoundKind.ValueDecision: 
+                    return VisitValueDecision(node as BoundValueDecision, arg);
+                case BoundKind.DagDeconstructEvaluation: 
+                    return VisitDagDeconstructEvaluation(node as BoundDagDeconstructEvaluation, arg);
+                case BoundKind.DagTypeEvaluation: 
+                    return VisitDagTypeEvaluation(node as BoundDagTypeEvaluation, arg);
+                case BoundKind.DagFieldEvaluation: 
+                    return VisitDagFieldEvaluation(node as BoundDagFieldEvaluation, arg);
+                case BoundKind.DagPropertyEvaluation: 
+                    return VisitDagPropertyEvaluation(node as BoundDagPropertyEvaluation, arg);
                 case BoundKind.PatternSwitchSection: 
                     return VisitPatternSwitchSection(node as BoundPatternSwitchSection, arg);
                 case BoundKind.PatternSwitchLabel: 
@@ -6440,12 +6989,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitStringInsert(node as BoundStringInsert, arg);
                 case BoundKind.IsPatternExpression: 
                     return VisitIsPatternExpression(node as BoundIsPatternExpression, arg);
-                case BoundKind.DeclarationPattern: 
-                    return VisitDeclarationPattern(node as BoundDeclarationPattern, arg);
                 case BoundKind.ConstantPattern: 
                     return VisitConstantPattern(node as BoundConstantPattern, arg);
-                case BoundKind.WildcardPattern: 
-                    return VisitWildcardPattern(node as BoundWildcardPattern, arg);
+                case BoundKind.DiscardPattern: 
+                    return VisitDiscardPattern(node as BoundDiscardPattern, arg);
+                case BoundKind.DeclarationPattern: 
+                    return VisitDeclarationPattern(node as BoundDeclarationPattern, arg);
+                case BoundKind.RecursivePattern: 
+                    return VisitRecursivePattern(node as BoundRecursivePattern, arg);
                 case BoundKind.DiscardExpression: 
                     return VisitDiscardExpression(node as BoundDiscardExpression, arg);
                 case BoundKind.ThrowExpression: 
@@ -6737,6 +7288,54 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.DefaultVisit(node, arg);
         }
         public virtual R VisitPatternSwitchStatement(BoundPatternSwitchStatement node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitEvaluationPoint(BoundEvaluationPoint node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDecisionPoint(BoundDecisionPoint node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitWhereClause(BoundWhereClause node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDecision(BoundDecision node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDagTemp(BoundDagTemp node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitNonNullDecision(BoundNonNullDecision node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitTypeDecision(BoundTypeDecision node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitValueDecision(BoundValueDecision node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDagTypeEvaluation(BoundDagTypeEvaluation node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDagFieldEvaluation(BoundDagFieldEvaluation node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -7032,15 +7631,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node, arg);
         }
-        public virtual R VisitDeclarationPattern(BoundDeclarationPattern node, A arg)
-        {
-            return this.DefaultVisit(node, arg);
-        }
         public virtual R VisitConstantPattern(BoundConstantPattern node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
-        public virtual R VisitWildcardPattern(BoundWildcardPattern node, A arg)
+        public virtual R VisitDiscardPattern(BoundDiscardPattern node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitDeclarationPattern(BoundDeclarationPattern node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitRecursivePattern(BoundRecursivePattern node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -7344,6 +7947,54 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node);
         }
+        public virtual BoundNode VisitEvaluationPoint(BoundEvaluationPoint node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDecisionPoint(BoundDecisionPoint node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitWhereClause(BoundWhereClause node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDecision(BoundDecision node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDagTemp(BoundDagTemp node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitNonNullDecision(BoundNonNullDecision node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitTypeDecision(BoundTypeDecision node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitValueDecision(BoundValueDecision node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
+        {
+            return this.DefaultVisit(node);
+        }
         public virtual BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
         {
             return this.DefaultVisit(node);
@@ -7636,15 +8287,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return this.DefaultVisit(node);
         }
-        public virtual BoundNode VisitDeclarationPattern(BoundDeclarationPattern node)
-        {
-            return this.DefaultVisit(node);
-        }
         public virtual BoundNode VisitConstantPattern(BoundConstantPattern node)
         {
             return this.DefaultVisit(node);
         }
-        public virtual BoundNode VisitWildcardPattern(BoundWildcardPattern node)
+        public virtual BoundNode VisitDiscardPattern(BoundDiscardPattern node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitDeclarationPattern(BoundDeclarationPattern node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitRecursivePattern(BoundRecursivePattern node)
         {
             return this.DefaultVisit(node);
         }
@@ -8017,6 +8672,71 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Expression);
             this.VisitList(node.SwitchSections);
             this.Visit(node.DefaultLabel);
+            this.Visit(node.DecisionDag);
+            return null;
+        }
+        public override BoundNode VisitEvaluationPoint(BoundEvaluationPoint node)
+        {
+            this.Visit(node.Evaluation);
+            this.Visit(node.Next);
+            return null;
+        }
+        public override BoundNode VisitDecisionPoint(BoundDecisionPoint node)
+        {
+            this.Visit(node.Decision);
+            this.Visit(node.WhenTrue);
+            this.Visit(node.WhenFalse);
+            return null;
+        }
+        public override BoundNode VisitWhereClause(BoundWhereClause node)
+        {
+            this.Visit(node.Where);
+            this.Visit(node.WhenTrue);
+            this.Visit(node.WhenFalse);
+            return null;
+        }
+        public override BoundNode VisitDecision(BoundDecision node)
+        {
+            return null;
+        }
+        public override BoundNode VisitDagTemp(BoundDagTemp node)
+        {
+            this.Visit(node.Source);
+            return null;
+        }
+        public override BoundNode VisitNonNullDecision(BoundNonNullDecision node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitTypeDecision(BoundTypeDecision node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitValueDecision(BoundValueDecision node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
+        {
+            this.Visit(node.Input);
             return null;
         }
         public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
@@ -8407,19 +9127,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Pattern);
             return null;
         }
+        public override BoundNode VisitConstantPattern(BoundConstantPattern node)
+        {
+            this.Visit(node.Value);
+            return null;
+        }
+        public override BoundNode VisitDiscardPattern(BoundDiscardPattern node)
+        {
+            return null;
+        }
         public override BoundNode VisitDeclarationPattern(BoundDeclarationPattern node)
         {
             this.Visit(node.VariableAccess);
             this.Visit(node.DeclaredType);
             return null;
         }
-        public override BoundNode VisitConstantPattern(BoundConstantPattern node)
+        public override BoundNode VisitRecursivePattern(BoundRecursivePattern node)
         {
-            this.Visit(node.Value);
-            return null;
-        }
-        public override BoundNode VisitWildcardPattern(BoundWildcardPattern node)
-        {
+            this.Visit(node.DeclaredType);
+            this.VisitList(node.Deconstruction);
+            this.Visit(node.VariableAccess);
             return null;
         }
         public override BoundNode VisitDiscardExpression(BoundDiscardExpression node)
@@ -8838,7 +9565,75 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundPatternSwitchSection> switchSections = (ImmutableArray<BoundPatternSwitchSection>)this.VisitList(node.SwitchSections);
             BoundPatternSwitchLabel defaultLabel = (BoundPatternSwitchLabel)this.Visit(node.DefaultLabel);
-            return node.Update(expression, node.SomeLabelAlwaysMatches, node.InnerLocals, node.InnerLocalFunctions, switchSections, defaultLabel, node.BreakLabel, node.Binder, node.IsComplete);
+            BoundDecisionDag decisionDag = (BoundDecisionDag)this.Visit(node.DecisionDag);
+            return node.Update(expression, node.SomeLabelAlwaysMatches, node.InnerLocals, node.InnerLocalFunctions, switchSections, defaultLabel, node.BreakLabel, decisionDag, node.IsComplete);
+        }
+        public override BoundNode VisitEvaluationPoint(BoundEvaluationPoint node)
+        {
+            BoundDagEvaluation evaluation = (BoundDagEvaluation)this.Visit(node.Evaluation);
+            BoundDecisionDag next = (BoundDecisionDag)this.Visit(node.Next);
+            return node.Update(evaluation, next, node.Label);
+        }
+        public override BoundNode VisitDecisionPoint(BoundDecisionPoint node)
+        {
+            BoundDagDecision decision = (BoundDagDecision)this.Visit(node.Decision);
+            BoundDecisionDag whenTrue = (BoundDecisionDag)this.Visit(node.WhenTrue);
+            BoundDecisionDag whenFalse = (BoundDecisionDag)this.Visit(node.WhenFalse);
+            return node.Update(decision, whenTrue, whenFalse, node.Label);
+        }
+        public override BoundNode VisitWhereClause(BoundWhereClause node)
+        {
+            BoundExpression @where = (BoundExpression)this.Visit(node.Where);
+            BoundDecisionDag whenTrue = (BoundDecisionDag)this.Visit(node.WhenTrue);
+            BoundDecisionDag whenFalse = (BoundDecisionDag)this.Visit(node.WhenFalse);
+            return node.Update(node.Bindings, @where, whenTrue, whenFalse, node.Label);
+        }
+        public override BoundNode VisitDecision(BoundDecision node)
+        {
+            return node;
+        }
+        public override BoundNode VisitDagTemp(BoundDagTemp node)
+        {
+            BoundDagEvaluation source = (BoundDagEvaluation)this.Visit(node.Source);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(type, source, node.Index);
+        }
+        public override BoundNode VisitNonNullDecision(BoundNonNullDecision node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(input);
+        }
+        public override BoundNode VisitTypeDecision(BoundTypeDecision node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(type, input);
+        }
+        public override BoundNode VisitValueDecision(BoundValueDecision node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(node.Value, input);
+        }
+        public override BoundNode VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(node.DeconstructMethod, node.Symbol, input);
+        }
+        public override BoundNode VisitDagTypeEvaluation(BoundDagTypeEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(type, node.Symbol, input);
+        }
+        public override BoundNode VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(node.Field, node.Symbol, input);
+        }
+        public override BoundNode VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(node.Property, node.Symbol, input);
         }
         public override BoundNode VisitPatternSwitchSection(BoundPatternSwitchSection node)
         {
@@ -9287,20 +10082,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(expression, pattern, type);
         }
+        public override BoundNode VisitConstantPattern(BoundConstantPattern node)
+        {
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(value, node.ConstantValue);
+        }
+        public override BoundNode VisitDiscardPattern(BoundDiscardPattern node)
+        {
+            return node;
+        }
         public override BoundNode VisitDeclarationPattern(BoundDeclarationPattern node)
         {
             BoundExpression variableAccess = (BoundExpression)this.Visit(node.VariableAccess);
             BoundTypeExpression declaredType = (BoundTypeExpression)this.Visit(node.DeclaredType);
             return node.Update(node.Variable, variableAccess, declaredType, node.IsVar);
         }
-        public override BoundNode VisitConstantPattern(BoundConstantPattern node)
+        public override BoundNode VisitRecursivePattern(BoundRecursivePattern node)
         {
-            BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(value, node.ConstantValue);
-        }
-        public override BoundNode VisitWildcardPattern(BoundWildcardPattern node)
-        {
-            return node;
+            BoundTypeExpression declaredType = (BoundTypeExpression)this.Visit(node.DeclaredType);
+            ImmutableArray<BoundPattern> deconstruction = (ImmutableArray<BoundPattern>)this.VisitList(node.Deconstruction);
+            BoundExpression variableAccess = (BoundExpression)this.Visit(node.VariableAccess);
+            TypeSymbol inputType = this.VisitType(node.InputType);
+            return node.Update(declaredType, inputType, node.DeconstructMethodOpt, deconstruction, node.PropertiesOpt, node.Variable, variableAccess);
         }
         public override BoundNode VisitDiscardExpression(BoundDiscardExpression node)
         {
@@ -10021,8 +10824,125 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("switchSections", null, from x in node.SwitchSections select Visit(x, null)),
                 new TreeDumperNode("defaultLabel", null, new TreeDumperNode[] { Visit(node.DefaultLabel, null) }),
                 new TreeDumperNode("breakLabel", node.BreakLabel, null),
-                new TreeDumperNode("binder", node.Binder, null),
+                new TreeDumperNode("decisionDag", null, new TreeDumperNode[] { Visit(node.DecisionDag, null) }),
                 new TreeDumperNode("isComplete", node.IsComplete, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitEvaluationPoint(BoundEvaluationPoint node, object arg)
+        {
+            return new TreeDumperNode("evaluationPoint", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("evaluation", null, new TreeDumperNode[] { Visit(node.Evaluation, null) }),
+                new TreeDumperNode("next", null, new TreeDumperNode[] { Visit(node.Next, null) }),
+                new TreeDumperNode("label", node.Label, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitDecisionPoint(BoundDecisionPoint node, object arg)
+        {
+            return new TreeDumperNode("decisionPoint", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("decision", null, new TreeDumperNode[] { Visit(node.Decision, null) }),
+                new TreeDumperNode("whenTrue", null, new TreeDumperNode[] { Visit(node.WhenTrue, null) }),
+                new TreeDumperNode("whenFalse", null, new TreeDumperNode[] { Visit(node.WhenFalse, null) }),
+                new TreeDumperNode("label", node.Label, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitWhereClause(BoundWhereClause node, object arg)
+        {
+            return new TreeDumperNode("whereClause", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("bindings", node.Bindings, null),
+                new TreeDumperNode("@where", null, new TreeDumperNode[] { Visit(node.Where, null) }),
+                new TreeDumperNode("whenTrue", null, new TreeDumperNode[] { Visit(node.WhenTrue, null) }),
+                new TreeDumperNode("whenFalse", null, new TreeDumperNode[] { Visit(node.WhenFalse, null) }),
+                new TreeDumperNode("label", node.Label, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitDecision(BoundDecision node, object arg)
+        {
+            return new TreeDumperNode("decision", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("label", node.Label, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitDagTemp(BoundDagTemp node, object arg)
+        {
+            return new TreeDumperNode("dagTemp", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("type", node.Type, null),
+                new TreeDumperNode("source", null, new TreeDumperNode[] { Visit(node.Source, null) }),
+                new TreeDumperNode("index", node.Index, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitNonNullDecision(BoundNonNullDecision node, object arg)
+        {
+            return new TreeDumperNode("nonNullDecision", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitTypeDecision(BoundTypeDecision node, object arg)
+        {
+            return new TreeDumperNode("typeDecision", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("type", node.Type, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitValueDecision(BoundValueDecision node, object arg)
+        {
+            return new TreeDumperNode("valueDecision", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("value", node.Value, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node, object arg)
+        {
+            return new TreeDumperNode("dagDeconstructEvaluation", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("deconstructMethod", node.DeconstructMethod, null),
+                new TreeDumperNode("symbol", node.Symbol, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitDagTypeEvaluation(BoundDagTypeEvaluation node, object arg)
+        {
+            return new TreeDumperNode("dagTypeEvaluation", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("type", node.Type, null),
+                new TreeDumperNode("symbol", node.Symbol, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitDagFieldEvaluation(BoundDagFieldEvaluation node, object arg)
+        {
+            return new TreeDumperNode("dagFieldEvaluation", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("field", node.Field, null),
+                new TreeDumperNode("symbol", node.Symbol, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node, object arg)
+        {
+            return new TreeDumperNode("dagPropertyEvaluation", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("property", node.Property, null),
+                new TreeDumperNode("symbol", node.Symbol, null),
+                new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) })
             }
             );
         }
@@ -10826,6 +11746,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             );
         }
+        public override TreeDumperNode VisitConstantPattern(BoundConstantPattern node, object arg)
+        {
+            return new TreeDumperNode("constantPattern", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
+                new TreeDumperNode("constantValue", node.ConstantValue, null)
+            }
+            );
+        }
+        public override TreeDumperNode VisitDiscardPattern(BoundDiscardPattern node, object arg)
+        {
+            return new TreeDumperNode("discardPattern", null, Array.Empty<TreeDumperNode>()
+            );
+        }
         public override TreeDumperNode VisitDeclarationPattern(BoundDeclarationPattern node, object arg)
         {
             return new TreeDumperNode("declarationPattern", null, new TreeDumperNode[]
@@ -10837,18 +11771,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             );
         }
-        public override TreeDumperNode VisitConstantPattern(BoundConstantPattern node, object arg)
+        public override TreeDumperNode VisitRecursivePattern(BoundRecursivePattern node, object arg)
         {
-            return new TreeDumperNode("constantPattern", null, new TreeDumperNode[]
+            return new TreeDumperNode("recursivePattern", null, new TreeDumperNode[]
             {
-                new TreeDumperNode("value", null, new TreeDumperNode[] { Visit(node.Value, null) }),
-                new TreeDumperNode("constantValue", node.ConstantValue, null)
+                new TreeDumperNode("declaredType", null, new TreeDumperNode[] { Visit(node.DeclaredType, null) }),
+                new TreeDumperNode("inputType", node.InputType, null),
+                new TreeDumperNode("deconstructMethodOpt", node.DeconstructMethodOpt, null),
+                new TreeDumperNode("deconstruction", null, node.Deconstruction.IsDefault ? Array.Empty<TreeDumperNode>() : from x in node.Deconstruction select Visit(x, null)),
+                new TreeDumperNode("propertiesOpt", node.PropertiesOpt, null),
+                new TreeDumperNode("variable", node.Variable, null),
+                new TreeDumperNode("variableAccess", null, new TreeDumperNode[] { Visit(node.VariableAccess, null) })
             }
-            );
-        }
-        public override TreeDumperNode VisitWildcardPattern(BoundWildcardPattern node, object arg)
-        {
-            return new TreeDumperNode("wildcardPattern", null, Array.Empty<TreeDumperNode>()
             );
         }
         public override TreeDumperNode VisitDiscardExpression(BoundDiscardExpression node, object arg)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -454,6 +454,12 @@ namespace Microsoft.CodeAnalysis.CSharp
       return this.DefaultVisit(node);
     }
 
+    /// <summary>Called when the visitor visits a DiscardPatternSyntax node.</summary>
+    public virtual TResult VisitDiscardPattern(DiscardPatternSyntax node)
+    {
+      return this.DefaultVisit(node);
+    }
+
     /// <summary>Called when the visitor visits a DeclarationPatternSyntax node.</summary>
     public virtual TResult VisitDeclarationPattern(DeclarationPatternSyntax node)
     {
@@ -1701,6 +1707,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     /// <summary>Called when the visitor visits a WhenClauseSyntax node.</summary>
     public virtual void VisitWhenClause(WhenClauseSyntax node)
+    {
+      this.DefaultVisit(node);
+    }
+
+    /// <summary>Called when the visitor visits a DiscardPatternSyntax node.</summary>
+    public virtual void VisitDiscardPattern(DiscardPatternSyntax node)
     {
       this.DefaultVisit(node);
     }
@@ -3088,6 +3100,12 @@ namespace Microsoft.CodeAnalysis.CSharp
       var whenKeyword = this.VisitToken(node.WhenKeyword);
       var condition = (ExpressionSyntax)this.Visit(node.Condition);
       return node.Update(whenKeyword, condition);
+    }
+
+    public override SyntaxNode VisitDiscardPattern(DiscardPatternSyntax node)
+    {
+      var underscoreToken = this.VisitToken(node.UnderscoreToken);
+      return node.Update(underscoreToken);
     }
 
     public override SyntaxNode VisitDeclarationPattern(DeclarationPatternSyntax node)
@@ -6608,6 +6626,20 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
       return SyntaxFactory.WhenClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), condition);
     }
+
+    /// <summary>Creates a new DiscardPatternSyntax instance.</summary>
+    public static DiscardPatternSyntax DiscardPattern(SyntaxToken underscoreToken)
+    {
+      switch (underscoreToken.Kind())
+      {
+        case SyntaxKind.IdentifierToken:
+          break;
+        default:
+          throw new ArgumentException("underscoreToken");
+      }
+      return (DiscardPatternSyntax)Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.DiscardPattern((Syntax.InternalSyntax.SyntaxToken)underscoreToken.Node).CreateRed();
+    }
+
 
     /// <summary>Creates a new DeclarationPatternSyntax instance.</summary>
     public static DeclarationPatternSyntax DeclarationPattern(TypeSyntax type, VariableDesignationSyntax designation)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -6711,6 +6711,63 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     }
   }
 
+  public sealed partial class DiscardPatternSyntax : PatternSyntax
+  {
+    internal DiscardPatternSyntax(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode green, SyntaxNode parent, int position)
+        : base(green, parent, position)
+    {
+    }
+
+    public SyntaxToken UnderscoreToken 
+    {
+      get { return new SyntaxToken(this, ((Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DiscardPatternSyntax)this.Green).underscoreToken, this.Position, 0); }
+    }
+
+    internal override SyntaxNode GetNodeSlot(int index)
+    {
+        switch (index)
+        {
+            default: return null;
+        }
+    }
+    internal override SyntaxNode GetCachedSlot(int index)
+    {
+        switch (index)
+        {
+            default: return null;
+        }
+    }
+
+    public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor)
+    {
+        return visitor.VisitDiscardPattern(this);
+    }
+
+    public override void Accept(CSharpSyntaxVisitor visitor)
+    {
+        visitor.VisitDiscardPattern(this);
+    }
+
+    public DiscardPatternSyntax Update(SyntaxToken underscoreToken)
+    {
+        if (underscoreToken != this.UnderscoreToken)
+        {
+            var newNode = SyntaxFactory.DiscardPattern(underscoreToken);
+            var annotations = this.GetAnnotations();
+            if (annotations != null && annotations.Length > 0)
+               return newNode.WithAnnotations(annotations);
+            return newNode;
+        }
+
+        return this;
+    }
+
+    public DiscardPatternSyntax WithUnderscoreToken(SyntaxToken underscoreToken)
+    {
+        return this.Update(underscoreToken);
+    }
+  }
+
   public sealed partial class DeclarationPatternSyntax : PatternSyntax
   {
     private TypeSyntax type;
@@ -9914,7 +9971,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     /// <summary>
     /// The variable(s) of the loop. In correct code this is a tuple
     /// literal, declaration expression with a tuple designator, or
-    /// a wildcard syntax in the form of a simple identifier. In broken
+    /// a discard syntax in the form of a simple identifier. In broken
     /// code it could be something else.
     /// </summary>
     public ExpressionSyntax Variable 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -1,47 +1,460 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
-using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class LocalRewriter
     {
-        public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
+        private struct IsPatternTranslator : IDisposable
         {
-            var loweredExpression = VisitExpression(node.Expression);
-            var loweredPattern = LowerPattern(node.Pattern);
-            return MakeIsPattern(loweredPattern, loweredExpression);
-        }
+            private readonly LocalRewriter _localRewriter;
+            private readonly SyntheticBoundNodeFactory _factory;
 
-        // Input must be used no more than once in the result. If it is needed repeatedly store its value in a temp and use the temp.
-        BoundExpression MakeIsPattern(BoundPattern loweredPattern, BoundExpression loweredInput)
-        {
-            var syntax = _factory.Syntax = loweredPattern.Syntax;
-            switch (loweredPattern.Kind)
+            private readonly ArrayBuilder<BoundExpression> _conjunctBuilder;
+            private readonly ArrayBuilder<BoundExpression> _sideEffectBuilder;
+            private readonly DagTempAllocator _tempAllocator;
+
+            private readonly BoundExpression _loweredInput;
+            private readonly BoundDagTemp _inputTemp;
+
+            public IsPatternTranslator(LocalRewriter localRewriter, BoundExpression loweredInput)
             {
-                case BoundKind.DeclarationPattern:
+                this._localRewriter = localRewriter;
+                this._factory = localRewriter._factory;
+                this._tempAllocator = new DagTempAllocator(localRewriter._factory);
+                this._loweredInput = loweredInput;
+                this._inputTemp = new BoundDagTemp(loweredInput.Syntax, loweredInput.Type, null, 0);
+                this._conjunctBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+                this._sideEffectBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+            }
+
+            public void Dispose()
+            {
+                _conjunctBuilder.Free();
+                _sideEffectBuilder.Free();
+                _tempAllocator.Dispose();
+            }
+
+            public class DagTempAllocator : IDisposable
+            {
+                private readonly SyntheticBoundNodeFactory _factory;
+                private readonly PooledDictionary<BoundDagTemp, BoundExpression> _map = PooledDictionary<BoundDagTemp, BoundExpression>.GetInstance();
+                private readonly ArrayBuilder<LocalSymbol> _temps = ArrayBuilder<LocalSymbol>.GetInstance();
+
+                public DagTempAllocator(SyntheticBoundNodeFactory factory)
+                {
+                    this._factory = factory;
+                }
+
+                public void Dispose()
+                {
+                    _temps.Free();
+                    _map.Free();
+                }
+
+                public BoundExpression GetTemp(BoundDagTemp dagTemp)
+                {
+                    if (!_map.TryGetValue(dagTemp, out var result))
                     {
-                        var declPattern = (BoundDeclarationPattern)loweredPattern;
-                        return MakeIsDeclarationPattern(declPattern, loweredInput);
+                        // PROTOTYPE(patterns2): Not sure what temp kind should be used for `is pattern`.
+                        var temp = _factory.SynthesizedLocal(dagTemp.Type, syntax: _factory.Syntax, kind: SynthesizedLocalKind.SwitchCasePatternMatching);
+                        _map.Add(dagTemp, _factory.Local(temp));
+                        _temps.Add(temp);
+                        result = _factory.Local(temp);
                     }
 
-                case BoundKind.WildcardPattern:
-                    return _factory.Literal(true);
+                    return result;
+                }
 
-                case BoundKind.ConstantPattern:
+                public ImmutableArray<LocalSymbol> AllTemps()
+                {
+                    return _temps.ToImmutableArray();
+                }
+
+                public void AssignTemp(BoundDagTemp dagTemp, BoundExpression value)
+                {
+                    _map.Add(dagTemp, value);
+                }
+            }
+
+            private bool LowerDecision(BoundDagDecision decision)
+            {
+                var oldSyntax = _factory.Syntax;
+                _factory.Syntax = decision.Syntax;
+                var result = LowerDecisionCore(decision);
+                _factory.Syntax = oldSyntax;
+                return result;
+            }
+
+            private bool LowerDecisionCore(BoundDagDecision decision)
+            {
+                void addConjunct(ref IsPatternTranslator self, BoundExpression expression)
+                {
+                    // PROTOTYPE(patterns2): could handle constant expressions more efficiently.
+                    if (self._sideEffectBuilder.Count != 0)
                     {
-                        var constantPattern = (BoundConstantPattern)loweredPattern;
-                        return MakeIsConstantPattern(constantPattern, loweredInput);
+                        expression = self._factory.Sequence(ImmutableArray<LocalSymbol>.Empty, self._sideEffectBuilder.ToImmutable(), expression);
+                        self._sideEffectBuilder.Clear();
                     }
 
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(loweredPattern.Kind);
+                    self._conjunctBuilder.Add(expression);
+                }
+
+                var input = _tempAllocator.GetTemp(decision.Input);
+                switch (decision)
+                {
+                    case BoundNonNullDecision d:
+                        // If the actual input is a constant, short-circuit this test
+                        if (d.Input == _inputTemp && _loweredInput.ConstantValue != null)
+                        {
+                            var decisionResult = _loweredInput.ConstantValue != ConstantValue.Null;
+                            if (!decisionResult)
+                            {
+                                _conjunctBuilder.Add(_factory.Literal(decisionResult));
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            // PROTOTYPE(patterns2): combine null test and type test when possible for improved code
+                            addConjunct(ref this, _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullNotEqual : BinaryOperatorKind.NotEqual));
+                        }
+                        break;
+                    case BoundTypeDecision d:
+                        {
+                            addConjunct(ref this, _factory.Is(input, d.Type));
+                        }
+                        break;
+                    case BoundValueDecision d:
+                        // If the actual input is a constant, short-circuit this test
+                        if (d.Input == _inputTemp && _loweredInput.ConstantValue != null)
+                        {
+                            var decisionResult = _loweredInput.ConstantValue == d.Value;
+                            if (!decisionResult)
+                            {
+                                _conjunctBuilder.Add(_factory.Literal(decisionResult));
+                                return true;
+                            }
+                        }
+                        else if (d.Value == ConstantValue.Null)
+                        {
+                            addConjunct(ref this, _localRewriter.MakeNullCheck(d.Syntax, input, input.Type.IsNullableType() ? BinaryOperatorKind.NullableNullEqual : BinaryOperatorKind.Equal));
+                        }
+                        else
+                        {
+                            var systemObject = _factory.SpecialType(SpecialType.System_Object);
+                            addConjunct(ref this, _localRewriter.MakeEqual(_factory.Literal(d.Value, input.Type), input));
+                        }
+                        break;
+                    case BoundDagFieldEvaluation f:
+                        {
+                            var field = f.Field;
+                            var outputTemp = new BoundDagTemp(f.Syntax, field.Type, f, 0);
+                            var output = _tempAllocator.GetTemp(outputTemp);
+                            _sideEffectBuilder.Add(_factory.AssignmentExpression(output, _factory.Field(input, field)));
+                        }
+                        break;
+                    case BoundDagPropertyEvaluation p:
+                        {
+                            var property = p.Property;
+                            var outputTemp = new BoundDagTemp(p.Syntax, property.Type, p, 0);
+                            var output = _tempAllocator.GetTemp(outputTemp);
+                            _sideEffectBuilder.Add(_factory.AssignmentExpression(output, _factory.Property(input, property)));
+                        }
+                        break;
+                    case BoundDagDeconstructEvaluation d:
+                        {
+                            var method = d.DeconstructMethod;
+                            var refKindBuilder = ArrayBuilder<RefKind>.GetInstance();
+                            var argBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+                            BoundExpression receiver;
+                            void addArg(RefKind refKind, BoundExpression expression)
+                            {
+                                refKindBuilder.Add(refKind);
+                                argBuilder.Add(expression);
+                            }
+                            Debug.Assert(method.Name == "Deconstruct");
+                            int extensionExtra;
+                            if (method.IsStatic)
+                            {
+                                Debug.Assert(method.IsExtensionMethod);
+                                receiver = _factory.Type(method.ContainingType);
+                                addArg(RefKind.None, input);
+                                extensionExtra = 1;
+                            }
+                            else
+                            {
+                                receiver = input;
+                                extensionExtra = 0;
+                            }
+                            for (int i = extensionExtra; i < method.ParameterCount; i++)
+                            {
+                                var parameter = method.Parameters[i];
+                                Debug.Assert(parameter.RefKind == RefKind.Out);
+                                var outputTemp = new BoundDagTemp(d.Syntax, parameter.Type, d, i - extensionExtra);
+                                addArg(RefKind.Out, _tempAllocator.GetTemp(outputTemp));
+                            }
+                            _sideEffectBuilder.Add(_factory.Call(receiver, method, refKindBuilder.ToImmutableAndFree(), argBuilder.ToImmutableAndFree()));
+                        }
+                        break;
+                    case BoundDagTypeEvaluation t:
+                        {
+                            var inputType = input.Type;
+                            if (inputType.IsDynamic())
+                            {
+                                inputType = _factory.SpecialType(SpecialType.System_Object);
+                            }
+
+                            var type = t.Type;
+                            var outputTemp = new BoundDagTemp(t.Syntax, type, t, 0);
+                            var output = _tempAllocator.GetTemp(outputTemp);
+                            var conversion = _factory.Compilation.ClassifyConversion(inputType, output.Type);
+                            if (conversion.Exists)
+                            {
+                                _sideEffectBuilder.Add(_factory.AssignmentExpression(output, _factory.Convert(type, input, conversion)));
+                            }
+                            else
+                            {
+                                _sideEffectBuilder.Add(_factory.AssignmentExpression(output, _factory.As(input, type)));
+                            }
+                        }
+                        break;
+                }
+
+                return false;
+            }
+
+            public BoundExpression LowerIsPattern(BoundPattern pattern, CSharpCompilation compilation)
+            {
+                var decisionBuilder = new DecisionDagBuilder(compilation);
+                var inputTemp = decisionBuilder.LowerPattern(_loweredInput, pattern, out var decisions, out var bindings);
+                Debug.Assert(inputTemp == _inputTemp);
+
+                // first, copy the input expression into the input temp
+                if (pattern.Kind != BoundKind.RecursivePattern &&
+                    (_loweredInput.Kind == BoundKind.Local || _loweredInput.Kind == BoundKind.Parameter || _loweredInput.ConstantValue != null))
+                {
+                    // Since non-recursive patterns cannot have side-effects on locals, we reuse an existing local
+                    // if present. A recursive pattern, on the other hand, may mutate a local through a captured lambda
+                    // when a `Deconstruct` method is invoked.
+                    _tempAllocator.AssignTemp(inputTemp, _loweredInput);
+                }
+                else
+                {
+                    _sideEffectBuilder.Add(_factory.AssignmentExpression(_tempAllocator.GetTemp(inputTemp), _loweredInput));
+                }
+
+                // then process all of the individual decisions
+                foreach (var decision in decisions)
+                {
+                    if (LowerDecision(decision))
+                    {
+                        break;
+                    }
+                }
+
+                if (_sideEffectBuilder.Count != 0)
+                {
+                    _conjunctBuilder.Add(_factory.Sequence(ImmutableArray<LocalSymbol>.Empty, _sideEffectBuilder.ToImmutable(), _factory.Literal(true)));
+                    _sideEffectBuilder.Clear();
+                }
+                BoundExpression result = null;
+                foreach (var conjunct in _conjunctBuilder)
+                {
+                    result = (result == null) ? conjunct : _factory.LogicalAnd(result, conjunct);
+                }
+
+                var bindingsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+                foreach (var (left, right) in bindings)
+                {
+                    bindingsBuilder.Add(_factory.AssignmentExpression(left, _tempAllocator.GetTemp(right)));
+                }
+
+                if (bindingsBuilder.Count > 0)
+                {
+                    var c = _factory.Sequence(ImmutableArray<LocalSymbol>.Empty, bindingsBuilder.ToImmutableAndFree(), _factory.Literal(true));
+                    result = (result == null) ? c : (BoundExpression)_factory.LogicalAnd(result, c);
+                }
+                else if (result == null)
+                {
+                    result = _factory.Literal(true);
+                }
+
+                return _factory.Sequence(_tempAllocator.AllTemps(), ImmutableArray<BoundExpression>.Empty, result);
             }
         }
+
+        private BoundExpression MakeTypeTestAndAssignment(BoundExpression loweredTarget, BoundExpression loweredInput, TypeSymbol type)
+        {
+            Debug.Assert(type == loweredTarget.Type);
+
+            // If the match is impossible, we simply evaluate the input and yield false.
+            var matchConstantValue = MatchConstantValue(loweredInput, type, false);
+            if (matchConstantValue == false)
+            {
+                return _factory.MakeSequence(loweredInput, _factory.Literal(false));
+            }
+
+            // It is possible that the input value is already of the correct type, in which case the pattern
+            // is irrefutable, and we can just do the assignment and return true (or perform the null test).
+            if (matchConstantValue == true)
+            {
+                BoundExpression convertedInput;
+                if (loweredInput.Type.IsNullableType())
+                {
+                    var getValueOrDefault = _factory.SpecialMethod(SpecialMember.System_Nullable_T_GetValueOrDefault).AsMember((NamedTypeSymbol)loweredInput.Type);
+                    convertedInput = _factory.Convert(type, _factory.Call(loweredInput, getValueOrDefault));
+                }
+                else
+                {
+                    convertedInput = _factory.Convert(type, loweredInput);
+                }
+                var assignment = _factory.AssignmentExpression(loweredTarget, convertedInput);
+                return _factory.MakeSequence(assignment, _factory.Literal(true));
+            }
+
+            // a pattern match of the form "expression is Type identifier" is equivalent to
+            // an invocation of one of these helpers:
+            if (type.IsReferenceType)
+            {
+                // bool Is<T>(object e, out T t) where T : class // reference type
+                // {
+                //     t = e as T;
+                //     return t != null;
+                // }
+
+                return _factory.ObjectNotEqual(
+                    _factory.AssignmentExpression(loweredTarget, _factory.As(loweredInput, type)),
+                    _factory.Null(type));
+            }
+            else // type parameter or value type
+            {
+                // bool Is<T>(this object i, out T o)
+                // {
+                //     // inefficient because it performs the type test twice, and also because it boxes the input.
+                //     bool s;
+                //     o = (s = i is T) ? (T)i : default(T);
+                //     return s;
+                // }
+
+                // Because a cast involving a type parameter is not necessarily a valid conversion (or, if it is, it might not
+                // be of a kind appropriate for pattern-matching), we use `object` as an intermediate type for the input expression.
+                var objectType = _factory.SpecialType(SpecialType.System_Object);
+                var s = _factory.SynthesizedLocal(_factory.SpecialType(SpecialType.System_Boolean), loweredTarget.Syntax);
+                var i = _factory.SynthesizedLocal(objectType, loweredTarget.Syntax); // we copy the input to avoid double evaluation
+                return _factory.Sequence(
+                    ImmutableArray.Create(s, i),
+                    ImmutableArray.Create<BoundExpression>(
+                        _factory.AssignmentExpression(_factory.Local(i), _factory.Convert(objectType, loweredInput)),
+                        _factory.AssignmentExpression(loweredTarget, _factory.Conditional(
+                            _factory.AssignmentExpression(_factory.Local(s), _factory.Is(_factory.Local(i), type)),
+                            _factory.Convert(type, _factory.Local(i)),
+                            _factory.Default(type), type))
+                        ),
+                    _factory.Local(s)
+                    );
+            }
+        }
+
+        private BoundExpression MakeEqual(BoundLiteral boundLiteral, BoundExpression input)
+        {
+            if (boundLiteral.Type.SpecialType == SpecialType.System_Double && Double.IsNaN(boundLiteral.ConstantValue.DoubleValue) ||
+                boundLiteral.Type.SpecialType == SpecialType.System_Single && Single.IsNaN(boundLiteral.ConstantValue.SingleValue))
+            {
+                // NaN must be treated specially, as operator== doesn't treat it as equal to anything, even itself.
+                Debug.Assert(boundLiteral.Type == input.Type);
+                return _factory.InstanceCall(boundLiteral, "Equals", input);
+            }
+
+            var booleanType = _factory.SpecialType(SpecialType.System_Boolean);
+            var intType = _factory.SpecialType(SpecialType.System_Int32);
+            switch (boundLiteral.Type.SpecialType)
+            {
+                case SpecialType.System_Boolean:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.BoolEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_Byte:
+                case SpecialType.System_Char:
+                case SpecialType.System_Int16:
+                case SpecialType.System_SByte:
+                case SpecialType.System_UInt16:
+                    // PROTOTYPE(patterns2): need to check that this produces efficient code
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, _factory.Convert(intType, boundLiteral), _factory.Convert(intType, input), booleanType, method: null);
+                case SpecialType.System_Decimal:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DecimalEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_Double:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.DoubleEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_Int32:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.IntEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_Int64:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.LongEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_Single:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.FloatEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_String:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.StringEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_UInt32:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.UIntEqual, boundLiteral, input, booleanType, method: null);
+                case SpecialType.System_UInt64:
+                    return MakeBinaryOperator(_factory.Syntax, BinaryOperatorKind.ULongEqual, boundLiteral, input, booleanType, method: null);
+                default:
+                    // PROTOTYPE(patterns2): need more efficient code for enum test, e.g. `color is Color.Red`
+                    // This is the (correct but inefficient) fallback for any type that isn't yet implemented (e.g. enums)
+                    var systemObject = _factory.SpecialType(SpecialType.System_Object);
+                    return _factory.StaticCall(
+                        systemObject,
+                        "Equals",
+                        _factory.Convert(systemObject, boundLiteral),
+                        _factory.Convert(systemObject, input)
+                        );
+            }
+        }
+
+        public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
+        {
+            using (var x = new IsPatternTranslator(this, VisitExpression(node.Expression)))
+            {
+                return x.LowerIsPattern(node.Pattern, this._compilation);
+            }
+        }
+
+        //public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
+        //{
+        //    var loweredExpression = VisitExpression(node.Expression);
+        //    var loweredPattern = LowerPattern(node.Pattern);
+        //    return MakeIsPattern(loweredPattern, loweredExpression);
+        //}
+
+        //// Input must be used no more than once in the result. If it is needed repeatedly store its value in a temp and use the temp.
+        //BoundExpression MakeIsPattern(BoundPattern loweredPattern, BoundExpression loweredInput)
+        //{
+        //    var syntax = _factory.Syntax = loweredPattern.Syntax;
+        //    switch (loweredPattern.Kind)
+        //    {
+        //        case BoundKind.DeclarationPattern:
+        //            {
+        //                var declPattern = (BoundDeclarationPattern)loweredPattern;
+        //                return MakeIsDeclarationPattern(declPattern, loweredInput);
+        //            }
+
+        //        case BoundKind.WildcardPattern:
+        //            return _factory.Literal(true);
+
+        //        case BoundKind.ConstantPattern:
+        //            {
+        //                var constantPattern = (BoundConstantPattern)loweredPattern;
+        //                return MakeIsConstantPattern(constantPattern, loweredInput);
+        //            }
+
+        //        default:
+        //            throw ExceptionUtilities.UnexpectedValue(loweredPattern.Kind);
+        //    }
+        //}
 
         BoundPattern LowerPattern(BoundPattern pattern)
         {
@@ -51,6 +464,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var declPattern = (BoundDeclarationPattern)pattern;
                         return declPattern.Update(declPattern.Variable, VisitExpression(declPattern.VariableAccess), declPattern.DeclaredType, declPattern.IsVar);
+                    }
+                case BoundKind.RecursivePattern:
+                    {
+                        throw ExceptionUtilities.UnexpectedValue(pattern.Kind);
                     }
                 case BoundKind.ConstantPattern:
                     {
@@ -62,102 +479,102 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression MakeIsConstantPattern(BoundConstantPattern loweredPattern, BoundExpression loweredInput)
-        {
-            return CompareWithConstant(loweredInput, loweredPattern.Value);
-        }
+        //private BoundExpression MakeIsConstantPattern(BoundConstantPattern loweredPattern, BoundExpression loweredInput)
+        //{
+        //    return CompareWithConstant(loweredInput, loweredPattern.Value);
+        //}
 
-        private BoundExpression MakeIsDeclarationPattern(BoundDeclarationPattern loweredPattern, BoundExpression loweredInput)
-        {
-            Debug.Assert(((object)loweredPattern.Variable == null && loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression) ||
-                         loweredPattern.Variable.GetTypeOrReturnType() == loweredPattern.DeclaredType.Type);
+        //private BoundExpression MakeIsDeclarationPattern(BoundDeclarationPattern loweredPattern, BoundExpression loweredInput)
+        //{
+        //    Debug.Assert(((object)loweredPattern.Variable == null && loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression) ||
+        //                 loweredPattern.Variable.GetTypeOrReturnType() == loweredPattern.DeclaredType.Type);
 
-            if (loweredPattern.IsVar)
-            {
-                var result = _factory.Literal(true);
+        //    if (loweredPattern.IsVar)
+        //    {
+        //        var result = _factory.Literal(true);
 
-                if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
-                {
-                    return result;
-                }
+        //        if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
+        //        {
+        //            return result;
+        //        }
 
-                Debug.Assert((object)loweredPattern.Variable != null && loweredInput.Type.Equals(loweredPattern.Variable.GetTypeOrReturnType(), TypeCompareKind.AllIgnoreOptions));
+        //        Debug.Assert((object)loweredPattern.Variable != null && loweredInput.Type.Equals(loweredPattern.Variable.GetTypeOrReturnType(), TypeCompareKind.AllIgnoreOptions));
 
-                var assignment = _factory.AssignmentExpression(loweredPattern.VariableAccess, loweredInput);
-                return _factory.MakeSequence(assignment, result);
-            }
+        //        var assignment = _factory.AssignmentExpression(loweredPattern.VariableAccess, loweredInput);
+        //        return _factory.MakeSequence(assignment, result);
+        //    }
 
-            if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
-            {
-                LocalSymbol temp;
-                BoundLocal discard = _factory.MakeTempForDiscard((BoundDiscardExpression)loweredPattern.VariableAccess, out temp);
+        //    if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
+        //    {
+        //        LocalSymbol temp;
+        //        BoundLocal discard = _factory.MakeTempForDiscard((BoundDiscardExpression)loweredPattern.VariableAccess, out temp);
 
-                return _factory.Sequence(ImmutableArray.Create(temp),
-                         sideEffects: ImmutableArray<BoundExpression>.Empty,
-                         result: MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, discard, requiresNullTest: loweredInput.Type.CanContainNull()));
-            }
+        //        return _factory.Sequence(ImmutableArray.Create(temp),
+        //                 sideEffects: ImmutableArray<BoundExpression>.Empty,
+        //                 result: MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, discard, requiresNullTest: loweredInput.Type.CanContainNull()));
+        //    }
 
-            return MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, loweredPattern.VariableAccess, requiresNullTest: loweredInput.Type.CanContainNull());
-        }
+        //    return MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, loweredPattern.VariableAccess, requiresNullTest: loweredInput.Type.CanContainNull());
+        //}
 
-        /// <summary>
-        /// Is the test, produced as a result of a pattern-matching operation, always true?
-        /// Knowing that enables us to construct slightly more efficient code.
-        /// </summary>
-        private bool IsIrrefutablePatternTest(BoundExpression test)
-        {
-            while (true)
-            {
-                switch (test.Kind)
-                {
-                    case BoundKind.Literal:
-                        {
-                            var value = ((BoundLiteral)test).ConstantValue;
-                            return value.IsBoolean && value.BooleanValue;
-                        }
-                    case BoundKind.Sequence:
-                        test = ((BoundSequence)test).Value;
-                        continue;
-                    default:
-                        return false;
-                }
-            }
-        }
+        ///// <summary>
+        ///// Is the test, produced as a result of a pattern-matching operation, always true?
+        ///// Knowing that enables us to construct slightly more efficient code.
+        ///// </summary>
+        //private bool IsIrrefutablePatternTest(BoundExpression test)
+        //{
+        //    while (true)
+        //    {
+        //        switch (test.Kind)
+        //        {
+        //            case BoundKind.Literal:
+        //                {
+        //                    var value = ((BoundLiteral)test).ConstantValue;
+        //                    return value.IsBoolean && value.BooleanValue;
+        //                }
+        //            case BoundKind.Sequence:
+        //                test = ((BoundSequence)test).Value;
+        //                continue;
+        //            default:
+        //                return false;
+        //        }
+        //    }
+        //}
 
-        private BoundExpression CompareWithConstant(BoundExpression input, BoundExpression boundConstant)
-        {
-            var systemObject = _factory.SpecialType(SpecialType.System_Object);
-            if (boundConstant.ConstantValue == ConstantValue.Null)
-            {
-                if (input.Type.IsNonNullableValueType())
-                {
-                    var systemBoolean = _factory.SpecialType(SpecialType.System_Boolean);
-                    return RewriteNullableNullEquality(
-                        syntax: _factory.Syntax,
-                        kind: BinaryOperatorKind.NullableNullEqual,
-                        loweredLeft: input,
-                        loweredRight: boundConstant,
-                        returnType: systemBoolean);
-                }
-                else
-                {
-                    return _factory.ObjectEqual(_factory.Convert(systemObject, input), boundConstant);
-                }
-            }
-            else if (input.Type.IsNullableType() && boundConstant.NullableNeverHasValue())
-            {
-                return _factory.Not(MakeNullableHasValue(_factory.Syntax, input));
-            }
-            else
-            {
-                return _factory.StaticCall(
-                    systemObject,
-                    "Equals",
-                    _factory.Convert(systemObject, boundConstant),
-                    _factory.Convert(systemObject, input)
-                    );
-            }
-        }
+        //private BoundExpression CompareWithConstant(BoundExpression input, BoundExpression boundConstant)
+        //{
+        //    var systemObject = _factory.SpecialType(SpecialType.System_Object);
+        //    if (boundConstant.ConstantValue == ConstantValue.Null)
+        //    {
+        //        if (input.Type.IsNonNullableValueType())
+        //        {
+        //            var systemBoolean = _factory.SpecialType(SpecialType.System_Boolean);
+        //            return RewriteNullableNullEquality(
+        //                syntax: _factory.Syntax,
+        //                kind: BinaryOperatorKind.NullableNullEqual,
+        //                loweredLeft: input,
+        //                loweredRight: boundConstant,
+        //                returnType: systemBoolean);
+        //        }
+        //        else
+        //        {
+        //            return _factory.ObjectEqual(_factory.Convert(systemObject, input), boundConstant);
+        //        }
+        //    }
+        //    else if (input.Type.IsNullableType() && boundConstant.NullableNeverHasValue())
+        //    {
+        //        return _factory.Not(MakeNullableHasValue(_factory.Syntax, input));
+        //    }
+        //    else
+        //    {
+        //        return _factory.StaticCall(
+        //            systemObject,
+        //            "Equals",
+        //            _factory.Convert(systemObject, boundConstant),
+        //            _factory.Convert(systemObject, input)
+        //            );
+        //    }
+        //}
 
         private bool? MatchConstantValue(BoundExpression source, TypeSymbol targetType, bool requiredNullTest)
         {
@@ -215,7 +632,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var assignment = _factory.AssignmentExpression(loweredTarget, convertedInput);
                         return _factory.MakeSequence(assignment, _factory.Literal(true));
                     }
-                    
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -381,6 +381,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundAssignmentOperator(Syntax, left, right, left.Type, refKind: refKind) { WasCompilerGenerated = true };
         }
 
+        public BoundAssignmentOperator AssignmentExpression(LocalSymbol left, BoundExpression right, RefKind refKind = RefKind.None)
+        {
+            return new BoundAssignmentOperator(Syntax, this.Local(left), right, left.Type, refKind: refKind) { WasCompilerGenerated = true };
+        }
+
         public BoundBlock Block()
         {
             return Block(ImmutableArray<BoundStatement>.Empty);
@@ -551,6 +556,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundLiteral Literal(uint value)
         {
             return new BoundLiteral(Syntax, ConstantValue.Create(value), SpecialType(Microsoft.CodeAnalysis.SpecialType.System_UInt32)) { WasCompilerGenerated = true };
+        }
+
+        public BoundLiteral Literal(ConstantValue value, TypeSymbol type)
+        {
+            return new BoundLiteral(Syntax, value, type) { WasCompilerGenerated = true };
         }
 
         public BoundObjectCreationExpression New(NamedTypeSymbol type, params BoundExpression[] args)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -5146,25 +5146,6 @@ tryAgain:
             // then assume it is unless we see specific tokens following it.
             switch (this.CurrentToken.Kind)
             {
-                case SyntaxKind.IdentifierToken:
-                    // C#7: In certain contexts, we treat *identifier* as a disambiguating token. Those
-                    // contexts are where the sequence of tokens being disambiguated is immediately preceded by one
-                    // of the keywords is, case, or out, or arises while parsing the first element of a tuple literal
-                    // (in which case the tokens are preceded by `(` and the identifier is followed by a `,`) or a
-                    // subsequent element of a tuple literal (in which case the tokens are preceded by `,` and the
-                    // identifier is followed by a `,` or `)`).
-                    // Note that we treat query contextual keywords (which appear here as identifiers) as disambiguating tokens as well.
-                    if ((options & (NameOptions.AfterIs | NameOptions.DefinitePattern | NameOptions.AfterOut)) != 0 ||
-                        (options & NameOptions.AfterTupleComma) != 0 && (this.PeekToken(1).Kind == SyntaxKind.CommaToken || this.PeekToken(1).Kind == SyntaxKind.CloseParenToken) ||
-                        (options & NameOptions.FirstElementOfPossibleTupleLiteral) != 0 && this.PeekToken(1).Kind == SyntaxKind.CommaToken
-                        )
-                    {
-                        // we allow 'G<T,U> x' as a pattern-matching operation and a declaration expression in a tuple.
-                        return ScanTypeArgumentListKind.DefiniteTypeArgumentList;
-                    }
-
-                    return ScanTypeArgumentListKind.PossibleTypeArgumentList;
-
                 case SyntaxKind.OpenParenToken:
                 case SyntaxKind.CloseParenToken:
                 case SyntaxKind.CloseBracketToken:
@@ -5202,6 +5183,27 @@ tryAgain:
                     // `(x is A<B>>C)` is parsed as `(x is A<B>) > C`
                     // `A<B>>C` elsewhere is parsed as `A < (B >> C)`
                     return ScanTypeArgumentListKind.DefiniteTypeArgumentList;
+
+                case SyntaxKind.IdentifierToken:
+                    // C#7: In certain contexts, we treat *identifier* as a disambiguating token. Those
+                    // contexts are where the sequence of tokens being disambiguated is immediately preceded by one
+                    // of the keywords is, case, or out, or arises while parsing the first element of a tuple literal
+                    // (in which case the tokens are preceded by `(` and the identifier is followed by a `,`) or a
+                    // subsequent element of a tuple literal (in which case the tokens are preceded by `,` and the
+                    // identifier is followed by a `,` or `)`).
+                    // In C#8 (or whenever recursive patterns are introduced) we also treat an identifier as a
+                    // disambiguating token if we're parsing the type of a pattern.
+                    // Note that we treat query contextual keywords (which appear here as identifiers) as disambiguating tokens as well.
+                    if ((options & (NameOptions.AfterIs | NameOptions.DefinitePattern | NameOptions.AfterOut)) != 0 ||
+                        (options & NameOptions.AfterTupleComma) != 0 && (this.PeekToken(1).Kind == SyntaxKind.CommaToken || this.PeekToken(1).Kind == SyntaxKind.CloseParenToken) ||
+                        (options & NameOptions.FirstElementOfPossibleTupleLiteral) != 0 && this.PeekToken(1).Kind == SyntaxKind.CommaToken
+                        )
+                    {
+                        // we allow 'G<T,U> x' as a pattern-matching operation and a declaration expression in a tuple.
+                        return ScanTypeArgumentListKind.DefiniteTypeArgumentList;
+                    }
+
+                    return ScanTypeArgumentListKind.PossibleTypeArgumentList;
 
                 case SyntaxKind.EndOfFileToken:          // e.g. `e is A<B>`
                     // This is useful for parsing expressions in isolation

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -17,6 +17,10 @@ Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.WithOpenParenTo
 Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.WithPropertySubpattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax propertySubpattern) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.WithSubPatterns(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax> subPatterns) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.WithType(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax.UnderscoreToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken underscoreToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax.WithUnderscoreToken(Microsoft.CodeAnalysis.SyntaxToken underscoreToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax.AddPropertySubpatternSubPatterns(params Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax.Designation.get -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDesignationSyntax
@@ -45,15 +49,19 @@ Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax.Update(Microsoft.Co
 Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax.WithNameColon(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax.WithPattern(Microsoft.CodeAnalysis.CSharp.Syntax.PatternSyntax pattern) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.DeconstructionPattern = 9023 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.DiscardPattern = 9024 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.PropertyPattern = 9020 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.PropertySubpattern = 9021 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.SubpatternElement = 9022 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitDeconstructionPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitDiscardPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitPropertyPattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitPropertySubpattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitSubpatternElement(Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
 override Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
+override Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
+override Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
 override Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
 override Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
 override Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
@@ -64,6 +72,7 @@ static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microso
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DeconstructionPattern(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax> subPatterns, Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax propertySubpattern, Microsoft.CodeAnalysis.CSharp.Syntax.VariableDesignationSyntax designation) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DeconstructionPattern(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.SyntaxToken openParenToken, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax> subPatterns, Microsoft.CodeAnalysis.SyntaxToken closeParenToken, Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax propertySubpattern, Microsoft.CodeAnalysis.CSharp.Syntax.VariableDesignationSyntax designation) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DeconstructionPattern(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax> subPatterns = default(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax>)) -> Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DiscardPattern(Microsoft.CodeAnalysis.SyntaxToken underscoreToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.PropertyPattern() -> Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.PropertyPattern(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax propertySubpattern, Microsoft.CodeAnalysis.CSharp.Syntax.VariableDesignationSyntax designation) -> Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.PropertySubpattern(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax> subPatterns = default(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax>)) -> Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax
@@ -72,10 +81,12 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.RefType(Microsoft.CodeAnalysi
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SubpatternElement(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.CSharp.Syntax.PatternSyntax pattern) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SubpatternElement(Microsoft.CodeAnalysis.CSharp.Syntax.PatternSyntax pattern) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitDeconstructionPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax node) -> void
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitDiscardPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitPropertyPattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitPropertySubpattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitSubpatternElement(Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitDeconstructionPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DeconstructionPatternSyntax node) -> TResult
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitDiscardPattern(Microsoft.CodeAnalysis.CSharp.Syntax.DiscardPatternSyntax node) -> TResult
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitPropertyPattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertyPatternSyntax node) -> TResult
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitPropertySubpattern(Microsoft.CodeAnalysis.CSharp.Syntax.PropertySubpatternSyntax node) -> TResult
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitSubpatternElement(Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternElementSyntax node) -> TResult

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this._scopeBinder = scopeBinder;
             this._containingSymbol = containingSymbol;
             this._identifierToken = identifierToken;
-            this._typeSyntax = allowRefKind ? typeSyntax.SkipRef(out this._refKind) : typeSyntax;
+            this._typeSyntax = allowRefKind ? typeSyntax?.SkipRef(out this._refKind) : typeSyntax;
             this._declarationKind = declarationKind;
 
             // create this eagerly as it will always be needed for the EnsureSingleDefinition
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     new[] { SyntaxKind.LocalDeclarationStatement, SyntaxKind.ForStatement, SyntaxKind.UsingStatement, SyntaxKind.FixedStatement }.
                         Contains(nodeToBind.Ancestors().OfType<StatementSyntax>().First().Kind()) ||
                 nodeToBind is ExpressionSyntax);
-            return typeSyntax.IsVar && kind != LocalDeclarationKind.DeclarationExpressionVariable
+            return typeSyntax?.IsVar != false && kind != LocalDeclarationKind.DeclarationExpressionVariable
                 ? new LocalSymbolWithEnclosingContext(containingSymbol, scopeBinder, nodeBinder, typeSyntax, identifierToken, kind, nodeToBind, forbiddenZone)
                 : new SourceLocalSymbol(containingSymbol, scopeBinder, false, typeSyntax, identifierToken, kind);
         }
@@ -303,14 +303,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_typeSyntax == null)
                 {
-                    // in "let x = 1;" there is no syntax corresponding to the type.
+                    // in "e is {} x" there is no syntax corresponding to the type.
                     return true;
                 }
 
                 if (_typeSyntax.IsVar)
                 {
-                    bool isVar;
-                    TypeSymbol declType = this.TypeSyntaxBinder.BindType(_typeSyntax, new DiagnosticBag(), out isVar);
+                    TypeSymbol declType = this.TypeSyntaxBinder.BindType(_typeSyntax, new DiagnosticBag(), out var isVar);
                     return isVar;
                 }
 
@@ -325,8 +324,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Binder typeBinder = this.TypeSyntaxBinder;
 
             bool isVar;
-            RefKind refKind;
-            TypeSymbol declType = typeBinder.BindType(_typeSyntax.SkipRef(out refKind), diagnostics, out isVar);
+            TypeSymbol declType;
+            if (_typeSyntax == null) // In recursive patterns the type may be omitted.
+            {
+                isVar = true;
+                declType = null;
+            }
+            else
+            {
+                declType = typeBinder.BindType(_typeSyntax.SkipRef(out var refKind), diagnostics, out isVar);
+            }
 
             if (isVar)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -49,15 +49,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (type.SpecialType == SpecialType.System_Void)
             {
-                diagnostics.Add(ErrorCode.ERR_FieldCantHaveVoidType, TypeSyntax.Location);
+                diagnostics.Add(ErrorCode.ERR_FieldCantHaveVoidType, TypeSyntax?.Location ?? this.Locations[0]);
             }
             else if (type.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
-                diagnostics.Add(ErrorCode.ERR_FieldCantBeRefAny, TypeSyntax.Location, type);
+                diagnostics.Add(ErrorCode.ERR_FieldCantBeRefAny, TypeSyntax?.Location ?? this.Locations[0], type);
             }
             else if (type.IsByRefLikeType && (this.IsStatic || !containingType.IsByRefLikeType))
             {
-                diagnostics.Add(ErrorCode.ERR_FieldAutoPropCantBeByRefLike, TypeSyntax.Location, type);
+                diagnostics.Add(ErrorCode.ERR_FieldAutoPropCantBeByRefLike, TypeSyntax?.Location ?? this.Locations[0], type);
             }
             else if (IsConst && !type.CanBeConst())
             {

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1718,6 +1718,12 @@
     <Field Name="Condition" Type="ExpressionSyntax"/>
   </Node>
   <AbstractNode Name="PatternSyntax" Base="CSharpSyntaxNode" />
+  <Node Name="DiscardPatternSyntax" Base="PatternSyntax">
+    <Kind Name="DiscardPattern" />
+    <Field Name="UnderscoreToken" Type="SyntaxToken">
+      <Kind Name="IdentifierToken"/>
+    </Field>
+  </Node>
   <Node Name="DeclarationPatternSyntax" Base="PatternSyntax">
     <Kind Name="DeclarationPattern" />
     <Field Name="Type" Type="TypeSyntax"/>
@@ -2169,7 +2175,7 @@
         <summary>
            The variable(s) of the loop. In correct code this is a tuple
            literal, declaration expression with a tuple designator, or
-           a wildcard syntax in the form of a simple identifier. In broken
+           a discard syntax in the form of a simple identifier. In broken
            code it could be something else.
         </summary>
       </PropertyComment>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -560,6 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         PropertySubpattern = 9021,
         SubpatternElement = 9022,
         DeconstructionPattern = 9023,
+        DiscardPattern = 9024,
 
         // Kinds between 9000 and 9039 are "reserved" for pattern matching.
         // Please start with 9040 if you add more kinds below.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5906,6 +5906,12 @@ class C
                 // (8,18): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
                 //         bool b = 3 is int _;
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "3 is int _").WithArguments("pattern matching", "7.0").WithLocation(8, 18),
+                // (11,13): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
+                //             case _: // not a discard
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case _:").WithArguments("pattern matching", "7.0").WithLocation(11, 13),
+                // (11,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             case _: // not a discard
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "_").WithArguments("recursive patterns", "patterns2").WithLocation(11, 18),
                 // (16,13): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
                 //             case int _:
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case int _:").WithArguments("pattern matching", "7.0").WithLocation(16, 13),
@@ -5918,15 +5924,9 @@ class C
                 // (6,10): error CS8059: Feature 'tuples' is not available in C# 6. Please use language version 7.0 or greater.
                 //         (_, var _, int _) = (1, 2, 3);
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7.0").WithLocation(6, 10),
-                // (11,18): error CS0103: The name '_' does not exist in the current context
-                //             case _: // not a discard
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(11, 18),
                 // (21,15): error CS8059: Feature 'tuples' is not available in C# 6. Please use language version 7.0 or greater.
                 //         M(out _);
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7.0").WithLocation(21, 15),
-                // (12,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(12, 17)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7.0").WithLocation(21, 15)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -11,9 +11,8 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
-    public class CodeGenOperatorTests : CSharpTestBase
+    public class CodeGenOperators : CSharpTestBase
     {
-
         [Fact]
         public void TestIsNullPattern()
         {
@@ -258,40 +257,34 @@ class C
             // Release
             var compilation = CompileAndVerify(source, expectedOutput: "True Branch taken", options: TestOptions.ReleaseExe);
             compilation.VerifyIL("C.Main", @"{
-    // Code size       20 (0x14)
-    .maxstack  2
-    IL_0000:  ldnull
-    IL_0001:  ldnull
-    IL_0002:  ceq
-    IL_0004:  call       ""void System.Console.Write(bool)""
-    IL_0009:  ldstr      "" Branch taken""
-    IL_000e:  call       ""void System.Console.Write(string)""
-    IL_0013:  ret
+  // Code size       17 (0x11)
+  .maxstack  1
+  IL_0000:  ldc.i4.1
+  IL_0001:  call       ""void System.Console.Write(bool)""
+  IL_0006:  ldstr      "" Branch taken""
+  IL_000b:  call       ""void System.Console.Write(string)""
+  IL_0010:  ret
 }");
             // Debug
             compilation = CompileAndVerify(source, expectedOutput: "True Branch taken", options: TestOptions.DebugExe);
             compilation.VerifyIL("C.Main", @"{
-    // Code size       33 (0x21)
-    .maxstack  2
-    .locals init (bool V_0)
-    IL_0000:  nop
-    IL_0001:  ldnull
-    IL_0002:  ldnull
-    IL_0003:  ceq
-    IL_0005:  call       ""void System.Console.Write(bool)""
-    IL_000a:  nop
-    IL_000b:  ldnull
-    IL_000c:  ldnull
-    IL_000d:  ceq
-    IL_000f:  stloc.0
-    IL_0010:  ldloc.0
-    IL_0011:  brfalse.s  IL_0020
-    IL_0013:  nop
-    IL_0014:  ldstr      "" Branch taken""
-    IL_0019:  call       ""void System.Console.Write(string)""
-    IL_001e:  nop
-    IL_001f:  nop
-    IL_0020:  ret
+  // Code size       27 (0x1b)
+  .maxstack  1
+  .locals init (bool V_0)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.1
+  IL_0002:  call       ""void System.Console.Write(bool)""
+  IL_0007:  nop
+  IL_0008:  ldc.i4.1
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  brfalse.s  IL_001a
+  IL_000d:  nop
+  IL_000e:  ldstr      "" Branch taken""
+  IL_0013:  call       ""void System.Console.Write(string)""
+  IL_0018:  nop
+  IL_0019:  nop
+  IL_001a:  ret
 }");
         }
 
@@ -316,40 +309,34 @@ class C
             // Release
             var compilation = CompileAndVerify(source, expectedOutput: "True Branch taken", options: TestOptions.ReleaseExe);
             compilation.VerifyIL("C.Main", @"{
-    // Code size       20 (0x14)
-    .maxstack  2
-    IL_0000:  ldnull
-    IL_0001:  ldnull
-    IL_0002:  ceq
-    IL_0004:  call       ""void System.Console.Write(bool)""
-    IL_0009:  ldstr      "" Branch taken""
-    IL_000e:  call       ""void System.Console.Write(string)""
-    IL_0013:  ret
+  // Code size       17 (0x11)
+  .maxstack  1
+  IL_0000:  ldc.i4.1
+  IL_0001:  call       ""void System.Console.Write(bool)""
+  IL_0006:  ldstr      "" Branch taken""
+  IL_000b:  call       ""void System.Console.Write(string)""
+  IL_0010:  ret
 }");
             // Debug
             compilation = CompileAndVerify(source, expectedOutput: "True Branch taken", options: TestOptions.DebugExe);
             compilation.VerifyIL("C.Main", @"{
-    // Code size       33 (0x21)
-    .maxstack  2
-    .locals init (bool V_0)
-    IL_0000:  nop
-    IL_0001:  ldnull
-    IL_0002:  ldnull
-    IL_0003:  ceq
-    IL_0005:  call       ""void System.Console.Write(bool)""
-    IL_000a:  nop
-    IL_000b:  ldnull
-    IL_000c:  ldnull
-    IL_000d:  ceq
-    IL_000f:  stloc.0
-    IL_0010:  ldloc.0
-    IL_0011:  brfalse.s  IL_0020
-    IL_0013:  nop
-    IL_0014:  ldstr      "" Branch taken""
-    IL_0019:  call       ""void System.Console.Write(string)""
-    IL_001e:  nop
-    IL_001f:  nop
-    IL_0020:  ret
+  // Code size       27 (0x1b)
+  .maxstack  1
+  .locals init (bool V_0)
+  IL_0000:  nop
+  IL_0001:  ldc.i4.1
+  IL_0002:  call       ""void System.Console.Write(bool)""
+  IL_0007:  nop
+  IL_0008:  ldc.i4.1
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  brfalse.s  IL_001a
+  IL_000d:  nop
+  IL_000e:  ldstr      "" Branch taken""
+  IL_0013:  call       ""void System.Console.Write(string)""
+  IL_0018:  nop
+  IL_0019:  nop
+  IL_001a:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -14866,27 +14866,24 @@ class C
 
             var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
+                // (6,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //         if (o is (int, int) t) { }
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int, int) t").WithArguments("recursive patterns", "patterns2").WithLocation(6, 18),
                 // (6,19): error CS1525: Invalid expression term 'int'
                 //         if (o is (int, int) t) { }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 19),
                 // (6,24): error CS1525: Invalid expression term 'int'
                 //         if (o is (int, int) t) { }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 24),
-                // (6,29): error CS1026: ) expected
+                // (6,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //         if (o is (int, int) t) { }
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "t").WithLocation(6, 29),
-                // (6,30): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int) t").WithArguments("object", "2").WithLocation(6, 18),
+                // (6,19): error CS0150: A constant value is expected
                 //         if (o is (int, int) t) { }
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(6, 30),
-                // (6,30): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(6, 19),
+                // (6,24): error CS0150: A constant value is expected
                 //         if (o is (int, int) t) { }
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(6, 30),
-                // (6,18): error CS0150: A constant value is expected
-                //         if (o is (int, int) t) { }
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(6, 18),
-                // (6,29): error CS0103: The name 't' does not exist in the current context
-                //         if (o is (int, int) t) { }
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "t").WithArguments("t").WithLocation(6, 29)
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(6, 24)
                 );
         }
 
@@ -14927,21 +14924,12 @@ class C
 
             var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,19): error CS8185: A declaration is not allowed in this context.
+                // (6,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int a").WithLocation(6, 19),
-                // (6,26): error CS8185: A declaration is not allowed in this context.
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int a, int b)").WithArguments("recursive patterns", "patterns2").WithLocation(6, 18),
+                // (6,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int b").WithLocation(6, 26),
-                // (6,18): error CS0150: A constant value is expected
-                //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int a, int b)").WithLocation(6, 18),
-                // (6,19): error CS0165: Use of unassigned local variable 'a'
-                //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(6, 19),
-                // (6,26): error CS0165: Use of unassigned local variable 'b'
-                //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int b").WithArguments("b").WithLocation(6, 26)
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int a, int b)").WithArguments("object", "2").WithLocation(6, 18)
                 );
         }
 
@@ -14960,9 +14948,12 @@ class C
 
             var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,18): error CS0150: A constant value is expected
-                //         if (o is (1, 2))
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(1, 2)").WithLocation(6, 18)
+                // (6,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //         if (o is (1, 2)) { }
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(1, 2)").WithArguments("recursive patterns", "patterns2").WithLocation(6, 18),
+                // (6,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
+                //         if (o is (1, 2)) { }
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(1, 2)").WithArguments("object", "2").WithLocation(6, 18)
                 );
         }
 
@@ -14992,12 +14983,15 @@ class C
                 // (7,24): error CS1525: Invalid expression term 'int'
                 //             case (int, int) tuple: return;
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(7, 24),
-                // (7,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (7,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int, int) tuple: return;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int, int) tuple").WithArguments("recursive pattern").WithLocation(7, 18),
-                // (7,36): warning CS0162: Unreachable code detected
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int) tuple").WithArguments("object", "2").WithLocation(7, 18),
+                // (7,19): error CS0150: A constant value is expected
                 //             case (int, int) tuple: return;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(7, 36)
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(7, 19),
+                // (7,24): error CS0150: A constant value is expected
+                //             case (int, int) tuple: return;
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(7, 24)
                );
         }
 
@@ -15021,12 +15015,9 @@ class C
                 // (7,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             case (1, 1): return;
                 Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(1, 1)").WithArguments("recursive patterns", "patterns2").WithLocation(7, 18),
-                // (7,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (7,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (1, 1): return;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(1, 1)").WithArguments("recursive pattern").WithLocation(7, 18),
-                // (7,26): warning CS0162: Unreachable code detected
-                //             case (1, 1): return;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(7, 26)
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(1, 1)").WithArguments("object", "2").WithLocation(7, 18)
                 );
         }
 
@@ -15050,12 +15041,9 @@ class C
                 // (7,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             case (1, 1) t: return;
                 Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(1, 1) t").WithArguments("recursive patterns", "patterns2").WithLocation(7, 18),
-                // (7,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (7,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (1, 1) t: return;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(1, 1) t").WithArguments("recursive pattern").WithLocation(7, 18),
-                // (7,28): warning CS0162: Unreachable code detected
-                //             case (1, 1) t: return;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(7, 28)
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(1, 1) t").WithArguments("object", "2").WithLocation(7, 18)
                );
         }
 
@@ -23443,6 +23431,9 @@ class P
 }";
             var comp = CreateStandardCompilation( source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
+                // (6,28): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //         var x1 = (1, 1) is (int, int a)?;
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int, int a)").WithArguments("recursive patterns", "patterns2").WithLocation(6, 28),
                 // (6,29): error CS1525: Invalid expression term 'int'
                 //         var x1 = (1, 1) is (int, int a)?;
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 29),
@@ -23455,15 +23446,9 @@ class P
                 // (6,41): error CS1525: Invalid expression term ';'
                 //         var x1 = (1, 1) is (int, int a)?;
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(6, 41),
-                // (6,34): error CS8185: A declaration is not allowed in this context.
+                // (6,29): error CS0150: A constant value is expected
                 //         var x1 = (1, 1) is (int, int a)?;
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int a").WithLocation(6, 34),
-                // (6,28): error CS0150: A constant value is expected
-                //         var x1 = (1, 1) is (int, int a)?;
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int a)").WithLocation(6, 28),
-                // (6,34): error CS0165: Use of unassigned local variable 'a'
-                //         var x1 = (1, 1) is (int, int a)?;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(6, 34)
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(6, 29)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -97,9 +97,12 @@ static class C {
         {
             case int i: break;
         }").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(12, 9),
-                // (17,36): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                // (17,36): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
                 //     static bool M2(int? x) => x is int i;
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(17, 36)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(17, 36),
+                // (17,36): error CS0656: Missing compiler required member 'System.Nullable`1.get_Value'
+                //     static bool M2(int? x) => x is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_Value").WithLocation(17, 36)
                 );
         }
 
@@ -138,11 +141,14 @@ static class C {
         }").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(12, 9),
                 // (17,36): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
                 //     static bool M2(int? x) => x is int i;
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(17, 36)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(17, 36),
+                // (17,36): error CS0656: Missing compiler required member 'System.Nullable`1.get_Value'
+                //     static bool M2(int? x) => x is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_Value").WithLocation(17, 36)
                 );
         }
 
-        [Fact, WorkItem(17266, "https://github.com/dotnet/roslyn/issues/17266")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(17266, "https://github.com/dotnet/roslyn/issues/17266")]
         public void DoubleEvaluation01()
         {
             var source =
@@ -194,7 +200,7 @@ public class C
 }");
         }
 
-        [Fact, WorkItem(19122, "https://github.com/dotnet/roslyn/issues/19122")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(19122, "https://github.com/dotnet/roslyn/issues/19122")]
         public void PatternCrash_01()
         {
             var source = @"using System;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -8370,7 +8370,7 @@ public class Program
             );
         }
 
-        [Fact, WorkItem(18859, "https://github.com/dotnet/roslyn/issues/18859")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(18859, "https://github.com/dotnet/roslyn/issues/18859")]
         public void BoxInPatternIf_02()
         {
             var source = @"using System;
@@ -8428,7 +8428,7 @@ public class Program
             );
         }
 
-        [Fact, WorkItem(16195, "https://github.com/dotnet/roslyn/issues/16195")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(16195, "https://github.com/dotnet/roslyn/issues/16195")]
         public void TestMatchWithTypeParameter_01()
         {
             var source =
@@ -8631,7 +8631,7 @@ class Program
             );
         }
 
-        [Fact, WorkItem(16195, "https://github.com/dotnet/roslyn/issues/16195")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(16195, "https://github.com/dotnet/roslyn/issues/16195")]
         public void TestMatchWithTypeParameter_02()
         {
             var source =
@@ -9250,7 +9250,7 @@ Generic<object>.Color.Red");
             );
         }
 
-        [Fact, WorkItem(16129, "https://github.com/dotnet/roslyn/issues/16129")]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality"), WorkItem(16129, "https://github.com/dotnet/roslyn/issues/16129")]
         public void ExactPatternMatch()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7583,7 +7583,7 @@ class C
 ");
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality")]
         public void PatternVariable_TypeChange()
         {
             var source0 = MarkedSource(@"
@@ -7750,7 +7750,7 @@ class C
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality")]
         public void PatternVariable_DeleteInsert()
         {
             var source0 = MarkedSource(@"

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -3642,7 +3642,7 @@ class C
 ", methodToken: diff1.UpdatedMethods.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality")]
         public void PatternVariable()
         {
             var source = @"
@@ -3811,7 +3811,7 @@ class C
 ", methodToken: diff1.UpdatedMethods.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality")]
         public void PatternMatching_Variable()
         {
             var source = @"
@@ -3873,7 +3873,7 @@ class C
 }", methodToken: diff1.UpdatedMethods.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): code quality")]
         public void PatternMatching_NoVariable()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -7186,7 +7186,7 @@ class C
 
         #region Patterns
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): pdb details")]
         public void SyntaxOffset_Pattern()
         {
             var source = @"class C { bool F(object o) => o is int i && o is 3 && o is bool; }";

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -3614,12 +3614,12 @@ unsafe struct S
     }
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (7,29): error CS1525: Invalid expression term ')'
+                // (7,28): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (o.Equals is()) {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(7, 29),
-                // (8,34): error CS1525: Invalid expression term ')'
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(7, 28),
+                // (8,33): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (object.Equals is()) {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(8, 34),
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(8, 33),
                 // (7,17): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
                 //             if (o.Equals is()) {}
                 Diagnostic(ErrorCode.ERR_LambdaInIsAs, "o.Equals is()").WithLocation(7, 17),
@@ -3645,16 +3645,16 @@ unsafe struct S
     }
 }";
             CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
-                // (7,25): error CS1525: Invalid expression term ')'
+                // (7,24): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (null is()) {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(7, 25),
-                // (8,39): error CS1525: Invalid expression term ')'
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(7, 24),
+                // (8,38): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if ((1, object.Equals) is()) {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(8, 39),
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(8, 38),
                 // (7,17): error CS8117: Invalid operand for pattern match; value required, but found '<null>'.
                 //             if (null is()) {}
                 Diagnostic(ErrorCode.ERR_BadIsPatternExpression, "null").WithArguments("<null>").WithLocation(7, 17),
-                // (8,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                // (8,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported, or is declared in multiple referenced assemblies
                 //             if ((1, object.Equals) is()) {}
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, object.Equals)").WithArguments("System.ValueTuple`2").WithLocation(8, 17),
                 // (8,17): error CS0023: Operator 'is' cannot be applied to operand of type '(int, method group)'
@@ -4379,15 +4379,12 @@ public class C
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             compilation.VerifyDiagnostics(
-                // (8,29): error CS0246: The type or namespace name '_' could not be found (are you missing a using directive or an assembly reference?)
+                // (8,29): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //         Write($"is _: {i is _}, ");
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "_").WithArguments("_").WithLocation(8, 29),
-                // (11,18): error CS0103: The name '_' does not exist in the current context
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "_").WithArguments("recursive patterns", "patterns2").WithLocation(8, 29),
+                // (11,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             case _:
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(11, 18),
-                // (12,17): warning CS0162: Unreachable code detected
-                //                 Write("case _");
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "Write").WithLocation(12, 17)
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "_").WithArguments("recursive patterns", "patterns2").WithLocation(11, 18)
                 );
         }
 
@@ -4415,15 +4412,15 @@ public class C
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             compilation.VerifyDiagnostics(
-                // (9,29): error CS0150: A constant value is expected
+                // (9,29): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //         Write($"is _: {i is _}, ");
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "_").WithLocation(9, 29),
-                // (12,18): error CS0150: A constant value is expected
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "_").WithArguments("recursive patterns", "patterns2").WithLocation(9, 29),
+                // (12,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             case _:
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "_").WithLocation(12, 18),
-                // (13,17): warning CS0162: Unreachable code detected
-                //                 Write("case _");
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "Write").WithLocation(13, 17)
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "_").WithArguments("recursive patterns", "patterns2").WithLocation(12, 18),
+                // (8,13): warning CS0219: The variable '_' is assigned but its value is never used
+                //         int _ = 4;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "_").WithArguments("_").WithLocation(8, 13)
                 );
         }
 
@@ -6119,7 +6116,7 @@ unsafe public class C {
                 Diagnostic(ErrorCode.ERR_PatternWrongType, "object").WithArguments("System.TypedReference", "object").WithLocation(9, 23),
                 // (10,23): error CS0244: Neither 'is' nor 'as' is valid on pointer types
                 //         var b2 = p is object o2;         // not allowed 2
-                Diagnostic(ErrorCode.ERR_PointerInAsOrIs, "object o2").WithLocation(10, 23),
+                Diagnostic(ErrorCode.ERR_PointerInAsOrIs, "object").WithLocation(10, 23),
                 // (7,31): warning CS0168: The variable 'z0' is declared but never used
                 //         var r1 = z is ref int z0;        // syntax error 2
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "z0").WithArguments("z0").WithLocation(7, 31)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests2.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    [CompilerTrait(CompilerFeature.Patterns)]
+    public class PatternMatchingTests2 : PatternMatchingTestBase
+    {
+        [Fact]
+        public void Patterns2_00()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine(1 is int {} x ? x : -1);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: @"1");
+        }
+
+        [Fact]
+        public void Patterns2_01()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = new Point();
+        Check(true, p is Point(3, 4) { Length: 5 } q1 && Check(p, q1));
+        Check(false, p is Point(1, 4) { Length: 5 });
+        Check(false, p is Point(3, 1) { Length: 5 });
+        Check(false, p is Point(3, 4) { Length: 1 });
+        Check(true, p is (3, 4) { Length: 5 } q2 && Check(p, q2));
+        Check(false, p is (1, 4) { Length: 5 });
+        Check(false, p is (3, 1) { Length: 5 });
+        Check(false, p is (3, 4) { Length: 1 });
+    }
+    private static bool Check<T>(T expected, T actual)
+    {
+        if (!object.Equals(expected, actual)) throw new Exception($""expected: {expected}; actual: {actual}"");
+        return true;
+    }
+}
+public class Point
+{
+    public void Deconstruct(out int X, out int Y)
+    {
+        X = 3;
+        Y = 4;
+    }
+    public int Length => 5;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: "");
+        }
+
+        [Fact]
+        public void Patterns2_02()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = new Point();
+        Check(true, p is Point(3, 4) { Length: 5 } q1 && Check(p, q1));
+        Check(false, p is Point(1, 4) { Length: 5 });
+        Check(false, p is Point(3, 1) { Length: 5 });
+        Check(false, p is Point(3, 4) { Length: 1 });
+        Check(true, p is (3, 4) { Length: 5 } q2 && Check(p, q2));
+        Check(false, p is (1, 4) { Length: 5 });
+        Check(false, p is (3, 1) { Length: 5 });
+        Check(false, p is (3, 4) { Length: 1 });
+    }
+    private static bool Check<T>(T expected, T actual)
+    {
+        if (!object.Equals(expected, actual)) throw new Exception($""expected: {expected}; actual: {actual}"");
+        return true;
+    }
+}
+public class Point
+{
+    public int Length => 5;
+}
+public static class PointExtensions
+{
+    public static void Deconstruct(this Point p, out int X, out int Y)
+    {
+        X = 3;
+        Y = 4;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: "");
+        }
+
+        [Fact]
+        public void Patterns2_DiscardPattern_01()
+        {
+            var source =
+@"
+using System;
+class Program
+{
+    public static void Main()
+    {
+        Point p = new Point();
+        Check(true, p is Point(_, _) { Length: _ } q1 && Check(p, q1));
+        Check(false, p is Point(1, _) { Length: _ });
+        Check(false, p is Point(_, 1) { Length: _ });
+        Check(false, p is Point(_, _) { Length: 1 });
+        Check(true, p is (_, _) { Length: _ } q2 && Check(p, q2));
+        Check(false, p is (1, _) { Length: _ });
+        Check(false, p is (_, 1) { Length: _ });
+        Check(false, p is (_, _) { Length: 1 });
+    }
+    private static bool Check<T>(T expected, T actual)
+    {
+        if (!object.Equals(expected, actual)) throw new Exception($""expected: {expected}; actual: {actual}"");
+        return true;
+    }
+}
+public class Point
+{
+    public void Deconstruct(out int X, out int Y)
+    {
+        X = 3;
+        Y = 4;
+    }
+    public int Length => 5;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: "");
+        }
+
+        [Fact(Skip = "Pattern-based switch with recursive patterns is not yet implemented")]
+        public void Patterns2_Switch_Later()
+        {
+            var source =
+@"
+class Program
+{
+    public static void Main()
+    {
+        Point p = new Point();
+        switch (p)
+        {
+            case Point(3, 4) { Length: 5 }:
+                System.Console.WriteLine(true);
+                break;
+            default:
+                System.Console.WriteLine(false);
+                break;
+        }
+    }
+}
+public class Point
+{
+    public void Deconstruct(out int X, out int Y)
+    {
+        X = 3;
+        Y = 4;
+    }
+    public int Length => 5;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.RegularWithRecursivePatterns);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: "True");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -1569,186 +1569,177 @@ class Program
                 // (39,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             case (System.Int64, System.Int64) d:
                 Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(System.Int64, System.Int64) d").WithArguments("recursive patterns", "patterns2").WithLocation(39, 18),
+                // (43,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             if (o is (int, int)) {}
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int, int)").WithArguments("recursive patterns", "patterns2").WithLocation(43, 22),
                 // (43,23): error CS1525: Invalid expression term 'int'
                 //             if (o is (int, int)) {}
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(43, 23),
                 // (43,28): error CS1525: Invalid expression term 'int'
                 //             if (o is (int, int)) {}
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(43, 28),
+                // (44,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             if (o is (int x, int y)) {}
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int x, int y)").WithArguments("recursive patterns", "patterns2").WithLocation(44, 22),
+                // (45,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             if (o is (int, int) z)) {}
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int, int) z").WithArguments("recursive patterns", "patterns2").WithLocation(45, 22),
                 // (45,23): error CS1525: Invalid expression term 'int'
                 //             if (o is (int, int) z)) {}
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(45, 23),
                 // (45,28): error CS1525: Invalid expression term 'int'
                 //             if (o is (int, int) z)) {}
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(45, 28),
-                // (45,33): error CS1026: ) expected
+                // (45,35): error CS1525: Invalid expression term ')'
                 //             if (o is (int, int) z)) {}
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "z").WithLocation(45, 33),
-                // (45,34): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(45, 35),
+                // (45,35): error CS1002: ; expected
                 //             if (o is (int, int) z)) {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(45, 34),
-                // (45,34): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(45, 35),
+                // (45,35): error CS1513: } expected
                 //             if (o is (int, int) z)) {}
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(45, 34),
-                // (46,37): error CS1026: ) expected
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(45, 35),
+                // (46,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "c").WithLocation(46, 37),
-                // (46,38): error CS1002: ; expected
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(46, 38),
-                // (46,38): error CS1513: } expected
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(46, 38),
-                // (51,51): error CS1026: ) expected
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int a, int b) c").WithArguments("recursive patterns", "patterns2").WithLocation(46, 22),
+                // (49,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             if (o is (System.Int32, System.Int32)) {}
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(System.Int32, System.Int32)").WithArguments("recursive patterns", "patterns2").WithLocation(49, 22),
+                // (50,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             if (o is (System.Int32 x, System.Int32 y)) {}
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(System.Int32 x, System.Int32 y)").WithArguments("recursive patterns", "patterns2").WithLocation(50, 22),
+                // (51,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (o is (System.Int32, System.Int32) z)) {}
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "z").WithLocation(51, 51),
-                // (51,52): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(System.Int32, System.Int32) z").WithArguments("recursive patterns", "patterns2").WithLocation(51, 22),
+                // (51,53): error CS1525: Invalid expression term ')'
                 //             if (o is (System.Int32, System.Int32) z)) {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(51, 52),
-                // (51,52): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(51, 53),
+                // (51,53): error CS1002: ; expected
                 //             if (o is (System.Int32, System.Int32) z)) {}
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(51, 52),
-                // (52,55): error CS1026: ) expected
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(51, 53),
+                // (51,53): error CS1513: } expected
+                //             if (o is (System.Int32, System.Int32) z)) {}
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(51, 53),
+                // (52,22): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "c").WithLocation(52, 55),
-                // (52,56): error CS1002: ; expected
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(52, 56),
-                // (52,56): error CS1513: } expected
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(52, 56),
-                // (21,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(System.Int32 a, System.Int32 b) c").WithArguments("recursive patterns", "patterns2").WithLocation(52, 22),
+                // (21,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int, int):
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int, int)").WithArguments("recursive pattern").WithLocation(21, 18),
-                // (22,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int)").WithArguments("object", "2").WithLocation(21, 18),
+                // (21,19): error CS0150: A constant value is expected
+                //             case (int, int):
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(21, 19),
+                // (21,24): error CS0150: A constant value is expected
+                //             case (int, int):
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(21, 24),
+                // (22,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int x, int y):
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int x, int y)").WithArguments("recursive pattern").WithLocation(22, 18),
-                // (23,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int x, int y)").WithArguments("object", "2").WithLocation(22, 18),
+                // (23,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int, int) z:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int, int) z").WithArguments("recursive pattern").WithLocation(23, 18),
-                // (24,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int) z").WithArguments("object", "2").WithLocation(23, 18),
+                // (23,19): error CS0150: A constant value is expected
+                //             case (int, int) z:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(23, 19),
+                // (23,24): error CS0150: A constant value is expected
+                //             case (int, int) z:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(23, 24),
+                // (24,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int a, int b) c:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int a, int b) c").WithArguments("recursive pattern").WithLocation(24, 18),
-                // (25,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int a, int b) c").WithArguments("object", "2").WithLocation(24, 18),
+                // (25,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (long, long) d:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(long, long) d").WithArguments("recursive pattern").WithLocation(25, 18),
-                // (30,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(long, long) d").WithArguments("object", "2").WithLocation(25, 18),
+                // (25,19): error CS0150: A constant value is expected
+                //             case (long, long) d:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "long").WithLocation(25, 19),
+                // (25,25): error CS0150: A constant value is expected
+                //             case (long, long) d:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "long").WithLocation(25, 25),
+                // (30,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (int, int) z:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(int, int) z").WithArguments("recursive pattern").WithLocation(30, 18),
-                // (32,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int) z").WithArguments("object", "2").WithLocation(30, 18),
+                // (30,19): error CS0150: A constant value is expected
+                //             case (int, int) z:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(30, 19),
+                // (30,24): error CS0150: A constant value is expected
+                //             case (int, int) z:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(30, 24),
+                // (32,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (long, long) d:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(long, long) d").WithArguments("recursive pattern").WithLocation(32, 18),
-                // (37,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(long, long) d").WithArguments("object", "2").WithLocation(32, 18),
+                // (32,19): error CS0150: A constant value is expected
+                //             case (long, long) d:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "long").WithLocation(32, 19),
+                // (32,25): error CS0150: A constant value is expected
+                //             case (long, long) d:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "long").WithLocation(32, 25),
+                // (37,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (System.Int32, System.Int32) z:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(System.Int32, System.Int32) z").WithArguments("recursive pattern").WithLocation(37, 18),
-                // (39,18): error CS0570: 'recursive pattern' is not supported by the language
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int32, System.Int32) z").WithArguments("object", "2").WithLocation(37, 18),
+                // (37,19): error CS0119: 'int' is a type, which is not valid in the given context
+                //             case (System.Int32, System.Int32) z:
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(37, 19),
+                // (37,33): error CS0119: 'int' is a type, which is not valid in the given context
+                //             case (System.Int32, System.Int32) z:
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(37, 33),
+                // (39,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             case (System.Int64, System.Int64) d:
-                Diagnostic(ErrorCode.ERR_BindToBogus, "(System.Int64, System.Int64) d").WithArguments("recursive pattern").WithLocation(39, 18),
-                // (43,22): error CS0150: A constant value is expected
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int64, System.Int64) d").WithArguments("object", "2").WithLocation(39, 18),
+                // (39,19): error CS0119: 'long' is a type, which is not valid in the given context
+                //             case (System.Int64, System.Int64) d:
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int64").WithArguments("long", "type").WithLocation(39, 19),
+                // (39,33): error CS0119: 'long' is a type, which is not valid in the given context
+                //             case (System.Int64, System.Int64) d:
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int64").WithArguments("long", "type").WithLocation(39, 33),
+                // (43,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (int, int)) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(43, 22),
-                // (44,23): error CS8185: A declaration is not allowed in this context.
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int)").WithArguments("object", "2").WithLocation(43, 22),
+                // (43,23): error CS0150: A constant value is expected
+                //             if (o is (int, int)) {}
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(43, 23),
+                // (43,28): error CS0150: A constant value is expected
+                //             if (o is (int, int)) {}
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(43, 28),
+                // (44,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x").WithLocation(44, 23),
-                // (44,30): error CS8185: A declaration is not allowed in this context.
-                //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int y").WithLocation(44, 30),
-                // (44,22): error CS0150: A constant value is expected
-                //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int x, int y)").WithLocation(44, 22),
-                // (45,22): error CS0150: A constant value is expected
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int x, int y)").WithArguments("object", "2").WithLocation(44, 22),
+                // (45,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (int, int) z)) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(45, 22),
-                // (45,33): error CS0103: The name 'z' does not exist in the current context
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int, int) z").WithArguments("object", "2").WithLocation(45, 22),
+                // (45,23): error CS0150: A constant value is expected
                 //             if (o is (int, int) z)) {}
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z").WithArguments("z").WithLocation(45, 33),
-                // (46,23): error CS8185: A declaration is not allowed in this context.
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(45, 23),
+                // (45,28): error CS0150: A constant value is expected
+                //             if (o is (int, int) z)) {}
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "int").WithLocation(45, 28),
+                // (46,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int a").WithLocation(46, 23),
-                // (46,30): error CS8185: A declaration is not allowed in this context.
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int b").WithLocation(46, 30),
-                // (46,22): error CS0150: A constant value is expected
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(int a, int b)").WithLocation(46, 22),
-                // (46,37): error CS0103: The name 'c' does not exist in the current context
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "c").WithArguments("c").WithLocation(46, 37),
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(int a, int b) c").WithArguments("object", "2").WithLocation(46, 22),
+                // (49,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
+                //             if (o is (System.Int32, System.Int32)) {}
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int32, System.Int32)").WithArguments("object", "2").WithLocation(49, 22),
                 // (49,23): error CS0119: 'int' is a type, which is not valid in the given context
                 //             if (o is (System.Int32, System.Int32)) {}
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(49, 23),
                 // (49,37): error CS0119: 'int' is a type, which is not valid in the given context
                 //             if (o is (System.Int32, System.Int32)) {}
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(49, 37),
-                // (50,23): error CS8185: A declaration is not allowed in this context.
+                // (50,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 x").WithLocation(50, 23),
-                // (50,39): error CS8185: A declaration is not allowed in this context.
-                //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 y").WithLocation(50, 39),
-                // (50,22): error CS0150: A constant value is expected
-                //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(System.Int32 x, System.Int32 y)").WithLocation(50, 22),
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int32 x, System.Int32 y)").WithArguments("object", "2").WithLocation(50, 22),
+                // (51,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
+                //             if (o is (System.Int32, System.Int32) z)) {}
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int32, System.Int32) z").WithArguments("object", "2").WithLocation(51, 22),
                 // (51,23): error CS0119: 'int' is a type, which is not valid in the given context
                 //             if (o is (System.Int32, System.Int32) z)) {}
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(51, 23),
                 // (51,37): error CS0119: 'int' is a type, which is not valid in the given context
                 //             if (o is (System.Int32, System.Int32) z)) {}
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(51, 37),
-                // (51,51): error CS0103: The name 'z' does not exist in the current context
-                //             if (o is (System.Int32, System.Int32) z)) {}
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z").WithArguments("z").WithLocation(51, 51),
-                // (52,23): error CS8185: A declaration is not allowed in this context.
+                // (52,22): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 2 out parameters and a void return type.
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 a").WithLocation(52, 23),
-                // (52,39): error CS8185: A declaration is not allowed in this context.
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 b").WithLocation(52, 39),
-                // (52,22): error CS0150: A constant value is expected
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_ConstantExpected, "(System.Int32 a, System.Int32 b)").WithLocation(52, 22),
-                // (52,55): error CS0103: The name 'c' does not exist in the current context
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "c").WithArguments("c").WithLocation(52, 55),
-                // (26,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(26, 17),
-                // (31,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(31, 17),
-                // (33,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(33, 17),
-                // (38,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(38, 17),
-                // (40,17): warning CS0162: Unreachable code detected
-                //                 break;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(40, 17),
-                // (44,23): error CS0165: Use of unassigned local variable 'x'
-                //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int x").WithArguments("x").WithLocation(44, 23),
-                // (44,30): error CS0165: Use of unassigned local variable 'y'
-                //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int y").WithArguments("y").WithLocation(44, 30),
-                // (46,23): error CS0165: Use of unassigned local variable 'a'
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(46, 23),
-                // (46,30): error CS0165: Use of unassigned local variable 'b'
-                //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "int b").WithArguments("b").WithLocation(46, 30),
-                // (50,23): error CS0165: Use of unassigned local variable 'x'
-                //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 x").WithArguments("x").WithLocation(50, 23),
-                // (50,39): error CS0165: Use of unassigned local variable 'y'
-                //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 y").WithArguments("y").WithLocation(50, 39),
-                // (52,23): error CS0165: Use of unassigned local variable 'a'
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 a").WithArguments("a").WithLocation(52, 23),
-                // (52,39): error CS0165: Use of unassigned local variable 'b'
-                //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 b").WithArguments("b").WithLocation(52, 39)
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "(System.Int32 a, System.Int32 b) c").WithArguments("object", "2").WithLocation(52, 22)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -1181,18 +1181,18 @@ class C
                 // (6,17): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type in C# 6 and earlier.
                 //         switch (o)
                 Diagnostic(ErrorCode.ERR_V6SwitchGoverningTypeValueExpected, "o").WithLocation(6, 17),
-                // (8,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (8,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 1 out parameters and a void return type.
                 //             case ((o.GetType().Name.Length)):
-                Diagnostic(ErrorCode.ERR_BindToBogus, "((o.GetType().Name.Length))").WithArguments("recursive pattern").WithLocation(8, 18),
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "((o.GetType().Name.Length))").WithArguments("object", "1").WithLocation(8, 18),
+                // (8,20): error CS0118: 'o' is a variable but is used like a type
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_BadSKknown, "o").WithArguments("o", "variable", "type").WithLocation(8, 20),
+                // (8,32): error CS0103: The name 'Name' does not exist in the current context
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Name").WithArguments("Name").WithLocation(8, 32),
                 // (9,17): error CS7036: There is no argument given that corresponds to the required formal parameter 'o' of 'C.M(object)'
                 //                 M();
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17),
-                // (12,13): error CS8120: The switch case has already been handled by a previous case.
-                //             case 0:
-                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "case 0:").WithLocation(12, 13),
-                // (9,17): warning CS0162: Unreachable code detected
-                //                 M();
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "M").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17)
                 );
             CreateStandardCompilation(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (8,13): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
@@ -1216,18 +1216,18 @@ class C
                 // (6,17): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type in C# 6 and earlier.
                 //         switch (o)
                 Diagnostic(ErrorCode.ERR_V6SwitchGoverningTypeValueExpected, "o").WithLocation(6, 17),
-                // (8,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (8,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 1 out parameters and a void return type.
                 //             case ((o.GetType().Name.Length)):
-                Diagnostic(ErrorCode.ERR_BindToBogus, "((o.GetType().Name.Length))").WithArguments("recursive pattern").WithLocation(8, 18),
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "((o.GetType().Name.Length))").WithArguments("object", "1").WithLocation(8, 18),
+                // (8,20): error CS0118: 'o' is a variable but is used like a type
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_BadSKknown, "o").WithArguments("o", "variable", "type").WithLocation(8, 20),
+                // (8,32): error CS0103: The name 'Name' does not exist in the current context
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Name").WithArguments("Name").WithLocation(8, 32),
                 // (9,17): error CS7036: There is no argument given that corresponds to the required formal parameter 'o' of 'C.M(object)'
                 //                 M();
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17),
-                // (12,13): error CS8120: The switch case has already been handled by a previous case.
-                //             case 0:
-                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "case 0:").WithLocation(12, 13),
-                // (9,17): warning CS0162: Unreachable code detected
-                //                 M();
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "M").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17)
                 );
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (8,18): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
@@ -1245,18 +1245,18 @@ class C
                 // (8,32): error CS1003: Syntax error, ',' expected
                 //             case ((o.GetType().Name.Length)):
                 Diagnostic(ErrorCode.ERR_SyntaxError, "Name").WithArguments(",", "").WithLocation(8, 32),
-                // (8,18): error CS0570: 'recursive pattern' is not supported by the language
+                // (8,18): error CS8129: No suitable Deconstruct instance or extension method was found for type 'object', with 1 out parameters and a void return type.
                 //             case ((o.GetType().Name.Length)):
-                Diagnostic(ErrorCode.ERR_BindToBogus, "((o.GetType().Name.Length))").WithArguments("recursive pattern").WithLocation(8, 18),
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "((o.GetType().Name.Length))").WithArguments("object", "1").WithLocation(8, 18),
+                // (8,20): error CS0118: 'o' is a variable but is used like a type
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_BadSKknown, "o").WithArguments("o", "variable", "type").WithLocation(8, 20),
+                // (8,32): error CS0103: The name 'Name' does not exist in the current context
+                //             case ((o.GetType().Name.Length)):
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Name").WithArguments("Name").WithLocation(8, 32),
                 // (9,17): error CS7036: There is no argument given that corresponds to the required formal parameter 'o' of 'C.M(object)'
                 //                 M();
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17),
-                // (12,13): error CS8120: The switch case has already been handled by a previous case.
-                //             case 0:
-                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "case 0:").WithLocation(12, 13),
-                // (9,17): warning CS0162: Unreachable code detected
-                //                 M();
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "M").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -8873,20 +8873,43 @@ public class Test
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode);
+            CreateStandardCompilation(sourceCode).VerifyDiagnostics(
+                // (12,28): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(12, 28),
+                // (12,30): error CS1003: Syntax error, ':' expected
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments(":", "=>").WithLocation(12, 30),
+                // (12,30): error CS1513: } expected
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(12, 30),
+                // (12,44): error CS1002: ; expected
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ":").WithLocation(12, 44),
+                // (12,44): error CS1513: } expected
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ":").WithLocation(12, 44),
+                // (12,28): error CS8129: No suitable Deconstruct instance or extension method was found for type 'string', with 0 out parameters and a void return type.
+                //             case /*<bind>*/()=>3/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "()").WithArguments("string", "0").WithLocation(12, 28)
+                );
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Equal("System.String", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
-            Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
+            // Due to language changes to support recursive patterns, the parser will no longer treat this syntax as a lambda.
 
-            Assert.Equal("lambda expression", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
-            Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
+            //var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode);
 
-            Assert.Equal(0, semanticInfo.MethodGroup.Length);
+            //Assert.Null(semanticInfo.Type);
+            //Assert.Equal("System.String", semanticInfo.ConvertedType.ToTestDisplayString());
+            //Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
+            //Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.False(semanticInfo.IsCompileTimeConstant);
+            //Assert.Equal("lambda expression", semanticInfo.Symbol.ToTestDisplayString());
+            //Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
+            //Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
+
+            //Assert.Equal(0, semanticInfo.MethodGroup.Length);
+
+            //Assert.False(semanticInfo.IsCompileTimeConstant);
         }
 
         [Fact]
@@ -8914,20 +8937,36 @@ public class Test
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode);
+            CreateStandardCompilation(sourceCode).VerifyDiagnostics(
+                // (13,28): error CS8058: Feature 'recursive patterns' is experimental and unsupported; use '/features:patterns2' to enable.
+                //             case /*<bind>*/()=>/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("recursive patterns", "patterns2").WithLocation(13, 28),
+                // (13,30): error CS1003: Syntax error, ':' expected
+                //             case /*<bind>*/()=>/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_SyntaxError, "=>").WithArguments(":", "=>").WithLocation(13, 30),
+                // (13,30): error CS1513: } expected
+                //             case /*<bind>*/()=>/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(13, 30),
+                // (13,28): error CS8129: No suitable Deconstruct instance or extension method was found for type 'string', with 0 out parameters and a void return type.
+                //             case /*<bind>*/()=>/*</bind>*/:
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "()").WithArguments("string", "0").WithLocation(13, 28)
+                );
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Equal("System.String", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
-            Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
+            // Due to language changes to support recursive patterns, the parser will no longer treat this syntax as a lambda.
+            //var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode);
 
-            Assert.Equal("lambda expression", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
-            Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
+            //Assert.Null(semanticInfo.Type);
+            //Assert.Equal("System.String", semanticInfo.ConvertedType.ToTestDisplayString());
+            //Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
+            //Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal(0, semanticInfo.MethodGroup.Length);
+            //Assert.Equal("lambda expression", semanticInfo.Symbol.ToTestDisplayString());
+            //Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
+            //Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
 
-            Assert.False(semanticInfo.IsCompileTimeConstant);
+            //Assert.Equal(0, semanticInfo.MethodGroup.Length);
+
+            //Assert.False(semanticInfo.IsCompileTimeConstant);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -1982,7 +1982,7 @@ static class LiveList
                 );
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(patterns2): when do we detect this lowering error?")]
         public void System_Nullable_T_GetValueOrDefault_10()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.IsPatternExpressionSyntax GenerateIsPatternExpression()
         {
-            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.IsPatternExpression(GenerateIdentifierName(), Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.IsKeyword), GenerateDeclarationPattern());
+            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.IsPatternExpression(GenerateIdentifierName(), Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.IsKeyword), GenerateDiscardPattern());
         }
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.ThrowExpressionSyntax GenerateThrowExpression()
@@ -372,6 +372,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.WhenClauseSyntax GenerateWhenClause()
         {
             return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.WhenClause(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.WhenKeyword), GenerateIdentifierName());
+        }
+        
+        private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DiscardPatternSyntax GenerateDiscardPattern()
+        {
+            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.DiscardPattern(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Identifier("UnderscoreToken"));
         }
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.DeclarationPatternSyntax GenerateDeclarationPattern()
@@ -386,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SubpatternElementSyntax GenerateSubpatternElement()
         {
-            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.SubpatternElement(null, GenerateDeclarationPattern());
+            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.SubpatternElement(null, GenerateDiscardPattern());
         }
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.PropertyPatternSyntax GeneratePropertyPattern()
@@ -591,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CasePatternSwitchLabelSyntax GenerateCasePatternSwitchLabel()
         {
-            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.CasePatternSwitchLabel(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDeclarationPattern(), null, Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Identifier("ColonToken"));
+            return Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.CasePatternSwitchLabel(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), null, Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.Identifier("ColonToken"));
         }
         
         private static Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CaseSwitchLabelSyntax GenerateCaseSwitchLabel()
@@ -1911,6 +1916,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.WhenKeyword, node.WhenKeyword.Kind);
             Assert.NotNull(node.Condition);
+            
+            AttachAndCheckDiagnostics(node);
+        }
+        
+        [Fact]
+        public void TestDiscardPatternFactoryAndProperties()
+        {
+            var node = GenerateDiscardPattern();
+            
+            Assert.Equal(SyntaxKind.IdentifierToken, node.UnderscoreToken.Kind);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -5581,6 +5596,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestWhenClauseIdentityRewriter()
         {
             var oldNode = GenerateWhenClause();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+            
+            Assert.Same(oldNode, newNode);
+        }
+        
+        [Fact]
+        public void TestDiscardPatternTokenDeleteRewriter()
+        {
+            var oldNode = GenerateDiscardPattern();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+            
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+            
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+        
+        [Fact]
+        public void TestDiscardPatternIdentityRewriter()
+        {
+            var oldNode = GenerateDiscardPattern();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
             
@@ -9454,7 +9495,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static IsPatternExpressionSyntax GenerateIsPatternExpression()
         {
-            return SyntaxFactory.IsPatternExpression(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.IsKeyword), GenerateDeclarationPattern());
+            return SyntaxFactory.IsPatternExpression(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.IsKeyword), GenerateDiscardPattern());
         }
         
         private static ThrowExpressionSyntax GenerateThrowExpression()
@@ -9465,6 +9506,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static WhenClauseSyntax GenerateWhenClause()
         {
             return SyntaxFactory.WhenClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), GenerateIdentifierName());
+        }
+        
+        private static DiscardPatternSyntax GenerateDiscardPattern()
+        {
+            return SyntaxFactory.DiscardPattern(SyntaxFactory.Identifier("UnderscoreToken"));
         }
         
         private static DeclarationPatternSyntax GenerateDeclarationPattern()
@@ -9479,7 +9525,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static SubpatternElementSyntax GenerateSubpatternElement()
         {
-            return SyntaxFactory.SubpatternElement(default(NameColonSyntax), GenerateDeclarationPattern());
+            return SyntaxFactory.SubpatternElement(default(NameColonSyntax), GenerateDiscardPattern());
         }
         
         private static PropertyPatternSyntax GeneratePropertyPattern()
@@ -9684,7 +9730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         
         private static CasePatternSwitchLabelSyntax GenerateCasePatternSwitchLabel()
         {
-            return SyntaxFactory.CasePatternSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDeclarationPattern(), default(WhenClauseSyntax), SyntaxFactory.Identifier("ColonToken"));
+            return SyntaxFactory.CasePatternSwitchLabel(SyntaxFactory.Token(SyntaxKind.CaseKeyword), GenerateDiscardPattern(), default(WhenClauseSyntax), SyntaxFactory.Identifier("ColonToken"));
         }
         
         private static CaseSwitchLabelSyntax GenerateCaseSwitchLabel()
@@ -11005,6 +11051,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.WhenKeyword, node.WhenKeyword.Kind());
             Assert.NotNull(node.Condition);
             var newNode = node.WithWhenKeyword(node.WhenKeyword).WithCondition(node.Condition);
+            Assert.Equal(node, newNode);
+        }
+        
+        [Fact]
+        public void TestDiscardPatternFactoryAndProperties()
+        {
+            var node = GenerateDiscardPattern();
+            
+            Assert.Equal(SyntaxKind.IdentifierToken, node.UnderscoreToken.Kind());
+            var newNode = node.WithUnderscoreToken(node.UnderscoreToken);
             Assert.Equal(node, newNode);
         }
         
@@ -14674,6 +14730,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestWhenClauseIdentityRewriter()
         {
             var oldNode = GenerateWhenClause();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+            
+            Assert.Same(oldNode, newNode);
+        }
+        
+        [Fact]
+        public void TestDiscardPatternTokenDeleteRewriter()
+        {
+            var oldNode = GenerateDiscardPattern();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+            
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+            
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+        
+        [Fact]
+        public void TestDiscardPatternIdentityRewriter()
+        {
+            var oldNode = GenerateDiscardPattern();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
             

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+// Despite its name, this file IS NOT (yet) automatically generated.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -5782,6 +5784,64 @@ namespace Microsoft.CodeAnalysis.Semantics
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             return visitor.VisitDeclarationPattern(this, argument);
+        }
+    }
+
+    /// <summary>
+    /// Represents a C# discard pattern.
+    /// </summary>
+    internal sealed partial class DiscardPattern : Operation, IDiscardPattern
+    {
+        public DiscardPattern(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+                    base(OperationKind.DeclarationPattern, semanticModel, syntax, type, constantValue, isImplicit)
+        {
+        }
+        public override IEnumerable<IOperation> Children
+        {
+            get
+            {
+                yield break;
+            }
+        }
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitDiscardPattern(this);
+        }
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitDiscardPattern(this, argument);
+        }
+    }
+
+    /// <summary>
+    /// Represents a C# declaration pattern.
+    /// </summary>
+    internal sealed partial class RecursivePattern : Operation, IRecursivePattern
+    {
+        public RecursivePattern(ISymbol declaredSymbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+                    base(OperationKind.DeclarationPattern, semanticModel, syntax, type, constantValue, isImplicit)
+        {
+            DeclaredSymbol = declaredSymbol;
+        }
+        /// <summary>
+        /// Symbol declared by the pattern.
+        /// </summary>
+        public ISymbol DeclaredSymbol { get; }
+        public override IEnumerable<IOperation> Children
+        {
+            // PROTOTYPE(patterns2): Need to define what else is needed to support the IOperation framework
+            get
+            {
+                yield break;
+            }
+        }
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitRecursivePattern(this);
+        }
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitRecursivePattern(this, argument);
         }
     }
 

--- a/src/Compilers/Core/Portable/Operations/IDiscardPattern.cs
+++ b/src/Compilers/Core/Portable/Operations/IDiscardPattern.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a C# discard pattern.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface IDiscardPattern : IPattern
+    {
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/IRecursivePattern.cs
+++ b/src/Compilers/Core/Portable/Operations/IRecursivePattern.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a C# recursive pattern.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface IRecursivePattern : IPattern
+    {
+        /// <summary>
+        /// Symbol declared by the pattern.
+        /// </summary>
+        ISymbol DeclaredSymbol { get; }
+
+        // PROTOTYPE(patterns2): Need to define what else is needed for IOperation.
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/OperationCloner.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationCloner.cs
@@ -486,6 +486,16 @@ namespace Microsoft.CodeAnalysis.Semantics
             return new DeclarationPattern(operation.DeclaredSymbol, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
         }
 
+        public override IOperation VisitDiscardPattern(IDiscardPattern operation, object argument)
+        {
+            return new DiscardPattern(((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+        }
+
+        public override IOperation VisitRecursivePattern(IRecursivePattern operation, object argument)
+        {
+            return new RecursivePattern(operation.DeclaredSymbol, ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);
+        }
+
         public override IOperation VisitPatternCaseClause(IPatternCaseClause operation, object argument)
         {
             return new PatternCaseClause(operation.Label, Visit(operation.Pattern), Visit(operation.GuardExpression), ((Operation)operation).SemanticModel, operation.Syntax, operation.Type, operation.ConstantValue, operation.IsImplicit);

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -490,6 +490,16 @@ namespace Microsoft.CodeAnalysis.Semantics
             DefaultVisit(operation);
         }
 
+        public virtual void VisitDiscardPattern(IDiscardPattern operation)
+        {
+            DefaultVisit(operation);
+        }
+
+        public virtual void VisitRecursivePattern(IRecursivePattern operation)
+        {
+            DefaultVisit(operation);
+        }
+
         public virtual void VisitPatternCaseClause(IPatternCaseClause operation)
         {
             DefaultVisit(operation);
@@ -1001,6 +1011,16 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitDeclarationPattern(IDeclarationPattern operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitDiscardPattern(IDiscardPattern operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitRecursivePattern(IRecursivePattern operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -283,6 +283,7 @@ Microsoft.CodeAnalysis.Semantics.IDefaultCaseClause
 Microsoft.CodeAnalysis.Semantics.IDefaultValueExpression
 Microsoft.CodeAnalysis.Semantics.IDelegateCreationExpression
 Microsoft.CodeAnalysis.Semantics.IDelegateCreationExpression.Target.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Semantics.IDiscardPattern
 Microsoft.CodeAnalysis.Semantics.IDoLoopStatement
 Microsoft.CodeAnalysis.Semantics.IDoLoopStatement.Condition.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IDoLoopStatement.DoLoopKind.get -> Microsoft.CodeAnalysis.Semantics.DoLoopKind
@@ -421,6 +422,8 @@ Microsoft.CodeAnalysis.Semantics.IRaiseEventStatement.EventReference.get -> Micr
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause.MaximumValue.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause.MinimumValue.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Semantics.IRecursivePattern
+Microsoft.CodeAnalysis.Semantics.IRecursivePattern.DeclaredSymbol.get -> Microsoft.CodeAnalysis.ISymbol
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause.Relation.get -> Microsoft.CodeAnalysis.Semantics.BinaryOperatorKind
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause.Value.get -> Microsoft.CodeAnalysis.IOperation
@@ -554,6 +557,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDeconstructionAss
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDefaultCaseClause(Microsoft.CodeAnalysis.Semantics.IDefaultCaseClause operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDefaultValueExpression(Microsoft.CodeAnalysis.Semantics.IDefaultValueExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDelegateCreationExpression(Microsoft.CodeAnalysis.Semantics.IDelegateCreationExpression operation) -> void
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDiscardPattern(Microsoft.CodeAnalysis.Semantics.IDiscardPattern operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDoLoopStatement(Microsoft.CodeAnalysis.Semantics.IDoLoopStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDynamicIndexerAccessExpression(Microsoft.CodeAnalysis.Semantics.IDynamicIndexerAccessExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitDynamicInvocationExpression(Microsoft.CodeAnalysis.Semantics.IDynamicInvocationExpression operation) -> void
@@ -599,6 +603,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitPropertyInitializ
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitPropertyReferenceExpression(Microsoft.CodeAnalysis.Semantics.IPropertyReferenceExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitRaiseEventStatement(Microsoft.CodeAnalysis.Semantics.IRaiseEventStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitRangeCaseClause(Microsoft.CodeAnalysis.Semantics.IRangeCaseClause operation) -> void
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitRecursivePattern(Microsoft.CodeAnalysis.Semantics.IRecursivePattern operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitRelationalCaseClause(Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitReturnStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitSimpleAssignmentExpression(Microsoft.CodeAnalysis.Semantics.ISimpleAssignmentExpression operation) -> void
@@ -648,6 +653,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDefaultCaseClause(Microsoft.CodeAnalysis.Semantics.IDefaultCaseClause operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDefaultValueExpression(Microsoft.CodeAnalysis.Semantics.IDefaultValueExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDelegateCreationExpression(Microsoft.CodeAnalysis.Semantics.IDelegateCreationExpression operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDiscardPattern(Microsoft.CodeAnalysis.Semantics.IDiscardPattern operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDoLoopStatement(Microsoft.CodeAnalysis.Semantics.IDoLoopStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDynamicIndexerAccessExpression(Microsoft.CodeAnalysis.Semantics.IDynamicIndexerAccessExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitDynamicInvocationExpression(Microsoft.CodeAnalysis.Semantics.IDynamicInvocationExpression operation, TArgument argument) -> TResult
@@ -693,6 +699,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitPropertyReferenceExpression(Microsoft.CodeAnalysis.Semantics.IPropertyReferenceExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitRaiseEventStatement(Microsoft.CodeAnalysis.Semantics.IRaiseEventStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitRangeCaseClause(Microsoft.CodeAnalysis.Semantics.IRangeCaseClause operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitRecursivePattern(Microsoft.CodeAnalysis.Semantics.IRecursivePattern operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitRelationalCaseClause(Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitReturnStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitSimpleAssignmentExpression(Microsoft.CodeAnalysis.Semantics.ISimpleAssignmentExpression operation, TArgument argument) -> TResult

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -29,7 +29,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular6WithV7SwitchBinder = Regular6.WithFeatures(new Dictionary<string, string>() { { "testV7SwitchBinder", "true" } });
 
         public static readonly CSharpParseOptions RegularWithIOperationFeature = Regular.WithIOperationsFeature();
-        
+
+        public static readonly CSharpParseOptions RegularWithRecursivePatterns = Regular.WithRecursivePatterns();
+
         public static readonly CSharpCompilationOptions ReleaseDll = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Release);
         public static readonly CSharpCompilationOptions ReleaseExe = new CSharpCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel: OptimizationLevel.Release);
 
@@ -110,6 +112,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static CSharpParseOptions WithIOperationsFeature(this CSharpParseOptions options)
         {
             return options.WithFeatures(options.Features.Concat(new[] { new KeyValuePair<string, string>("IOperation", "true") }));
+        }
+
+        public static CSharpParseOptions WithRecursivePatterns(this CSharpParseOptions options)
+        {
+            return options.WithFeatures(options.Features.Concat(new[] { new KeyValuePair<string, string>("patterns2", "true") }));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1299,7 +1299,7 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "PROTOTYPE(patterns2): need to implement indentation for recursive patterns")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task IndentPatternPropertyFirst()
         {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2591,7 +2591,7 @@ class Program
                 expectedIndentation: 8);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact(Skip = "PROTOTYPE(patterns2): need to implement indentation for recursive patterns"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void PatternPropertyIndentFirst()
         {
             var code = @"
@@ -2634,7 +2634,7 @@ class C
                 expectedIndentation: 12);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact(Skip = "PROTOTYPE(patterns2): need to implement indentation for recursive patterns"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public void PatternPropertyIndentNestedFirst()
         {
             var code = @"

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -309,14 +309,13 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       77 (0x4d)
+  // Code size       72 (0x48)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                int V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z""
@@ -326,24 +325,22 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldstr      ""z""
-  IL_0026:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_002b:  ldloc.s    V_5
-  IL_002d:  isinst     ""int""
-  IL_0032:  ldnull
-  IL_0033:  cgt.un
-  IL_0035:  dup
-  IL_0036:  stloc.s    V_4
-  IL_0038:  brtrue.s   IL_003d
-  IL_003a:  ldc.i4.0
-  IL_003b:  br.s       IL_0044
-  IL_003d:  ldloc.s    V_5
-  IL_003f:  unbox.any  ""int""
-  IL_0044:  stind.i4
-  IL_0045:  ldloc.s    V_4
-  IL_0047:  call       ""void C.Test(bool)""
-  IL_004c:  ret
+  IL_001f:  brfalse.s  IL_0041
+  IL_0021:  ldarg.0
+  IL_0022:  isinst     ""int""
+  IL_0027:  brfalse.s  IL_0041
+  IL_0029:  ldarg.0
+  IL_002a:  unbox.any  ""int""
+  IL_002f:  stloc.s    V_4
+  IL_0031:  ldstr      ""z""
+  IL_0036:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_003b:  ldloc.s    V_4
+  IL_003d:  stind.i4
+  IL_003e:  ldc.i4.1
+  IL_003f:  br.s       IL_0042
+  IL_0041:  ldc.i4.0
+  IL_0042:  call       ""void C.Test(bool)""
+  IL_0047:  ret
 }");
             });
         }
@@ -1848,7 +1845,7 @@ class C
                 context.CompileAssignment("x", "Test(x is string i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       63 (0x3f)
+  // Code size       74 (0x4a)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
@@ -1863,19 +1860,24 @@ class C
   IL_0017:  ldloc.3
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001e:  ldstr      ""i""
-  IL_0023:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
-  IL_0028:  ldarg.0
-  IL_0029:  isinst     ""string""
-  IL_002e:  dup
+  IL_001e:  ldarg.0
+  IL_001f:  brfalse.s  IL_0041
+  IL_0021:  ldarg.0
+  IL_0022:  isinst     ""string""
+  IL_0027:  brfalse.s  IL_0041
+  IL_0029:  ldarg.0
+  IL_002a:  castclass  ""string""
   IL_002f:  stloc.s    V_4
-  IL_0031:  stind.ref
-  IL_0032:  ldloc.s    V_4
-  IL_0034:  ldnull
-  IL_0035:  cgt.un
-  IL_0037:  call       ""object C.Test(bool)""
-  IL_003c:  starg.s    V_0
-  IL_003e:  ret
+  IL_0031:  ldstr      ""i""
+  IL_0036:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
+  IL_003b:  ldloc.s    V_4
+  IL_003d:  stind.ref
+  IL_003e:  ldc.i4.1
+  IL_003f:  br.s       IL_0042
+  IL_0041:  ldc.i4.0
+  IL_0042:  call       ""object C.Test(bool)""
+  IL_0047:  starg.s    V_0
+  IL_0049:  ret
 }");
             });
         }
@@ -1913,13 +1915,12 @@ class C
                 context.CompileAssignment("x", "Test(x is object i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       58 (0x3a)
+  // Code size       57 (0x39)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
-                System.Guid V_3,
-                object V_4)
+                System.Guid V_3)
   IL_0000:  ldtoken    ""object""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -1928,18 +1929,18 @@ class C
   IL_0017:  ldloc.3
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001e:  ldstr      ""i""
-  IL_0023:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<object>(string)""
-  IL_0028:  ldarg.0
-  IL_0029:  dup
-  IL_002a:  stloc.s    V_4
+  IL_001e:  ldarg.0
+  IL_001f:  brfalse.s  IL_0030
+  IL_0021:  ldstr      ""i""
+  IL_0026:  call       ""object Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<object>(string)""
+  IL_002b:  ldarg.0
   IL_002c:  stind.ref
-  IL_002d:  ldloc.s    V_4
-  IL_002f:  ldnull
-  IL_0030:  cgt.un
-  IL_0032:  call       ""object C.Test(bool)""
-  IL_0037:  starg.s    V_0
-  IL_0039:  ret
+  IL_002d:  ldc.i4.1
+  IL_002e:  br.s       IL_0031
+  IL_0030:  ldc.i4.0
+  IL_0031:  call       ""object C.Test(bool)""
+  IL_0036:  starg.s    V_0
+  IL_0038:  ret
 }");
             });
         }
@@ -2036,7 +2037,7 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       67 (0x43)
+  // Code size       74 (0x4a)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
@@ -2044,7 +2045,7 @@ class C
                 int V_3,
                 object V_4,
                 System.Guid V_5,
-                int? V_6)
+                int V_6)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -2053,18 +2054,22 @@ class C
   IL_0017:  ldloc.s    V_5
   IL_0019:  ldnull
   IL_001a:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001f:  ldarg.0
-  IL_0020:  stloc.s    V_6
-  IL_0022:  ldstr      ""i""
-  IL_0027:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_002c:  ldloca.s   V_6
-  IL_002e:  call       ""int int?.GetValueOrDefault()""
-  IL_0033:  stind.i4
-  IL_0034:  ldloca.s   V_6
-  IL_0036:  call       ""bool int?.HasValue.get""
-  IL_003b:  call       ""int? C.Test(bool)""
-  IL_0040:  starg.s    V_0
-  IL_0042:  ret
+  IL_001f:  ldarga.s   V_0
+  IL_0021:  call       ""bool int?.HasValue.get""
+  IL_0026:  brfalse.s  IL_0041
+  IL_0028:  ldarga.s   V_0
+  IL_002a:  call       ""int int?.Value.get""
+  IL_002f:  stloc.s    V_6
+  IL_0031:  ldstr      ""i""
+  IL_0036:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_003b:  ldloc.s    V_6
+  IL_003d:  stind.i4
+  IL_003e:  ldc.i4.1
+  IL_003f:  br.s       IL_0042
+  IL_0041:  ldc.i4.0
+  IL_0042:  call       ""int? C.Test(bool)""
+  IL_0047:  starg.s    V_0
+  IL_0049:  ret
 }");
             });
         }
@@ -2102,14 +2107,13 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size      118 (0x76)
+  // Code size      113 (0x71)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                int V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z""
@@ -2129,25 +2133,23 @@ class C
   IL_003c:  ldstr      ""z""
   IL_0041:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
   IL_0046:  ldarg.0
-  IL_0047:  stloc.s    V_5
-  IL_0049:  ldstr      ""i""
-  IL_004e:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0053:  ldloc.s    V_5
-  IL_0055:  isinst     ""int""
-  IL_005a:  ldnull
-  IL_005b:  cgt.un
-  IL_005d:  dup
-  IL_005e:  stloc.s    V_4
-  IL_0060:  brtrue.s   IL_0065
-  IL_0062:  ldc.i4.0
-  IL_0063:  br.s       IL_006c
-  IL_0065:  ldloc.s    V_5
-  IL_0067:  unbox.any  ""int""
-  IL_006c:  stind.i4
-  IL_006d:  ldloc.s    V_4
-  IL_006f:  call       ""int C.Test(bool)""
-  IL_0074:  stind.i4
-  IL_0075:  ret
+  IL_0047:  brfalse.s  IL_0069
+  IL_0049:  ldarg.0
+  IL_004a:  isinst     ""int""
+  IL_004f:  brfalse.s  IL_0069
+  IL_0051:  ldarg.0
+  IL_0052:  unbox.any  ""int""
+  IL_0057:  stloc.s    V_4
+  IL_0059:  ldstr      ""i""
+  IL_005e:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0063:  ldloc.s    V_4
+  IL_0065:  stind.i4
+  IL_0066:  ldc.i4.1
+  IL_0067:  br.s       IL_006a
+  IL_0069:  ldc.i4.0
+  IL_006a:  call       ""int C.Test(bool)""
+  IL_006f:  stind.i4
+  IL_0070:  ret
 }");
             });
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -1778,14 +1778,13 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       79 (0x4f)
+  // Code size       74 (0x4a)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                int V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -1795,25 +1794,23 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldstr      ""i""
-  IL_0026:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_002b:  ldloc.s    V_5
-  IL_002d:  isinst     ""int""
-  IL_0032:  ldnull
-  IL_0033:  cgt.un
-  IL_0035:  dup
-  IL_0036:  stloc.s    V_4
-  IL_0038:  brtrue.s   IL_003d
-  IL_003a:  ldc.i4.0
-  IL_003b:  br.s       IL_0044
-  IL_003d:  ldloc.s    V_5
-  IL_003f:  unbox.any  ""int""
-  IL_0044:  stind.i4
-  IL_0045:  ldloc.s    V_4
-  IL_0047:  call       ""object C.Test(bool)""
-  IL_004c:  starg.s    V_0
-  IL_004e:  ret
+  IL_001f:  brfalse.s  IL_0041
+  IL_0021:  ldarg.0
+  IL_0022:  isinst     ""int""
+  IL_0027:  brfalse.s  IL_0041
+  IL_0029:  ldarg.0
+  IL_002a:  unbox.any  ""int""
+  IL_002f:  stloc.s    V_4
+  IL_0031:  ldstr      ""i""
+  IL_0036:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_003b:  ldloc.s    V_4
+  IL_003d:  stind.i4
+  IL_003e:  ldc.i4.1
+  IL_003f:  br.s       IL_0042
+  IL_0041:  ldc.i4.0
+  IL_0042:  call       ""object C.Test(bool)""
+  IL_0047:  starg.s    V_0
+  IL_0049:  ret
 }");
             });
         }

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -324,7 +324,7 @@ namespace My
                     break;
                 case int i:
                     break;
-                case Type (int x, 3) { A: 5, B: 7 } identifier:
+                case Type (int x, 3) { A: _, B: 7 } identifier:
                     break;
                 default:
                     {


### PR DESCRIPTION
- Add support for recursive patterns in `is`.
- Add the discard pattern `_`.
- Add skeletal IOperation support.
