### PR TITLE
Change the 'Use auto property' code fixer to not be a 'compilation end' analyzer.

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -46,15 +46,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             {
                 AnalyzeMembers(context, namespaceDeclaration.Members, analysisResults);
             }
-
-            // If we have a class or struct, recurse inwards.
-            if (member.IsKind(SyntaxKind.ClassDeclaration, out TypeDeclarationSyntax typeDeclaration) ||
+            else if (member.IsKind(SyntaxKind.ClassDeclaration, out TypeDeclarationSyntax typeDeclaration) ||
                 member.IsKind(SyntaxKind.StructDeclaration, out typeDeclaration))
             {
+                // If we have a class or struct, recurse inwards.
                 AnalyzeMembers(context, typeDeclaration.Members, analysisResults);
             }
-
-            if (member is PropertyDeclarationSyntax propertyDeclaration)
+            else if (member.IsKind(SyntaxKind.PropertyDeclaration, out PropertyDeclarationSyntax propertyDeclaration))
             {
                 AnalyzeProperty(context, propertyDeclaration, analysisResults);
             }

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -56,8 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 
             if (member is PropertyDeclarationSyntax propertyDeclaration)
             {
-                var property = (IPropertySymbol)context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken);
-                AnalyzeProperty(context, property, analysisResults);
+                AnalyzeProperty(context, propertyDeclaration, analysisResults);
             }
         }
 

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.UseAutoProperty;
@@ -12,21 +14,74 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
     [Export]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal class UseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
+    internal class CSharpUseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
     {
         protected override bool SupportsReadOnlyProperties(Compilation compilation)
-        {
-            return ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
-        }
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
 
         protected override bool SupportsPropertyInitializer(Compilation compilation)
+            => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
+
+        protected override void AnalyzeCompilationUnit(
+            SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults)
+            => AnalyzeMembers(context, ((CompilationUnitSyntax)root).Members, analysisResults);
+
+        private void AnalyzeMembers(
+            SemanticModelAnalysisContext context, 
+            SyntaxList<MemberDeclarationSyntax> members,
+            List<AnalysisResult> analysisResults)
         {
-            return ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
+            foreach (var memberDeclaration in members)
+            {
+                AnalyzeMemberDeclaration(context, memberDeclaration, analysisResults);
+            }
         }
 
-        protected override void RegisterIneligibleFieldsAction(CompilationStartAnalysisContext context, ConcurrentBag<IFieldSymbol> ineligibleFields)
+        private void AnalyzeMemberDeclaration(
+            SemanticModelAnalysisContext context,
+            MemberDeclarationSyntax member,
+            List<AnalysisResult> analysisResults)
         {
-            context.RegisterSyntaxNodeAction(snac => AnalyzeArgument(ineligibleFields, snac), SyntaxKind.Argument);
+            if (member.IsKind(SyntaxKind.NamespaceDeclaration, out NamespaceDeclarationSyntax namespaceDeclaration))
+            {
+                AnalyzeMembers(context, namespaceDeclaration.Members, analysisResults);
+            }
+
+            // If we have a class or struct, recurse inwards.
+            if (member.IsKind(SyntaxKind.ClassDeclaration, out TypeDeclarationSyntax typeDeclaration) ||
+                member.IsKind(SyntaxKind.StructDeclaration, out typeDeclaration))
+            {
+                AnalyzeMembers(context, typeDeclaration.Members, analysisResults);
+            }
+
+            if (member is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                var property = (IPropertySymbol)context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken);
+                AnalyzeProperty(context, property, analysisResults);
+            }
+        }
+
+        protected override void RegisterIneligibleFieldsAction(
+            List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
+            Compilation compilation, CancellationToken cancellationToken)
+        {
+            var groups = analysisResults.Select(r => (TypeDeclarationSyntax)r.PropertyDeclaration.Parent)
+                                        .Distinct()
+                                        .GroupBy(n => n.SyntaxTree);
+
+            foreach (var group in groups)
+            {
+                var tree = group.Key;
+                var semanticModel = compilation.GetSemanticModel(tree);
+
+                foreach (var typeDeclaration in group)
+                {
+                    foreach (var argument in typeDeclaration.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
+                    {
+                        AnalyzeArgument(semanticModel, argument, ineligibleFields, cancellationToken);
+                    }
+                }
+            }
         }
 
         protected override ExpressionSyntax GetFieldInitializer(VariableDeclaratorSyntax variable, CancellationToken cancellationToken)
@@ -34,18 +89,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             return variable.Initializer?.Value;
         }
 
