### PR TITLE
Removed missing references and p2p transitiveness from project succes…

### DIFF
--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -400,5 +400,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         AssetStorage_ForceGC,
         RemoteHost_Bitness,
         Intellisense_Completion,
+        MetadataOnlyImage_EmitFailure,
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/MetadataOnlyImage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/MetadataOnlyImage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Emit;
@@ -65,6 +66,15 @@ namespace Microsoft.CodeAnalysis
                             {
                                 workspace.LogTestMessage("  " + diagnostic.GetMessage());
                             }
+
+                            // log emit failures so that we can improve most common cases
+                            Logger.Log(FunctionId.MetadataOnlyImage_EmitFailure, KeyValueLogMessage.Create(m =>
+                            {
+                                // log errors in the format of
+                                // CS0001:1;CS002:10;...
+                                var groups = emitResult.Diagnostics.GroupBy(d => d.Id).Select(g => $"{g.Key}:{g.Count()}");
+                                m["Errors"] = string.Join(";", groups);
+                            }));
                         }
                     }
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.State.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
                 /// Specifies whether <see cref="FinalCompilation"/> and all compilations it depends on contain full information or not. This can return
                 /// null if the state isn't at the point where it would know, and it's necessary to transition to <see cref="FinalState"/> to figure that out.
                 /// </summary>
-                public virtual bool? HasSuccessfullyLoadedTransitively => null;
+                public virtual bool? HasSuccessfullyLoaded => null;
 
                 /// <summary>
                 /// The final compilation if available, otherwise an empty <see cref="ValueSource{Compilation}"/>.
@@ -132,15 +132,15 @@ namespace Microsoft.CodeAnalysis
             /// </summary>
             private sealed class FinalState : State
             {
-                private readonly bool _hasSuccessfullyLoadedTransitively;
+                private readonly bool _hasSuccessfullyLoaded;
 
-                public override bool? HasSuccessfullyLoadedTransitively => _hasSuccessfullyLoadedTransitively;
+                public override bool? HasSuccessfullyLoaded => _hasSuccessfullyLoaded;
                 public override ValueSource<Compilation> FinalCompilation => this.Compilation;
 
-                public FinalState(ValueSource<Compilation> finalCompilationSource, bool hasSuccessfullyLoadedTransitively)
+                public FinalState(ValueSource<Compilation> finalCompilationSource, bool hasSuccessfullyLoaded)
                     : base(finalCompilationSource, finalCompilationSource.GetValue().Clone().RemoveAllReferences())
                 {
-                    _hasSuccessfullyLoadedTransitively = hasSuccessfullyLoadedTransitively;
+                    _hasSuccessfullyLoaded = hasSuccessfullyLoaded;
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis
                 // have the compilation immediately disappear.  So we force it to stay around with a ConstantValueSource.
                 // As a policy, all partial-state projects are said to have incomplete references, since the state has no guarantees.
                 return new CompilationTracker(inProgressProject,
-                    new FinalState(new ConstantValueSource<Compilation>(inProgressCompilation), hasSuccessfullyLoadedTransitively: false));
+                    new FinalState(new ConstantValueSource<Compilation>(inProgressCompilation), hasSuccessfullyLoaded: false));
             }
 
             /// <summary>
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis
                         var finalCompilation = state.FinalCompilation.GetValue(cancellationToken);
                         if (finalCompilation != null)
                         {
-                            return new CompilationInfo(finalCompilation, state.HasSuccessfullyLoadedTransitively.Value);
+                            return new CompilationInfo(finalCompilation, state.HasSuccessfullyLoaded.Value);
                         }
 
                         // Otherwise, we actually have to build it.  Ensure that only one thread is trying to
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis
                 var compilation = state.FinalCompilation.GetValue(cancellationToken);
                 if (compilation != null)
                 {
-                    return Task.FromResult(new CompilationInfo(compilation, state.HasSuccessfullyLoadedTransitively.Value));
+                    return Task.FromResult(new CompilationInfo(compilation, state.HasSuccessfullyLoaded.Value));
                 }
 
                 compilation = state.Compilation.GetValue(cancellationToken);
@@ -571,12 +571,12 @@ namespace Microsoft.CodeAnalysis
             private struct CompilationInfo
             {
                 public Compilation Compilation { get; }
-                public bool HasSuccessfullyLoadedTransitively { get; }
+                public bool HasSuccessfullyLoaded { get; }
 
-                public CompilationInfo(Compilation compilation, bool hasSuccessfullyLoadedTransitively)
+                public CompilationInfo(Compilation compilation, bool hasSuccessfullyLoaded)
                 {
                     this.Compilation = compilation;
-                    this.HasSuccessfullyLoadedTransitively = hasSuccessfullyLoadedTransitively;
+                    this.HasSuccessfullyLoaded = hasSuccessfullyLoaded;
                 }
             }
 
