### PR TITLE
Fix an InvalidCastException in IOperation factory when a name of a range variable conflicts with another range variable.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
@@ -157,9 +157,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim propertyDefName As String = propertyDef.Name
 
-                If propertyDefName.StartsWith("$"c, StringComparison.Ordinal) AndAlso Not String.Equals(propertyDefName, StringConstants.Group, StringComparison.Ordinal) Then
+                If propertyDefName.StartsWith("$"c, StringComparison.Ordinal) AndAlso
+                   (propertyDefName.Equals(StringConstants.It) OrElse propertyDefName.Equals(StringConstants.It1) OrElse propertyDefName.Equals(StringConstants.It2)) Then
                     ' Nested compound variable.
-                    Debug.Assert(propertyDefName.Equals(StringConstants.It) OrElse propertyDefName.Equals(StringConstants.It1) OrElse propertyDefName.Equals(StringConstants.It2))
                     PopulateRangeVariableMapForAnonymousType(syntax, getCallOrPropertyAccess.MakeCompilerGenerated(), rangeVariables, firstUnmappedRangeVariable, rangeVariableMap, inExpressionLambda)
                 Else
                     Debug.Assert(IdentifierComparison.Equals(propertyDefName, rangeVariables(firstUnmappedRangeVariable).Name))

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
@@ -99,14 +99,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        False,
                                                        parameter.Type)
 
-                    If isReservedName AndAlso Not String.Equals(parameterName, StringConstants.Group, StringComparison.Ordinal) Then
+                    If isReservedName AndAlso IsCompoundVariableName(parameterName) Then
                         If parameter.Type.IsErrorType() Then
                             ' Skip adding variables to the range variable map and bail out for error case.
                             Return
                         Else
                             ' Compound variable.
                             ' Each range variable is an Anonymous Type property.
-                            Debug.Assert(parameterName.Equals(StringConstants.It) OrElse parameterName.Equals(StringConstants.It1) OrElse parameterName.Equals(StringConstants.It2))
                             PopulateRangeVariableMapForAnonymousType(node.Syntax, paramRef.MakeCompilerGenerated(), nodeRangeVariables, firstUnmappedRangeVariable, rangeVariableMap, inExpressionLambda)
                         End If
                     Else
@@ -158,9 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim propertyDefName As String = propertyDef.Name
 
                 If propertyDefName.StartsWith("$"c, StringComparison.Ordinal) AndAlso
-                   (propertyDefName.Equals(StringConstants.It, StringComparison.Ordinal) OrElse
-                   propertyDefName.Equals(StringConstants.It1, StringComparison.Ordinal) OrElse
-                   propertyDefName.Equals(StringConstants.It2, StringComparison.Ordinal)) Then
+                   IsCompoundVariableName(propertyDefName) Then
                     ' Nested compound variable.
                     PopulateRangeVariableMapForAnonymousType(syntax, getCallOrPropertyAccess.MakeCompilerGenerated(), rangeVariables, firstUnmappedRangeVariable, rangeVariableMap, inExpressionLambda)
                 Else
@@ -170,6 +167,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             Next
         End Sub
