### PR TITLE
Tighten PE verification in compiler tests

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string s = @"[assembly: System.Reflection.AssemblyCultureAttribute(""\uD800"")]";
             var comp = CreateStandardCompilation(s, options: TestOptions.ReleaseDll);
 
-            CompileAndVerify(comp, verify: false, symbolValidator: m =>
+            CompileAndVerify(comp, verify: Verification.Skipped, symbolValidator: m =>
             {
                 var utf8 = new System.Text.UTF8Encoding(false, false);
                 Assert.Equal(utf8.GetString(utf8.GetBytes("\uD800")), m.ContainingAssembly.Identity.CultureName);
@@ -370,7 +370,7 @@ public class en_US
 
             compilation = CreateStandardCompilation("", new MetadataReference[] { compilation.EmitToImageReference() }, TestOptions.ReleaseDll, assemblyName: assemblyNameBase + "20");
 
-            CompileAndVerify(compilation, verify: false).VerifyDiagnostics(
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics(
     // warning CS8009: Referenced assembly 'de, Version=0.0.0.0, Culture=de, PublicKeyToken=null' has different culture setting of 'de'.
     Diagnostic(ErrorCode.WRN_RefCultureMismatch).WithArguments("de, Version=0.0.0.0, Culture=de, PublicKeyToken=null", "de")
                 );
@@ -432,7 +432,7 @@ public class en_US
                     Assert.Equal(2, ((PEModuleSymbol)m).GetReferencedAssemblySymbols().Length);
                     Assert.Equal("neutral, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", m.GetReferencedAssemblySymbols()[1].ToTestDisplayString());
                 },
-                verify: false).VerifyDiagnostics();
+                verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation(
 @"
@@ -453,7 +453,7 @@ public class neutral
 
             compilation = CreateStandardCompilation("", new MetadataReference[] { compilation.EmitToImageReference() }, TestOptions.ReleaseDll, assemblyName: assemblyNameBase + "60");
 
-            CompileAndVerify(compilation, verify: false).VerifyDiagnostics(
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics(
     // warning CS8009: Referenced assembly 'de, Version=0.0.0.0, Culture=de, PublicKeyToken=null' has different culture setting of 'de'.
     Diagnostic(ErrorCode.WRN_RefCultureMismatch).WithArguments("de, Version=0.0.0.0, Culture=de, PublicKeyToken=null", "de")
                 );
@@ -655,7 +655,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: false,
+            CompileAndVerify(compilation, verify: Verification.Skipped,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {
@@ -684,7 +684,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: false,
+            CompileAndVerify(compilation, verify: Verification.Skipped,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {
@@ -717,7 +717,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: false,
+            CompileAndVerify(compilation, verify: Verification.Skipped,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string s = @"[assembly: System.Reflection.AssemblyCultureAttribute(""\uD800"")]";
             var comp = CreateStandardCompilation(s, options: TestOptions.ReleaseDll);
 
-            CompileAndVerify(comp, verify: Verification.Skipped, symbolValidator: m =>
+            CompileAndVerify(comp, verify: Verification.Fails, symbolValidator: m =>
             {
                 var utf8 = new System.Text.UTF8Encoding(false, false);
                 Assert.Equal(utf8.GetString(utf8.GetBytes("\uD800")), m.ContainingAssembly.Identity.CultureName);
@@ -655,7 +655,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: Verification.Skipped,
+            CompileAndVerify(compilation, verify: Verification.Fails,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {
@@ -684,7 +684,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: Verification.Skipped,
+            CompileAndVerify(compilation, verify: Verification.Fails,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {
@@ -717,7 +717,7 @@ class Program
 }
 ", options: TestOptions.ReleaseDll, references: new[] { MscorlibRef_v4_0_30316_17626, hash_module });
 
-            CompileAndVerify(compilation, verify: Verification.Skipped,
+            CompileAndVerify(compilation, verify: Verification.Fails,
                 manifestResources: hash_resources,
                 validator: (peAssembly) =>
                 {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -1290,7 +1290,7 @@ class C
             comp = CreateCompilation(source1, references: new[] { ref0, SystemCoreRef });
             comp.VerifyDiagnostics();
             // Make sure we emit without errors when System.Boolean is missing.
-            CompileAndVerify(comp, verify: Verification.Skipped);
+            CompileAndVerify(comp, verify: Verification.Fails);
         }
 
         [Fact]
@@ -1324,7 +1324,7 @@ class C
             comp = CreateCompilation(source1, references: new[] { ref0, SystemCoreRef });
             comp.VerifyDiagnostics();
             // Make sure we emit without errors when System.Boolean is missing.
-            CompileAndVerify(comp, verify: Verification.Skipped);
+            CompileAndVerify(comp, verify: Verification.Fails);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -1290,7 +1290,7 @@ class C
             comp = CreateCompilation(source1, references: new[] { ref0, SystemCoreRef });
             comp.VerifyDiagnostics();
             // Make sure we emit without errors when System.Boolean is missing.
-            CompileAndVerify(comp, verify: false);
+            CompileAndVerify(comp, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -1324,7 +1324,7 @@ class C
             comp = CreateCompilation(source1, references: new[] { ref0, SystemCoreRef });
             comp.VerifyDiagnostics();
             // Make sure we emit without errors when System.Boolean is missing.
-            CompileAndVerify(comp, verify: false);
+            CompileAndVerify(comp, verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Embedded.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Embedded.cs
@@ -185,7 +185,7 @@ class Test
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, expectedOutput: "3");
+            CompileAndVerify(code, verify: Verification.Passes, expectedOutput: "3");
         }
 
         [Fact]
@@ -282,7 +282,7 @@ class Test
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var attributeName = AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName;
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Embedded.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Embedded.cs
@@ -185,7 +185,7 @@ class Test
     }
 }";
 
-            CompileAndVerify(code, verify: false, expectedOutput: "3");
+            CompileAndVerify(code, verify: Verification.Skipped, expectedOutput: "3");
         }
 
         [Fact]
@@ -282,7 +282,7 @@ class Test
     }
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var attributeName = AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName;
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -29,7 +29,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name);
@@ -43,7 +43,7 @@ class Test
 ref struct S1{}
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -60,7 +60,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -77,7 +77,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -94,7 +94,7 @@ class Test<T>
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -119,7 +119,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Passes, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
@@ -343,7 +343,7 @@ public class Test1
 	public ref struct S1{}
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Passes, symbolValidator: module =>
             {
                 // IsByRefLike is not generated in assembly
                 var isByRefLikeAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute);
@@ -413,7 +413,7 @@ public class Test
     public ref struct S1{}
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Fails, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
@@ -434,7 +434,7 @@ public class Test1
 	public ref struct S1{}
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Passes, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsByRefLikeAttribute.FullName);
@@ -467,7 +467,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });
@@ -640,7 +640,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -683,7 +683,7 @@ namespace System
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name, hasObsolete: false);
@@ -725,7 +725,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -783,7 +783,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -852,7 +852,7 @@ class Test
         {
             var text = @"public ref struct S {}";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -959,7 +959,7 @@ namespace System
 }";
             var compilation1 = CreateCompilation(source1, assemblyName: GetUniqueName());
 
-            CompileAndVerify(compilation1, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(compilation1, verify: Verification.Fails, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: false);
@@ -986,7 +986,7 @@ namespace System
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -29,7 +29,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name);
@@ -43,7 +43,7 @@ class Test
 ref struct S1{}
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -60,7 +60,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -77,7 +77,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -94,7 +94,7 @@ class Test<T>
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -119,7 +119,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: false, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
@@ -343,7 +343,7 @@ public class Test1
 	public ref struct S1{}
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: false, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
             {
                 // IsByRefLike is not generated in assembly
                 var isByRefLikeAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute);
@@ -413,7 +413,7 @@ public class Test
     public ref struct S1{}
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
@@ -434,7 +434,7 @@ public class Test1
 	public ref struct S1{}
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: false, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsByRefLikeAttribute.FullName);
@@ -467,7 +467,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });
@@ -640,7 +640,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -683,7 +683,7 @@ namespace System
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name, hasObsolete: false);
@@ -725,7 +725,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -783,7 +783,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
@@ -852,7 +852,7 @@ class Test
         {
             var text = @"public ref struct S {}";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
@@ -959,7 +959,7 @@ namespace System
 }";
             var compilation1 = CreateCompilation(source1, assemblyName: GetUniqueName());
 
-            CompileAndVerify(compilation1, verify: false, symbolValidator: module =>
+            CompileAndVerify(compilation1, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
                 AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: false);
@@ -986,7 +986,7 @@ namespace System
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
@@ -30,7 +30,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -46,7 +46,7 @@ class Test
 readonly struct S1{}
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
                 Assert.True(type.IsReadOnly);
@@ -65,7 +65,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -84,7 +84,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 Assert.True(type.IsReadOnly);
@@ -103,7 +103,7 @@ class Test<T>
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -130,7 +130,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: false, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -355,7 +355,7 @@ public class Test1
 	public readonly struct S1{}
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: false, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
             {
                 // IsReadOnly is not generated in assembly
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
@@ -425,7 +425,7 @@ public class Test
     public readonly struct S1{}
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -447,7 +447,7 @@ public class Test1
 	public readonly struct S1{}
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: false, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsReadOnlyAttribute.FullName);
@@ -480,7 +480,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
@@ -30,7 +30,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -46,7 +46,7 @@ class Test
 readonly struct S1{}
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
                 Assert.True(type.IsReadOnly);
@@ -65,7 +65,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -84,7 +84,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 Assert.True(type.IsReadOnly);
@@ -103,7 +103,7 @@ class Test<T>
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -130,7 +130,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Passes, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -355,7 +355,7 @@ public class Test1
 	public readonly struct S1{}
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Passes, symbolValidator: module =>
             {
                 // IsReadOnly is not generated in assembly
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
@@ -425,7 +425,7 @@ public class Test
     public readonly struct S1{}
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Fails, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
@@ -447,7 +447,7 @@ public class Test1
 	public readonly struct S1{}
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Passes, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsReadOnlyAttribute.FullName);
@@ -480,7 +480,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -29,7 +29,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -101,7 +101,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Fails, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -384,7 +384,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, symbolValidator: module =>
             {
                 var indexer = module.ContainingAssembly.GetTypeByMetadataName("Test").GetProperty("this[]");
                 Assert.Equal(RefKind.RefReadOnly, indexer.RefKind);
@@ -456,7 +456,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Fails, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var indexer = module.ContainingAssembly.GetTypeByMetadataName("Test").GetProperty("this[]");
                 Assert.Equal(RefKind.RefReadOnly, indexer.RefKind);
@@ -582,7 +582,7 @@ public class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -637,7 +637,7 @@ public class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|1_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -671,7 +671,7 @@ public class Test
 }
 ";
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, options: options, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Fails, additionalRefs: new[] { referenceA }, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -710,7 +710,7 @@ class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, options: options, symbolValidator: module =>
             {
                 var method = module.GlobalNamespace.GetMember<MethodSymbol>("Test.<>c.<M1>b__0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -806,7 +806,7 @@ class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(codeB, verify: Verification.Skipped, options: options, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Fails, options: options, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var method = module.GlobalNamespace.GetMember<MethodSymbol>("Test.<>c.<M1>b__0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -1055,7 +1055,7 @@ public class Test1
 	public static ref readonly int M(in int p) => ref p;
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Fails, symbolValidator: module =>
             {
                 // IsReadOnly is not generated in assembly
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
@@ -1146,7 +1146,7 @@ public class Test
     public void M(in int x) { }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Fails, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 AssertNoIsReadOnlyAttributeExists(module.ContainingAssembly);
 
@@ -1168,7 +1168,7 @@ public class Test1
 	public static ref readonly int M(in int p) => ref p;
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Fails, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsReadOnlyAttribute.FullName);
@@ -1201,7 +1201,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Fails, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });
@@ -1577,7 +1577,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1619,7 +1619,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1664,7 +1664,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1713,7 +1713,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public override ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1760,7 +1760,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public override ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1803,7 +1803,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -1852,7 +1852,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -1892,7 +1892,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1961,7 +1961,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -2010,7 +2010,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -2051,7 +2051,7 @@ public class TestImpl : ITest
     ref readonly int ITest.this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("TestImpl");
 
@@ -2093,7 +2093,7 @@ public class TestImpl : ITest
     ref readonly int ITest.this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("TestImpl");
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -29,7 +29,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -101,7 +101,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: false, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -384,7 +384,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var indexer = module.ContainingAssembly.GetTypeByMetadataName("Test").GetProperty("this[]");
                 Assert.Equal(RefKind.RefReadOnly, indexer.RefKind);
@@ -456,7 +456,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(codeB, verify: false, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var indexer = module.ContainingAssembly.GetTypeByMetadataName("Test").GetProperty("this[]");
                 Assert.Equal(RefKind.RefReadOnly, indexer.RefKind);
@@ -582,7 +582,7 @@ public class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: false, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -637,7 +637,7 @@ public class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: false, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|1_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -671,7 +671,7 @@ public class Test
 }
 ";
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(codeB, verify: false, additionalRefs: new[] { referenceA }, options: options, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, additionalRefs: new[] { referenceA }, options: options, symbolValidator: module =>
             {
                 var method = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("<M>g__Inner|0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -710,7 +710,7 @@ class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(text, verify: false, options: options, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, options: options, symbolValidator: module =>
             {
                 var method = module.GlobalNamespace.GetMember<MethodSymbol>("Test.<>c.<M1>b__0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -806,7 +806,7 @@ class Test
 ";
 
             var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
-            CompileAndVerify(codeB, verify: false, options: options, additionalRefs: new[] { referenceA }, symbolValidator: module =>
+            CompileAndVerify(codeB, verify: Verification.Skipped, options: options, additionalRefs: new[] { referenceA }, symbolValidator: module =>
             {
                 var method = module.GlobalNamespace.GetMember<MethodSymbol>("Test.<>c.<M1>b__0_0");
                 Assert.Equal(RefKind.RefReadOnly, method.RefKind);
@@ -1055,7 +1055,7 @@ public class Test1
 	public static ref readonly int M(in int p) => ref p;
 }", references: new[] { code1.ToMetadataReference() }, options: options);
 
-            CompileAndVerify(code2, verify: false, symbolValidator: module =>
+            CompileAndVerify(code2, verify: Verification.Skipped, symbolValidator: module =>
             {
                 // IsReadOnly is not generated in assembly
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
@@ -1146,7 +1146,7 @@ public class Test
     public void M(in int x) { }
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
             {
                 AssertNoIsReadOnlyAttributeExists(module.ContainingAssembly);
 
@@ -1168,7 +1168,7 @@ public class Test1
 	public static ref readonly int M(in int p) => ref p;
 }";
 
-            var comp1 = CompileAndVerify(code1, options: options, verify: false, symbolValidator: module =>
+            var comp1 = CompileAndVerify(code1, options: options, verify: Verification.Skipped, symbolValidator: module =>
             {
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
                 AssertGeneratedEmbeddedAttribute(module.ContainingAssembly, AttributeDescription.IsReadOnlyAttribute.FullName);
@@ -1201,7 +1201,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: false, symbolValidator: module =>
+            CompileAndVerify(text, verify: Verification.Skipped, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });
@@ -1577,7 +1577,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1619,7 +1619,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1664,7 +1664,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1713,7 +1713,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public override ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1760,7 +1760,7 @@ public class Child : System.Runtime.CompilerServices.IsReadOnlyAttribute
     public override ref readonly int this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Child");
 
@@ -1803,7 +1803,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -1852,7 +1852,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -1892,7 +1892,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var isReadOnlyAttributeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(isReadOnlyAttributeName);
@@ -1961,7 +1961,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -2010,7 +2010,7 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var typeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute);
                 var type = module.ContainingAssembly.GetTypeByMetadataName(typeName);
@@ -2051,7 +2051,7 @@ public class TestImpl : ITest
     ref readonly int ITest.this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("TestImpl");
 
@@ -2093,7 +2093,7 @@ public class TestImpl : ITest
     ref readonly int ITest.this[in int x] => ref value;
 }";
 
-            CompileAndVerify(code, verify: false, additionalRefs: new[] { reference }, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, additionalRefs: new[] { reference }, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("TestImpl");
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
@@ -211,10 +211,10 @@ class Structs
             };
 
             CompileAndVerify(verifiable, assemblyValidator: validator);
-            CompileAndVerify(unverifiable, assemblyValidator: validator, verify: false);
+            CompileAndVerify(unverifiable, assemblyValidator: validator, verify: Verification.Skipped);
 
             // CLR limitation on type size, not a RefEmit bug:
-            CompileAndVerify(unloadable, assemblyValidator: validator, verify: false);
+            CompileAndVerify(unloadable, assemblyValidator: validator, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ public class C : B
 }
 ";
             // type C can't be loaded
-            CompileAndVerify(source, verify: false);
+            CompileAndVerify(source, verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_StructLayout.cs
@@ -211,10 +211,10 @@ class Structs
             };
 
             CompileAndVerify(verifiable, assemblyValidator: validator);
-            CompileAndVerify(unverifiable, assemblyValidator: validator, verify: Verification.Skipped);
+            CompileAndVerify(unverifiable, assemblyValidator: validator, verify: Verification.Fails);
 
             // CLR limitation on type size, not a RefEmit bug:
-            CompileAndVerify(unloadable, assemblyValidator: validator, verify: Verification.Skipped);
+            CompileAndVerify(unloadable, assemblyValidator: validator, verify: Verification.Fails);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ public class C : B
 }
 ";
             // type C can't be loaded
-            CompileAndVerify(source, verify: Verification.Skipped);
+            CompileAndVerify(source, verify: Verification.Fails);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -827,7 +827,7 @@ public class Test
                 // NYI: /addmodule support
                 // TODO: PEVerify currently fails for netmodules with error: "The module X was expected to contain an assembly manifest".
                 // TODO: Remove the 'verify' named argument once /addmodule support has been added.
-                CompileAndVerify(compilation, verify: !outputKind.IsNetModule());
+                CompileAndVerify(compilation, verify: outputKind.IsNetModule() ? Verification.Skipped : Verification.Passes);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -3539,7 +3539,7 @@ public class MainClass
 
             // the resulting code does not need to verify
             // This is consistent with Dev10 behavior
-            CompileAndVerify(source, options: TestOptions.ReleaseDll, verify: false, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator);
+            CompileAndVerify(source, options: TestOptions.ReleaseDll, verify: Verification.Skipped, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator);
         }
 
         [Fact, WorkItem(544507, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544507")]
@@ -5341,7 +5341,7 @@ class A
             // Dev10 Runtime Exception:
             // Unhandled Exception: System.TypeLoadException: Windows Runtime types can only be declared in Windows Runtime assemblies.
 
-            var verifier = CompileAndVerify(source, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator, verify: false);
+            var verifier = CompileAndVerify(source, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator, verify: Verification.Skipped);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -3539,7 +3539,7 @@ public class MainClass
 
             // the resulting code does not need to verify
             // This is consistent with Dev10 behavior
-            CompileAndVerify(source, options: TestOptions.ReleaseDll, verify: Verification.Skipped, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator);
+            CompileAndVerify(source, options: TestOptions.ReleaseDll, verify: Verification.Fails, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator);
         }
 
         [Fact, WorkItem(544507, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544507")]
@@ -5341,7 +5341,7 @@ class A
             // Dev10 Runtime Exception:
             // Unhandled Exception: System.TypeLoadException: Windows Runtime types can only be declared in Windows Runtime assemblies.
 
-            var verifier = CompileAndVerify(source, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator, verify: Verification.Skipped);
+            var verifier = CompileAndVerify(source, sourceSymbolValidator: sourceValidator, symbolValidator: metadataValidator, verify: Verification.Fails);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2200,7 +2200,7 @@ internal class B
                 assemblyName: "Bug769840_B",
                 references: new[] { new CSharpCompilationReference(ca) });
 
-            CompileAndVerify(cb, verify: Verification.Skipped).Diagnostics.Verify();
+            CompileAndVerify(cb, verify: Verification.Fails).Diagnostics.Verify();
         }
 
         [Fact, WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2200,7 +2200,7 @@ internal class B
                 assemblyName: "Bug769840_B",
                 references: new[] { new CSharpCompilationReference(ca) });
 
-            CompileAndVerify(cb, verify: false).Diagnostics.Verify();
+            CompileAndVerify(cb, verify: Verification.Skipped).Diagnostics.Verify();
         }
 
         [Fact, WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -967,7 +967,7 @@ public class C
                 }, module.GetFieldNames("C.<F>d__3"));
             });
 
-            CompileAndVerify(source, additionalRefs: s_asyncRefs, verify: Verification.Skipped, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
+            CompileAndVerify(source, additionalRefs: s_asyncRefs, verify: Verification.Passes, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
              {
                  AssertEx.Equal(new[]
                  {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -967,7 +967,7 @@ public class C
                 }, module.GetFieldNames("C.<F>d__3"));
             });
 
-            CompileAndVerify(source, additionalRefs: s_asyncRefs, verify: false, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
+            CompileAndVerify(source, additionalRefs: s_asyncRefs, verify: Verification.Skipped, options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All), symbolValidator: module =>
              {
                  AssertEx.Equal(new[]
                  {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6893,7 +6893,7 @@ class C
     static ref int var(int a, int b) { return ref i; }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "42", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "42", verify: Verification.Passes);
             comp.VerifyDiagnostics();
         }
 
@@ -6918,7 +6918,7 @@ class Program
             compilation.VerifyDiagnostics();
 
             // PEVerify fails with ref return https://github.com/dotnet/roslyn/issues/12285
-            CompileAndVerify(compilation, expectedOutput: "10", verify: Verification.Skipped);
+            CompileAndVerify(compilation, expectedOutput: "10", verify: Verification.Fails);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6893,7 +6893,7 @@ class C
     static ref int var(int a, int b) { return ref i; }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "42", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "42", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
         }
 
@@ -6918,7 +6918,7 @@ class Program
             compilation.VerifyDiagnostics();
 
             // PEVerify fails with ref return https://github.com/dotnet/roslyn/issues/12285
-            CompileAndVerify(compilation, expectedOutput: "10", verify: false);
+            CompileAndVerify(compilation, expectedOutput: "10", verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -330,7 +330,7 @@ class C
 ";
             // Desired: the delegate is generated, no error is reported.
             // Actual: use the malformed Func`13 time and failed to PEVerify.  Not presently worthwhile to fix.
-            CompileAndVerify(source, new[] { systemCoreRef, csrtRef }, verify: Verification.Skipped).VerifyIL("C.F", @"
+            CompileAndVerify(source, new[] { systemCoreRef, csrtRef }, verify: Verification.Fails).VerifyIL("C.F", @"
 {
   // Code size      189 (0xbd)
   .maxstack  13

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -330,7 +330,7 @@ class C
 ";
             // Desired: the delegate is generated, no error is reported.
             // Actual: use the malformed Func`13 time and failed to PEVerify.  Not presently worthwhile to fix.
-            CompileAndVerify(source, new[] { systemCoreRef, csrtRef }, verify: false).VerifyIL("C.F", @"
+            CompileAndVerify(source, new[] { systemCoreRef, csrtRef }, verify: Verification.Skipped).VerifyIL("C.F", @"
 {
   // Code size      189 (0xbd)
   .maxstack  13

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3052,7 +3052,7 @@ unsafe class Test
             var c = CompileAndVerify(text,
                 additionalRefs: new[] { SystemCoreRef },
                 options: TestOptions.UnsafeReleaseDll,
-                verify: false);
+                verify: Verification.Skipped);
 
             c.VerifyDiagnostics();
         }
@@ -5132,7 +5132,7 @@ Public Class Cells
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
 
             var source2 =
 @"class A

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3052,7 +3052,7 @@ unsafe class Test
             var c = CompileAndVerify(text,
                 additionalRefs: new[] { SystemCoreRef },
                 options: TestOptions.UnsafeReleaseDll,
-                verify: Verification.Skipped);
+                verify: Verification.Passes);
 
             c.VerifyDiagnostics();
         }
@@ -5132,7 +5132,7 @@ Public Class Cells
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
 
             var source2 =
 @"class A

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -28,7 +28,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -76,7 +76,7 @@ struct Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42
 84");
 
             comp.VerifyIL("Program.Main()", @"
@@ -130,7 +130,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42
 11
 42
 42");
@@ -193,7 +193,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -215,7 +215,7 @@ class Program
   IL_0001:  ret
 }");
 
-            comp = CompileAndVerify(text, verify: false, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(text, verify: Verification.Skipped, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -254,7 +254,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -276,7 +276,7 @@ class Program
   IL_0001:  ret
 }");
 
-            comp = CompileAndVerify(text, verify: false, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(text, verify: Verification.Skipped, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -316,7 +316,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -367,7 +367,7 @@ class P1 : Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"hi
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hi
 42");
 
             comp.VerifyIL("P1..ctor(in string)", @"
@@ -404,7 +404,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -611,7 +611,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.M", @"
 {
@@ -654,7 +654,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.<M>g__M1|0_0(in int, in (int Alice, int Bob))", @"
 {
@@ -724,7 +724,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput:@"42");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput:@"42");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -757,7 +757,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -807,7 +807,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"6");
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"6");
         }
 
         [Fact]
@@ -901,7 +901,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe);
-            var result = CompileAndVerify(comp, verify: false, expectedOutput: @"47");
+            var result = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"47");
 
             var expectedIL = @"
 {
@@ -987,7 +987,7 @@ class Program
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
 
             comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
-            result = CompileAndVerify(comp, verify: false, expectedOutput: @"47");
+            result = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"47");
 
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
 
@@ -1026,7 +1026,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"6");
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"6");
         }
 
         [WorkItem(20764, "https://github.com/dotnet/roslyn/issues/20764")]
@@ -1086,7 +1086,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 3
 42
 3
@@ -1154,7 +1154,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 3
 42
 3
@@ -1217,7 +1217,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 2
 42
 2
@@ -1274,7 +1274,7 @@ public class S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 2
 42
 2
@@ -1334,7 +1334,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 2
 42
 2
@@ -1413,7 +1413,7 @@ public readonly struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 3
 42
 3
@@ -1428,7 +1428,7 @@ public readonly struct S1
 3");
 
             comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
-            CompileAndVerify(comp, verify: false, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 3
 42
 2
@@ -1494,7 +1494,7 @@ public readonly struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            var v = CompileAndVerify(comp, verify: false, expectedOutput: @"
+            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
 1
 2
 3
@@ -1581,7 +1581,7 @@ public readonly struct S1
 ");
 
             comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
-            v = CompileAndVerify(comp, verify: true, expectedOutput: @"
+            v = CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"
 1
 2
 3
@@ -1724,7 +1724,7 @@ public readonly struct S1
     }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"0");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"0");
 
             comp.VerifyIL("D.M1<T>(in T)", @"
 {
@@ -1782,7 +1782,7 @@ public readonly struct S1
     }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"");
 
             comp.VerifyIL("D.M1<T>(in T)", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -28,7 +28,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails);
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -76,7 +76,7 @@ struct Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"42
 84");
 
             comp.VerifyIL("Program.Main()", @"
@@ -130,7 +130,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"42
 11
 42
 42");
@@ -193,7 +193,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: "42");
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -215,7 +215,7 @@ class Program
   IL_0001:  ret
 }");
 
-            comp = CompileAndVerify(text, verify: Verification.Skipped, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(text, verify: Verification.Fails, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -254,7 +254,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: "42");
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -276,7 +276,7 @@ class Program
   IL_0001:  ret
 }");
 
-            comp = CompileAndVerify(text, verify: Verification.Skipped, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(text, verify: Verification.Fails, expectedOutput: "42", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main()", @"
 {
@@ -316,7 +316,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: "42");
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -367,7 +367,7 @@ class P1 : Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hi
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"hi
 42");
 
             comp.VerifyIL("P1..ctor(in string)", @"
@@ -404,7 +404,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Fails);
 
             comp.VerifyIL("Program.M(in int)", @"
 {
@@ -611,7 +611,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails);
 
             comp.VerifyIL("Program.M", @"
 {
@@ -654,7 +654,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails);
 
             comp.VerifyIL("Program.<M>g__M1|0_0(in int, in (int Alice, int Bob))", @"
 {
@@ -724,7 +724,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput:@"42");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput:@"42");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -757,7 +757,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"42");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"42");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -807,7 +807,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"6");
+            CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"6");
         }
 
         [Fact]
@@ -901,7 +901,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe);
-            var result = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"47");
+            var result = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"47");
 
             var expectedIL = @"
 {
@@ -987,7 +987,7 @@ class Program
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
 
             comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
-            result = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"47");
+            result = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"47");
 
             result.VerifyIL("Program.<Test>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", expectedIL);
 
@@ -1026,7 +1026,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"6");
+            CompileAndVerify(comp, verify: Verification.Passes, expectedOutput: @"6");
         }
 
         [WorkItem(20764, "https://github.com/dotnet/roslyn/issues/20764")]
@@ -1086,7 +1086,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
 3
@@ -1154,7 +1154,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
 3
@@ -1217,7 +1217,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
 2
@@ -1274,7 +1274,7 @@ public class S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
 2
@@ -1334,7 +1334,7 @@ public struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 2
 42
 2
@@ -1413,7 +1413,7 @@ public readonly struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
 3
@@ -1428,7 +1428,7 @@ public readonly struct S1
 3");
 
             comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 3
 42
 2
@@ -1494,7 +1494,7 @@ public readonly struct S1
 ";
 
             var comp = CreateCompilationWithMscorlib46(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
-            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"
+            var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 1
 2
 3
@@ -1724,7 +1724,7 @@ public readonly struct S1
     }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"0");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"0");
 
             comp.VerifyIL("D.M1<T>(in T)", @"
 {
@@ -1782,7 +1782,7 @@ public readonly struct S1
     }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"");
 
             comp.VerifyIL("D.M1<T>(in T)", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -2382,7 +2382,7 @@ public class C
 }";
             // The compilation succeeds even though CompilerGeneratedAttribute and DebuggerNonUserCodeAttribute are not available.
             var compilation = CreateCompilation(new[] { Parse(source), Parse(corlib) });
-            var verifier = CompileAndVerify(compilation, verify: Verification.Skipped);
+            var verifier = CompileAndVerify(compilation, verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
                 Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenIterators.cs
@@ -2382,7 +2382,7 @@ public class C
 }";
             // The compilation succeeds even though CompilerGeneratedAttribute and DebuggerNonUserCodeAttribute are not available.
             var compilation = CreateCompilation(new[] { Parse(source), Parse(corlib) });
-            var verifier = CompileAndVerify(compilation, verify: false);
+            var verifier = CompileAndVerify(compilation, verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
                 Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -739,7 +739,7 @@ namespace System
             //IMPORTANT: we should NOT delegate E1.GetHashCode() to int.GetHashCode()
             //           it is entirely possible that Enum.GetHashCode and int.GetHashCode 
             //           have different implementations
-            CompileAndVerify(comp, verify: Verification.Skipped).
+            CompileAndVerify(comp, verify: Verification.Fails).
                 VerifyIL("program.Main()",
 @"
 {
@@ -867,7 +867,7 @@ namespace System
             //           but see the bug see VSW #396011, JIT needs references when loading
             //           fields of certain clr-ambiguous structs (only possible when building mscorlib)
 
-            CompileAndVerify(comp, verify: Verification.Skipped).
+            CompileAndVerify(comp, verify: Verification.Fails).
                 VerifyIL("System.IntPtr..ctor(int)", @"
 {
   // Code size       10 (0xa)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -599,7 +599,7 @@ namespace System.Collections
 
 
             //IMPORTANT: we should NOT load fields of self-containing structs like - "ldfld int int.m_value"
-            CompileAndVerify(comp, verify: false).
+            CompileAndVerify(comp, verify: Verification.Skipped).
                 VerifyIL("int.CompareTo(int)", @"
 {
   // Code size       16 (0x10)
@@ -739,7 +739,7 @@ namespace System
             //IMPORTANT: we should NOT delegate E1.GetHashCode() to int.GetHashCode()
             //           it is entirely possible that Enum.GetHashCode and int.GetHashCode 
             //           have different implementations
-            CompileAndVerify(comp, verify: false).
+            CompileAndVerify(comp, verify: Verification.Skipped).
                 VerifyIL("program.Main()",
 @"
 {
@@ -867,7 +867,7 @@ namespace System
             //           but see the bug see VSW #396011, JIT needs references when loading
             //           fields of certain clr-ambiguous structs (only possible when building mscorlib)
 
-            CompileAndVerify(comp, verify: false).
+            CompileAndVerify(comp, verify: Verification.Skipped).
                 VerifyIL("System.IntPtr..ctor(int)", @"
 {
   // Code size       10 (0xa)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -2452,7 +2452,7 @@ public class Test
             // from assembly 'Dev10, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
             // is overriding a method that is not visible from that assembly.
 
-            CompileAndVerify(outerCompilation, verify: false).VerifyIL("Test.Main", @"
+            CompileAndVerify(outerCompilation, verify: Verification.Skipped).VerifyIL("Test.Main", @"
 {
   // Code size       65 (0x41)
   .maxstack  4

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -2452,7 +2452,7 @@ public class Test
             // from assembly 'Dev10, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
             // is overriding a method that is not visible from that assembly.
 
-            CompileAndVerify(outerCompilation, verify: Verification.Skipped).VerifyIL("Test.Main", @"
+            CompileAndVerify(outerCompilation, verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       65 (0x41)
   .maxstack  4

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -43,7 +43,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -59,7 +59,7 @@ class Program
   IL_0024:  ret
 }");
 
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -114,7 +114,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1}, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1}, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -130,7 +130,7 @@ class Program
   IL_0024:  ret
 }");
 
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -180,7 +180,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -198,7 +198,7 @@ class Program
   IL_002a:  ret
 }");
 
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"12");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -253,7 +253,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"hello2");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -272,7 +272,7 @@ class Program
   IL_002f:  ret
 }");
 
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"hello2");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -333,7 +333,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"hello2");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -352,7 +352,7 @@ class Program
   IL_002f:  ret
 }");
 
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true, expectedOutput: @"hello2");
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -406,7 +406,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -452,7 +452,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
 
             comp.VerifyIL("Program.S1.Test()", @"
 {
@@ -503,7 +503,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"Program+S1Program+S1");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"Program+S1Program+S1");
 
             comp.VerifyIL("Program.S1.Test()", @"
 {
@@ -554,7 +554,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"4242");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"4242");
 
             comp.VerifyIL("Program.S1..ctor(int)", @"
 {
@@ -1075,7 +1075,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "10", verify: false).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "10", verify: Verification.Skipped).VerifyIL("Test.Main", @"
 {
   // Code size       29 (0x1d)
   .maxstack  2
@@ -1122,7 +1122,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "12345", verify: false).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Skipped).VerifyIL("Test.Main", @"
 {
   // Code size       44 (0x2c)
   .maxstack  2
@@ -1183,7 +1183,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: false);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Skipped);
         }
 
         [Fact]
@@ -1205,7 +1205,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: false);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Skipped);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -43,7 +43,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -114,7 +114,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1}, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1}, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -180,7 +180,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -253,7 +253,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hello2");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -333,7 +333,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"hello2");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"hello2");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -406,7 +406,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -452,7 +452,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"12");
 
             comp.VerifyIL("Program.S1.Test()", @"
 {
@@ -503,7 +503,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"Program+S1Program+S1");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"Program+S1Program+S1");
 
             comp.VerifyIL("Program.S1.Test()", @"
 {
@@ -554,7 +554,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped, expectedOutput: @"4242");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"4242");
 
             comp.VerifyIL("Program.S1..ctor(int)", @"
 {
@@ -1075,7 +1075,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "10", verify: Verification.Skipped).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "10", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       29 (0x1d)
   .maxstack  2
@@ -1122,7 +1122,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Skipped).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       44 (0x2c)
   .maxstack  2
