### PR TITLE
Ensure the operand of an is-pattern expression is evaluated.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardExpression)
                 {
-                    return result;
+                    return _factory.MakeSequence(loweredInput, result);
                 }
 
                 Debug.Assert((object)loweredPattern.Variable != null && loweredInput.Type.Equals(loweredPattern.Variable.GetTypeOrReturnType(), TypeCompareKind.AllIgnoreOptions));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -6403,5 +6403,37 @@ class Program
                 );
             CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
+
+        [Fact, WorkItem(22619, "https://github.com/dotnet/roslyn/issues/22619")]
+        public void MissingSideEffect()
+        {
+            var source =
+@"using System;
+internal class Program
+{
+    private static void Main()
+    {
+        try
+        {
+            var test = new Program();
+            var result = test.IsVarMethod();
+            Console.WriteLine($""Result = {result}"");
+            Console.Read();
+        }
+        catch (Exception)
+        {
+            Console.WriteLine(""Exception"");
+        }
+    }
+
+    private int IsVarMethod() => ThrowingMethod() is var _ ? 1 : 0;
+    private bool ThrowingMethod() => throw new Exception(""Oh"");
+}
+";
+            var expectedOutput = @"Exception";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Writing the expression `expr is var _` yields true without evaluating `expr` for its side-effects. It should evaluate `expr`.

**Bugs this fixes:**

Fixes #22619

**Workarounds, if any**

Change `_` to some otherwise unused identifier.

**Risk**

Very low. The fix is very focused on the particular scenario.

**Performance impact**

None. Does not change any algorithms of the compiler.

**Is this a regression from a previous update?**

No. This bug existed since pattern-matching was first introduced.

**Root cause analysis:**

The scenario is a little nonsensical, so we did not think to test it.

**How was the bug found?**

(Internal) customer reported.

**Test documentation updated?**

No.

-----------------
@dotnet/roslyn-compiler  Please review.
