### PR TITLE
Fixes that arrays of pointers cannot be used in pattern matching

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4615,6 +4615,36 @@ public class Program
         }
 
         [Fact]
+        public void ArrayOfPointerInPattern()
+        {
+            // pointer types are not supported in patterns but they are supported as base type of an array.
+            var source =
+@"
+public class Program
+{
+    public static unsafe void Main()
+    {
+        object x = new int*[10];
+        if (x is int*[]) { }
+        if (x is int****[]) { }
+
+        switch (x)
+        {
+            case int*[] t:
+            System.Console.WriteLine(true);
+            break;
+            case int****[] t2:
+            break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeDebugExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput: "True");
+        }
+
+        [Fact]
         public void ColorColorConstantPattern()
         {
             var source =


### PR DESCRIPTION
This PR fixes #23100. The compiler was not able to parse arrays of pointers in pattern places. It would wrongly assume that a pointer was not allowed in this context even though it was followed by an array creation.

**Risk**

The issue suggests that the bug is a regression that causes the compiler to not compile valid code.

**Performance impact**

The performance impact should be low. The reset is only executed in very few cases e.g. if there is a multiplication in a pattern or if a pointer is used in a pattern (which does not compile).

**Is this a regression from a previous update?**

Yes! The code compiled with the native compiler.

**Root cause analysis:**

It was missed that a pointer type can follow an is/case if it is part of an array type. I added a test for that.



@gafter You were assigned to this. i hope it is not a problem that I went ahead and took a shot at this.

Pro Tip: This diff is easier to read by adding ?w=0 to the github url. This hides changes because of indentation.