### PR TITLE
improve error case handling.

### DIFF
--- a/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                         {
                             // The DesignerCategoryAttribute doesn't exist. either not applicable or
                             // no idea on design attribute status, just leave things as it is.
-                            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, notApplicable: true);
+                            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, applicable: false);
                         }
                     }
 
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                         if (attribute != null && attribute.ConstructorArguments.Length == 1)
                         {
                             designerAttributeArgument = GetArgumentString(attribute.ConstructorArguments[0]);
-                            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, notApplicable: false);
+                            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, applicable: true);
                         }
                     }
                 }
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                 }
             }
 
-            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, notApplicable: false);
+            return new DesignerAttributeResult(designerAttributeArgument, documentHasError, applicable: true);
         }
 
         private static string GetArgumentString(TypedConstant argument)

--- a/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeResult.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeResult.cs
@@ -15,15 +15,15 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
         public bool ContainsErrors { get; }
 
         /// <summary>
-        /// The document asked is not applicable for the designer attribute
+        /// The document asked is applicable for the designer attribute
         /// </summary>
-        public bool NotApplicable { get; }
+        public bool Applicable { get; }
 
-        public DesignerAttributeResult(string designerAttributeArgument, bool containsErrors, bool notApplicable)
+        public DesignerAttributeResult(string designerAttributeArgument, bool containsErrors, bool applicable)
         {
             DesignerAttributeArgument = designerAttributeArgument;
             ContainsErrors = containsErrors;
-            NotApplicable = notApplicable;
+            Applicable = applicable;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             }
 
             var result = await ScanDesignerAttributesOnRemoteHostIfPossibleAsync(document, cancellationToken).ConfigureAwait(false);
-            if (result.NotApplicable)
+            if (!result.Applicable)
             {
                 _state.Remove(document.Id);
                 return;
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             var service = document.GetLanguageService<IDesignerAttributeService>();
             if (service == null)
             {
-                return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: true, notApplicable: true);
+                return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: true, applicable: false);
             }
 
             return await service.ScanDesignerAttributesAsync(document, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         return await service.ScanDesignerAttributesAsync(document, token).ConfigureAwait(false);
                     }
 
-                    return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: true, notApplicable: true);
+                    return new DesignerAttributeResult(designerAttributeArgument: null, containsErrors: true, applicable: false);
                 }
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.RoslynOnly.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/RoslynJsonConverter.RoslynOnly.cs
@@ -108,12 +108,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var designerAttributeArgument = ReadProperty<string>(reader);
                 var containsErrors = ReadProperty<bool>(reader);
-                var notApplicable = ReadProperty<bool>(reader);
+                var applicable = ReadProperty<bool>(reader);
 
                 Contract.ThrowIfFalse(reader.Read());
                 Contract.ThrowIfFalse(reader.TokenType == JsonToken.EndObject);
 
-                return new DesignerAttributeResult(designerAttributeArgument, containsErrors, notApplicable);
+                return new DesignerAttributeResult(designerAttributeArgument, containsErrors, applicable);
             }
 
             protected override void WriteValue(JsonWriter writer, DesignerAttributeResult result, JsonSerializer serializer)
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 writer.WritePropertyName(nameof(DesignerAttributeResult.ContainsErrors));
                 writer.WriteValue(result.ContainsErrors);
 
-                writer.WritePropertyName(nameof(DesignerAttributeResult.NotApplicable));
-                writer.WriteValue(result.NotApplicable);
+                writer.WritePropertyName(nameof(DesignerAttributeResult.Applicable));
+                writer.WriteValue(result.Applicable);
 
                 writer.WriteEndObject();
             }


### PR DESCRIPTION
when OOP is killed by users, default(DesignerAttributeResult) is returned by designer scanner. it was okay when it was class, but now it being struct, it causes issue because NotApplicable return false rather than true in error case.

so, changed NotApplicable to Applicable so that it can handle the error case better.

**Customer scenario**

User killed OOP while using VS with winforms and VS wrongly detect winform file as normal files.

**Bugs this fixes:**

Fixes #23242

**Workarounds, if any**

don't kill OOP

**Risk**

Very safe change

**Performance impact**

No impact

**Is this a regression from a previous update?**

No

**Root cause analysis:**

default(T) made return to be valid rather than invalid.

**How was the bug found?**

dogfooding