-        private void AnalyzeArgument(ConcurrentBag<IFieldSymbol> ineligibleFields, SyntaxNodeAnalysisContext context)
+        private void AnalyzeArgument(
+            SemanticModel semanticModel, ArgumentSyntax argument,
+            HashSet<IFieldSymbol> ineligibleFields, CancellationToken cancellationToken)
         {
             // An argument will disqualify a field if that field is used in a ref/out position.  
             // We can't change such field references to be property references in C#.
-            var argument = (ArgumentSyntax)context.Node;
             if (argument.RefOrOutKeyword.Kind() == SyntaxKind.None)
             {
                 return;
             }
 
-            var cancellationToken = context.CancellationToken;
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(argument.Expression, cancellationToken);
+            var symbolInfo = semanticModel.GetSymbolInfo(argument.Expression, cancellationToken);
             AddIneligibleField(symbolInfo.Symbol, ineligibleFields);
             foreach (var symbol in symbolInfo.CandidateSymbols)
             {
@@ -53,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             }
         }
 
-        private static void AddIneligibleField(ISymbol symbol, ConcurrentBag<IFieldSymbol> ineligibleFields)
+        private static void AddIneligibleField(ISymbol symbol, HashSet<IFieldSymbol> ineligibleFields)
         {
             if (symbol is IFieldSymbol field)
             {

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
@@ -18,8 +18,8 @@ using Microsoft.CodeAnalysis.UseAutoProperty;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
 {
     [Shared]
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseAutoPropertyCodeFixProvider))]
-    internal class UseAutoPropertyCodeFixProvider : AbstractUseAutoPropertyCodeFixProvider<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ConstructorDeclarationSyntax, ExpressionSyntax>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpUseAutoPropertyCodeFixProvider))]
+    internal class CSharpUseAutoPropertyCodeFixProvider : AbstractUseAutoPropertyCodeFixProvider<PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ConstructorDeclarationSyntax, ExpressionSyntax>
     {
         protected override SyntaxNode GetNodeToRemove(VariableDeclaratorSyntax declarator)
         {

--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyCodeFixProvider.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
             var sourceText = await propertyDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var getAccessor = propertyDeclaration.AccessorList.Accessors.First(d => d.IsKind(SyntaxKind.GetAccessorDeclaration));
-            var isSingleLine = sourceText.AreOnSameLine(getAccessor.GetFirstToken(), getAccessor.GetLastToken());
 
             var updatedProperty = propertyDeclaration.WithAccessorList(UpdateAccessorList(propertyDeclaration.AccessorList));
 
@@ -63,10 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
                                                  .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
             }
 
-            if (isSingleLine)
-            {
-                updatedProperty = updatedProperty.WithAdditionalAnnotations(SpecializedFormattingAnnotation);
-            }
+            updatedProperty = updatedProperty.WithAdditionalAnnotations(SpecializedFormattingAnnotation);
 
             return updatedProperty;
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
     public class UseAutoPropertyTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (new UseAutoPropertyAnalyzer(), new UseAutoPropertyCodeFixProvider());
+            => (new CSharpUseAutoPropertyAnalyzer(), new CSharpUseAutoPropertyCodeFixProvider());
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
         public async Task TestSingleGetterFromField()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -35,9 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -60,9 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    public int P
-    {
-        get; private set; }
+    public int P { get; private set; }
 }",
             CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
         }
@@ -104,9 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; } = 1;
+    int P { get; } = 1;
 }");
         }
 
@@ -147,9 +141,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -195,9 +187,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; set; }
+    int P { get; set; }
 }");
         }
 
@@ -220,9 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -268,9 +256,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 @"class Class
 {
 
-    int P
-    {
-        get; set; }
+    int P { get; set; }
 }");
         }
 
@@ -503,9 +489,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int j, k;
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -529,9 +513,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int i, k;
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -555,9 +537,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int i, j;
 
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -586,9 +566,7 @@ partial class Class
 
 partial class Class
 {
-    int P
-    {
-        get; }
+    int P { get; }
 }");
         }
 
