### PR TITLE
Do not expose type expression as IDynamicMemberReferenceOperation.Instance

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     methodGroup.LookupSymbolOpt,
                                     methodGroup.LookupError,
                                     methodGroup.Flags & ~BoundMethodGroupFlags.HasImplicitReceiver,
-                                    receiverOpt: new BoundTypeExpression(node, null, this.ContainingType),
+                                    receiverOpt: new BoundTypeExpression(node, null, this.ContainingType).MakeCompilerGenerated(),
                                     resultKind: methodGroup.ResultKind);
                             }
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -675,7 +675,7 @@ namespace Microsoft.CodeAnalysis.Operations
         }
 
         private IDynamicMemberReferenceOperation CreateBoundDynamicMemberAccessOperation(
-            BoundExpression receiver,
+            BoundExpression receiverOpt,
             ImmutableArray<TypeSymbol> typeArgumentsOpt,
             string memberName,
             SyntaxNode syntaxNode,
@@ -683,13 +683,16 @@ namespace Microsoft.CodeAnalysis.Operations
             ConstantValue value,
             bool isImplicit)
         {
-            Lazy<IOperation> instance = new Lazy<IOperation>(() => Create(receiver));
+            Lazy<IOperation> instance = receiverOpt == null || receiverOpt.Kind == BoundKind.TypeExpression ? 
+                                            OperationFactory.NullOperation :
+                                            new Lazy<IOperation>(() => Create(receiverOpt));
+
             ImmutableArray<ITypeSymbol> typeArguments = ImmutableArray<ITypeSymbol>.Empty;
             if (!typeArgumentsOpt.IsDefault)
             {
                 typeArguments = ImmutableArray<ITypeSymbol>.CastUp(typeArgumentsOpt);
             }
-            ITypeSymbol containingType = null;
+            ITypeSymbol containingType = receiverOpt?.Kind == BoundKind.TypeExpression ? receiverOpt.Type : null;
             Optional<object> constantValue = ConvertToOptional(value);
             return new LazyDynamicMemberReferenceExpression(instance, memberName, typeArguments, containingType, _semanticModel, syntaxNode, type, constantValue, isImplicit);
         }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IUsingStatement.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IUsingStatement.cs
@@ -723,10 +723,10 @@ IUsingOperation (OperationKind.Using, Type: null) (Syntax: 'using (d) ... }')
         Expression: 
           IDynamicInvocationOperation (OperationKind.DynamicInvocation, Type: dynamic) (Syntax: 'Console.WriteLine(d)')
             Expression: 
-              IDynamicMemberReferenceOperation (Member Name: ""WriteLine"", Containing Type: null) (OperationKind.DynamicMemberReference, Type: null) (Syntax: 'Console.WriteLine')
+              IDynamicMemberReferenceOperation (Member Name: ""WriteLine"", Containing Type: System.Console) (OperationKind.DynamicMemberReference, Type: null) (Syntax: 'Console.WriteLine')
                 Type Arguments(0)
                 Instance Receiver: 
-                  IOperation:  (OperationKind.None, Type: null) (Syntax: 'Console')
+                  null
             Arguments(1):
                 ILocalReferenceOperation: d (OperationKind.LocalReference, Type: dynamic) (Syntax: 'd')
             ArgumentNames(0)

--- a/src/Compilers/Core/Portable/Operations/IDynamicMemberReferenceOperation.cs
+++ b/src/Compilers/Core/Portable/Operations/IDynamicMemberReferenceOperation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Operations
         ImmutableArray<ITypeSymbol> TypeArguments { get; }
 
         /// <summary>
-        /// The containing type of the referenced member. In C#, this will always be null.
+        /// The containing type of the referenced member, if different from type of the <see cref="Instance"/>.
         /// </summary>
         ITypeSymbol ContainingType { get; }
     }

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundLateMemberAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundLateMemberAccess.vb
@@ -33,6 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub Validate()
             Debug.Assert((AccessKind And LateBoundAccessKind.Call) = 0 OrElse (AccessKind And Not LateBoundAccessKind.Call) = 0)
             Debug.Assert(Type.IsObjectType())
+            Debug.Assert(ReceiverOpt Is Nothing OrElse ReceiverOpt.Kind <> BoundKind.TypeExpression)
         End Sub
 #End If
     End Class

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -840,6 +840,8 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundLateMemberAccessOperation(boundLateMemberAccess As BoundLateMemberAccess) As IDynamicMemberReferenceOperation
+            Debug.Assert(boundLateMemberAccess.ReceiverOpt Is Nothing OrElse boundLateMemberAccess.ReceiverOpt.Kind <> BoundKind.TypeExpression)
+
             Dim instance As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundLateMemberAccess.ReceiverOpt))
             Dim memberName As String = boundLateMemberAccess.NameOpt
             Dim typeArguments As ImmutableArray(Of ITypeSymbol) = ImmutableArray(Of ITypeSymbol).Empty


### PR DESCRIPTION
Related to #22548 and #22229.