+
+        Private Shared Function IsCompoundVariableName(name As String) As Boolean
+            Return name.Equals(StringConstants.It, StringComparison.Ordinal) OrElse
+                   name.Equals(StringConstants.It1, StringComparison.Ordinal) OrElse
+                   name.Equals(StringConstants.It2, StringComparison.Ordinal)
+        End Function
 
         Friend Shared Function CreateReturnStatementForQueryLambdaBody(
             rewrittenBody As BoundExpression,

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
@@ -158,7 +158,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim propertyDefName As String = propertyDef.Name
 
                 If propertyDefName.StartsWith("$"c, StringComparison.Ordinal) AndAlso
-                   (propertyDefName.Equals(StringConstants.It) OrElse propertyDefName.Equals(StringConstants.It1) OrElse propertyDefName.Equals(StringConstants.It2)) Then
+                   (propertyDefName.Equals(StringConstants.It, StringComparison.Ordinal) OrElse
+                   propertyDefName.Equals(StringConstants.It1, StringComparison.Ordinal) OrElse
+                   propertyDefName.Equals(StringConstants.It2, StringComparison.Ordinal)) Then
                     ' Nested compound variable.
                     PopulateRangeVariableMapForAnonymousType(syntax, getCallOrPropertyAccess.MakeCompilerGenerated(), rangeVariables, firstUnmappedRangeVariable, rangeVariableMap, inExpressionLambda)
                 Else

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
@@ -14713,7 +14713,7 @@ ITranslatedQueryOperation (OperationKind.TranslatedQuery, Type: QueryAble) (Synt
 
         <CompilerTrait(CompilerFeature.IOperation)>
         <WorkItem(23223, "https://github.com/dotnet/roslyn/issues/23223")>
-        Public Sub DiplicateRangeVariableName_IOperation()
+        Public Sub DuplicateRangeVariableName_IOperation()
             Dim source = <![CDATA[
 Option Strict Off
 Imports System

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions.vb
@@ -14710,6 +14710,77 @@ ITranslatedQueryOperation (OperationKind.TranslatedQuery, Type: QueryAble) (Synt
 
             VerifyOperationTreeAndDiagnosticsForTest(Of QueryExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
         End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <WorkItem(23223, "https://github.com/dotnet/roslyn/issues/23223")>
+        Public Sub DiplicateRangeVariableName_IOperation()
+            Dim source = <![CDATA[
+Option Strict Off
+Imports System
+Imports System.Linq
+
+Module Module1
+    Sub Main()
+        Dim q As Object = From implicit In New Integer() {1, 2, 3} Let implicit = "1" Select implicit 'BIND:"From implicit In New Integer() {1, 2, 3} Let implicit = "1" Select implicit"
+    End Sub
+End Module]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+ITranslatedQueryOperation (OperationKind.TranslatedQuery, Type: System.Collections.Generic.IEnumerable(Of System.Int32), IsInvalid) (Syntax: 'From implic ... ct implicit')
+	  Expression:
+	    IInvocationOperation ( Function System.Collections.Generic.IEnumerable(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>).Select(Of System.Int32)(selector As System.Func(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>, System.Int32)) As System.Collections.Generic.IEnumerable(Of System.Int32)) (OperationKind.Invocation, Type: System.Collections.Generic.IEnumerable(Of System.Int32), IsImplicit) (Syntax: 'Select implicit')
+	      Instance Receiver:
+	        IInvocationOperation ( Function System.Collections.Generic.IEnumerable(Of System.Int32).Select(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>)(selector As System.Func(Of System.Int32, <anonymous type: Key implicit As System.Int32, Key $156 As System.String>)) As System.Collections.Generic.IEnumerable(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>)) (OperationKind.Invocation, Type: System.Collections.Generic.IEnumerable(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>), IsInvalid, IsImplicit) (Syntax: 'implicit = "1"')
+	          Instance Receiver:
+	            IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Collections.Generic.IEnumerable(Of System.Int32), IsImplicit) (Syntax: 'implicit In ... ) {1, 2, 3}')
+	              Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+	              Operand:
+	                IArrayCreationOperation (OperationKind.ArrayCreation, Type: System.Int32()) (Syntax: 'New Integer() {1, 2, 3}')
+	                  Dimension Sizes(1):
+	                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3, IsImplicit) (Syntax: 'New Integer() {1, 2, 3}')
+	                  Initializer:
+	                    IArrayInitializerOperation (3 elements) (OperationKind.ArrayInitializer, Type: null) (Syntax: '{1, 2, 3}')
+	                      Element Values(3):
+	                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+	                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+	                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+	          Arguments(1):
+	              IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: selector) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: '"1"')
+	                IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Func(Of System.Int32, <anonymous type: Key implicit As System.Int32, Key $156 As System.String>), IsImplicit) (Syntax: '"1"')
+	                  Target:
+	                    IAnonymousFunctionOperation (Symbol: Function (implicit As System.Int32) As <anonymous type: Key implicit As System.Int32, Key $156 As System.String>) (OperationKind.AnonymousFunction, Type: null, IsImplicit) (Syntax: '"1"')
+	                      IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsImplicit) (Syntax: '"1"')
+	                        IReturnOperation (OperationKind.Return, Type: null, IsImplicit) (Syntax: '"1"')
+	                          ReturnedValue:
+	                            IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: <anonymous type: Key implicit As System.Int32, Key $156 As System.String>, IsInvalid, IsImplicit) (Syntax: 'implicit = "1"')
+	                              Initializers(2):
+	                                  IParameterReferenceOperation: implicit (OperationKind.ParameterReference, Type: System.Int32, IsImplicit) (Syntax: 'implicit')
+	                                  ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: "1") (Syntax: '"1"')
+	                InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+	                OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+	      Arguments(1):
+	          IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: selector) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'implicit')
+	            IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Func(Of <anonymous type: Key implicit As System.Int32, Key $156 As System.String>, System.Int32), IsImplicit) (Syntax: 'implicit')
+	              Target:
+	                IAnonymousFunctionOperation (Symbol: Function ($VB$It As <anonymous type: Key implicit As System.Int32, Key $156 As System.String>) As System.Int32) (OperationKind.AnonymousFunction, Type: null, IsImplicit) (Syntax: 'implicit')
+	                  IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsImplicit) (Syntax: 'implicit')
+	                    IReturnOperation (OperationKind.Return, Type: null, IsImplicit) (Syntax: 'implicit')
+	                      ReturnedValue:
+	                        IPropertyReferenceOperation: ReadOnly Property <anonymous type: Key implicit As System.Int32, Key $156 As System.String>.implicit As System.Int32 (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'implicit')
+	                          Instance Receiver:
+	                            IParameterReferenceOperation: $VB$It (OperationKind.ParameterReference, Type: <anonymous type: Key implicit As System.Int32, Key $156 As System.String>, IsImplicit) (Syntax: 'implicit')
+	            InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+	            OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30978: Range variable 'implicit' hides a variable in an enclosing block or a range variable previously defined in the query expression.
+        Dim q As Object = From implicit In New Integer() {1, 2, 3} Let implicit = "1" Select implicit 'BIND:"From implicit In New Integer() {1, 2, 3} Let implicit = "1" Select implicit"
+                                                                       ~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of QueryExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #23223.

**Customer scenario**

Request IOperation tree for a query expression like the one below:
```
Dim q As Object = From implicit In New Integer() {1, 2, 3} Let implicit = "1" Select implicit
```

An InvalidCastException is thrown by IOperation factory.

**Bugs this fixes:**

Fixes #23223.

**Workarounds, if any**

No

**Risk**

Low

**Performance impact**

Low perf impact because no extra allocations/no complexity changes

**Is this a regression from a previous update?**

No

**Root cause analysis:**

A test gap. Unit-tests are added.

**How was the bug found?**

Running existing compiler tests with IOperation validation test hook enabled.