@@ -1183,7 +1183,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Fails);
         }
 
         [Fact]
@@ -1205,7 +1205,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Fails);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -85,7 +85,7 @@ class C
     static ref int M1(ref int arg) => ref arg;
 
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "44", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -121,7 +121,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "44", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -157,7 +157,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "55", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "55", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -195,7 +195,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "5555", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "5555", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -242,7 +242,7 @@ class C
     static ref int M1(ref int arg) => ref arg;
 
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "67", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "67", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -296,7 +296,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "446767", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "446767", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -798,7 +798,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Test", @"
@@ -842,7 +842,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Test", @"
@@ -873,7 +873,7 @@ class C
     static int val2;
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main()", @"
@@ -1025,7 +1025,7 @@ class C
     }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef, SystemCoreRef }, expectedOutput: "00", verify: false);
+            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef, SystemCoreRef }, expectedOutput: "00", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Main", @"
@@ -1113,7 +1113,7 @@ class C
     }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, expectedOutput: "00", verify: false);
+            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, expectedOutput: "00", verify: Verification.Skipped);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Test", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -85,7 +85,7 @@ class C
     static ref int M1(ref int arg) => ref arg;
 
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Fails);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -121,7 +121,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -157,7 +157,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "55", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "55", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -195,7 +195,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "5555", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "5555", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -242,7 +242,7 @@ class C
     static ref int M1(ref int arg) => ref arg;
 
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "67", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "67", verify: Verification.Fails);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -296,7 +296,7 @@ class C
     static int val1 = 33;
     static int val2 = 44;
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "446767", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "446767", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main", @"
@@ -798,7 +798,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Test", @"
@@ -842,7 +842,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Test", @"
@@ -873,7 +873,7 @@ class C
     static int val2;
 }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: Verification.Passes);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.Main()", @"