@@ -635,9 +613,7 @@ partial class Class
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 
     public Class()
     {
@@ -670,9 +646,7 @@ partial class Class
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 
     public Class(int P)
     {
@@ -705,9 +679,7 @@ partial class Class
 @"class Class
 {
 
-    int P
-    {
-        get; }
+    int P { get; }
 
     public Class()
     {
@@ -740,9 +712,7 @@ partial class Class
 @"class Class
 {
 
-    int P
-    {
-        get; set; }
+    int P { get; set; }
 
     public void Goo()
     {
@@ -775,9 +745,7 @@ partial class Class
 @"class Class
 {
 
-    public int P
-    {
-        get; private set; }
+    public int P { get; private set; }
 
     public void Goo()
     {
@@ -877,9 +845,7 @@ partial class Class
 @"class Class
 {
 
-    (int, string) P
-    {
-        get; }
+    (int, string) P { get; }
 }");
         }
 
@@ -902,9 +868,7 @@ partial class Class
 @"class Class
 {
 
-    (int a, string b) P
-    {
-        get; }
+    (int a, string b) P { get; }
 }");
         }
 
@@ -945,9 +909,7 @@ partial class Class
 @"class Class
 {
 
-    (int a, string) P
-    {
-        get; }
+    (int a, string) P { get; }
 }");
         }
 
@@ -970,9 +932,7 @@ partial class Class
 @"class Class
 {
 
-    (int, string) P
-    {
-        get; } = (1, ""hello"");
+    (int, string) P { get; } = (1, ""hello"");
 }");
         }
 
@@ -1000,9 +960,42 @@ partial class Class
 @"class Class
 {
 
-    (int, string) P
+    (int, string) P { get; set; }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task TestFixAllInDocument()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    {|FixAllInDocument:int i|};
+
+    int P
     {
-        get; set; }
+        get
+        {
+            return i;
+        }
+    }
+
+    int j;
+
+    int Q
+    {
+        get
+        {
+            return j;
+        }
+    }
+}",
+@"class Class
+{
+
+    int P { get; }
+
+    int Q { get; }
 }");
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -996,7 +996,7 @@ partial class Class
     int P { get; }
 
     int Q { get; }
-}");
+}", fixAllActionEquivalenceKey: FeaturesResources.Use_auto_property);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -964,6 +964,8 @@ partial class Class
 }");
         }
 
+        [WorkItem(23215, "https://github.com/dotnet/roslyn/issues/23215")]
+        [WorkItem(23216, "https://github.com/dotnet/roslyn/issues/23216")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
         public async Task TestFixAllInDocument()
         {

--- a/src/EditorFeatures/Test2/Diagnostics/AbstractCrossLanguageUserDiagnosticTest.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AbstractCrossLanguageUserDiagnosticTest.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                             Optional codeActionIndex As Integer = 0,
                             Optional verifyTokens As Boolean = True,
                             Optional fileNameToExpected As Dictionary(Of String, String) = Nothing,
-                            Optional verifySolutions As Action(Of Solution, Solution) = Nothing,
+                            Optional verifySolutions As Func(Of Solution, Solution, Task) = Nothing,
                             Optional onAfterWorkspaceCreated As Action(Of TestWorkspace) = Nothing) As Task
             Using workspace = TestWorkspace.CreateWorkspace(definition)
                 onAfterWorkspaceCreated?.Invoke(workspace)
@@ -65,16 +65,20 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
                 Dim updatedSolution = workspace.CurrentSolution
 
-                verifySolutions?.Invoke(oldSolution, updatedSolution)
+                If verifySolutions IsNot Nothing Then
+                    Await verifySolutions(oldSolution, updatedSolution)
+                End If
 
-                If expected Is Nothing AndAlso fileNameToExpected Is Nothing Then
+                If expected Is Nothing AndAlso
+                   fileNameToExpected Is Nothing AndAlso
+                   verifySolutions Is Nothing Then
                     Dim projectChanges = SolutionUtilities.GetSingleChangedProjectChanges(oldSolution, updatedSolution)
                     Assert.Empty(projectChanges.GetChangedDocuments())
                 ElseIf expected IsNot Nothing Then
                     Dim updatedDocument = SolutionUtilities.GetSingleChangedDocument(oldSolution, updatedSolution)
 
                     Await VerifyAsync(expected, verifyTokens, updatedDocument)
-                Else
+                ElseIf fileNameToExpected IsNot Nothing Then
                     For Each kvp In fileNameToExpected
                         Dim updatedDocument = updatedSolution.Projects.SelectMany(Function(p) p.Documents).Single(Function(d) d.Name = kvp.Key)
                         Await VerifyAsync(kvp.Value, verifyTokens, updatedDocument)
@@ -134,7 +138,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Dim hostDocument = GetHostDocument(workspace)
 
             Dim invocationBuffer = hostDocument.TextBuffer
-            Dim invocationPoint = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+            Dim invocationPoint = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue AndAlso Not d.IsLinkFile).CursorPosition.Value
 
             Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
 

--- a/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/AddImport/AddImportCrossLanguageTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.IncrementalCaches
 Imports Microsoft.CodeAnalysis.SolutionCrawler
 Imports Microsoft.CodeAnalysis.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.AddImport
+Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.AddImport
 
@@ -509,12 +510,12 @@ namespace CSAssembly2
                             Optional codeActionIndex As Integer = 0,
                             Optional addedReference As String = Nothing,
                             Optional onAfterWorkspaceCreated As Action(Of TestWorkspace) = Nothing) As Task
-            Dim verifySolutions As Action(Of Solution, Solution) = Nothing
+            Dim verifySolutions As Func(Of Solution, Solution, Task) = Nothing
             Dim workspace As TestWorkspace = Nothing
 
             If addedReference IsNot Nothing Then
                 verifySolutions =
-                    Sub(oldSolution As Solution, newSolution As Solution)
+                    Function(oldSolution As Solution, newSolution As Solution)
                         Dim initialDocId = workspace.DocumentWithCursor.Id
                         Dim oldProject = oldSolution.GetDocument(initialDocId).Project
                         Dim newProject = newSolution.GetDocument(initialDocId).Project
@@ -529,7 +530,8 @@ namespace CSAssembly2
                                                    Select p.Name
 
                         Assert.True(newProjectReferences.Contains(addedReference))
-                    End Sub
+                        Return SpecializedTasks.EmptyTask
+                    End Function
             End If
 
             Await TestAsync(definition, expected, codeActionIndex,

--- a/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -95,6 +95,7 @@ end class
                 })
         End Function
 
+        <WorkItem(20855, "https://github.com/dotnet/roslyn/issues/20855")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
         Public Async Function TestLinkedFile() As System.Threading.Tasks.Task
             Dim input =

--- a/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -94,5 +94,54 @@ end class
 </text>.Value.Trim()}
                 })
         End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        Public Async Function TestLinkedFile() As System.Threading.Tasks.Task
+            Dim input =
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.1">
+                        <Document FilePath='C.cs'>
+partial class C
+{
+    $$int i;
+
+    public int P { get { return i; } }
+
+    public C()
+    {
+        this.i = 0;
+    }
+}
+                        </Document>
+                    </Project>
+                    <Project Language="C#" CommonReferences="true" AssemblyName="LinkedProj" Name="CSProj.2">
+                        <Document IsLinkFile="true" LinkProjectName="CSProj.1" LinkFilePath="C.cs"/>
+                    </Project>
+                </Workspace>
+
+            Dim expectedText = "
+partial class C
+{
+
+    public int P { get; private set; }
+
+    public C()
+    {
+        this.P = 0;
+    }
+}".Trim()
+
+            Await TestAsync(input, verifySolutions:=
+                Async Function(oldSolution, newSolution)
+                    Dim documents = newSolution.Projects.SelectMany(Function(p) p.Documents).
+                                                         Where(Function(d) d.Name = "C.cs")
+                    Assert.Equal(2, documents.Count())
+
+                    For Each doc In documents
+                        Dim text = (Await doc.GetTextAsync()).ToString().Trim()
+                        Assert.Equal(expectedText, text)
+                    Next
+                End Function)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -2,6 +2,8 @@
 
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.UseAutoProperty
     Public Class UseAutoPropertyTests
@@ -9,9 +11,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.UseAutoProperty
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, language As String) As (DiagnosticAnalyzer, CodeFixProvider)
             If language = LanguageNames.CSharp Then
-                Return (New CSharp.UseAutoProperty.UseAutoPropertyAnalyzer(), New CSharp.UseAutoProperty.UseAutoPropertyCodeFixProvider())
+                Return (New CSharpUseAutoPropertyAnalyzer(), New CSharpUseAutoPropertyCodeFixProvider())
             ElseIf language = LanguageNames.VisualBasic Then
-                Return (New VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer(), New VisualBasic.UseAutoProperty.UseAutoPropertyCodeFixProvider())
+                Return (New VisualBasicUseAutoPropertyAnalyzer(), New VisualBasicUseAutoPropertyCodeFixProvider())
             Else
                 Throw New Exception()
             End If

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -53,8 +53,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
 
             Dim propertyDeclaration = TryCast(member, PropertyBlockSyntax)
             If propertyDeclaration IsNot Nothing Then
-                Dim [property] = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken)
-                AnalyzeProperty(context, [property], analysisResults)
+                AnalyzeProperty(context, propertyDeclaration, analysisResults)
             End If
         End Sub
 

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
     <Export>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-    Friend Class UseAutoPropertyAnalyzer
