### PR TITLE
Fix an InvalidCastException in IOperation factory for an ambiguous user-defined short-circuiting operator

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
             catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
                 // Log a Non-fatal-watson and then ignore the crash in the attempt of getting operation
-                Debug.Assert(false, e.ToString());
+                Debug.Assert(false, "\n" + e.ToString());
             }
 
             return null;

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -472,18 +472,21 @@ Namespace Microsoft.CodeAnalysis.Operations
         End Function
 
         Private Function CreateBoundUserDefinedShortCircuitingOperatorOperation(boundUserDefinedShortCircuitingOperator As BoundUserDefinedShortCircuitingOperator) As IBinaryOperation
-            Dim operatorKind As BinaryOperatorKind = If((boundUserDefinedShortCircuitingOperator.BitwiseOperator.OperatorKind And VisualBasic.BinaryOperatorKind.And) <> 0, BinaryOperatorKind.ConditionalAnd, BinaryOperatorKind.ConditionalOr)
-            Dim leftOperand As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundUserDefinedShortCircuitingOperator.LeftOperand))
-            Dim rightOperand As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() Create(boundUserDefinedShortCircuitingOperator.BitwiseOperator.Right))
-            Dim operatorMethod As IMethodSymbol = boundUserDefinedShortCircuitingOperator.BitwiseOperator.Call.Method
+            Dim bitwiseOperator As BoundUserDefinedBinaryOperator = boundUserDefinedShortCircuitingOperator.BitwiseOperator
+            Dim binaryOperatorInfo As BinaryOperatorInfo = GetUserDefinedBinaryOperatorInfo(bitwiseOperator)
+            Dim operatorKind As BinaryOperatorKind = If(binaryOperatorInfo.OperatorKind = BinaryOperatorKind.And, BinaryOperatorKind.ConditionalAnd, BinaryOperatorKind.ConditionalOr)
+
+            Dim leftOperand As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() If(boundUserDefinedShortCircuitingOperator.LeftOperand IsNot Nothing,
+                                                                                           Create(boundUserDefinedShortCircuitingOperator.LeftOperand), ' Possibly dropping conversions https://github.com/dotnet/roslyn/issues/23236
+                                                                                           GetUserDefinedBinaryOperatorChild(bitwiseOperator, binaryOperatorInfo.LeftOperand)))
+            Dim rightOperand As Lazy(Of IOperation) = New Lazy(Of IOperation)(Function() GetUserDefinedBinaryOperatorChild(bitwiseOperator, binaryOperatorInfo.RightOperand))
             Dim syntax As SyntaxNode = boundUserDefinedShortCircuitingOperator.Syntax
             Dim type As ITypeSymbol = boundUserDefinedShortCircuitingOperator.Type
             Dim constantValue As [Optional](Of Object) = ConvertToOptional(boundUserDefinedShortCircuitingOperator.ConstantValueOpt)
-            Dim isLifted As Boolean = (boundUserDefinedShortCircuitingOperator.BitwiseOperator.OperatorKind And VisualBasic.BinaryOperatorKind.Lifted) <> 0
             Dim isChecked As Boolean = False
             Dim isCompareText As Boolean = False
             Dim isImplicit As Boolean = boundUserDefinedShortCircuitingOperator.WasCompilerGenerated