@@ -1025,7 +1025,7 @@ class C
     }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef, SystemCoreRef }, expectedOutput: "00", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef, SystemCoreRef }, expectedOutput: "00", verify: Verification.Fails);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Main", @"
@@ -1113,7 +1113,7 @@ class C
     }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, expectedOutput: "00", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, expectedOutput: "00", verify: Verification.Fails);
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("Program.Test", @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -139,7 +139,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
   .maxstack  1
@@ -172,7 +172,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -243,7 +243,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -395,7 +395,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -462,7 +462,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -810,7 +810,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M()", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -847,7 +847,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -918,7 +918,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -1015,7 +1015,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program<T>.M()", @"
 {
   // Code size       25 (0x19)
@@ -1085,7 +1085,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       16 (0x10)
   .maxstack  3
@@ -1125,7 +1125,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1202,7 +1202,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1308,7 +1308,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
             comp.VerifyIL("Program<T>.M(ref int, ref int, object)", @"
 {
   // Code size       28 (0x1c)
@@ -1417,7 +1417,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(D, ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M(D, ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
   .maxstack  4

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -139,7 +139,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails).VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
   .maxstack  1
@@ -172,7 +172,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -243,7 +243,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -395,7 +395,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -462,7 +462,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -810,7 +810,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails).VerifyIL("Program.M()", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -847,7 +847,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -918,7 +918,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -1015,7 +1015,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program<T>.M()", @"
 {
   // Code size       25 (0x19)
@@ -1085,7 +1085,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M(ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails).VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       16 (0x10)
   .maxstack  3
@@ -1125,7 +1125,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1202,7 +1202,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1308,7 +1308,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails);
             comp.VerifyIL("Program<T>.M(ref int, ref int, object)", @"
 {
   // Code size       28 (0x1c)
@@ -1417,7 +1417,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Skipped).VerifyIL("Program.M(D, ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: Verification.Fails).VerifyIL("Program.M(D, ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
   .maxstack  4

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -55,7 +55,7 @@ class C
 }";
 
             // WithPEVerifyCompatFeature should not cause us to get a ref of a temp in ref assignments
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: false);
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Skipped);
             comp.VerifyIL("C.M", @"
 {
   // Code size       59 (0x3b)
@@ -80,7 +80,7 @@ class C
   IL_003a:  ret
 }");
 
-            comp = CompileAndVerify(source, verify: false);
+            comp = CompileAndVerify(source, verify: Verification.Skipped);
             comp.VerifyIL("C.M", @"
 {
   // Code size       59 (0x3b)
@@ -287,7 +287,7 @@ class C
         ref readonly int rp = ref p;
         return ref rp;
     }
-}", verify: false);
+}", verify: Verification.Skipped);
             comp.VerifyIL("C.M", @"
 {
   // Code size        2 (0x2)
@@ -751,7 +751,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -829,7 +829,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -861,7 +861,7 @@ class Program
 }");
 
             // WithPEVerifyCompatFeature should not cause us to get a ref of a temp in ref returns
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: false);
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Skipped);
             comp.VerifyIL("Program.Test", @"
 {
   // Code size       57 (0x39)
@@ -1169,7 +1169,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1198,7 +1198,7 @@ class Test
     {
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1225,7 +1225,7 @@ class Test
     {
         x.M().M().M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
@@ -1253,7 +1253,7 @@ class Test
     {
         5.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1282,7 +1282,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1311,7 +1311,7 @@ class Test
     {
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1338,7 +1338,7 @@ class Test
     {
         x.M().M().M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: false).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
@@ -1366,7 +1366,7 @@ class Program
         System.Console.Write(""-"");
         System.Console.Write(M(""provided""));
     }
-}", verify: false, expectedOutput: "optional-provided");
+}", verify: Verification.Skipped, expectedOutput: "optional-provided");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -55,7 +55,7 @@ class C
 }";
 
             // WithPEVerifyCompatFeature should not cause us to get a ref of a temp in ref assignments
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Fails);
             comp.VerifyIL("C.M", @"
 {
   // Code size       59 (0x3b)
@@ -80,7 +80,7 @@ class C
   IL_003a:  ret
 }");
 
-            comp = CompileAndVerify(source, verify: Verification.Skipped);
+            comp = CompileAndVerify(source, verify: Verification.Fails);
             comp.VerifyIL("C.M", @"
 {
   // Code size       59 (0x3b)
@@ -287,7 +287,7 @@ class C
         ref readonly int rp = ref p;
         return ref rp;
     }
-}", verify: Verification.Skipped);
+}", verify: Verification.Fails);
             comp.VerifyIL("C.M", @"
 {
   // Code size        2 (0x2)
@@ -751,7 +751,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Passes);
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -829,7 +829,7 @@ class Program
 
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Skipped);
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: Verification.Fails);
 
             comp.VerifyIL("Program.Test", @"
 {
@@ -861,7 +861,7 @@ class Program
 }");
 
             // WithPEVerifyCompatFeature should not cause us to get a ref of a temp in ref returns
-            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Skipped);
+            comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Fails);
             comp.VerifyIL("Program.Test", @"
 {
   // Code size       57 (0x39)
@@ -1169,7 +1169,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1198,7 +1198,7 @@ class Test
     {
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1225,7 +1225,7 @@ class Test
     {
         x.M().M().M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
@@ -1253,7 +1253,7 @@ class Test
     {
         5.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1282,7 +1282,7 @@ class Test
         int x = 5;
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       11 (0xb)
   .maxstack  1
@@ -1311,7 +1311,7 @@ class Test
     {
         x.M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -1338,7 +1338,7 @@ class Test
     {
         x.M().M().M();
     }
-}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Skipped).VerifyIL("Test.M", @"
+}", additionalRefs: new[] { SystemCoreRef }, verify: Verification.Fails).VerifyIL("Test.M", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
@@ -1366,7 +1366,7 @@ class Program
         System.Console.Write(""-"");
         System.Console.Write(M(""provided""));
     }
-}", verify: Verification.Skipped, expectedOutput: "optional-provided");
+}", verify: Verification.Fails, expectedOutput: "optional-provided");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source,
             string expectedOutput = null,
             CSharpCompilationOptions options = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             return CompileAndVerify(
                 source,
@@ -65,7 +65,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, verify: false).VerifyIL("Program.M(ref int)", @"
+            CompileAndVerifyRef(text, verify: Verification.Skipped).VerifyIL("Program.M(ref int)", @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -88,7 +88,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, verify: false).VerifyIL("Program.M(out int)", @"
+            CompileAndVerifyRef(text, verify: Verification.Skipped).VerifyIL("Program.M(out int)", @"
 {
   // Code size        5 (0x5)
   .maxstack  2
@@ -115,7 +115,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, verify: false).VerifyIL("Program.M(ref int)", @"
+            CompileAndVerifyRef(text, verify: Verification.Skipped).VerifyIL("Program.M(ref int)", @"
 {
   // Code size        5 (0x5)
   .maxstack  3
@@ -268,7 +268,7 @@ class Program3
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: false);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
             compilation.VerifyIL("Program.M()", @"
 {
   // Code size        7 (0x7)
@@ -460,7 +460,7 @@ class Program3
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: false);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
             compilation.VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
@@ -723,7 +723,7 @@ class Program2
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: false);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
             compilation.VerifyIL("Program2.M(ref Program)", @"
 {
   // Code size        7 (0x7)
@@ -1601,7 +1601,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Skipped).VerifyIL("Program.M()", @"
 {
   // Code size       26 (0x1a)
   .maxstack  5
@@ -1674,7 +1674,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Skipped).VerifyIL("Program.M()", @"
 {
   // Code size       36 (0x24)
   .maxstack  5
@@ -1860,7 +1860,7 @@ struct Mutable : IDisposable
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "12", verify: false)
+            CompileAndVerifyRef(text, expectedOutput: "12", verify: Verification.Skipped)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      115 (0x73)
@@ -1958,7 +1958,7 @@ struct Mutable : IDisposable
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1234", verify: false)
+            CompileAndVerifyRef(text, expectedOutput: "1234", verify: Verification.Skipped)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      129 (0x81)
@@ -2063,7 +2063,7 @@ class Goo : IGoo<Goo>
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1True", verify: false)
+            CompileAndVerifyRef(text, expectedOutput: "1True", verify: Verification.Skipped)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size       84 (0x54)
@@ -2161,7 +2161,7 @@ class Goo : IGoo<Goo>
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1TrueTrue1TrueTrueTrueTrue1TrueTrue", verify: false)
+            CompileAndVerifyRef(text, expectedOutput: "1TrueTrue1TrueTrueTrueTrue1TrueTrue", verify: Verification.Skipped)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      215 (0xd7)
@@ -2912,7 +2912,7 @@ public class C
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe);
 
-            var v = CompileAndVerify(comp, verify: false, expectedOutput: "2");
+            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "2");
 
             v.VerifyIL("C.F(ref dynamic)", @"
 {
@@ -3025,7 +3025,7 @@ public class C
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe);
 
-            var v = CompileAndVerify(comp, verify: false, expectedOutput: "2");
+            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "2");
         }
 
         [Fact]
@@ -3390,7 +3390,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Base", verify: true);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Base", verify: Verification.Passes);
         }
 
         [Fact]
@@ -3481,7 +3481,7 @@ class Program
 
 ";
 
-            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Program+RefFunc1`2[Derived2,Derived1]", verify: true);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Program+RefFunc1`2[Derived2,Derived1]", verify: Verification.Passes);
         }
 
         [Fact]
@@ -3522,7 +3522,7 @@ class Program
 ";
 
             CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"System.Func`2[Derived1,Base]
-Program+RefFunc1`2[Derived1,Base]", verify: true);
+Program+RefFunc1`2[Derived1,Base]", verify: Verification.Passes);
         }
 
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -88,7 +88,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, verify: Verification.Skipped).VerifyIL("Program.M(out int)", @"
+            CompileAndVerifyRef(text, verify: Verification.Fails).VerifyIL("Program.M(out int)", @"
 {
   // Code size        5 (0x5)
   .maxstack  2
@@ -115,7 +115,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, verify: Verification.Skipped).VerifyIL("Program.M(ref int)", @"
+            CompileAndVerifyRef(text, verify: Verification.Fails).VerifyIL("Program.M(ref int)", @"
 {
   // Code size        5 (0x5)
   .maxstack  3
@@ -268,7 +268,7 @@ class Program3
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Passes);
             compilation.VerifyIL("Program.M()", @"
 {
   // Code size        7 (0x7)
@@ -460,7 +460,7 @@ class Program3
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Passes);
             compilation.VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
@@ -723,7 +723,7 @@ class Program2
 }
 ";
 
-            var compilation = CompileAndVerifyRef(text, verify: Verification.Skipped);
+            var compilation = CompileAndVerifyRef(text, verify: Verification.Fails);
             compilation.VerifyIL("Program2.M(ref Program)", @"
 {
   // Code size        7 (0x7)
@@ -1601,7 +1601,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Skipped).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Fails).VerifyIL("Program.M()", @"
 {
   // Code size       26 (0x1a)
   .maxstack  5
@@ -1674,7 +1674,7 @@ class Program
 }
 ";
 
-            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Skipped).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: Verification.Fails).VerifyIL("Program.M()", @"
 {
   // Code size       36 (0x24)
   .maxstack  5
@@ -1860,7 +1860,7 @@ struct Mutable : IDisposable
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "12", verify: Verification.Skipped)
+            CompileAndVerifyRef(text, expectedOutput: "12", verify: Verification.Fails)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      115 (0x73)
@@ -1958,7 +1958,7 @@ struct Mutable : IDisposable
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1234", verify: Verification.Skipped)
+            CompileAndVerifyRef(text, expectedOutput: "1234", verify: Verification.Fails)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      129 (0x81)
@@ -2063,7 +2063,7 @@ class Goo : IGoo<Goo>
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1True", verify: Verification.Skipped)
+            CompileAndVerifyRef(text, expectedOutput: "1True", verify: Verification.Fails)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size       84 (0x54)
@@ -2161,7 +2161,7 @@ class Goo : IGoo<Goo>
 }
 ";
 
-            CompileAndVerifyRef(text, expectedOutput: "1TrueTrue1TrueTrueTrueTrue1TrueTrue", verify: Verification.Skipped)
+            CompileAndVerifyRef(text, expectedOutput: "1TrueTrue1TrueTrueTrueTrue1TrueTrue", verify: Verification.Fails)
                 .VerifyIL("Program.C1<T>.Test()", @"
 {
   // Code size      215 (0xd7)
@@ -2912,7 +2912,7 @@ public class C
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe);
 
-            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "2");
+            var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "2");
 
             v.VerifyIL("C.F(ref dynamic)", @"
 {
@@ -3025,7 +3025,7 @@ public class C
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe);
 
-            var v = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "2");
+            var v = CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "2");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -552,7 +552,7 @@ public abstract class C
                 "s0.dll",
                 SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script),
                 references);
-            var verifier = CompileAndVerify(s0, verify: false);
+            var verifier = CompileAndVerify(s0, verify: Verification.Skipped);
             var methodData = verifier.TestData.GetMethodData("<Initialize>");
             Assert.Equal("System.Threading.Tasks.Task<object>", methodData.Method.ReturnType.ToDisplayString());
             methodData.VerifyIL(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -552,7 +552,7 @@ public abstract class C
                 "s0.dll",
                 SyntaxFactory.ParseSyntaxTree(source0, options: TestOptions.Script),
                 references);
-            var verifier = CompileAndVerify(s0, verify: Verification.Skipped);
+            var verifier = CompileAndVerify(s0, verify: Verification.Fails);
             var methodData = verifier.TestData.GetMethodData("<Initialize>");
             Assert.Equal("System.Threading.Tasks.Task<object>", methodData.Method.ReturnType.ToDisplayString());
             methodData.VerifyIL(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7238,7 +7238,7 @@ class Program
     }
 }
 ";
-            var comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", verify: Verification.Fails);
 
             comp.VerifyIL("Program.Main", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7238,7 +7238,7 @@ class Program
     }
 }
 ";
-            var comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", verify: false);
+            var comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", verify: Verification.Skipped);
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -7263,7 +7263,7 @@ class Program
   IL_002b:  ret
 }");
 
