### PR TITLE
Enable full signing during bootstrap for CI

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -140,8 +140,8 @@
             <PublicKey>$(RoslynInternalKey)</PublicKey>
             <PublicKeyToken>fc793a00266884fb</PublicKeyToken>
           </PropertyGroup>
-          <!-- Real-signing is not currently supported cross-platform -->
-          <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+          <!-- Real-signing is only supported cross-platform in the boostrap toolset -->
+          <PropertyGroup Condition="'$(OS)' != 'Windows_NT' AND '$(BootstrapBuildPath)' == ''">
               <PublicSign>true</PublicSign>
           </PropertyGroup>
         </Otherwise>


### PR DESCRIPTION
Currently, full signing is always disabled on Linux/Mac because it was
not supported. Now, it is supported. To avoid taking a dependency on
full signing, this only enables full signing when we're confirmed to be
building with a bootstrap compiler.