-            Return New LazyBinaryOperatorExpression(operatorKind, leftOperand, rightOperand, isLifted, isChecked, isCompareText, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New LazyBinaryOperatorExpression(operatorKind, leftOperand, rightOperand, binaryOperatorInfo.IsLifted, isChecked, isCompareText, binaryOperatorInfo.OperatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
         Private Function CreateBoundBadExpressionOperation(boundBadExpression As BoundBadExpression) As IInvalidOperation

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IUnaryOperatorExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IUnaryOperatorExpression.vb
@@ -1907,7 +1907,7 @@ IConditionalOperation (OperationKind.Conditional, Type: null) (Syntax: 'If x OrE
   Condition: 
     IUnaryOperation (UnaryOperatorKind.True) (OperatorMethod: Function CustomType.op_True(x As CustomType) As System.Boolean) (OperationKind.UnaryOperator, Type: System.Boolean, IsImplicit) (Syntax: 'x OrElse y')
       Operand: 
-        IBinaryOperation (BinaryOperatorKind.ConditionalAnd) (OperatorMethod: Function CustomType.op_BitwiseOr(x As CustomType, y As CustomType) As CustomType) (OperationKind.BinaryOperator, Type: CustomType) (Syntax: 'x OrElse y')
+        IBinaryOperation (BinaryOperatorKind.ConditionalOr) (OperatorMethod: Function CustomType.op_BitwiseOr(x As CustomType, y As CustomType) As CustomType) (OperationKind.BinaryOperator, Type: CustomType) (Syntax: 'x OrElse y')
           Left: 
             ILocalReferenceOperation: x (OperationKind.LocalReference, Type: CustomType) (Syntax: 'x')
           Right: 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedBinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedBinaryOperators.vb
@@ -521,7 +521,9 @@ BC30452: Operator 'OrElse' is not defined for types 'Module1.B3' and 'Module1.B3
             Next
         End Sub
 
+        <CompilerTrait(CompilerFeature.IOperation)>
         <Fact>
+        <WorkItem(23232, "https://github.com/dotnet/roslyn/issues/23232")>
         Public Sub ShortCircuiting5()
             Dim compilationDef =
 <compilation name="SimpleTest1">
@@ -585,6 +587,36 @@ BC30521: Overload resolution failed because no accessible 'Or' is most specific 
                 Dim symbolInfo = model.GetSymbolInfo(node)
                 Assert.Null(symbolInfo.Symbol)
             Next
+
+            compilation.VerifyOperationTree(CompilationUtils.FindBindingText(Of ExpressionSyntax)(compilation, "a.vb", 1), expectedOperationTree:=
+            <![CDATA[
+IBinaryOperation (BinaryOperatorKind.ConditionalAnd) (OperationKind.BinaryOperator, Type: ?, IsInvalid) (Syntax: 'New B3() An ... so New B2()')
+  Left: 
+    IObjectCreationOperation (Constructor: Sub Module1.B3..ctor()) (OperationKind.ObjectCreation, Type: Module1.B3, IsInvalid) (Syntax: 'New B3()')
+      Arguments(0)
+      Initializer: 
+        null
+  Right: 
+    IObjectCreationOperation (Constructor: Sub Module1.B2..ctor()) (OperationKind.ObjectCreation, Type: Module1.B2, IsInvalid) (Syntax: 'New B2()')
+      Arguments(0)
+      Initializer: 
+        null
+]]>.Value)
+
+            compilation.VerifyOperationTree(CompilationUtils.FindBindingText(Of ExpressionSyntax)(compilation, "a.vb", 2), expectedOperationTree:=
+            <![CDATA[
+IBinaryOperation (BinaryOperatorKind.ConditionalOr) (OperationKind.BinaryOperator, Type: ?, IsInvalid) (Syntax: 'New B3() OrElse New B2()')
+  Left: 
+    IObjectCreationOperation (Constructor: Sub Module1.B3..ctor()) (OperationKind.ObjectCreation, Type: Module1.B3, IsInvalid) (Syntax: 'New B3()')
+      Arguments(0)
+      Initializer: 
+        null
+  Right: 
+    IObjectCreationOperation (Constructor: Sub Module1.B2..ctor()) (OperationKind.ObjectCreation, Type: Module1.B2, IsInvalid) (Syntax: 'New B2()')
+      Arguments(0)
+      Initializer: 
+        null
+]]>.Value)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes #23232.
Also fixes incorrect calculation of BinaryOperatorKind for the same node.

**Customer scenario**

Request IOperation tree for an ambiguous user-defined short-circuiting operator like the one below:
```
Option Strict Off

Imports System

Module Module1

    Class B2
        Public Shared Operator And(x As B3, y As B2) As B2
            Return Nothing
        End Operator

        Public Shared Operator Or(x As B3, y As B2) As B2
            Return Nothing
        End Operator
    End Class

    Class B3
        Public Shared Operator And(x As B3, y As B2) As B3
            Return Nothing
        End Operator

        Public Shared Operator Or(x As B3, y As B2) As B3
            Return Nothing
        End Operator
    End Class

    Sub Main()
        Dim x As Object

        x = New B3() AndAlso New B2() 'BIND1:"New B3() AndAlso New B2()"
    End Sub
End Module
```

An InvalidCastException is thrown by IOperation factory.

**Bugs this fixes:**

Fixes #23232.

**Workarounds, if any**

No

**Risk**

Low

**Performance impact**

Low perf impact because no extra allocations/no complexity changes

**Is this a regression from a previous update?**

No

**Root cause analysis:**

A test gap. Unit-tests are added.

**How was the bug found?**

Running existing compiler tests with IOperation validation test hook enabled.