-            comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature(), verify: true);
+            comp = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: @"", parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature(), verify: Verification.Passes);
 
             comp.VerifyIL("Program.Main", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -2066,7 +2066,7 @@ readonly struct S
 
 ";
 
-            var compilation = CompileAndVerify(source, verify: Verification.Skipped, expectedOutput: "True");
+            var compilation = CompileAndVerify(source, verify: Verification.Fails, expectedOutput: "True");
 
             compilation.VerifyIL("S.Main",
 @"
@@ -2187,7 +2187,7 @@ readonly struct S
 
 ";
 
-            var compilation = CompileAndVerify(source, verify: Verification.Skipped, expectedOutput: @"353
+            var compilation = CompileAndVerify(source, verify: Verification.Fails, expectedOutput: @"353
 353");
 
             compilation.VerifyIL("S.TestRO",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1545,7 +1546,7 @@ public class D
     }
 ";
 
-            var compilation = CompileAndVerify(source, expectedOutput: "S1", verify: false);
+            var compilation = CompileAndVerify(source, expectedOutput: "S1", verify: Verification.Skipped);
 
             compilation.VerifyIL("Program.Main",
 @"
@@ -2065,7 +2066,7 @@ readonly struct S
 
 ";
 
-            var compilation = CompileAndVerify(source, verify: false, expectedOutput: "True");
+            var compilation = CompileAndVerify(source, verify: Verification.Skipped, expectedOutput: "True");
 
             compilation.VerifyIL("S.Main",
 @"
@@ -2186,7 +2187,7 @@ readonly struct S
 
 ";
 
-            var compilation = CompileAndVerify(source, verify: false, expectedOutput: @"353
+            var compilation = CompileAndVerify(source, verify: Verification.Skipped, expectedOutput: @"353
 353");
 
             compilation.VerifyIL("S.TestRO",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -4326,7 +4326,7 @@ public class Program
         Callee3<T>(default(T), default(T));
     }
 }
-", verify: false, options: TestOptions.ReleaseExe);
+", verify: Verification.Skipped, options: TestOptions.ReleaseExe);
             verifier.VerifyIL("Program.M<T>()",
 @"{
   // Code size      297 (0x129)
@@ -4459,7 +4459,7 @@ public class Program
         Callee3<string>();
     }
 }
-", verify: false, options: TestOptions.ReleaseExe);
+", verify: Verification.Skipped, options: TestOptions.ReleaseExe);
             verifier.VerifyIL("Program.M<T>()",
 @"{
   // Code size       34 (0x22)
@@ -5079,7 +5079,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
         }
     }";
 
-            var compilation = CompileAndVerify(source, expectedOutput: @"PASS", verify: true);
+            var compilation = CompileAndVerify(source, expectedOutput: @"PASS", verify: Verification.Passes);
 
             compilation.VerifyIL("Program.Main(string[])",
 @"
@@ -5140,7 +5140,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
         }
     }";
 
-            var compilation = CompileAndVerify(source, expectedOutput: @"hi", verify: false);
+            var compilation = CompileAndVerify(source, expectedOutput: @"hi", verify: Verification.Skipped);
 
             compilation.VerifyIL("Program.Main(string[])",
 @"
@@ -5167,7 +5167,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
   IL_0025:  ret
 }
 ");
-            compilation = CompileAndVerify(source, expectedOutput: @"hi",  verify: true, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            compilation = CompileAndVerify(source, expectedOutput: @"hi",  verify: Verification.Passes, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             compilation.VerifyIL("Program.Main(string[])",
 @"
@@ -5226,7 +5226,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
         }
     }";
 
-            var compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: false);
+            var compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Skipped);
 
             var expectedIL = @"
 {
@@ -5247,7 +5247,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
             compilation.VerifyIL("Program.GetElementRef<T>(T[])", expectedIL);
 
             // expect the same IL in the compat case since direct references are required and must be emitted with "readonly.", even though unverifiable
-            compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: false, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Skipped, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             compilation.VerifyIL("Program.GetElementRef<T>(T[])", expectedIL);
         }
@@ -10423,7 +10423,7 @@ class Test
                 Diagnostic(ErrorCode.WRN_ExternMethodNoImplementation, "Goo").WithArguments("Test.Goo()"));
 
             // NOTE: the resulting IL is unverifiable, but not an error for compat reasons
-            CompileAndVerify(comp, verify: false).VerifyIL("Test.Main",
+            CompileAndVerify(comp, verify: Verification.Skipped).VerifyIL("Test.Main",
                 @"
 {
   // Code size       11 (0xb)
@@ -12223,7 +12223,7 @@ struct MyManagedStruct
         n.n.num = x;
     }
 }";
-            var comp = CompileAndVerify(source, expectedOutput: @"42", parseOptions: TestOptions.Regular7_2, verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: @"42", parseOptions: TestOptions.Regular7_2, verify: Verification.Skipped);
 
             comp.VerifyIL("Program.Main",
 @"
@@ -12256,7 +12256,7 @@ struct MyManagedStruct
 }
 ");
 
-            comp = CompileAndVerify(source, expectedOutput: @"42", verify: true, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(source, expectedOutput: @"42", verify: Verification.Passes, parseOptions:TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main",
 @"
@@ -12288,7 +12288,7 @@ struct MyManagedStruct
 }
 ");
 
-            comp = CompileAndVerify(source, expectedOutput: @"42", verify: true, parseOptions: TestOptions.Regular7_1);
+            comp = CompileAndVerify(source, expectedOutput: @"42", verify: Verification.Passes, parseOptions: TestOptions.Regular7_1);
 
             comp.VerifyIL("Program.Main",
 @"
@@ -12376,7 +12376,7 @@ struct MyManagedStruct
             return null;
         }
     }";
-            var comp = CompileAndVerify(source, expectedOutput: @"-10", verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: @"-10", verify: Verification.Skipped);
 
             comp.VerifyIL("Program.Main",
 @"
@@ -12405,7 +12405,7 @@ struct MyManagedStruct
 }
 ");
 
-            comp = CompileAndVerify(source, expectedOutput: @"-10", verify: true, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            comp = CompileAndVerify(source, expectedOutput: @"-10", verify: Verification.Passes, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             comp.VerifyIL("Program.Main",
 @"
@@ -15936,7 +15936,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "330", verify: false).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "330", verify: Verification.Skipped).VerifyIL("Test.Main", @"
 {
   // Code size       49 (0x31)
   .maxstack  2
@@ -15988,7 +15988,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "12345", verify: false).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Skipped).VerifyIL("Test.Main", @"
 {
   // Code size       44 (0x2c)
   .maxstack  2
@@ -16049,7 +16049,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: false);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Skipped);
         }
 
         [Fact]
@@ -16071,7 +16071,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: false);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Skipped);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -4326,7 +4326,7 @@ public class Program
         Callee3<T>(default(T), default(T));
     }
 }
-", verify: Verification.Skipped, options: TestOptions.ReleaseExe);
+", verify: Verification.Fails, options: TestOptions.ReleaseExe);
             verifier.VerifyIL("Program.M<T>()",
 @"{
   // Code size      297 (0x129)
@@ -4459,7 +4459,7 @@ public class Program
         Callee3<string>();
     }
 }
-", verify: Verification.Skipped, options: TestOptions.ReleaseExe);
+", verify: Verification.Fails, options: TestOptions.ReleaseExe);
             verifier.VerifyIL("Program.M<T>()",
 @"{
   // Code size       34 (0x22)
@@ -5140,7 +5140,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
         }
     }";
 
-            var compilation = CompileAndVerify(source, expectedOutput: @"hi", verify: Verification.Skipped);
+            var compilation = CompileAndVerify(source, expectedOutput: @"hi", verify: Verification.Fails);
 
             compilation.VerifyIL("Program.Main(string[])",
 @"
@@ -5226,7 +5226,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
         }
     }";
 
-            var compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Skipped);
+            var compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Fails);
 
             var expectedIL = @"
 {
@@ -5247,7 +5247,7 @@ System.ApplicationException[]System.ApplicationException: helloSystem.Applicatio
             compilation.VerifyIL("Program.GetElementRef<T>(T[])", expectedIL);
 
             // expect the same IL in the compat case since direct references are required and must be emitted with "readonly.", even though unverifiable
-            compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Skipped, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
+            compilation = CompileAndVerify(source, expectedOutput: @"hihi", verify: Verification.Fails, parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
 
             compilation.VerifyIL("Program.GetElementRef<T>(T[])", expectedIL);
         }
@@ -10423,7 +10423,7 @@ class Test
                 Diagnostic(ErrorCode.WRN_ExternMethodNoImplementation, "Goo").WithArguments("Test.Goo()"));
 
             // NOTE: the resulting IL is unverifiable, but not an error for compat reasons
-            CompileAndVerify(comp, verify: Verification.Skipped).VerifyIL("Test.Main",
+            CompileAndVerify(comp, verify: Verification.Fails).VerifyIL("Test.Main",
                 @"
 {
   // Code size       11 (0xb)
@@ -12223,7 +12223,7 @@ struct MyManagedStruct
         n.n.num = x;
     }
 }";
-            var comp = CompileAndVerify(source, expectedOutput: @"42", parseOptions: TestOptions.Regular7_2, verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: @"42", parseOptions: TestOptions.Regular7_2, verify: Verification.Fails);
 
             comp.VerifyIL("Program.Main",
 @"
@@ -12376,7 +12376,7 @@ struct MyManagedStruct
             return null;
         }
     }";
-            var comp = CompileAndVerify(source, expectedOutput: @"-10", verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: @"-10", verify: Verification.Fails);
 
             comp.VerifyIL("Program.Main",
 @"
@@ -15936,7 +15936,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "330", verify: Verification.Skipped).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "330", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       49 (0x31)
   .maxstack  2
@@ -15988,7 +15988,7 @@ class Test
     }
 }", TestOptions.ReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Skipped).VerifyIL("Test.Main", @"
+            CompileAndVerify(comp, expectedOutput: "12345", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       44 (0x2c)
   .maxstack  2
@@ -16049,7 +16049,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled|PointerOpCalled", verify: Verification.Fails);
         }
 
         [Fact]
@@ -16071,7 +16071,7 @@ unsafe class Test
     }
 }", TestOptions.UnsafeReleaseExe);
 
-            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Fails);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -21559,7 +21559,7 @@ namespace ConsoleApplication5
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libComp.ToMetadataReference() }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libComp.ToMetadataReference() }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
 
             var m = (MethodSymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -21615,7 +21615,7 @@ namespace ConsoleApplication5
 
             var libCompRef = AssemblyMetadata.CreateFromImage(libComp.EmitToArray()).GetReference();
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
 
             var m = (MethodSymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -21968,7 +21968,7 @@ namespace ConsoleApplication5
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs).ToArray(), options: TestOptions.DebugExe);
 
-            CompileAndVerify(comp, expectedOutput: "42qq", verify: false);
+            CompileAndVerify(comp, expectedOutput: "42qq", verify: Verification.Skipped);
 
             var m = (MethodSymbol)(comp.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, dynamic) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -22021,7 +22021,7 @@ namespace ConsoleApplication5
 
             var libCompRef = AssemblyMetadata.CreateFromImage(libComp.EmitToArray()).GetReference();
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: false);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
 
             var m = (PropertySymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo { get; }", m.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -21559,7 +21559,7 @@ namespace ConsoleApplication5
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libComp.ToMetadataReference() }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libComp.ToMetadataReference() }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Fails);
 
             var m = (MethodSymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -21615,7 +21615,7 @@ namespace ConsoleApplication5
 
             var libCompRef = AssemblyMetadata.CreateFromImage(libComp.EmitToArray()).GetReference();
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Fails);
 
             var m = (MethodSymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -21968,7 +21968,7 @@ namespace ConsoleApplication5
 
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs).ToArray(), options: TestOptions.DebugExe);
 
-            CompileAndVerify(comp, expectedOutput: "42qq", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: "42qq", verify: Verification.Fails);
 
             var m = (MethodSymbol)(comp.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, dynamic) ConsoleApplication5.C2.Goo(System.Int32 arg)", m.ToTestDisplayString());
@@ -22021,7 +22021,7 @@ namespace ConsoleApplication5
 
             var libCompRef = AssemblyMetadata.CreateFromImage(libComp.EmitToArray()).GetReference();
 
-            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Skipped);
+            var comp = CompileAndVerify(source, expectedOutput: "42qq", additionalRefs: new[] { libCompRef }.Concat(s_valueTupleRefs), options: TestOptions.DebugExe, verify: Verification.Passes);
 
             var m = (PropertySymbol)(comp.Compilation.GetTypeByMetadataName("ConsoleApplication5.C2").GetMembers("Goo").First());
             Assert.Equal("ref (System.Int32, System.Object) ConsoleApplication5.C2.Goo { get; }", m.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
@@ -694,7 +694,7 @@ public class B : A
                 Diagnostic(ErrorCode.WRN_FinalizeMethod, "Finalize"));
 
             // We produce unverifiable code here as per bug resolution (compat concerns, not common case).
-            CompileAndVerify(compilation, verify: false).VerifyIL("B.Finalize",
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyIL("B.Finalize",
 
                 @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/DestructorTests.cs
@@ -694,7 +694,7 @@ public class B : A
                 Diagnostic(ErrorCode.WRN_FinalizeMethod, "Finalize"));
 
             // We produce unverifiable code here as per bug resolution (compat concerns, not common case).
-            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyIL("B.Finalize",
+            CompileAndVerify(compilation, verify: Verification.Fails).VerifyIL("B.Finalize",
 
                 @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
@@ -817,7 +817,7 @@ L0: ;
 @"True
 False";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: false);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -868,7 +868,7 @@ if (Q < 4) goto L;";
 3: F
 4: Q";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: false);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -951,7 +951,7 @@ default:
             string expectedOutput =
 @"3";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: false);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/GotoTest.cs
@@ -817,7 +817,7 @@ L0: ;
 @"True
 False";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Passes);
         }
 
         [Fact]
@@ -868,7 +868,7 @@ if (Q < 4) goto L;";
 3: F
 4: Q";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Fails);
         }
 
         [Fact]
@@ -951,7 +951,7 @@ default:
             string expectedOutput =
 @"3";
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { SystemCoreRef }, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Skipped);
+            CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: Verification.Passes);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -4197,7 +4197,7 @@ class Program
                 references: new[] { AacorlibRef });
 
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Skipped);
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails);
             verifier.VerifyIL("Program.Main", @"
 {
   // Code size      223 (0xdf)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -4197,7 +4197,7 @@ class Program
                 references: new[] { AacorlibRef });
 
 
-            var verifier = CompileAndVerify(comp, verify: false);
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped);
             verifier.VerifyIL("Program.Main", @"
 {
   // Code size      223 (0xdf)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -8714,7 +8714,7 @@ public class Test
     }
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.Skipped).VerifyDiagnostics();
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.Fails).VerifyDiagnostics();
         }
 
         [WorkItem(545026, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545026")]
@@ -8728,7 +8728,7 @@ class C
     unsafe int* p = (int*)2;
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Fails).VerifyDiagnostics(
                 // (4,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));
@@ -8745,7 +8745,7 @@ class C
     int x = 1;
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Fails).VerifyDiagnostics(
                 // (5,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));
@@ -8818,7 +8818,7 @@ public struct OuterStruct
     override public string ToString() { return (ES.ToString() + FS.ToString()); }
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Passes).VerifyDiagnostics(
                 // (8,17): warning CS0649: Field 'OuterStruct.FS' is never assigned to, and will always have its default value 
                 //     FixedStruct FS;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "FS").WithArguments("OuterStruct.FS", "").WithLocation(8, 17),
@@ -8841,7 +8841,7 @@ unsafe public struct FixedStruct
     }
 }
 ";
-            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics();
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Fails).VerifyDiagnostics();
 
             comp.VerifyIL("FixedStruct.ToString", @"
 {
@@ -8894,7 +8894,7 @@ unsafe public struct FixedStruct
             }
         }
     }";
-            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput:"ABC", verify: Verification.Skipped).VerifyDiagnostics();
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput:"ABC", verify: Verification.Fails).VerifyDiagnostics();
 
             comp.VerifyIL("FixedStruct.ToString", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -8714,7 +8714,7 @@ public class Test
     }
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: false).VerifyDiagnostics();
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.Skipped).VerifyDiagnostics();
         }
 
         [WorkItem(545026, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545026")]
@@ -8728,7 +8728,7 @@ class C
     unsafe int* p = (int*)2;
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
                 // (4,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));
@@ -8745,7 +8745,7 @@ class C
     int x = 1;
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
                 // (5,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));
@@ -8818,7 +8818,7 @@ public struct OuterStruct
     override public string ToString() { return (ES.ToString() + FS.ToString()); }
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics(
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics(
                 // (8,17): warning CS0649: Field 'OuterStruct.FS' is never assigned to, and will always have its default value 
                 //     FixedStruct FS;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "FS").WithArguments("OuterStruct.FS", "").WithLocation(8, 17),
@@ -8841,7 +8841,7 @@ unsafe public struct FixedStruct
     }
 }
 ";
-            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics();
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.Skipped).VerifyDiagnostics();
 
             comp.VerifyIL("FixedStruct.ToString", @"
 {
@@ -8894,7 +8894,7 @@ unsafe public struct FixedStruct
             }
         }
     }";
-            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput:"ABC", verify: false).VerifyDiagnostics();
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput:"ABC", verify: Verification.Skipped).VerifyDiagnostics();
 
             comp.VerifyIL("FixedStruct.ToString", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -4076,7 +4076,7 @@ public class Test
             string source2 = @"public class B: A {}";
             var comp = CreateStandardCompilation(source1, options: TestOptions.ReleaseModule);
             var metadataRef = ModuleMetadata.CreateFromStream(comp.EmitToStream()).GetReference();
-            CompileAndVerify(source2, additionalRefs: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: Verification.Skipped);
+            CompileAndVerify(source2, additionalRefs: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: Verification.Fails);
         }
 
         [Fact]
@@ -4491,7 +4491,7 @@ public interface IUsePlatform
         {
             var comp = CreateCompilation("", new[] { TestReferences.SymbolsTests.netModule.x64COFF }, options: TestOptions.DebugDll);
             // modules not supported in ref emit
-            CompileAndVerify(comp, verify: Verification.Skipped);
+            CompileAndVerify(comp, verify: Verification.Fails);
             Assert.NotSame(comp.Assembly.CorLibrary, comp.Assembly);
             comp.GetSpecialType(SpecialType.System_Int32);
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1623,7 +1623,7 @@ public class PublicClass
                 options: TestOptions.DebugDll.WithDeterministic(true));
 
             // verify metadata (types, members, attributes) of the regular assembly
-            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: Verification.Passes);
 
             var realImage = comp.EmitToImageReference(EmitOptions.Default);
             var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
@@ -1654,7 +1654,7 @@ public class PublicClass
             // In this case, IncludePrivateMembers is silently set to true when emitting
             // See https://github.com/dotnet/roslyn/issues/20873
             var emitRegularWithoutPrivateMembers = EmitOptions.Default.WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRegularWithoutPrivateMembers, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRegularWithoutPrivateMembers, verify: Verification.Passes);
 
             var realImage2 = comp.EmitToImageReference(emitRegularWithoutPrivateMembers);
             var compWithReal2 = CreateCompilation("", references: new[] { MscorlibRef, realImage2 },
@@ -1682,7 +1682,7 @@ public class PublicClass
 
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
-            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: Verification.Passes);
 
             var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
             var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
@@ -1711,7 +1711,7 @@ public class PublicClass
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -1759,7 +1759,7 @@ public class C : I
                 options: TestOptions.DebugDll.WithDeterministic(true));
 
             // verify metadata (types, members, attributes) of the regular assembly
-            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: Verification.Passes);
 
             var realImage = comp.EmitToImageReference(EmitOptions.Default);
             var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
@@ -1769,7 +1769,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
-            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: Verification.Passes);
 
             var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
             var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
@@ -1781,7 +1781,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -1825,7 +1825,7 @@ public class C : I
                 options: TestOptions.DebugDll.WithDeterministic(true));
 
             // verify metadata (types, members, attributes) of the regular assembly