+    Friend Class VisualBasicUseAutoPropertyAnalyzer
         Inherits AbstractUseAutoPropertyAnalyzer(Of PropertyBlockSyntax, FieldDeclarationSyntax, ModifiedIdentifierSyntax, ExpressionSyntax)
 
         Protected Overrides Function SupportsReadOnlyProperties(compilation As Compilation) As Boolean
@@ -21,7 +21,44 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
             Return DirectCast(compilation, VisualBasicCompilation).LanguageVersion >= LanguageVersion.VisualBasic10
         End Function
 
-        Protected Overrides Sub RegisterIneligibleFieldsAction(context As CompilationStartAnalysisContext, ineligibleFields As ConcurrentBag(Of IFieldSymbol))
+        Protected Overrides Sub AnalyzeCompilationUnit(context As SemanticModelAnalysisContext, root As SyntaxNode, analysisResults As List(Of AnalysisResult))
+            AnalyzeMembers(context, DirectCast(root, CompilationUnitSyntax).Members, analysisResults)
+        End Sub
+
+        Private Sub AnalyzeMembers(context As SemanticModelAnalysisContext,
+                                   members As SyntaxList(Of StatementSyntax),
+                                   analysisResults As List(Of AnalysisResult))
+            For Each member In members
+                AnalyzeMember(context, member, analysisResults)
+            Next
+        End Sub
+
+        Private Sub AnalyzeMember(context As SemanticModelAnalysisContext,
+                                  member As StatementSyntax,
+                                  analysisResults As List(Of AnalysisResult))
+
+            If member.Kind() = SyntaxKind.NamespaceBlock Then
+                Dim namespaceBlock = DirectCast(member, NamespaceBlockSyntax)
+                AnalyzeMembers(context, namespaceBlock.Members, analysisResults)
+            End If
+
+            ' If we have a class or struct or module, recurse inwards.
+            If member.IsKind(SyntaxKind.ClassBlock) OrElse
+               member.IsKind(SyntaxKind.StructureBlock) OrElse
+               member.IsKind(SyntaxKind.ModuleBlock) Then
+
+                Dim typeBlock = DirectCast(member, TypeBlockSyntax)
+                AnalyzeMembers(context, typeBlock.Members, analysisResults)
+            End If
+
+            Dim propertyDeclaration = TryCast(member, PropertyBlockSyntax)
+            If propertyDeclaration IsNot Nothing Then
+                Dim [property] = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken)
+                AnalyzeProperty(context, [property], analysisResults)
+            End If
+        End Sub
+
+        Protected Overrides Sub RegisterIneligibleFieldsAction(analysisResults As List(Of AnalysisResult), ineligibleFields As HashSet(Of IFieldSymbol), compilation As Compilation, cancellationToken As CancellationToken)
             ' There are no syntactic constructs that make a field ineligible to be replaced with 
             ' a property.  In C# you can't use a property in a ref/out position.  But that restriction
             ' doesn't apply to VB.
@@ -37,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
                 Dim memberAccessExpression = DirectCast(expression, MemberAccessExpressionSyntax)
                 Return memberAccessExpression.Expression.Kind() = SyntaxKind.MeExpression AndAlso
                     memberAccessExpression.Name.Kind() = SyntaxKind.IdentifierName
-            ElseIf expression.IsKind(SyntaxKind.IdentifierName)
+            ElseIf expression.IsKind(SyntaxKind.IdentifierName) Then
                 Return True
             End If
 

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyCodeFixProvider.vb
@@ -11,8 +11,8 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
     <[Shared]>
-    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(UseAutoPropertyCodeFixProvider))>
-    Friend Class UseAutoPropertyCodeFixProvider
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(VisualBasicUseAutoPropertyCodeFixProvider))>
+    Friend Class VisualBasicUseAutoPropertyCodeFixProvider
         Inherits AbstractUseAutoPropertyCodeFixProvider(Of PropertyBlockSyntax, FieldDeclarationSyntax, ModifiedIdentifierSyntax, ConstructorBlockSyntax, ExpressionSyntax)
 
         Protected Overrides Function GetNodeToRemove(identifier As ModifiedIdentifierSyntax) As SyntaxNode

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.UseAut
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Return (New UseAutoPropertyAnalyzer(), New UseAutoPropertyCodeFixProvider())
+            Return (New VisualBasicUseAutoPropertyAnalyzer(), New VisualBasicUseAutoPropertyCodeFixProvider())
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -28,15 +28,17 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         public override bool OpenFileOnly(Workspace workspace) => false;
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        protected abstract void RegisterIneligibleFieldsAction(
-            List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
-            Compilation compilation, CancellationToken cancellationToken);
+        protected abstract void AnalyzeCompilationUnit(SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults);
         protected abstract bool SupportsReadOnlyProperties(Compilation compilation);
         protected abstract bool SupportsPropertyInitializer(Compilation compilation);
         protected abstract TExpression GetFieldInitializer(TVariableDeclarator variable, CancellationToken cancellationToken);
         protected abstract TExpression GetGetterExpression(IMethodSymbol getMethod, CancellationToken cancellationToken);
         protected abstract TExpression GetSetterExpression(IMethodSymbol setMethod, SemanticModel semanticModel, CancellationToken cancellationToken);
         protected abstract SyntaxNode GetNodeToFade(TFieldDeclaration fieldDeclaration, TVariableDeclarator variableDeclarator);
