### PR TITLE
Enable multicore JIT in the compilers

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -542,6 +542,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning: Could not enable multicore JIT due to exception: {0}..
+        /// </summary>
+        internal static string ExceptionEnablingMulticoreJit {
+            get {
+                return ResourceManager.GetString("ExceptionEnablingMulticoreJit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Expected non-empty public key.
         /// </summary>
         internal static string ExpectedNonEmptyPublicKey {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -609,4 +609,7 @@
   <data name="InvalidDiagnosticSpanReported" xml:space="preserve">
     <value>Reported diagnostic '{0}' has a source location '{1}' in file '{2}', which is outside of the given file.</value>
   </data>
+  <data name="ExceptionEnablingMulticoreJit" xml:space="preserve">
+    <value>Warning: Could not enable multicore JIT due to exception: {0}.</value>
+  </data>
 </root>

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -6,11 +6,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NET46
+using System.Runtime;
+#else
+using System.Runtime.Loader;
+#endif
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using static Microsoft.CodeAnalysis.CommandLine.CompilerServerLogger;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -51,28 +54,33 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
             var args = originalArguments.Select(arg => arg.Trim()).ToArray();
 
-            bool hasShared;
-            string keepAlive;
-            string errorMessage;
-            string sessionKey;
             List<string> parsedArgs;
+            bool hasShared;
+            string keepAliveOpt;
+            string sessionKeyOpt;
+            string errorMessageOpt;
             if (!CommandLineParser.TryParseClientArgs(
                     args,
                     out parsedArgs,
                     out hasShared,
-                    out keepAlive,
-                    out sessionKey,
-                    out errorMessage))
+                    out keepAliveOpt,
+                    out sessionKeyOpt,
+                    out errorMessageOpt))
             {
-                textWriter.WriteLine(errorMessage);
+                textWriter.WriteLine(errorMessageOpt);
                 return RunCompilationResult.Failed;
+            }
+
+            if (!TryEnableMulticoreJitting(out errorMessageOpt))
+            {
+                textWriter.WriteLine(errorMessageOpt);
             }
 
             if (hasShared)
             {
-                sessionKey = sessionKey ?? GetSessionKey(buildPaths);
+                sessionKeyOpt = sessionKeyOpt ?? GetSessionKey(buildPaths);
                 var libDirectory = Environment.GetEnvironmentVariable("LIB");
-                var serverResult = RunServerCompilation(textWriter, parsedArgs, buildPaths, libDirectory, sessionKey, keepAlive);
+                var serverResult = RunServerCompilation(textWriter, parsedArgs, buildPaths, libDirectory, sessionKeyOpt, keepAliveOpt);
                 if (serverResult.HasValue)
                 {
                     Debug.Assert(serverResult.Value.RanOnServer);
@@ -84,6 +92,37 @@ namespace Microsoft.CodeAnalysis.CommandLine
             // back to normal compilation. 
             var exitCode = RunLocalCompilation(parsedArgs.ToArray(), buildPaths, textWriter);
             return new RunCompilationResult(exitCode);
+        }
+
+        private static bool TryEnableMulticoreJitting(out string errorMessage)
+        {
+            errorMessage = null;
+            try
+            {
+                // Enable multi-core JITing
+                // https://blogs.msdn.microsoft.com/dotnet/2012/10/18/an-easy-solution-for-improving-app-launch-performance/
+                var profileRoot = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "RoslynCompiler",
+                    "ProfileOptimization");
+                var assemblyName = Assembly.GetExecutingAssembly().GetName();
+                var profileName = assemblyName.Name + assemblyName.Version + ".profile";
+                Directory.CreateDirectory(profileRoot);
+#if NET46
+                ProfileOptimization.SetProfileRoot(profileRoot);
+                ProfileOptimization.StartProfile(profileName);
+#else
+                AssemblyLoadContext.Default.SetProfileOptimizationRoot(profileRoot);
+                AssemblyLoadContext.Default.StartProfileOptimization(profileName);
+#endif
+            }
+            catch (Exception e)
+            {
+                errorMessage = string.Format(CodeAnalysisResources.ExceptionEnablingMulticoreJit, e.Message);
+                return false;
+            }
+
+            return true;
         }
 
         public Task<RunCompilationResult> RunCompilationAsync(IEnumerable<string> originalArguments, BuildPaths buildPaths, TextWriter textWriter = null)


### PR DESCRIPTION
Here is the output from my perf testing tool currently in review that
shows a significant difference in csc.exe after the change:

```
// * Detailed results *
PlaceholderBenchmarkRunner.PlaceholderMethod: Job-TGYVCW(Toolchain=Perf.ExternalProcessToolchain, LaunchCount=0, RunStrategy=Monitoring, TargetCount=25, WarmupCount=0) [Commit=HEAD^]
Runtime = ; GC =
Mean = 4.8018 s, StdErr = 0.0215 s (0.45%); N = 25, StdDev = 0.1073 s
Min = 4.6717 s, Q1 = 4.7297 s, Median = 4.7892 s, Q3 = 4.8438 s, Max = 5.1998 s
IQR = 0.1141 s, LowerFence = 4.5585 s, UpperFence = 5.0149 s
ConfidenceInterval = [4.7214 s; 4.8822 s] (CI 99.9%), Margin = 0.0804 s (1.67% of Mean)
Skewness = 1.87, Kurtosis = 7.98

PlaceholderBenchmarkRunner.PlaceholderMethod: Job-TGYVCW(Toolchain=Perf.ExternalProcessToolchain, LaunchCount=0, RunStrategy=Monitoring, TargetCount=25, WarmupCount=0) [Commit=HEAD]
Runtime = ; GC =
Mean = 3.6409 s, StdErr = 0.0650 s (1.78%); N = 25, StdDev = 0.3249 s
Min = 3.4381 s, Q1 = 3.5510 s, Median = 3.5781 s, Q3 = 3.6189 s, Max = 5.1720 s
IQR = 0.0679 s, LowerFence = 3.4491 s, UpperFence = 3.7209 s
ConfidenceInterval = [3.3975 s; 3.8842 s] (CI 99.9%), Margin = 0.2433 s (6.68% of Mean)
Skewness = 4.16, Kurtosis = 19.76

Total time: 00:07:11 (431.13 sec)

// * Summary *

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 1 (10.0.14393)
Processor=Intel Xeon CPU E5645 2.40GHz, ProcessorCount=24
Frequency=2337892 Hz, Resolution=427.7358 ns, Timer=TSC
.NET Core SDK=2.1.1-preview-007094
  [Host] : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT

Toolchain=Perf.ExternalProcessToolchain  LaunchCount=0  RunStrategy=Monitoring
TargetCount=25  WarmupCount=0

            Method | Commit |    Mean |    Error |   StdDev | Rank |
------------------ |------- |--------:|---------:|---------:|-----:|
 PlaceholderMethod |   HEAD | 3.641 s | 0.2433 s | 0.3249 s |    1 |
 PlaceholderMethod |  HEAD^ | 4.802 s | 0.0804 s | 0.1073 s |    2 |

// * Legends *
  Commit : Value of the 'Commit' parameter
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  Rank   : Relative position of current benchmark mean among all benchmarks (Arabic style)
  1 s    : 1 Second (1 sec)

```