-            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: Verification.Passes);
 
             var realImage = comp.EmitToImageReference(EmitOptions.Default);
             var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
@@ -1835,7 +1835,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
-            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: Verification.Passes);
 
             var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
             var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
@@ -1847,7 +1847,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -1891,7 +1891,7 @@ public class C : I
                 options: TestOptions.DebugDll.WithDeterministic(true));
 
             // verify metadata (types, members, attributes) of the regular assembly
-            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: Verification.Passes);
 
             var realImage = comp.EmitToImageReference(EmitOptions.Default);
             var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
@@ -1901,7 +1901,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
-            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: Verification.Passes);
 
             var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
             var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
@@ -1913,7 +1913,7 @@ public class C : I
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -1951,7 +1951,7 @@ internal struct InternalStruct
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -1980,7 +1980,7 @@ struct S
 
             // verify metadata (types, members, attributes) of the ref assembly
             var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
-            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: Verification.Passes);
 
             var refImage = comp.EmitToImageReference(emitRefOnly);
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
@@ -4076,7 +4076,7 @@ public class Test
             string source2 = @"public class B: A {}";
             var comp = CreateStandardCompilation(source1, options: TestOptions.ReleaseModule);
             var metadataRef = ModuleMetadata.CreateFromStream(comp.EmitToStream()).GetReference();
-            CompileAndVerify(source2, additionalRefs: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: false);
+            CompileAndVerify(source2, additionalRefs: new[] { metadataRef }, options: TestOptions.ReleaseModule, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -4491,7 +4491,7 @@ public interface IUsePlatform
         {
             var comp = CreateCompilation("", new[] { TestReferences.SymbolsTests.netModule.x64COFF }, options: TestOptions.DebugDll);
             // modules not supported in ref emit
-            CompileAndVerify(comp, verify: false);
+            CompileAndVerify(comp, verify: Verification.Skipped);
             Assert.NotSame(comp.Assembly.CorLibrary, comp.Assembly);
             comp.GetSpecialType(SpecialType.System_Int32);
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
@@ -575,7 +575,7 @@ class C
             var compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 20)));
             var compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 30)));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
             var reader0 = md0.MetadataReader;
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
@@ -575,7 +575,7 @@ class C
             var compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 20)));
             var compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 30)));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Passes);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
             var reader0 = md0.MetadataReader;
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -4981,7 +4981,7 @@ class C
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Fails);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5040,7 +5040,7 @@ class C
             // older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Fails);
             v0.VerifyDiagnostics();
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
@@ -5104,7 +5104,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Fails);
             v0.VerifyDiagnostics();
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
@@ -5154,7 +5154,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Passes);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5205,7 +5205,7 @@ class C
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Fails);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5256,7 +5256,7 @@ class C
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Passes);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5317,7 +5317,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Passes);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5372,7 +5372,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Passes);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -4981,7 +4981,7 @@ class C
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5040,7 +5040,7 @@ class C
             // older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             v0.VerifyDiagnostics();
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
@@ -5104,7 +5104,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             v0.VerifyDiagnostics();
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
@@ -5154,7 +5154,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5205,7 +5205,7 @@ class C
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5256,7 +5256,7 @@ class C
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5317,7 +5317,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");
@@ -5372,7 +5372,7 @@ class C
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
 
-            var v0 = CompileAndVerify(compilation0, verify: false);
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var f0 = compilation0.GetMember<MethodSymbol>("C.F");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitErrorTests.cs
@@ -109,7 +109,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: false);
+                verify: Verification.Skipped);
         }
 
         [WorkItem(543039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543039")]
@@ -141,7 +141,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: false);
+                verify: Verification.Skipped);
         }
 
         [WorkItem(543039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543039")]
@@ -178,7 +178,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: false);
+                verify: Verification.Skipped);
             compilation2.VerifyIL("B.Main()", @"
 {
   // Code size       25 (0x19)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitErrorTests.cs
@@ -109,7 +109,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
         }
 
         [WorkItem(543039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543039")]
@@ -141,7 +141,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
         }
 
         [WorkItem(543039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543039")]
@@ -178,7 +178,7 @@ public class B
             var compilation2 = CompileAndVerify(
                 source2,
                 new[] { new CSharpCompilationReference(compilation1) },
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             compilation2.VerifyIL("B.Main()", @"
 {
   // Code size       25 (0x19)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -194,7 +194,7 @@ public class Test : Class2
         {
             CompileAndVerify(
                 "public class C { }",
-                verify: Verification.Skipped,
+                verify: Verification.Fails,
                 options: TestOptions.DebugDll.WithOutputKind(OutputKind.NetModule));
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -194,7 +194,7 @@ public class Test : Class2
         {
             CompileAndVerify(
                 "public class C { }",
-                verify: false,
+                verify: Verification.Skipped,
                 options: TestOptions.DebugDll.WithOutputKind(OutputKind.NetModule));
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
@@ -1636,7 +1636,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1656,7 +1656,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1677,7 +1677,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1697,7 +1697,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1718,7 +1718,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1739,7 +1739,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1760,7 +1760,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1780,7 +1780,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1801,7 +1801,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1822,7 +1822,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1842,7 +1842,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1862,7 +1862,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1883,7 +1883,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1904,7 +1904,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1925,7 +1925,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1950,7 +1950,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(endInvokeParameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1971,7 +1971,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(endInvokeMethod.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1991,7 +1991,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2011,7 +2011,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2031,7 +2031,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2051,7 +2051,7 @@ public class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2075,7 +2075,7 @@ public class Test
                 Assert.Empty(parameters[1].RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2095,7 +2095,7 @@ public class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Passes, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -4422,7 +4422,7 @@ class Child: Parent, IM
     public void M(in int x) { }
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 // Nothing on Parent
                 var parentMethod = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M");
@@ -4465,7 +4465,7 @@ class Child: Parent, IM
 {
 }";
 
-            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Passes, symbolValidator: module =>
             {
                 // Nothing on Parent
                 var parentMethod = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M");

--- a/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
@@ -1636,7 +1636,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1656,7 +1656,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1677,7 +1677,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1697,7 +1697,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1718,7 +1718,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1739,7 +1739,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(method.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1760,7 +1760,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1780,7 +1780,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1801,7 +1801,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1822,7 +1822,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(property.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1842,7 +1842,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1862,7 +1862,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1883,7 +1883,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1904,7 +1904,7 @@ abstract class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1925,7 +1925,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(indexer.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1950,7 +1950,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(endInvokeParameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1971,7 +1971,7 @@ class Test
                 AssertSingleInAttributeRequiredModifier(endInvokeMethod.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -1991,7 +1991,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2011,7 +2011,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2031,7 +2031,7 @@ class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2051,7 +2051,7 @@ public class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2075,7 +2075,7 @@ public class Test
                 Assert.Empty(parameters[1].RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -2095,7 +2095,7 @@ public class Test
                 Assert.Empty(parameter.RefCustomModifiers);
             };
 
-            CompileAndVerify(code, verify: false, sourceSymbolValidator: validator, symbolValidator: validator);
+            CompileAndVerify(code, verify: Verification.Skipped, sourceSymbolValidator: validator, symbolValidator: validator);
         }
 
         [Fact]
@@ -4422,7 +4422,7 @@ class Child: Parent, IM
     public void M(in int x) { }
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 // Nothing on Parent
                 var parentMethod = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M");
@@ -4465,7 +4465,7 @@ class Child: Parent, IM
 {
 }";
 
-            CompileAndVerify(code, verify: false, symbolValidator: module =>
+            CompileAndVerify(code, verify: Verification.Skipped, symbolValidator: module =>
             {
                 // Nothing on Parent
                 var parentMethod = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M");

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1763,9 +1763,9 @@ interface UsePia5 : ITest29
                     Assert.Equal(VarianceKind.None, t7.Variance);
                 };
 
-            CompileAndVerify(compilation1, symbolValidator: metadataValidator, verify: Verification.Skipped);
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator, verify: Verification.Fails);
 
-            CompileAndVerify(compilation2, symbolValidator: metadataValidator, verify: Verification.Skipped);
+            CompileAndVerify(compilation2, symbolValidator: metadataValidator, verify: Verification.Fails);
         }
 
         [Fact]
@@ -4692,11 +4692,11 @@ class UsePia5
 
             var compilation3 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2) });
-            CompileAndVerify(compilation3, verify: Verification.Skipped);
+            CompileAndVerify(compilation3, verify: Verification.Fails);
 
             var compilation4 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { MetadataReference.CreateFromStream(piaCompilation2.EmitToStream()) });
-            CompileAndVerify(compilation4, verify: Verification.Skipped);
+            CompileAndVerify(compilation4, verify: Verification.Fails);
         }
 
         [Fact]
@@ -5169,11 +5169,11 @@ class UsePia5
 
             var compilation3 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2) });
-            CompileAndVerify(compilation3, verify: Verification.Skipped);
+            CompileAndVerify(compilation3, verify: Verification.Fails);
 
             var compilation4 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { MetadataReference.CreateFromStream(piaCompilation2.EmitToStream()) });
-            CompileAndVerify(compilation4, verify: Verification.Skipped);
+            CompileAndVerify(compilation4, verify: Verification.Fails);
         }
 
         [Fact, WorkItem(611578, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/611578")]

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1763,9 +1763,9 @@ interface UsePia5 : ITest29
                     Assert.Equal(VarianceKind.None, t7.Variance);
                 };
 
-            CompileAndVerify(compilation1, symbolValidator: metadataValidator, verify: false);
+            CompileAndVerify(compilation1, symbolValidator: metadataValidator, verify: Verification.Skipped);
 
-            CompileAndVerify(compilation2, symbolValidator: metadataValidator, verify: false);
+            CompileAndVerify(compilation2, symbolValidator: metadataValidator, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -4692,11 +4692,11 @@ class UsePia5
 
             var compilation3 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2) });
-            CompileAndVerify(compilation3, verify: false);
+            CompileAndVerify(compilation3, verify: Verification.Skipped);
 
             var compilation4 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { MetadataReference.CreateFromStream(piaCompilation2.EmitToStream()) });
-            CompileAndVerify(compilation4, verify: false);
+            CompileAndVerify(compilation4, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -5169,11 +5169,11 @@ class UsePia5
 
             var compilation3 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2) });
-            CompileAndVerify(compilation3, verify: false);
+            CompileAndVerify(compilation3, verify: Verification.Skipped);
 
             var compilation4 = CreateStandardCompilation(consumer, options: TestOptions.DebugExe,
                 references: new MetadataReference[] { MetadataReference.CreateFromStream(piaCompilation2.EmitToStream()) });
-            CompileAndVerify(compilation4, verify: false);
+            CompileAndVerify(compilation4, verify: Verification.Skipped);
         }
 
         [Fact, WorkItem(611578, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/611578")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -2831,7 +2831,7 @@ class Repro
                 // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
                 Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1));
 
-            var compiled = CompileAndVerify(comp, expectedOutput: "dynamic42", verify: false);
+            var compiled = CompileAndVerify(comp, expectedOutput: "dynamic42", verify: Verification.Skipped);
 
             compiled.VerifyIL("MyAwaiter.OnCompleted(System.Action)", @"
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -2831,7 +2832,7 @@ class Repro
                 // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
                 Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1));
 
-            var compiled = CompileAndVerify(comp, expectedOutput: "dynamic42", verify: Verification.Skipped);
+            var compiled = CompileAndVerify(comp, expectedOutput: "dynamic42", verify: Verification.Fails);
 
             compiled.VerifyIL("MyAwaiter.OnCompleted(System.Action)", @"
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -2960,7 +2960,7 @@ namespace System.Collections
 }";
 
             var comp = CreateCompilation(text, new[] { reference1 });
-            CompileAndVerify(comp, verify: Verification.Skipped).
+            CompileAndVerify(comp, verify: Verification.Fails).
             VerifyIL("C.M", @"
 {
   // Code size       28 (0x1c)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -2960,7 +2960,7 @@ namespace System.Collections
 }";
 
             var comp = CreateCompilation(text, new[] { reference1 });
-            CompileAndVerify(comp, verify: false).
+            CompileAndVerify(comp, verify: Verification.Skipped).
             VerifyIL("C.M", @"
 {
   // Code size       28 (0x1c)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Linq;
 using Xunit;
@@ -1006,7 +1007,7 @@ class Program {
     }
 }";
             var comp = CreateCompilation(text, options: Test.Utilities.TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
-            var compilation = CompileAndVerify(comp, verify: Verification.Skipped);
+            var compilation = CompileAndVerify(comp, verify: Verification.Fails);
             compilation.VerifyIL("System.Program.Main",
 @"{
   // Code size       35 (0x23)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -1006,7 +1006,7 @@ class Program {
     }
 }";
             var comp = CreateCompilation(text, options: Test.Utilities.TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
-            var compilation = CompileAndVerify(comp, verify: false);
+            var compilation = CompileAndVerify(comp, verify: Verification.Skipped);
             compilation.VerifyIL("System.Program.Main",
 @"{
   // Code size       35 (0x23)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2480,7 +2480,7 @@ class Program
             var comp = CreateCompilationWithMscorlibAndSpan(text);
             comp.VerifyDiagnostics();
 
-            var compiled = CompileAndVerify(comp, verify: false);
+            var compiled = CompileAndVerify(comp, verify: Verification.Skipped);
             compiled.VerifyIL("C.M(ref System.Span<int>)", @"
 {
   // Code size        8 (0x8)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2480,7 +2480,7 @@ class Program
             var comp = CreateCompilationWithMscorlibAndSpan(text);
             comp.VerifyDiagnostics();
 
-            var compiled = CompileAndVerify(comp, verify: Verification.Skipped);
+            var compiled = CompileAndVerify(comp, verify: Verification.Passes);
             compiled.VerifyIL("C.M(ref System.Span<int>)", @"
 {
   // Code size        8 (0x8)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7030,7 +7030,7 @@ initializing for System.String
 String
 ";
             // Although we accept this nasty code, it will not verify.
-            CompileAndVerify(text, expectedOutput: expectedOutput, verify: false);
+            CompileAndVerify(text, expectedOutput: expectedOutput, verify: Verification.Skipped);
         }
 
         [Fact]
@@ -12658,7 +12658,7 @@ Public Class A
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
             var source2 =
 @"class B
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7030,7 +7030,7 @@ initializing for System.String
 String
 ";
             // Although we accept this nasty code, it will not verify.
-            CompileAndVerify(text, expectedOutput: expectedOutput, verify: Verification.Skipped);
+            CompileAndVerify(text, expectedOutput: expectedOutput, verify: Verification.Fails);
         }
 
         [Fact]
@@ -12658,7 +12658,7 @@ Public Class A
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"class B
 {

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
@@ -196,7 +196,7 @@ Public Class A
 End Class
 ";
 
-            var reference = BasicCompilationUtils.CompileToMetadata(COMSource, verify: true);
+            var reference = BasicCompilationUtils.CompileToMetadata(COMSource, verify: Verification.Passes);
             return reference;
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -387,8 +387,8 @@ public class OKImpl : I
                 // Dev11 adds "Lib 1.0" to the references, we don't (see DevDiv #15580)
                 AssertEx.SetEqual(new[] { $"{RuntimeCorLibName.Name} {RuntimeCorLibName.Version.ToString(2)}", "RefLibV1 1.0", "Lib 2.0", "X 2.0" }, reader.DumpAssemblyReferences());
             },
-            // PE verification would need .config file with Lib v1 -> Lib v2 binding redirect 
-            verify: Verification.Fails);
+            // PE verification fails on some platforms. Would need .config file with Lib v1 -> Lib v2 binding redirect
+            verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -388,7 +388,7 @@ public class OKImpl : I
                 AssertEx.SetEqual(new[] { $"{RuntimeCorLibName.Name} {RuntimeCorLibName.Version.ToString(2)}", "RefLibV1 1.0", "Lib 2.0", "X 2.0" }, reader.DumpAssemblyReferences());
             },
             // PE verification would need .config file with Lib v1 -> Lib v2 binding redirect 
-            verify: Verification.Skipped);
+            verify: Verification.Fails);
         }
 
         [Fact]
@@ -1737,7 +1737,7 @@ public class C : I { }
                 var reader = pe.GetMetadataReader();
                 AssertEx.SetEqual(new[] { "mscorlib 4.0" }, reader.DumpAssemblyReferences());
             },
-            verify: Verification.Skipped);
+            verify: Verification.Passes);
         }
 
         [WorkItem(531537, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531537")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -388,7 +388,7 @@ public class OKImpl : I
                 AssertEx.SetEqual(new[] { $"{RuntimeCorLibName.Name} {RuntimeCorLibName.Version.ToString(2)}", "RefLibV1 1.0", "Lib 2.0", "X 2.0" }, reader.DumpAssemblyReferences());
             },
             // PE verification would need .config file with Lib v1 -> Lib v2 binding redirect 
-            verify: false);
+            verify: Verification.Skipped);
         }
 
         [Fact]
@@ -1737,7 +1737,7 @@ public class C : I { }
                 var reader = pe.GetMetadataReader();
                 AssertEx.SetEqual(new[] { "mscorlib 4.0" }, reader.DumpAssemblyReferences());
             },
-            verify: false);
+            verify: Verification.Skipped);
         }
 
         [WorkItem(531537, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531537")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -1433,7 +1433,7 @@ Public Class A
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
 
             // Assignment (property group).
             var source2 =
@@ -1572,7 +1572,7 @@ Public Class B
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
 
             // Overridden property.
             var source2 =

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -1078,7 +1078,7 @@ Q[6] = 5
         o = i.valid_name(1);
     }
 }";
-            var compilation2 = CompileAndVerify(source2, additionalRefs: new[] { reference1 }, verify: true);
+            var compilation2 = CompileAndVerify(source2, additionalRefs: new[] { reference1 }, verify: Verification.Passes);
 
             var @namespace = (NamespaceSymbol)compilation2.Compilation.GlobalNamespace;
             // Indexed property with valid name.