+
+        protected abstract void RegisterIneligibleFieldsAction(
+            List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
+            Compilation compilation, CancellationToken cancellationToken);
 
         protected sealed override void InitializeWorker(AnalysisContext context)
             => context.RegisterSemanticModelAction(AnalyzeSemanticModel);
@@ -54,8 +56,6 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 context.SemanticModel.Compilation, context.CancellationToken);
             Process(analysisResults, ineligibleFields, context);
         }
-
-        protected abstract void AnalyzeCompilationUnit(SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults);
 
         protected void AnalyzeProperty(SemanticModelAnalysisContext context, TPropertyDeclaration propertyDeclaration, List<AnalysisResult> analysisResults)
         {

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -33,7 +33,9 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         public override bool OpenFileOnly(Workspace workspace) => false;
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.ProjectAnalysis;
 
-        protected abstract void RegisterIneligibleFieldsAction(CompilationStartAnalysisContext context, ConcurrentBag<IFieldSymbol> ineligibleFields);
+        protected abstract void RegisterIneligibleFieldsAction(
+            List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
+            Compilation compilation, CancellationToken cancellationToken);
         protected abstract bool SupportsReadOnlyProperties(Compilation compilation);
         protected abstract bool SupportsPropertyInitializer(Compilation compilation);
         protected abstract TExpression GetFieldInitializer(TVariableDeclarator variable, CancellationToken cancellationToken);
@@ -42,20 +44,26 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         protected abstract SyntaxNode GetNodeToFade(TFieldDeclaration fieldDeclaration, TVariableDeclarator variableDeclarator);
 
         protected sealed override void InitializeWorker(AnalysisContext context)
-            => context.RegisterCompilationStartAction(csac =>
-               {
-                   var analysisResults = new ConcurrentBag<AnalysisResult>();
-                   var ineligibleFields = new ConcurrentBag<IFieldSymbol>();
+            => context.RegisterSemanticModelAction(AnalyzeSemanticModel);
 
-                   csac.RegisterSymbolAction(sac => AnalyzeProperty(analysisResults, sac), SymbolKind.Property);
-                   RegisterIneligibleFieldsAction(csac, ineligibleFields);
-
-                   csac.RegisterCompilationEndAction(cac => Process(analysisResults, ineligibleFields, cac));
-               });
-
-        private void AnalyzeProperty(ConcurrentBag<AnalysisResult> analysisResults, SymbolAnalysisContext symbolContext)
+        private void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
         {
-            var property = (IPropertySymbol)symbolContext.Symbol;
+            var analysisResults = new List<AnalysisResult>();
+            var ineligibleFields = new HashSet<IFieldSymbol>();
+
+            var root = context.SemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
+            AnalyzeCompilationUnit(context, root, analysisResults);
+
+            RegisterIneligibleFieldsAction(
+                analysisResults, ineligibleFields,
+                context.SemanticModel.Compilation, context.CancellationToken);
+            Process(analysisResults, ineligibleFields, context);
+        }
+
+        protected abstract void AnalyzeCompilationUnit(SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults);
+
+        protected void AnalyzeProperty(SemanticModelAnalysisContext context, IPropertySymbol property, List<AnalysisResult> analysisResults)
+        {
             if (property.IsIndexer)
             {
                 return;
@@ -96,23 +104,30 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 return;
             }
 
-            var cancellationToken = symbolContext.CancellationToken;
+            var cancellationToken = context.CancellationToken;
             var propertyDeclaration = property.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken).FirstAncestorOrSelf<TPropertyDeclaration>();
             if (propertyDeclaration == null)
             {
                 return;
             }
 
-            var semanticModel = symbolContext.Compilation.GetSemanticModel(propertyDeclaration.SyntaxTree);
+            var semanticModel = context.SemanticModel;
             var getterField = GetGetterField(semanticModel, property.GetMethod, cancellationToken);
             if (getterField == null)
             {
                 return;
             }
 
+            if (getterField.DeclaredAccessibility != Accessibility.Private)
+            {
+                // Only support this for private fields.  It limits the scope of hte program
+                // we have to analyze to make sure this is safe to do.
+                return;
+            }
+
             // If the user made the field readonly, we only want to convert it to a property if we
             // can keep it readonly.
-            if (getterField.IsReadOnly && !SupportsReadOnlyProperties(symbolContext.Compilation))
+            if (getterField.IsReadOnly && !SupportsReadOnlyProperties(semanticModel.Compilation))
             {
                 return;
             }
@@ -160,14 +175,14 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             }
 
             var fieldReference = getterField.DeclaringSyntaxReferences[0];
