### PR TITLE
Create build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set -e
+set -u
+
+usage()
+{
+    echo "Main interface to running builds on Mac/Linux"
+    echo "Usage: build.sh [options]"
+    echo ""
+    echo "Options"
+    echo "  --debug               Build Debug (default)"
+    echo "  --release             Build Release"
+    echo "  --restore             Restore projects required to build"
+    echo "  --build               Build all projects"
+    echo "  --test                Run unit tests"
+    echo "  --build-bootstrap     Build the bootstrap compilers"
+    echo "  --use-bootstrap       Use the built bootstrap compilers when running main build"
+    echo "  --bootstrap           Implies --build-bootstrap and --use-bootstrap"
+}
+
+this_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${this_dir}"/build/scripts/build-utils.sh
+root_path="$(get_repo_dir)"
+binaries_path="${root_path}"/Binaries
+bootstrap_path="${binaries_path}"/Bootstrap
+bootstrap_framework=netcoreapp2.0
+
+build_configuration=Debug
+restore=false
+build=false
+test_=false
+build_bootstrap=false
+use_bootstrap=false
+
+# LTTNG is the logging infrastructure used by coreclr.  Need this variable set
+# so it doesn't output warnings to the console.
+export LTTNG_HOME="$HOME"
+
+while [[ $# > 0 ]]
+do
+    opt="$(echo "$1" | awk '{print tolower($0)}')"
+    case "$opt" in
+        -h|--help)
+        usage
+        exit 1
+        ;;
+        --debug)
+        build_configuration=Debug
+        shift 1
+        ;;
+        --release)
+        build_configuration=Release
+        shift 1
+        ;;
+        --restore)
+        restore=true
+        shift 1
+        ;;
+        --build)
+        build=true
+        shift 1
+        ;;
+        --test)
+        test_=true
+        shift 1
+        ;;
+        --build-bootstrap)
+        build_bootstrap=true
+        shift 1
+        ;;
+        --use-bootstrap)
+        use_bootstrap=true
+        shift 1
+        ;;
+        --bootstrap)
+        build_bootstrap=true
+        use_bootstrap=true
+        shift 1
+        ;;
+        *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+if [[ "$restore" == true ]]
+then
+    "${root_path}"/build/scripts/restore.sh
+fi
+
+build_args="--no-restore -c ${build_configuration} /nologo /maxcpucount:1"
+
+if [[ "$build_bootstrap" == true ]]
+then
+    echo "Building bootstrap toolset"
+    bootstrap_build_args="${build_args} /p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP"
+    dotnet publish "${root_path}"/src/Compilers/CSharp/csc -o "${bootstrap_path}/bincore" --framework ${bootstrap_framework} ${bootstrap_build_args} "/bl:${binaries_path}/BootstrapCsc.binlog"
+    dotnet publish "${root_path}"/src/Compilers/VisualBasic/vbc -o "${bootstrap_path}/bincore" --framework ${bootstrap_framework} ${bootstrap_build_args} "/bl:${binaries_path}/BootstrapVbc.binlog"
+    dotnet publish "${root_path}"/src/Compilers/Server/VBCSCompiler -o "${bootstrap_path}/bincore" --framework ${bootstrap_framework} ${bootstrap_build_args} "/bl:${binaries_path}/BootstrapVBCSCompiler.binlog"
+    dotnet publish "${root_path}"/src/Compilers/Core/MSBuildTask -o "${bootstrap_path}" ${bootstrap_build_args} "/bl:${binaries_path}/BoostrapMSBuildTask.binlog"
+fi
+
+if [[ "${use_bootstrap}" == true ]]
+then
+    build_args+=" /p:BootstrapBuildPath=${bootstrap_path}"
+fi
+
+if [[ "${build}" == true ]]
+then
+    echo "Building Compilers.sln"
+    dotnet build "${root_path}"/Compilers.sln ${build_args} "/bl:${binaries_path}/Build.binlog"
+fi
+
+if [[ "${test_}" == true ]]
+then
+    "${root_path}"/build/scripts/tests.sh
+fi

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -2,22 +2,12 @@
 
 THIS_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# Workaround, see https://github.com/dotnet/roslyn/issues/10210