@@ -1166,7 +1166,7 @@ Public Class A
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"class B : A
 {
@@ -1202,7 +1202,7 @@ Public Class A
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"class B : A
 {
@@ -1532,7 +1532,7 @@ Public Class B
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
             var source2 =
 @"class C
 {
@@ -1555,7 +1555,7 @@ End Class";
         o = b.Q[2, 3];
     }
 }";
-            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: false);
+            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: Verification.Skipped);
             compilation3.VerifyIL("C.M(B)",
 @"{
   // Code size       33 (0x21)
@@ -1948,7 +1948,7 @@ Public Class A
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"class B
 {
@@ -1960,7 +1960,7 @@ End Class";
         a = new IA() { P3 = { 6, 7 } };
     }
 }";
-            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: true, expectedOutput:
+            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: Verification.Passes, expectedOutput:
 @"P1(1).set
 P2(2).get
 P1(1).set
@@ -2036,7 +2036,7 @@ Public Class A
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"class B
 {
@@ -2095,7 +2095,7 @@ Public Class A2
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: false);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
             var source2 =
 @"[A1(P = 1)] // Not ComImport
 class B
@@ -2228,7 +2228,7 @@ Public Class A
 End Class
 ";
 
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"
 using System;
@@ -2252,7 +2252,7 @@ class B
     }
 }
 ";
-            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: true, expectedOutput:
+            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: Verification.Passes, expectedOutput:
 @"P1(1).set
 P2(2).get
 P1(1).set
@@ -2300,7 +2300,7 @@ Public Class A
 End Class
 ";
 
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"
 using System;
@@ -2322,7 +2322,7 @@ class B
 }
 ";
 
-            var compilation2 = CompileAndVerify(source2, new[] { reference1, SystemCoreRef }, verify: true, expectedOutput:
+            var compilation2 = CompileAndVerify(source2, new[] { reference1, SystemCoreRef }, verify: Verification.Passes, expectedOutput:
 @"P1(2).get
 P1(2).get
 P1(2).get
@@ -2377,7 +2377,7 @@ Public Class A
 End Class
 ";
 
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: true);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Passes);
             var source2 =
 @"
 using System;
@@ -2397,7 +2397,7 @@ class B
     }
 }
 ";
-            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: true, expectedOutput:
+            var compilation2 = CompileAndVerify(source2, new[] { reference1 }, verify: Verification.Passes, expectedOutput:
 @"P1(3).get
 P1(3).set
 6

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -1532,7 +1532,7 @@ Public Class B
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Fails);
             var source2 =
 @"class C
 {
@@ -1555,7 +1555,7 @@ End Class";
         o = b.Q[2, 3];
     }
 }";
-            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: Verification.Skipped);
+            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: Verification.Fails);
             compilation3.VerifyIL("C.M(B)",
 @"{
   // Code size       33 (0x21)
@@ -2095,7 +2095,7 @@ Public Class A2
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Fails);
             var source2 =
 @"[A1(P = 1)] // Not ComImport
 class B

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -1555,7 +1555,7 @@ End Class";
         o = b.Q[2, 3];
     }
 }";
-            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: Verification.Fails);
+            var compilation3 = CompileAndVerify(source3, additionalRefs: new[] { reference1 }, verify: Verification.Skipped);
             compilation3.VerifyIL("C.M(B)",
 @"{
   // Code size       33 (0x21)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -1532,7 +1532,7 @@ Public Class B
         End Get
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Fails);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
             var source2 =
 @"class C
 {
@@ -2095,7 +2095,7 @@ Public Class A2
         End Set
     End Property
 End Class";
-            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Fails);
+            var reference1 = BasicCompilationUtils.CompileToMetadata(source1, verify: Verification.Skipped);
             var source2 =
 @"[A1(P = 1)] // Not ComImport
 class B

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2448,7 +2448,7 @@ class Derived : Base, IDerived
 }";
 
             var comp = CreateCompilationWithCustomILSource(source, il, options: TestOptions.DebugExe);
-            CompileAndVerify(comp, verify: false, expectedOutput: @"set_P1
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"set_P1
 g_P1
 s_P2
 get_P2");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2448,7 +2448,7 @@ class Derived : Base, IDerived
 }";
 
             var comp = CreateCompilationWithCustomILSource(source, il, options: TestOptions.DebugExe);
-            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"set_P1
+            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"set_P1
 g_P1
 s_P2
 get_P2");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -2448,7 +2448,7 @@ class Derived : Base, IDerived
 }";
 
             var comp = CreateCompilationWithCustomILSource(source, il, options: TestOptions.DebugExe);
-            CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: @"set_P1
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"set_P1
 g_P1
 s_P2
 get_P2");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -1473,7 +1473,7 @@ public class CF1
             Assert.True(token.IsNil);   //could the type ref be located? If not then the attribute's not there.
 
             // Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify: false,
+            CompileAndVerify(appCompilation, verify: Verification.Skipped,
                 symbolValidator: m =>
                 {
                     var peReader1 = ((PEModuleSymbol)m).Module.GetMetadataReader();
@@ -1559,7 +1559,7 @@ public class CF1
         {
             var folder = Temp.CreateDirectory();
             var comp0 = CreateStandardCompilation(source0, options: TestOptions.ReleaseModule, assemblyName: "asm0");
-            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: false).EmittedAssemblyData);
+            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: Verification.Skipped).EmittedAssemblyData);
             var ref0 = asm0.GetReference();
 
             var comp1 = CreateStandardCompilation(source1, new[] { ref0 }, options: TestOptions.ReleaseDll, assemblyName: "asm1");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -1559,7 +1559,7 @@ public class CF1
         {
             var folder = Temp.CreateDirectory();
             var comp0 = CreateStandardCompilation(source0, options: TestOptions.ReleaseModule, assemblyName: "asm0");
-            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: Verification.Fails).EmittedAssemblyData);
+            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: Verification.Skipped).EmittedAssemblyData);
             var ref0 = asm0.GetReference();
 
             var comp1 = CreateStandardCompilation(source1, new[] { ref0 }, options: TestOptions.ReleaseDll, assemblyName: "asm1");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -1473,7 +1473,7 @@ public class CF1
             Assert.True(token.IsNil);   //could the type ref be located? If not then the attribute's not there.
 
             // Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify: Verification.Skipped,
+            CompileAndVerify(appCompilation, verify: Verification.Fails,
                 symbolValidator: m =>
                 {
                     var peReader1 = ((PEModuleSymbol)m).Module.GetMetadataReader();
@@ -1559,7 +1559,7 @@ public class CF1
         {
             var folder = Temp.CreateDirectory();
             var comp0 = CreateStandardCompilation(source0, options: TestOptions.ReleaseModule, assemblyName: "asm0");
-            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: Verification.Skipped).EmittedAssemblyData);
+            var asm0 = ModuleMetadata.CreateFromImage(CompileAndVerify(comp0, verify: Verification.Fails).EmittedAssemblyData);
             var ref0 = asm0.GetReference();
 
             var comp1 = CreateStandardCompilation(source1, new[] { ref0 }, options: TestOptions.ReleaseDll, assemblyName: "asm1");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -6929,7 +6929,7 @@ public class CF3<T>
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation(modSource,
                 new List<MetadataReference>()
@@ -7000,7 +7000,7 @@ extern alias FT1;
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("",
                 new List<MetadataReference>()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -6920,7 +6920,7 @@ public class CF3<T>
                 }, TestOptions.ReleaseDll);
 
             // Exported types in .Net modules cause PEVerify to fail.
-            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(CF3<byte>))]",
                 new List<MetadataReference>()
@@ -6929,7 +6929,7 @@ public class CF3<T>
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation(modSource,
                 new List<MetadataReference>()
@@ -7000,7 +7000,7 @@ extern alias FT1;
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("",
                 new List<MetadataReference>()
@@ -17457,7 +17457,7 @@ public class B : A
 ";
             var comp = CreateStandardCompilation(source, options: TestOptions.DebugDll);
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Skipped).
+            var verifier = CompileAndVerify(comp, verify: Verification.Fails).
                            VerifyDiagnostics(
     // (8,17): warning CS0824: Constructor 'B.B()' is marked external
     //   public extern B();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -6920,7 +6920,7 @@ public class CF3<T>
                 }, TestOptions.ReleaseDll);
 
             // Exported types in .Net modules cause PEVerify to fail.
-            CompileAndVerify(compilation, verify: false).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(CF3<byte>))]",
                 new List<MetadataReference>()
@@ -6929,7 +6929,7 @@ public class CF3<T>
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: false).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation(modSource,
                 new List<MetadataReference>()
@@ -7000,7 +7000,7 @@ extern alias FT1;
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            CompileAndVerify(compilation, verify: false).VerifyDiagnostics();
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("",
                 new List<MetadataReference>()
@@ -17457,7 +17457,7 @@ public class B : A
 ";
             var comp = CreateStandardCompilation(source, options: TestOptions.DebugDll);
 
-            var verifier = CompileAndVerify(comp, verify: false).
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped).
                            VerifyDiagnostics(
     // (8,17): warning CS0824: Constructor 'B.B()' is marked external
     //   public extern B();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -6919,8 +6919,8 @@ public class CF3<T>
                     forwardedTypes1Ref
                 }, TestOptions.ReleaseDll);
 
-            // Exported types in .Net modules cause PEVerify to fail.
-            CompileAndVerify(compilation, verify: Verification.Fails).VerifyDiagnostics();
+            // Exported types in .Net modules cause PEVerify to fail on some platforms.
+            CompileAndVerify(compilation, verify: Verification.Skipped).VerifyDiagnostics();
 
             compilation = CreateStandardCompilation("[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(CF3<byte>))]",
                 new List<MetadataReference>()
@@ -17457,7 +17457,7 @@ public class B : A
 ";
             var comp = CreateStandardCompilation(source, options: TestOptions.DebugDll);
 
-            var verifier = CompileAndVerify(comp, verify: Verification.Fails).
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped).
                            VerifyDiagnostics(
     // (8,17): warning CS0824: Constructor 'B.B()' is marked external
     //   public extern B();

--- a/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
@@ -1499,7 +1499,7 @@ class Class3
                         Assert.Equal("<>f__AnonymousType2", types[2]);
                         Assert.Equal("<>f__AnonymousType3<<b>j__TPar, <a>j__TPar>", types[3]);
                     },
-                    verify: false
+                    verify: Verification.Skipped
                 );
 
                 // do some speculative semantic query

--- a/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
@@ -1499,7 +1499,7 @@ class Class3
                         Assert.Equal("<>f__AnonymousType2", types[2]);
                         Assert.Equal("<>f__AnonymousType3<<b>j__TPar, <a>j__TPar>", types[3]);
                     },
-                    verify: Verification.Skipped
+                    verify: Verification.Passes
                 );
 
                 // do some speculative semantic query

--- a/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
@@ -426,7 +426,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -1824,7 +1824,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
                 //FIXME: Can't verify because the metadata adapter isn't implemented yet
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -3184,7 +3184,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4427,7 +4427,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4793,7 +4793,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4979,7 +4979,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
 
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
@@ -5176,7 +5176,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false,
+                verify: Verification.Skipped,
                 options: TestOptions.ReleaseExe.WithModuleName("MODULE"));
 
             verifier.VerifyDiagnostics(
@@ -5397,7 +5397,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -5534,7 +5534,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -5804,7 +5804,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6031,7 +6031,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6230,7 +6230,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -6589,7 +6589,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6750,7 +6750,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7022,7 +7022,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7149,7 +7149,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7270,7 +7270,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: false);
+                verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;

--- a/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/CodeGen/WinRTCollectionTests.cs
@@ -426,7 +426,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -1824,7 +1824,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
                 //FIXME: Can't verify because the metadata adapter isn't implemented yet
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -3184,7 +3184,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4427,7 +4427,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4793,7 +4793,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -4979,7 +4979,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
 
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
@@ -5176,7 +5176,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped,
+                verify: Verification.Fails,
                 options: TestOptions.ReleaseExe.WithModuleName("MODULE"));
 
             verifier.VerifyDiagnostics(
@@ -5397,7 +5397,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -5534,7 +5534,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -5804,7 +5804,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6031,7 +6031,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6230,7 +6230,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (3,1): info CS8019: Unnecessary using directive.
                 // using System.Reflection;
@@ -6589,7 +6589,7 @@ class AllMembers
 }";
             var verifier = CompileAndVerifyWinRt(source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -6750,7 +6750,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7022,7 +7022,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7149,7 +7149,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;
@@ -7270,7 +7270,7 @@ class AllMembers
             var verifier = CompileAndVerifyWinRt(
                 source,
                 additionalRefs: LegacyRefs,
-                verify: Verification.Skipped);
+                verify: Verification.Fails);
             verifier.VerifyDiagnostics(
                 // (2,1): info CS8019: Unnecessary using directive.
                 // using System.Collections.Generic;

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -2357,7 +2357,7 @@ public partial class A : I
                     SystemCoreRef_v4_0_30319_17929,
                     _eventLibRef,
                 },
-                verify: OSVersion.IsWin8);
+                verify: OSVersion.IsWin8 ? Verification.Passes : Verification.Fails);
 
             verifier.VerifyDiagnostics(
     // (6,42): warning CS0067: The event 'A.d2' is never used

--- a/src/Compilers/CSharp/Test/WinRT/WinRTUtil.cs
+++ b/src/Compilers/CSharp/Test/WinRT/WinRTUtil.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 source,
                 additionalRefs: additionalRefs,
                 expectedOutput: isWin8 ? expectedOutput : null,
-                verify: isWin8);
+                verify: isWin8 ? Verification.Passes : Verification.Fails);
         }
 
     }