@@ -640,11 +640,9 @@ namespace Microsoft.CodeAnalysis
 
                     compilation = UpdateCompilationWithNewReferencesAndRecordAssemblySymbols(compilation, newReferences, metadataReferenceToProjectId);
 
-                    bool hasSuccessfullyLoadedTransitively = !HasMissingReferences(compilation, this.ProjectState.MetadataReferences) && await ComputeHasSuccessfullyLoadedTransitivelyAsync(solution, hasSuccessfullyLoaded, cancellationToken).ConfigureAwait(false);
+                    this.WriteState(new FinalState(State.CreateValueSource(compilation, solution.Services), hasSuccessfullyLoaded), solution);
 
-                    this.WriteState(new FinalState(State.CreateValueSource(compilation, solution.Services), hasSuccessfullyLoadedTransitively), solution);
-
-                    return new CompilationInfo(compilation, hasSuccessfullyLoadedTransitively);
+                    return new CompilationInfo(compilation, hasSuccessfullyLoaded);
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                 {
@@ -673,44 +671,6 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 return compilation;
-            }
-
-            private bool HasMissingReferences(Compilation compilation, IReadOnlyList<MetadataReference> metadataReferences)
-            {
-                foreach (var reference in metadataReferences)
-                {
-                    if (compilation.GetAssemblyOrModuleSymbol(reference) == null)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            private async Task<bool> ComputeHasSuccessfullyLoadedTransitivelyAsync(
-                SolutionState solution, bool hasSuccessfullyLoaded, CancellationToken cancellationToken)
-            {
-                if (!hasSuccessfullyLoaded)
-                {
-                    return false;
-                }
-
-                foreach (var projectReference in this.ProjectState.ProjectReferences)
-                {
-                    var project = solution.GetProjectState(projectReference.ProjectId);
-                    if (project == null)
-                    {
-                        return false;
-                    }
-
-                    if (!await solution.HasSuccessfullyLoadedAsync(project, cancellationToken).ConfigureAwait(false))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
             }
 
             /// <summary>
@@ -853,9 +813,9 @@ namespace Microsoft.CodeAnalysis
             {
                 var state = this.ReadState();
 
-                if (state.HasSuccessfullyLoadedTransitively.HasValue)
+                if (state.HasSuccessfullyLoaded.HasValue)
                 {
-                    return state.HasSuccessfullyLoadedTransitively.Value ? SpecializedTasks.True : SpecializedTasks.False;
+                    return state.HasSuccessfullyLoaded.Value ? SpecializedTasks.True : SpecializedTasks.False;
                 }
                 else
                 {
@@ -866,7 +826,7 @@ namespace Microsoft.CodeAnalysis
             private async Task<bool> HasSuccessfullyLoadedSlowAsync(SolutionState solution, CancellationToken cancellationToken)
             {
                 var compilationInfo = await GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-                return compilationInfo.HasSuccessfullyLoadedTransitively;
+                return compilationInfo.HasSuccessfullyLoaded;
             }
 
             #region Versions

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1404,14 +1404,14 @@ public class C : A {
             Assert.True(vbNormalProject.HasSuccessfullyLoadedAsync().Result);
 
             // check flag for normal project that directly reference a broken project
-            Assert.False(dependsOnBrokenProject.HasSuccessfullyLoadedAsync().Result);
+            Assert.True(dependsOnBrokenProject.HasSuccessfullyLoadedAsync().Result);
 
             // check flag for normal project that directly reference only normal project
             Assert.True(dependsOnVbNormalProject.HasSuccessfullyLoadedAsync().Result);
 
             // check flag for normal project that indirectly reference a borken project
             // normal project -> normal project -> broken project
-            Assert.False(transitivelyDependsOnBrokenProjects.HasSuccessfullyLoadedAsync().Result);
+            Assert.True(transitivelyDependsOnBrokenProjects.HasSuccessfullyLoadedAsync().Result);
 
             // check flag for normal project that indirectly reference only normal project
             // normal project -> normal project -> normal project


### PR DESCRIPTION
…sfully loaded check.

also, now we log skeleton assembly failure reasons to improve those common cases

**Customer scenario**

User opens a solution and don't see any semantic errors from opened files

**Bugs this fixes:**

related to https://github.com/dotnet/roslyn/issues/21629
(either VSO or GitHub links)

**Workarounds, if any**

fix either design time errors or errors from cross language p2p reference project.

**Risk**

there is a risk where we might show more cascading semantic errors than before.

**Performance impact**

it shouldn't affect performance much.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

this is not a functional bug but rather we are tweaking user experience to find better error situation experience. users only get into this situation when solution has errors. we are experimenting with how much errors we should show users in such situation.

**How was the bug found?**

dogfooding, feedbacks