-# $HOME is unset when running the mac unit tests.
-if [[ -z ${HOME+x} ]]
-then
-    # Note that while ~ usually refers to $HOME, in the case where $HOME is unset,
-    # it looks up the current user's home dir, which is what we want.
-    # https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
-    export HOME=$(cd ~ && pwd)
-fi
-
 echo "Restoring toolset packages"
 
 RESTORE_ARGS="-v Minimal --disable-parallel"
 echo "Restoring BaseToolset.csproj"
-dotnet restore ${RESTORE_ARGS} ${THIS_DIR}/../ToolsetPackages/BaseToolset.csproj
+dotnet restore ${RESTORE_ARGS} "${THIS_DIR}/../ToolsetPackages/BaseToolset.csproj"
 echo "Restoring CoreToolset.csproj"
-dotnet restore ${RESTORE_ARGS} ${THIS_DIR}/../ToolsetPackages/CoreToolset.csproj
+dotnet restore ${RESTORE_ARGS} "${THIS_DIR}/../ToolsetPackages/CoreToolset.csproj"
 echo "Restoring Compilers.sln"
-dotnet restore ${RESTORE_ARGS} ${THIS_DIR}/../../Compilers.sln
+dotnet restore ${RESTORE_ARGS} "${THIS_DIR}/../../Compilers.sln"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -13,24 +13,13 @@ usage()
     echo "Options"
     echo "  --debug               Build Debug (default)"
     echo "  --release             Build Release"
-    echo "  --cleanrun            Clean the project before building"
-    echo "  --skiptest            Do not run tests"
-    echo "  --skipcommitprinting  Do not print commit information"
 }
 
 THIS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${THIS_DIR}"/build/scripts/build-utils.sh
 ROOT_PATH="$(get_repo_dir)"
-BINARIES_PATH="${ROOT_PATH}"/Binaries
-BOOTSTRAP_PATH="${BINARIES_PATH}"/Bootstrap
-SRC_PATH="${ROOT_PATH}"/src
-TARGET_FRAMEWORK=netcoreapp2.0
 
-BUILD_CONFIGURATION=Debug
-CLEAN_RUN=false
-SKIP_RESTORE=false
-SKIP_TESTS=false
-SKIP_COMMIT_PRINTING=false
+BUILD_CONFIGURATION=--debug
 
 # $HOME is unset when running the mac unit tests.
 if [[ -z "${HOME+x}" ]]
@@ -40,10 +29,6 @@ then
     # https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
     export HOME="$(cd ~ && pwd)"
 fi
-
-# LTTNG is the logging infrastructure used by coreclr.  Need this variable set 
-# so it doesn't output warnings to the console.
-export LTTNG_HOME="$HOME"
 
 # There's no reason to send telemetry or prime a local package cach when building
 # in CI.
@@ -59,27 +44,11 @@ do
         exit 1
         ;;
         --debug)
-        BUILD_CONFIGURATION=Debug
+        BUILD_CONFIGURATION=--debug
         shift 1
         ;;
         --release)
-        BUILD_CONFIGURATION=Release
-        shift 1
-        ;;
-        --cleanrun)
-        CLEAN_RUN=true
-        shift 1
-        ;;
-        --skiprestore)
-        SKIP_RESTORE=true
-        shift 1
-        ;;
-        --skiptests)
-        SKIP_TESTS=true
-        shift 1
-        ;;
-        --skipcommitprinting)
-        SKIP_COMMIT_PRINTING=true
+        BUILD_CONFIGURATION=--release
         shift 1
         ;;
         *)