--- a/src/Compilers/Test/Utilities/CSharp/BasicCompilationUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/BasicCompilationUtils.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public static class BasicCompilationUtils
     {
-        public static MetadataReference CompileToMetadata(string source, string assemblyName = null, IEnumerable<MetadataReference> references = null, bool verify = true)
+        public static MetadataReference CompileToMetadata(string source, string assemblyName = null, IEnumerable<MetadataReference> references = null, Verification verify = Verification.Passes)
         {
             if (references == null)
             {

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             CompilationOptions options = null,
             ParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             return base.CompileAndVerify(
                 source: source,
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             CompilationOptions options = null,
             ParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             return base.CompileAndVerify(
                 sources,
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             string expectedOutput = null,
             MetadataReference[] additionalRefs = null,
             CSharpCompilationOptions options = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             if (options == null)
             {
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             int? expectedReturnCode = null,
             string[] args = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             return base.CompileAndVerify(
                 compilation,

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -48,7 +48,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Boolean = True
+        Optional verify As Verification = Verification.Passes
     ) As CompilationVerifier
 
         Return CompileAndVerify(
@@ -80,7 +80,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedReturnCode As Integer? = Nothing,
         Optional args As String() = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Boolean = True) As CompilationVerifier
+        Optional verify As Verification = Verification.Passes) As CompilationVerifier
 
         Return MyBase.CompileAndVerify(
             compilation,
@@ -108,7 +108,7 @@ Public MustInherit Class BasicTestBase
         Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Boolean = True) As CompilationVerifier
+        Optional verify As Verification = Verification.Passes) As CompilationVerifier
 
         Return CompileAndVerify(
             compilation,
@@ -139,7 +139,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Boolean = True,
+        Optional verify As Verification = Verification.Passes,
         Optional useLatestFramework As Boolean = False
     ) As CompilationVerifier
 
@@ -177,7 +177,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Boolean = True
+        Optional verify As Verification = Verification.Passes
     ) As CompilationVerifier
 
         If options Is Nothing Then
@@ -218,7 +218,7 @@ Public MustInherit Class BasicTestBase
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
         Optional assemblyName As String = Nothing,
-        Optional verify As Boolean = True
+        Optional verify As Verification = Verification.Passes
     ) As CompilationVerifier
 
         If options Is Nothing Then
@@ -255,7 +255,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Boolean = True
+        Optional verify As Verification = Verification.Passes
     ) As CompilationVerifier
         Return Me.CompileAndVerify(
             source,
@@ -270,7 +270,7 @@ Public MustInherit Class BasicTestBase
             expectedSignatures,
             options,
             parseOptions,
-            verify:=OSVersion.IsWin8)
+            verify:=If(OSVersion.IsWin8, verify, Verification.Skipped))
     End Function
 
     Friend Shadows Function CompileAndVerifyOnWin8Only(
@@ -286,7 +286,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Boolean = True
+        Optional verify As Verification = Verification.Passes
     ) As CompilationVerifier
         Return CompileAndVerifyOnWin8Only(
             source,
@@ -315,7 +315,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Boolean = True,
+        Optional verify As Verification = Verification.Passes,
         Optional useLatestFramework As Boolean = False
     ) As CompilationVerifier
         Return CompileAndVerify(
@@ -329,7 +329,7 @@ Public MustInherit Class BasicTestBase
             expectedSignatures:=expectedSignatures,
             options:=options,
             parseOptions:=parseOptions,
-            verify:=OSVersion.IsWin8 AndAlso verify,
+            verify:=If(OSVersion.IsWin8, verify, Verification.Skipped),
             useLatestFramework:=useLatestFramework)
     End Function
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -882,7 +882,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=False,
+        CompileAndVerify(compilation, verify:=Verification.Skipped,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()
@@ -913,7 +913,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=False,
+        CompileAndVerify(compilation, verify:=Verification.Skipped,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()
@@ -947,7 +947,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=False,
+        CompileAndVerify(compilation, verify:=Verification.Skipped,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -882,7 +882,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=Verification.Skipped,
+        CompileAndVerify(compilation, verify:=Verification.Fails,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()
@@ -913,7 +913,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=Verification.Skipped,
+        CompileAndVerify(compilation, verify:=Verification.Fails,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()
@@ -947,7 +947,7 @@ end class
     ]]></file>
 </compilation>, options:=TestOptions.ReleaseDll, references:={MscorlibRef_v4_0_30316_17626, hash_module})
 
-        CompileAndVerify(compilation, verify:=Verification.Skipped,
+        CompileAndVerify(compilation, verify:=Verification.Fails,
             manifestResources:=hash_resources,
             validator:=Sub(peAssembly)
                            Dim reader = peAssembly.ManifestModule.GetMetadataReader()

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
@@ -799,7 +799,7 @@ End Class
 "
             Dim parseOptions As New VisualBasicParseOptions(preprocessorSymbols:={New KeyValuePair(Of String, Object)("Defined", True)})
             Dim comp = CreateCompilationWithMscorlib({VisualBasicSyntaxTree.ParseText(source, parseOptions)}, options:=TestOptions.ReleaseModule)
-            CompileAndVerify(comp, verify:=Verification.Skipped).VerifyIL("C.M", "
+            CompileAndVerify(comp, verify:=Verification.Fails).VerifyIL("C.M", "
 {
   // Code size        7 (0x7)
   .maxstack  1

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Conditional.vb
@@ -799,7 +799,7 @@ End Class
 "
             Dim parseOptions As New VisualBasicParseOptions(preprocessorSymbols:={New KeyValuePair(Of String, Object)("Defined", True)})
             Dim comp = CreateCompilationWithMscorlib({VisualBasicSyntaxTree.ParseText(source, parseOptions)}, options:=TestOptions.ReleaseModule)
-            CompileAndVerify(comp, verify:=False).VerifyIL("C.M", "
+            CompileAndVerify(comp, verify:=Verification.Skipped).VerifyIL("C.M", "
 {
   // Code size        7 (0x7)
   .maxstack  1

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_StructLayout.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_StructLayout.vb
@@ -387,8 +387,8 @@ End Class
                 End Sub
 
             CompileAndVerify(verifiable, validator:=validator)
-            CompileAndVerify(unverifiable, validator:=validator, verify:=False)
-            CompileAndVerify(unloadable, validator:=validator, verify:=False)
+            CompileAndVerify(unverifiable, validator:=validator, verify:=Verification.Skipped)
+            CompileAndVerify(unloadable, validator:=validator, verify:=Verification.Skipped)
         End Sub
 
         <Fact>
@@ -564,7 +564,7 @@ End Class
     </file>
 </compilation>
             ' type C can't be loaded
-            CompileAndVerify(source, verify:=False)
+            CompileAndVerify(source, verify:=Verification.Skipped)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_StructLayout.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_StructLayout.vb
@@ -387,8 +387,8 @@ End Class
                 End Sub
 
             CompileAndVerify(verifiable, validator:=validator)
-            CompileAndVerify(unverifiable, validator:=validator, verify:=Verification.Skipped)
-            CompileAndVerify(unloadable, validator:=validator, verify:=Verification.Skipped)
+            CompileAndVerify(unverifiable, validator:=validator, verify:=Verification.Fails)
+            CompileAndVerify(unloadable, validator:=validator, verify:=Verification.Fails)
         End Sub
 
         <Fact>
@@ -564,7 +564,7 @@ End Class
     </file>
 </compilation>
             ' type C can't be loaded
-            CompileAndVerify(source, verify:=Verification.Skipped)
+            CompileAndVerify(source, verify:=Verification.Fails)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Synthesized.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Synthesized.vb
@@ -934,7 +934,7 @@ BC35000: Requested operation is not available because the runtime library functi
                 ' NYI: /addmodule support
                 ' TODO: PEVerify currently fails for netmodules with error: "The module X was expected to contain an assembly manifest".
                 ' TODO: Remove the 'verify' named argument once /addmodule support has been added.
-                CompileAndVerify(comp, verify:=outputKindFlag <> OutputKind.NetModule)
+                CompileAndVerify(comp, verify:=If(outputKindFlag <> OutputKind.NetModule, Verification.Passes, Verification.Skipped))
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -4642,7 +4642,7 @@ End Class
             ' Dev10 Runtime Exception:
             ' Unhandled Exception: System.TypeLoadException: Windows Runtime types can only be declared in Windows Runtime assemblies.
 
-            Dim validator = CompileAndVerify(source, sourceSymbolValidator:=sourceValidator, symbolValidator:=metadataValidator, verify:=False)
+            Dim validator = CompileAndVerify(source, sourceSymbolValidator:=sourceValidator, symbolValidator:=metadataValidator, verify:=Verification.Skipped)
             validator.EmitAndVerify("Type load failed.")
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -4642,7 +4642,7 @@ End Class
             ' Dev10 Runtime Exception:
             ' Unhandled Exception: System.TypeLoadException: Windows Runtime types can only be declared in Windows Runtime assemblies.
 
-            Dim validator = CompileAndVerify(source, sourceSymbolValidator:=sourceValidator, symbolValidator:=metadataValidator, verify:=Verification.Skipped)
+            Dim validator = CompileAndVerify(source, sourceSymbolValidator:=sourceValidator, symbolValidator:=metadataValidator, verify:=Verification.Fails)
             validator.EmitAndVerify("Type load failed.")
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -2001,7 +2001,7 @@ End Class
 ]]></file>
 </compilation>, {New VisualBasicCompilationReference(ca)}, options:=TestOptions.ReleaseModule.WithStrongNameProvider(s_defaultProvider))
 
-        CompileAndVerify(cb, verify:=False).Diagnostics.Verify()
+        CompileAndVerify(cb, verify:=Verification.Skipped).Diagnostics.Verify()
     End Sub
 
     <Fact, WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -2001,7 +2001,7 @@ End Class
 ]]></file>
 </compilation>, {New VisualBasicCompilationReference(ca)}, options:=TestOptions.ReleaseModule.WithStrongNameProvider(s_defaultProvider))
 
-        CompileAndVerify(cb, verify:=Verification.Skipped).Diagnostics.Verify()
+        CompileAndVerify(cb, verify:=Verification.Fails).Diagnostics.Verify()
     End Sub
 
     <Fact, WorkItem(1072350, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1072350")>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1689,7 +1689,7 @@ End Class
 "
             ' The compilation succeeds even though CompilerGeneratedAttribute and DebuggerNonUserCodeAttribute are not available.
             Dim compilation = CompilationUtils.CreateCompilation({Parse(source), Parse(corlib)})
-            Dim verifier = CompileAndVerify(compilation, verify:=False)
+            Dim verifier = CompileAndVerify(compilation, verify:=Verification.Skipped)
             verifier.VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1689,7 +1689,7 @@ End Class
 "
             ' The compilation succeeds even though CompilerGeneratedAttribute and DebuggerNonUserCodeAttribute are not available.
             Dim compilation = CompilationUtils.CreateCompilation({Parse(source), Parse(corlib)})
-            Dim verifier = CompileAndVerify(compilation, verify:=Verification.Skipped)
+            Dim verifier = CompileAndVerify(compilation, verify:=Verification.Fails)
             verifier.VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
@@ -357,7 +357,7 @@ System.Console.Write("complete")
                 "s0.dll",
                 syntaxTree:=Parse(source0.Value, parseOptions),
                 references:=references)
-            Dim verifier = CompileAndVerify(s0, verify:=Verification.Skipped)
+            Dim verifier = CompileAndVerify(s0, verify:=Verification.Fails)
             Dim methodData = verifier.TestData.GetMethodData("Script.<Initialize>")
             Assert.Equal("System.Threading.Tasks.Task(Of Object)", methodData.Method.ReturnType.ToDisplayString())
             methodData.VerifyIL(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenScriptTests.vb
@@ -2,6 +2,7 @@
 
 Imports System.IO
 Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
@@ -356,7 +357,7 @@ System.Console.Write("complete")
                 "s0.dll",
                 syntaxTree:=Parse(source0.Value, parseOptions),
                 references:=references)
-            Dim verifier = CompileAndVerify(s0, verify:=False)
+            Dim verifier = CompileAndVerify(s0, verify:=Verification.Skipped)
             Dim methodData = verifier.TestData.GetMethodData("Script.<Initialize>")
             Assert.Equal("System.Threading.Tasks.Task(Of Object)", methodData.Method.ReturnType.ToDisplayString())
             methodData.VerifyIL(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -11272,7 +11272,7 @@ Class C
 End Class
     ]]></file>
 </compilation>)
-            CompileAndVerify(compilation, sourceSymbolValidator:=validator, symbolValidator:=validator, verify:=False)
+            CompileAndVerify(compilation, sourceSymbolValidator:=validator, symbolValidator:=validator, verify:=Verification.Skipped)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -11272,7 +11272,7 @@ Class C
 End Class
     ]]></file>
 </compilation>)
-            CompileAndVerify(compilation, sourceSymbolValidator:=validator, symbolValidator:=validator, verify:=Verification.Skipped)
+            CompileAndVerify(compilation, sourceSymbolValidator:=validator, symbolValidator:=validator, verify:=Verification.Passes)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -511,7 +511,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIIterableMembers", <![CDATA[
 {
@@ -1585,7 +1585,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             verifier.VerifyIL("AllMembers.TestIMapIntIntMembers", <![CDATA[
 {
   // Code size      756 (0x2f4)
@@ -2493,7 +2493,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIVectorIntIVectorViewIntIMapIntIntIMapViewIntIntMembers", <![CDATA[
 {
@@ -3700,7 +3700,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestISimpleInterfaceImplMembers", <![CDATA[
 {
@@ -4037,7 +4037,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestCollectionInitializers", <![CDATA[
 {
@@ -4207,7 +4207,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestExpressionTreeCompiler", <![CDATA[
 {
@@ -4378,7 +4378,7 @@ End Class
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
                 options:=TestOptions.ReleaseExe.WithModuleName("MODULE"),
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestLINQ", <![CDATA[
 {
@@ -4608,7 +4608,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNamedArguments", <![CDATA[
 {
@@ -4729,7 +4729,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNullableArgs", <![CDATA[
 {
@@ -4964,7 +4964,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorMembers", <![CDATA[
 {
@@ -5184,7 +5184,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableMembers", <![CDATA[
 {
@@ -5338,7 +5338,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorIVectorIntMembers", <![CDATA[
 {
@@ -5689,7 +5689,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableIIterableMembers", <![CDATA[
 {
@@ -5820,7 +5820,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionAndBindableVectorMembers", <![CDATA[
 {
@@ -6079,7 +6079,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionChangedMembers", <![CDATA[
 {
@@ -6181,7 +6181,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=False)
+                verify:=Verification.Skipped)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.IPropertyChangedMembers", <![CDATA[
 {
@@ -6239,7 +6239,7 @@ End Class
 
             Dim comp = CompileAndVerify(src,
                                         additionalRefs:=LegacyRefs,
-                                        verify:=False,
+                                        verify:=Verification.Skipped,
                                         options:=TestOptions.ReleaseExe)
 
             comp.VerifyIL("A.Main", <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -511,7 +511,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIIterableMembers", <![CDATA[
 {
@@ -1585,7 +1585,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             verifier.VerifyIL("AllMembers.TestIMapIntIntMembers", <![CDATA[
 {
   // Code size      756 (0x2f4)
@@ -2493,7 +2493,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIVectorIntIVectorViewIntIMapIntIntIMapViewIntIntMembers", <![CDATA[
 {
@@ -3700,7 +3700,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestISimpleInterfaceImplMembers", <![CDATA[
 {
@@ -4037,7 +4037,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestCollectionInitializers", <![CDATA[
 {
@@ -4207,7 +4207,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestExpressionTreeCompiler", <![CDATA[
 {
@@ -4378,7 +4378,7 @@ End Class
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
                 options:=TestOptions.ReleaseExe.WithModuleName("MODULE"),
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestLINQ", <![CDATA[
 {
@@ -4608,7 +4608,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNamedArguments", <![CDATA[
 {
@@ -4729,7 +4729,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestNullableArgs", <![CDATA[
 {
@@ -4964,7 +4964,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorMembers", <![CDATA[
 {
@@ -5184,7 +5184,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableMembers", <![CDATA[
 {
@@ -5338,7 +5338,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableVectorIVectorIntMembers", <![CDATA[
 {
@@ -5689,7 +5689,7 @@ End Class
 
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.TestIBindableIterableIIterableMembers", <![CDATA[
 {
@@ -5820,7 +5820,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionAndBindableVectorMembers", <![CDATA[
 {
@@ -6079,7 +6079,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.INotifyCollectionChangedMembers", <![CDATA[
 {
@@ -6181,7 +6181,7 @@ End Class
             Dim verifier = CompileAndVerify(
                 source,
                 additionalRefs:=LegacyRefs,
-                verify:=Verification.Skipped)
+                verify:=Verification.Fails)
             AssertNoErrorsOrWarnings(verifier)
             verifier.VerifyIL("AllMembers.IPropertyChangedMembers", <![CDATA[
 {
@@ -6239,7 +6239,7 @@ End Class
 
             Dim comp = CompileAndVerify(src,
                                         additionalRefs:=LegacyRefs,
-                                        verify:=Verification.Skipped,
+                                        verify:=Verification.Fails,
                                         options:=TestOptions.ReleaseExe)
 
             comp.VerifyIL("A.Main", <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -3379,7 +3379,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib(source1, OutputKind.NetModule)
             Dim metadataRef = comp.EmitToImageReference()
-            CompileAndVerify(source2, additionalRefs:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Skipped)
+            CompileAndVerify(source2, additionalRefs:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Fails)
         End Sub
 
         <Fact>
@@ -3825,7 +3825,7 @@ End interface
 
             Dim compilation = CreateCompilationWithReferences(source, {TestReferences.SymbolsTests.netModule.x64COFF}, TestOptions.DebugDll)
 
-            CompileAndVerify(compilation, verify:=Verification.Skipped)
+            CompileAndVerify(compilation, verify:=Verification.Fails)
             Assert.NotSame(compilation.Assembly.CorLibrary, compilation.Assembly)
             compilation.GetSpecialType(SpecialType.System_Int32)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -384,7 +384,7 @@ End Class"
             Dim source = <compilation>
                              <file name="a.vb"></file>
                          </compilation>
-            CompileAndVerify(source, emitOptions:=emitRefAssembly, verify:=True, validator:=assemblyValidator)
+            CompileAndVerify(source, emitOptions:=emitRefAssembly, verify:=Verification.Passes, validator:=assemblyValidator)
         End Sub
 
         <Fact>
@@ -400,7 +400,7 @@ End Class"
 
             Dim comp = CreateCompilation({Parse("")})
             comp.MakeMemberMissing(WellKnownMember.System_Runtime_CompilerServices_ReferenceAssemblyAttribute__ctor)
-            CompileAndVerify(comp, emitOptions:=emitRefAssembly, verify:=True, validator:=assemblyValidator)
+            CompileAndVerify(comp, emitOptions:=emitRefAssembly, verify:=Verification.Passes, validator:=assemblyValidator)
         End Sub
 
         <Fact>
@@ -425,7 +425,7 @@ End Class"
 <assembly:System.Runtime.CompilerServices.ReferenceAssembly()>
                          ]]></file>
                          </compilation>
-            CompileAndVerify(source, emitOptions:=emitRefAssembly, verify:=True, validator:=assemblyValidator)
+            CompileAndVerify(source, emitOptions:=emitRefAssembly, verify:=Verification.Passes, validator:=assemblyValidator)
         End Sub
 
         <Fact>
@@ -1025,7 +1025,7 @@ End Class"
                             parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5),
                             options:=TestOptions.DebugDll.WithDeterministic(True))
 
-            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=True)
+            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=Verification.Passes)
 
             ' verify metadata (types, members, attributes) of the regular assembly
             Dim realImage = comp.EmitToImageReference(EmitOptions.Default)
@@ -1058,7 +1058,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the metadata-only assembly
             Dim emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(True)
-            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=Verification.Passes)
 
             Dim metadataImage = comp.EmitToImageReference(emitMetadataOnly)
             Dim compWithMetadata = CreateCompilation("", references:={MscorlibRef, metadataImage},
@@ -1092,7 +1092,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the ref assembly
             Dim emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
-            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=Verification.Passes)
 
             Dim refImage = comp.EmitToImageReference(emitRefOnly)
             Dim compWithRef = CreateCompilation("", references:={MscorlibRef, refImage},
@@ -1142,7 +1142,7 @@ End Class"
             Dim comp As Compilation = CreateCompilation(source, references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))
 
-            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=True)
+            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=Verification.Passes)
 
             ' verify metadata (types, members, attributes) of the regular assembly
             Dim realImage = comp.EmitToImageReference(EmitOptions.Default)
@@ -1160,7 +1160,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the metadata-only assembly
             Dim emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(True)
-            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=Verification.Passes)
 
             Dim metadataImage = comp.EmitToImageReference(emitMetadataOnly)
             Dim compWithMetadata = CreateCompilation("", references:={MscorlibRef, metadataImage},
@@ -1179,7 +1179,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the ref assembly
             Dim emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
-            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=Verification.Passes)
 
             Dim refImage = comp.EmitToImageReference(emitRefOnly)
             Dim compWithRef = CreateCompilation("", references:={MscorlibRef, refImage},
@@ -1220,7 +1220,7 @@ End Class"
             Dim comp As Compilation = CreateCompilation(source, references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))
 
-            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=True)
+            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=Verification.Passes)
 
             ' verify metadata (types, members, attributes) of the regular assembly
             Dim realImage = comp.EmitToImageReference(EmitOptions.Default)
@@ -1239,7 +1239,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the metadata-only assembly
             Dim emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(True)
-            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitMetadataOnly, verify:=Verification.Passes)
 
             Dim metadataImage = comp.EmitToImageReference(emitMetadataOnly)
             Dim compWithMetadata = CreateCompilation("", references:={MscorlibRef, metadataImage},
@@ -1259,7 +1259,7 @@ End Class"
 
             ' verify metadata (types, members, attributes) of the ref assembly
             Dim emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
-            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=Verification.Passes)
 
             Dim refImage = comp.EmitToImageReference(emitRefOnly)
             Dim compWithRef = CreateCompilation("", references:={MscorlibRef, refImage},
@@ -1287,11 +1287,11 @@ End Structure"
             Dim comp As Compilation = CreateCompilation(source, references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))
 
-            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=True)
+            Dim verifier = CompileAndVerify(comp, emitOptions:=EmitOptions.Default.WithEmitMetadataOnly(True), verify:=Verification.Passes)
 
             ' verify metadata (types, members, attributes) of the ref assembly
             Dim emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
-            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=True)
+            CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=Verification.Passes)
 
             Dim refImage = comp.EmitToImageReference(emitRefOnly)
             Dim compWithRef = CreateCompilation("", references:={MscorlibRef, refImage},
@@ -3379,7 +3379,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib(source1, OutputKind.NetModule)
             Dim metadataRef = comp.EmitToImageReference()
-            CompileAndVerify(source2, additionalRefs:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=False)
+            CompileAndVerify(source2, additionalRefs:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Skipped)
         End Sub
 
         <Fact>
@@ -3825,7 +3825,7 @@ End interface
 
             Dim compilation = CreateCompilationWithReferences(source, {TestReferences.SymbolsTests.netModule.x64COFF}, TestOptions.DebugDll)
 
-            CompileAndVerify(compilation, verify:=False)
+            CompileAndVerify(compilation, verify:=Verification.Skipped)
             Assert.NotSame(compilation.Assembly.CorLibrary, compilation.Assembly)
             compilation.GetSpecialType(SpecialType.System_Int32)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -442,7 +442,7 @@ End Class")
             Dim compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 20)))
             Dim compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 30)))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim reader0 = md0.MetadataReader
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -442,7 +442,7 @@ End Class")
             Dim compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 20)))
             Dim compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 30)))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim reader0 = md0.MetadataReader
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4436,7 +4436,7 @@ End Class
             ' older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4495,7 +4495,7 @@ End Class
             ' the ctor is missing a parameter
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4550,7 +4550,7 @@ End Class
             ' older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4613,7 +4613,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
             Dim compilation1 = compilation0.WithSource(source1.Tree)
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4665,7 +4665,7 @@ End Class
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Fails)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4703,7 +4703,7 @@ End Class
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4742,7 +4742,7 @@ End Class
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Fails)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4782,7 +4782,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
             Dim compilation1 = compilation0.WithSource(source1.Tree)
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Passes)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4436,7 +4436,7 @@ End Class
             ' older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4495,7 +4495,7 @@ End Class
             ' the ctor is missing a parameter
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4550,7 +4550,7 @@ End Class
             ' older versions of mscorlib don't contain IteratorStateMachineAttribute
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4613,7 +4613,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
             Dim compilation1 = compilation0.WithSource(source1.Tree)
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
@@ -4665,7 +4665,7 @@ End Class
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4703,7 +4703,7 @@ End Class
 
             Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4742,7 +4742,7 @@ End Class
 
             Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
@@ -4782,7 +4782,7 @@ End Class
             Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
             Dim compilation1 = compilation0.WithSource(source1.Tree)
 
-            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim v0 = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
             Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
             Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -1530,7 +1530,7 @@ End Interface
 ]]></file>
                            </compilation>
             Dim compilation0 = CreateCompilationWithMscorlib(sources0)
-            Dim verifier = CompileAndVerify(compilation0, verify:=False)
+            Dim verifier = CompileAndVerify(compilation0, verify:=Verification.Skipped)
             AssertTheseDiagnostics(verifier, (<errors/>))
             Dim validator As Action(Of ModuleSymbol) = Sub([module])
                                                            DirectCast([module], PEModuleSymbol).Module.PretendThereArentNoPiaLocalTypes()
@@ -1600,13 +1600,13 @@ End Interface
                 sources1,
                 options:=TestOptions.DebugDll,
                 additionalRefs:={New VisualBasicCompilationReference(compilation0, embedInteropTypes:=True), SystemCoreRef})
-            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=False)
+            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Skipped)
             AssertTheseDiagnostics(verifier, (<errors/>))
             compilation1 = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
                 sources1,
                 options:=TestOptions.DebugDll,
                 additionalRefs:={compilation0.EmitToImageReference(embedInteropTypes:=True), SystemCoreRef})
-            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=False)
+            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Skipped)
             AssertTheseDiagnostics(verifier, (<errors/>))
         End Sub
 
@@ -3708,12 +3708,12 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
             Dim compilation3 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={New VisualBasicCompilationReference(piaCompilation2)})
-            CompileAndVerify(compilation3, verify:=False)
+            CompileAndVerify(compilation3, verify:=Verification.Skipped)
 
             Dim compilation4 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={MetadataReference.CreateFromImage(piaCompilation2.EmitToArray())})