-            var variableDeclarator = fieldReference.GetSyntax(symbolContext.CancellationToken) as TVariableDeclarator;
+            var variableDeclarator = fieldReference.GetSyntax(cancellationToken) as TVariableDeclarator;
             if (variableDeclarator == null)
             {
                 return;
             }
 
             var initializer = GetFieldInitializer(variableDeclarator, cancellationToken);
-            if (initializer != null && !SupportsPropertyInitializer(symbolContext.Compilation))
+            if (initializer != null && !SupportsPropertyInitializer(semanticModel.Compilation))
             {
                 return;
             }
@@ -223,9 +238,9 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         }
 
         private void Process(
-            ConcurrentBag<AnalysisResult> analysisResults,
-            ConcurrentBag<IFieldSymbol> ineligibleFields,
-            CompilationAnalysisContext compilationContext)
+            List<AnalysisResult> analysisResults,
+            HashSet<IFieldSymbol> ineligibleFields,
+            SemanticModelAnalysisContext context)
         {
             var ineligibleFieldsSet = new HashSet<IFieldSymbol>(ineligibleFields);
             foreach (var result in analysisResults)
@@ -236,15 +251,19 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                     continue;
                 }
 
-                Process(result, compilationContext);
+                Process(result, context);
             }
         }
 
-        private void Process(AnalysisResult result, CompilationAnalysisContext compilationContext)
+        private void Process(AnalysisResult result, SemanticModelAnalysisContext context)
         {
             // Check if there are additional reasons we think this field might be ineligible for 
             // replacing with an auto prop.
-            if (!IsEligibleHeuristic(result.Field, result.PropertyDeclaration, compilationContext.Compilation, compilationContext.CancellationToken))
+            var cancellationToken = context.CancellationToken;
+            var semanticModel = context.SemanticModel;
+            var compilation = semanticModel.Compilation;
+
+            if (!IsEligibleHeuristic(result.Field, result.PropertyDeclaration, compilation, cancellationToken))
             {
                 return;
             }
@@ -258,7 +277,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             // Fade out the field/variable we are going to remove.
             var diagnostic1 = Diagnostic.Create(UnnecessaryWithoutSuggestionDescriptor, nodeToFade.GetLocation());
-            compilationContext.ReportDiagnostic(diagnostic1);
+            context.ReportDiagnostic(diagnostic1);
 
             // Now add diagnostics to both the field and the property saying we can convert it to 
             // an auto property.  For each diagnostic store both location so we can easily retrieve
@@ -266,10 +285,10 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             IEnumerable<Location> additionalLocations = new Location[] { propertyDeclaration.GetLocation(), variableDeclarator.GetLocation() };
 
             var diagnostic2 = Diagnostic.Create(HiddenDescriptor, propertyDeclaration.GetLocation(), additionalLocations, properties);
-            compilationContext.ReportDiagnostic(diagnostic2);
+            context.ReportDiagnostic(diagnostic2);
 
             var diagnostic3 = Diagnostic.Create(HiddenDescriptor, nodeToFade.GetLocation(), additionalLocations, properties);
-            compilationContext.ReportDiagnostic(diagnostic3);
+            context.ReportDiagnostic(diagnostic3);
         }
 
         protected virtual bool IsEligibleHeuristic(IFieldSymbol field, TPropertyDeclaration propertyDeclaration, Compilation compilation, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -46,20 +46,17 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                var equivalenceKey = diagnostic.Properties[Constants.SymbolEquivalenceKey];
-
                 context.RegisterCodeFix(
                     new UseAutoPropertyCodeAction(
                         FeaturesResources.Use_auto_property,
-                        c => ProcessResult(context, diagnostic, c),
-                        equivalenceKey),
+                        c => ProcessResultAsync(context, diagnostic, c)),
                     diagnostic);
             }
 
             return SpecializedTasks.EmptyTask;
         }
 