@@ -89,44 +58,14 @@ do
     esac
 done
 
-if [ "$CLEAN_RUN" == "true" ]; then
-    echo Clean out the enlistment
-    git clean -dxf . 
-fi
-
-if [ "$SKIP_COMMIT_PRINTING" == "false" ]; then
-    echo Building this commit:
-    git show --no-patch --pretty=raw HEAD
-fi
+echo Building this commit:
+git show --no-patch --pretty=raw HEAD
 
 # obtain_dotnet.sh puts the right dotnet on the PATH
 FORCE_DOWNLOAD=true
 source "${ROOT_PATH}"/build/scripts/obtain_dotnet.sh
 
-if [[ "${SKIP_RESTORE}" == false ]]
-then
-    "${ROOT_PATH}"/build/scripts/restore.sh
-fi
-
-BUILD_ARGS="--no-restore -c ${BUILD_CONFIGURATION} /nologo /maxcpucount:1"
-BOOTSTRAP_BUILD_ARGS="${BUILD_ARGS} /p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP"
-
-echo "Building bootstrap toolset"
-dotnet publish "${ROOT_PATH}"/src/Compilers/CSharp/csc -o "${BOOTSTRAP_PATH}/bincore" --framework ${TARGET_FRAMEWORK} ${BOOTSTRAP_BUILD_ARGS} "/bl:${BINARIES_PATH}/BootstrapCsc.binlog"
-dotnet publish "${ROOT_PATH}"/src/Compilers/VisualBasic/vbc -o "${BOOTSTRAP_PATH}/bincore" --framework ${TARGET_FRAMEWORK} ${BOOTSTRAP_BUILD_ARGS} "/bl:${BINARIES_PATH}/BootstrapVbc.binlog"
-dotnet publish "${ROOT_PATH}"/src/Compilers/Server/VBCSCompiler -o "${BOOTSTRAP_PATH}/bincore" --framework ${TARGET_FRAMEWORK} ${BOOTSTRAP_BUILD_ARGS} "/bl:${BINARIES_PATH}/BootstrapVBCSCompiler.binlog"
-dotnet publish "${ROOT_PATH}"/src/Compilers/Core/MSBuildTask -o "${BOOTSTRAP_PATH}" ${BOOTSTRAP_BUILD_ARGS} "/bl:${BINARIES_PATH}/BoostrapMSBuildTask.binlog"
-
-BUILD_ARGS+=" /bl:${BINARIES_PATH}/Build.binlog /p:BootstrapBuildPath=${BOOTSTRAP_PATH}"
-
-echo "Building Compilers.sln"
-dotnet build "${ROOT_PATH}"/Compilers.sln ${BUILD_ARGS}
-
-if [[ "${SKIP_TESTS}" == false ]]
-then
-    echo "Running tests"
-    "${ROOT_PATH}"/build/scripts/tests.sh "${BUILD_CONFIGURATION}"
-fi
+"${ROOT_PATH}"/build.sh --restore --bootstrap --build --test "${BUILD_CONFIGURATION}"
 
 echo "Killing VBCSCompiler"
-dotnet "${BOOTSTRAP_PATH}"/bincore/VBCSCompiler.dll -shutdown
+dotnet "${ROOT_PATH}"/Binaries/Bootstrap/bincore/VBCSCompiler.dll -shutdown


### PR DESCRIPTION
The interface is a rough parallel to `build.cmd`. Note that this script will be compatible with the repo API going forward, and so minor changes may happen to make sure it's exactly aligned with the repo toolset - also note that this PR doesn't try to be 100% compatible with the repo API, it's just a starting point, because the linux story is painful right now and I can't stand it anymore 😛.

The biggest win here, in my opinion, is less telling users to run things in `./build/scripts`, which IMO should be an internal-only directory (nobody should ever run scripts directly from there).

(`obtain_dotnet.sh` is in there, but hey, one step at a time 😊)

ping @jaredpar 