-            CompileAndVerify(compilation4, verify:=False)
+            CompileAndVerify(compilation4, verify:=Verification.Skipped)
         End Sub
 
         <Fact()>
@@ -4128,12 +4128,12 @@ BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it
             Dim compilation3 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={New VisualBasicCompilationReference(piaCompilation2)})
-            CompileAndVerify(compilation3, verify:=False)
+            CompileAndVerify(compilation3, verify:=Verification.Skipped)
 
             Dim compilation4 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={MetadataReference.CreateFromImage(piaCompilation2.EmitToArray())})
-            CompileAndVerify(compilation4, verify:=False)
+            CompileAndVerify(compilation4, verify:=Verification.Skipped)
         End Sub
 
         <Fact(), WorkItem(673546, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673546")>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -1530,7 +1530,7 @@ End Interface
 ]]></file>
                            </compilation>
             Dim compilation0 = CreateCompilationWithMscorlib(sources0)
-            Dim verifier = CompileAndVerify(compilation0, verify:=Verification.Skipped)
+            Dim verifier = CompileAndVerify(compilation0, verify:=Verification.Fails)
             AssertTheseDiagnostics(verifier, (<errors/>))
             Dim validator As Action(Of ModuleSymbol) = Sub([module])
                                                            DirectCast([module], PEModuleSymbol).Module.PretendThereArentNoPiaLocalTypes()
@@ -1600,13 +1600,13 @@ End Interface
                 sources1,
                 options:=TestOptions.DebugDll,
                 additionalRefs:={New VisualBasicCompilationReference(compilation0, embedInteropTypes:=True), SystemCoreRef})
-            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Skipped)
+            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Fails)
             AssertTheseDiagnostics(verifier, (<errors/>))
             compilation1 = CreateCompilationWithMscorlibAndVBRuntimeAndReferences(
                 sources1,
                 options:=TestOptions.DebugDll,
                 additionalRefs:={compilation0.EmitToImageReference(embedInteropTypes:=True), SystemCoreRef})
-            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Skipped)
+            verifier = CompileAndVerify(compilation1, symbolValidator:=validator, verify:=Verification.Fails)
             AssertTheseDiagnostics(verifier, (<errors/>))
         End Sub
 
@@ -3708,12 +3708,12 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
             Dim compilation3 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={New VisualBasicCompilationReference(piaCompilation2)})
-            CompileAndVerify(compilation3, verify:=Verification.Skipped)
+            CompileAndVerify(compilation3, verify:=Verification.Fails)
 
             Dim compilation4 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={MetadataReference.CreateFromImage(piaCompilation2.EmitToArray())})
-            CompileAndVerify(compilation4, verify:=Verification.Skipped)
+            CompileAndVerify(compilation4, verify:=Verification.Fails)
         End Sub
 
         <Fact()>
@@ -4128,12 +4128,12 @@ BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it
             Dim compilation3 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={New VisualBasicCompilationReference(piaCompilation2)})
-            CompileAndVerify(compilation3, verify:=Verification.Skipped)
+            CompileAndVerify(compilation3, verify:=Verification.Fails)
 
             Dim compilation4 = CreateCompilationWithMscorlibAndReferences(
                 consumer,
                 references:={MetadataReference.CreateFromImage(piaCompilation2.EmitToArray())})
-            CompileAndVerify(compilation4, verify:=Verification.Skipped)
+            CompileAndVerify(compilation4, verify:=Verification.Fails)
         End Sub
 
         <Fact(), WorkItem(673546, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673546")>

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -556,7 +556,7 @@ End Class
             main.VerifyDiagnostics()
 
             ' Disable PE verification, it would need .config file with Lib v1 -> Lib v2 binding redirect.
-            CompileAndVerify(main, verify:=False, validator:=
+            CompileAndVerify(main, verify:=Verification.Skipped, validator:=
                 Sub(assembly)
                     Dim reader = assembly.GetMetadataReader()
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -556,7 +556,7 @@ End Class
             main.VerifyDiagnostics()
 
             ' Disable PE verification, it would need .config file with Lib v1 -> Lib v2 binding redirect.
-            CompileAndVerify(main, verify:=Verification.Skipped, validator:=
+            CompileAndVerify(main, verify:=Verification.Fails, validator:=
                 Sub(assembly)
                     Dim reader = assembly.GetMetadataReader()
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
@@ -1472,7 +1472,7 @@ Public Class Goo(Of T)
 End Class
     </file>
 </compilation>,
-verify:=False,
+verify:=Verification.Skipped,
 expectedOutput:=<![CDATA[Initializing for System.Int64
 Initializing for System.Int32
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
@@ -1472,7 +1472,7 @@ Public Class Goo(Of T)
 End Class
     </file>
 </compilation>,
-verify:=Verification.Skipped,
+verify:=Verification.Fails,
 expectedOutput:=<![CDATA[Initializing for System.Int64
 Initializing for System.Int32
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
@@ -1043,7 +1043,7 @@ End class
             Assert.True(token.IsNil)   'could the type ref be located? If not then the attribute's not there.
 
             ' Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify:=False,
+            CompileAndVerify(appCompilation, verify:=Verification.Skipped,
                 symbolValidator:=Sub(m)
                                      Dim metadataReader1 = DirectCast(m, PEModuleSymbol).Module.GetMetadataReader()
                                      Assert.Equal(1, metadataReader1.GetTableRowCount(TableIndex.ExportedType))
@@ -1143,11 +1143,11 @@ BC30652: Reference required to assembly 'ForwarderTargetAssembly, Version=0.0.0.
                 Assert.Equal("", reader.GetString(exportedTypeRow.Namespace)) 'Empty - presumably there's enough info on the containing type.
                 Assert.Equal(HandleKind.ExportedType, exportedTypeRow.Implementation.Kind)
             Else
-                Assert.Equal(System.Reflection.TypeAttributes.NotPublic Or TypeAttributesMissing.Forwarder, ExportedTypeRow.Attributes)
+                Assert.Equal(System.Reflection.TypeAttributes.NotPublic Or TypeAttributesMissing.Forwarder, exportedTypeRow.Attributes)
                 Assert.Equal(0, exportedTypeRow.GetTypeDefinitionId())
                 Assert.Equal(expectedType, reader.GetString(exportedTypeRow.Name))
                 Assert.Equal(expectedNamespace, reader.GetString(exportedTypeRow.Namespace))
-                Assert.Equal(HandleKind.AssemblyReference, ExportedTypeRow.Implementation.Kind)
+                Assert.Equal(HandleKind.AssemblyReference, exportedTypeRow.Implementation.Kind)
             End If
         End Sub
 
@@ -1211,7 +1211,7 @@ End class
             Dim appCompilation = CreateCompilationWithMscorlibAndReferences(app, {modRef, New VisualBasicCompilationReference(forwardedTypesCompilation)}, TestOptions.ReleaseDll)
 
             ' Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify:=False,
+            CompileAndVerify(appCompilation, verify:=Verification.Skipped,
                 symbolValidator:=Sub(m)
                                      Dim peReader1 = DirectCast(m, PEModuleSymbol).Module.GetMetadataReader()
                                      Assert.Equal(2, peReader1.GetTableRowCount(TableIndex.ExportedType))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/TypeForwarders.vb
@@ -1043,7 +1043,7 @@ End class
             Assert.True(token.IsNil)   'could the type ref be located? If not then the attribute's not there.
 
             ' Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify:=Verification.Skipped,
+            CompileAndVerify(appCompilation, verify:=Verification.Fails,
                 symbolValidator:=Sub(m)
                                      Dim metadataReader1 = DirectCast(m, PEModuleSymbol).Module.GetMetadataReader()
                                      Assert.Equal(1, metadataReader1.GetTableRowCount(TableIndex.ExportedType))
@@ -1211,7 +1211,7 @@ End class
             Dim appCompilation = CreateCompilationWithMscorlibAndReferences(app, {modRef, New VisualBasicCompilationReference(forwardedTypesCompilation)}, TestOptions.ReleaseDll)
 
             ' Exported types in .Net module cause PEVerify to fail.
-            CompileAndVerify(appCompilation, verify:=Verification.Skipped,
+            CompileAndVerify(appCompilation, verify:=Verification.Fails,
                 symbolValidator:=Sub(m)
                                      Dim peReader1 = DirectCast(m, PEModuleSymbol).Module.GetMetadataReader()
                                      Assert.Equal(2, peReader1.GetTableRowCount(TableIndex.ExportedType))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/WinMdEventTest.vb
@@ -846,7 +846,7 @@ End Class
 }
                     </output>
 
-            CompileAndVerify(compilation, verify:=OSVersion.IsWin8).VerifyIL("abcdef.goo", expectedIL.Value())
+            CompileAndVerify(compilation, verify:=If(OSVersion.IsWin8, Verification.Passes, Verification.Skipped)).VerifyIL("abcdef.goo", expectedIL.Value())
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
@@ -1661,7 +1661,7 @@ Imports System
                                 End Sub
 
             CompileAndVerify(source, options:=TestOptions.ReleaseDll, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(True, False))
-            CompileAndVerify(source, options:=TestOptions.ReleaseModule, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(False, True), verify:=False) ' PEVerify doesn't like netmodules
+            CompileAndVerify(source, options:=TestOptions.ReleaseModule, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(False, True), verify:=Verification.Skipped) ' PEVerify doesn't like netmodules
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
@@ -1661,7 +1661,7 @@ Imports System
                                 End Sub
 
             CompileAndVerify(source, options:=TestOptions.ReleaseDll, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(True, False))
-            CompileAndVerify(source, options:=TestOptions.ReleaseModule, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(False, True), verify:=Verification.Skipped) ' PEVerify doesn't like netmodules
+            CompileAndVerify(source, options:=TestOptions.ReleaseModule, sourceSymbolValidator:=validator(True, True), symbolValidator:=validator(False, True), verify:=Verification.Fails) ' PEVerify doesn't like netmodules
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -3196,7 +3196,7 @@ BC37218: Type 'ns.CF2' forwarded to assembly 'ForwardedTypes1, Version=0.0.0.0, 
                 }, TestOptions.ReleaseDll)
 
             ' Exported types in .Net modules cause PEVerify to fail.
-            CompileAndVerify(compilation, verify:=False).VerifyDiagnostics()
+            CompileAndVerify(compilation, verify:=Verification.Skipped).VerifyDiagnostics()
 
             compilation = CreateCompilationWithMscorlibAndReferences(emptySource,
                 {

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -3196,7 +3196,7 @@ BC37218: Type 'ns.CF2' forwarded to assembly 'ForwardedTypes1, Version=0.0.0.0, 
                 }, TestOptions.ReleaseDll)
 
             ' Exported types in .Net modules cause PEVerify to fail.
-            CompileAndVerify(compilation, verify:=Verification.Skipped).VerifyDiagnostics()
+            CompileAndVerify(compilation, verify:=Verification.Fails).VerifyDiagnostics()
 
             compilation = CreateCompilationWithMscorlibAndReferences(emptySource,
                 {

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -22,6 +22,13 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
+    public enum Verification
+    {
+        Passes = 0,
+        Fails,
+        Skipped
+    }
+
     /// <summary>
     /// Base class for all language specific tests.
     /// </summary>
@@ -49,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             CompilationOptions options = null,
             ParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             return CompileAndVerify(
                 sources: new string[] { source },
@@ -80,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             CompilationOptions options = null,
             ParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             if (options == null)
             {
@@ -116,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             int? expectedReturnCode = null,
             string[] args = null,
             EmitOptions emitOptions = null,
-            bool verify = true)
+            Verification verify = Verification.Passes)
         {
             Assert.NotNull(compilation);
 
@@ -124,11 +131,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 (compilation.Options.OutputKind == OutputKind.ConsoleApplication || compilation.Options.OutputKind == OutputKind.WindowsApplication),
                 "Compilation must be executable if output is expected.");
 
-            if (verify)
+            if (verify == Verification.Passes)
             {
                 // Unsafe code might not verify, so don't try.
                 var csharpOptions = compilation.Options as CSharp.CSharpCompilationOptions;
-                verify = (csharpOptions == null || !csharpOptions.AllowUnsafe);
+                verify = (csharpOptions == null || !csharpOptions.AllowUnsafe) ? Verification.Passes : Verification.Skipped;
             }
 
             if (sourceSymbolValidator != null)
@@ -214,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Action<PEAssembly> assemblyValidator,
             Action<IModuleSymbol> symbolValidator,
             EmitOptions emitOptions,
-            bool verify)
+            Verification verify)
         {
             var verifier = new CompilationVerifier(compilation, VisualizeRealIL, dependencies);
 

--- a/src/Test/Utilities/Portable/CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CompilationVerifier.cs
@@ -66,16 +66,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return modules;
         }
 
-        public void Emit(string expectedOutput, int? expectedReturnCode, string[] args, IEnumerable<ResourceDescription> manifestResources, EmitOptions emitOptions, bool peVerify, SignatureDescription[] expectedSignatures)
+        public void Emit(string expectedOutput, int? expectedReturnCode, string[] args, IEnumerable<ResourceDescription> manifestResources, EmitOptions emitOptions, Verification peVerify, SignatureDescription[] expectedSignatures)
         {
             using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
             {
                 string mainModuleName = Emit(testEnvironment, manifestResources, emitOptions);
                 _allModuleData = testEnvironment.GetAllModuleData();
 
-                if (peVerify)
+                if (peVerify == Verification.Passes)
                 {
                     testEnvironment.PeVerify();
+                }
+                else if (peVerify == Verification.Fails)
+                {
+                    Assert.Throws<PeVerifyException>(() => testEnvironment.PeVerify());
                 }
 
                 if (expectedSignatures != null)


### PR DESCRIPTION
We used to skip verification. In order to facilitate evaluation of ILVerify, I'm switching to a model where such cases will instead run verification and expect that it fails.
A few cases are left as "skip".

Fixes https://github.com/dotnet/roslyn/issues/23132