### PR TITLE
fix connection disconnected issue in the test.

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.DebugUtil;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.TodoComments;
+using Nerdbank;
 using Roslyn.Test.Utilities;
 using Roslyn.Test.Utilities.Remote;
 using Roslyn.VisualStudio.Next.UnitTests.Mocks;
@@ -27,19 +28,22 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public void TestRemoteHostCreation()
         {
-            var remoteHostService = CreateService();
-            Assert.NotNull(remoteHostService);
+            using (var remoteHostService = CreateService())
+            {
+                Assert.NotNull(remoteHostService);
+            }
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public void TestRemoteHostConnect()
         {
-            var remoteHostService = CreateService();
+            using (var remoteHostService = CreateService())
+            {
+                var input = "Test";
+                var output = remoteHostService.Connect(input, serializedSession: null, cancellationToken: CancellationToken.None);
 
-            var input = "Test";
-            var output = remoteHostService.Connect(input, serializedSession: null, cancellationToken: CancellationToken.None);
-
-            Assert.Equal(input, output);
+                Assert.Equal(input, output);
+            }
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
@@ -398,8 +402,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private static RemoteHostService CreateService()
         {
-            var stream = new MemoryStream();
-            return new RemoteHostService(stream, new InProcRemoteHostClient.ServiceProvider(runCacheCleanup: false));
+            var tuple = FullDuplexStream.CreateStreams();
+            return new RemoteHostService(tuple.Item1, new InProcRemoteHostClient.ServiceProvider(runCacheCleanup: false));
         }
 
         private static void SetEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)


### PR DESCRIPTION
use full duplex stream

..

fix https://github.com/dotnet/roslyn/issues/23112

this is test fix. 

looks like happening since I gave it memorystream rather than full duplex stream it is expecting. (https://ci.dot.net/job/dotnet_roslyn/job/post-dev15.5-contrib/job/windows_debug_unit32_prtest/354/testReport/junit/Roslyn.VisualStudio.Next.UnitTests.Remote/ServiceHubServicesTests/TestRemoteHostConnect/)

cancellation can only happen if given connection (stream) caused issue with JsonRpc.