### PR TITLE
Fix an InvalidCastException in IOperation factory when a user defined conversions involves an integer overflow.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -577,7 +577,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ReportNoConversionError(argument.Syntax, sourceType, targetType, diagnostics, copybackConversionParamName)
                 End If
 
-                Return New BoundConversion(tree, argument, convKind.Key, CheckOverflow, isExplicit, targetType, hasErrors:=True)
+                Return New BoundConversion(tree, argument, convKind.Key And (Not ConversionKind.UserDefined), CheckOverflow, isExplicit, targetType, hasErrors:=True)
             End If
 
 DoneWithDiagnostics:

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundConversion.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundConversion.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Operand.AssertRValue()
 
             If Conversions.NoConversion(ConversionKind) Then
-                Debug.Assert(Operand.Kind <> BoundKind.UserDefinedConversion)
+                Debug.Assert((ConversionKind And VisualBasic.ConversionKind.UserDefined) = 0)
             Else
                 Debug.Assert(((ConversionKind And VisualBasic.ConversionKind.UserDefined) <> 0) = (Operand.Kind = BoundKind.UserDefinedConversion))
 

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConversionExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IConversionExpression.vb
@@ -3,6 +3,7 @@
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Operations
+Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -2992,6 +2993,46 @@ BC36755: 'Action(Of Object)' cannot be converted to 'Action(Of Integer)' because
 
 
 #End Region
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact>
+        <WorkItem(23203, "https://github.com/dotnet/roslyn/issues/23203")>
+        Public Sub ConversionExpression_IntegerOverflow()
+            Dim source = <![CDATA[
+Imports System
+
+Module Module1
+
+    Class C1
+        Shared Widening Operator CType(x As Byte) As C1
+            Return Nothing
+        End Operator
+    End Class
+
+    Sub Main()
+
+        Dim z1 As C1 = &H7FFFFFFFL 'BIND:"= &H7FFFFFFFL"
+    End Sub
+End Module
+]]>.Value
+
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= &H7FFFFFFFL')
+  IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: Module1.C1, IsInvalid, IsImplicit) (Syntax: '&H7FFFFFFFL')
+    Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+    Operand: 
+      ILiteralOperation (OperationKind.Literal, Type: System.Int64, Constant: 2147483647, IsInvalid) (Syntax: '&H7FFFFFFFL')
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30439: Constant expression not representable in type 'Byte'.
+        Dim z1 As C1 = &H7FFFFFFFL 'BIND:"= &H7FFFFFFFL"
+                       ~~~~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of EqualsValueSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
 
         Private Class ExpectedSymbolVerifier
             Public Shared Function ConversionOrDelegateChildSelector(conv As IOperation) As IOperation


### PR DESCRIPTION
Fixes #23203.

**Customer scenario**

Request IOperation tree for a variable initializer like the one below:
```
Module Module1

    Class C1
        Shared Widening Operator CType(x As Byte) As C1
            Return Nothing
        End Operator
    End Class

    Sub Main()
        Dim z1 As C1 = &H7FFFFFFFL 'BIND:"= &H7FFFFFFFL"
    End Sub
End Module
```

An InvalidCastException is thrown by IOperation factory.

**Bugs this fixes:**

Fixes #23203.

**Workarounds, if any**

No

**Risk**

Low

**Performance impact**

Low perf impact because no extra allocations/no complexity changes

**Is this a regression from a previous update?**

No

**Root cause analysis:**

A test gap. Unit-tests are added.

**How was the bug found?**

Running existing compiler tests with IOperation validation test hook enabled.