-        private async Task<Solution> ProcessResult(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
+        private async Task<Solution> ProcessResultAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             var locations = diagnostic.AdditionalLocations;
             var propertyLocation = locations[0];
@@ -238,8 +235,8 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
         private class UseAutoPropertyCodeAction : CodeAction.SolutionChangeAction
         {
-            public UseAutoPropertyCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution, string equivalenceKey)
-                : base(title, createChangedSolution, equivalenceKey)
+            public UseAutoPropertyCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution)
+                : base(title, createChangedSolution, title)
             {
             }
         }

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -86,10 +86,34 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             var updatedProperty = await UpdatePropertyAsync(propertyDocument, compilation, fieldSymbol, propertySymbol, property,
                 isWrittenToOutsideOfConstructor, cancellationToken).ConfigureAwait(false);
 
+            // Note: rename will try to update all the references in linked files as well.  However, 
+            // this can lead to some very bad behavior as we will change the references in linked files
+            // but only remove the field and update the property in a single document.  So, you can
+            // end in the state where you do this in one of the linked file:
+            //
+            //      int Prop { get { return this.field; } } => int Prop { get { return this.Prop } }
+            //
+            // But in the main file we'll replace:
+            //
+            //      int Prop { get { return this.field; } } => int Prop { get; }
+            //
+            // The workspace will see these as two irreconcilable edits.  To avoid this, we disallow
+            // any edits to the other links for the files containing the field and property.  i.e.
+            // rename will only be allowed to edit the exact same doc we're removing the field from
+            // and the exact doc we're updating hte property in.  It can't touch the other linked
+            // files for those docs.  (It can of course touch any other documents unrelated to the
+            // docs that the field and prop are declared in).
+            var linkedFiles = new HashSet<DocumentId>();
+            linkedFiles.AddRange(fieldDocument.GetLinkedDocumentIds());
+            linkedFiles.AddRange(propertyDocument.GetLinkedDocumentIds());
+
+            var canEdit = new Dictionary<SyntaxTree, bool>();
+
             // Now, rename all usages of the field to point at the property.  Except don't actually 
             // rename the field itself.  We want to be able to find it again post rename.
             var updatedSolution = await Renamer.RenameAsync(fieldLocations, propertySymbol.Name,
-                location => !location.SourceSpan.IntersectsWith(declaratorLocation.SourceSpan),
+                location => !location.SourceSpan.IntersectsWith(declaratorLocation.SourceSpan) &&
+                            CanEditDocument(solution, location.SourceTree, linkedFiles, canEdit),
                 symbols => HasConflict(symbols, propertySymbol, compilation, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
@@ -146,6 +170,20 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
                 return updatedSolution;
             }
+        }
+
+        private bool CanEditDocument(
+            Solution solution, SyntaxTree sourceTree,
+            HashSet<DocumentId> linkedDocuments,
+            Dictionary<SyntaxTree, bool> canEdit)
+        {
+            if (!canEdit.ContainsKey(sourceTree))
+            {
+                var document = solution.GetDocument(sourceTree);
+                canEdit[sourceTree] = document != null && !linkedDocuments.Contains(document.Id);
+            }
+
+            return canEdit[sourceTree];
         }
 
         private async Task<SyntaxNode> FormatAsync(SyntaxNode newRoot, Document document, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 locations = new RenameLocations(
                     locations.Locations.Where(loc => filter(loc.Location)).ToSet(),
                     symbolAndProjectId, locations.Solution,
-                    locations.ReferencedSymbols, locations.ImplicitLocations,
+                    locations.ReferencedSymbols, locations.ImplicitLocations.Where(loc => filter(loc.Location)),
                     locations.Options);
             }
 


### PR DESCRIPTION
Fixes #23216
Fixes #23215
Fixes #20855
Closes #23217

This PR changes the 'use auto property' code fixer to work as a Semantic-Model-Analyzer, instead of a Compilation-End analyzer.  Compilation-End-Analyzers are basically an unusable part of the analyzer API for code that wants to run in VS.  They are too expensive, and users can't interact with their results in a timely manner, like they can with normal analyzers.

As part of making this happen, I had to make a small change to the functionality of the feature.  Specifically, we used to determine if it was safe to make the change by analyzing all usages of a the field-to-remove in the project the feature was analyzing.  This was very expensive, but was necessary in case some code was using the field in an unexpected manner.  Now, we limit the feature to only private fields.  This means we can do that analysis in a timely manner, as we only have to examine the type it is contained in.  

This should have very little end user impact as the majority of user fields are private (esp. the ones that are paired with a property that you'd want ot make an auto prop out of).
