### PR TITLE
Improve the syntax error when a conditional expression used in an interpolated string

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2951,6 +2951,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A conditional expression cannot be used directly in a string interpolation because the &apos;:&apos; ends the interpolation. Parenthesize the conditional expression..
+        /// </summary>
+        internal static string ERR_ConditionalInInterpolation {
+            get {
+                return ResourceManager.GetString("ERR_ConditionalInInterpolation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Conditional attribute is not valid on &apos;{0}&apos; because its return type is not void.
         /// </summary>
         internal static string ERR_ConditionalMustReturnVoid {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5235,4 +5235,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_FilterIsConstantFalseRedundantTryCatch_Title" xml:space="preserve">
     <value>Filter expression is a constant 'false'. </value>
   </data>
+  <data name="ERR_ConditionalInInterpolation" xml:space="preserve">
+    <value>A conditional expression cannot be used directly in a string interpolation because the ':' ends the interpolation. Parenthesize the conditional expression.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1539,6 +1539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_OutAttrOnInParam = 8355,
         #endregion diagnostics introduced for `ref readonly`, `ref ternary` and `ref-like` features in C# 7.2
 
+        #region diagnostics introduced for C# 7.3
         ERR_PredefinedValueTupleTypeAmbiguous3 = 8356,
         ERR_InvalidVersionFormatDeterministic = 8357,
 
@@ -1548,5 +1549,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_FilterIsConstantFalse = 8359,
         WRN_FilterIsConstantFalseRedundantTryCatch = 8360,
         #endregion diagnostics for FilterIsConstant warning message fix
+
+        ERR_ConditionalInInterpolation = 8361,
+        #endregion diagnostics introduced for C# 7.3
     }
 }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9055,9 +9055,23 @@ tryAgain:
             {
                 var questionToken = this.EatToken();
                 var colonLeft = this.ParsePossibleRefExpression();
-                var colon = this.EatToken(SyntaxKind.ColonToken);
-                var colonRight = this.ParsePossibleRefExpression();
-                leftOperand = _syntaxFactory.ConditionalExpression(leftOperand, questionToken, colonLeft, colon, colonRight);
+                if (this.CurrentToken.Kind == SyntaxKind.EndOfFileToken && this.lexer.FollowedByColon)
+                {
+                    // We have an interpolated string with an interpolation that contains a conditional expression.
+                    // Unfortunately, the precedence demands that the colon is considered part of the interpolated
+                    // string. Without this code, the compiler would complain about a missing colon, and point
+                    // to the colon token that is actually there. We need to give a better error message.
+                    var colon = SyntaxFactory.MissingToken(SyntaxKind.ColonToken);
+                    var colonRight = _syntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken));
+                    leftOperand = _syntaxFactory.ConditionalExpression(leftOperand, questionToken, colonLeft, colon, colonRight);
+                    leftOperand = this.AddError(leftOperand, ErrorCode.ERR_ConditionalInInterpolation);
+                }
+                else
+                {
+                    var colon = this.EatToken(SyntaxKind.ColonToken);
+                    var colonRight = this.ParsePossibleRefExpression();
+                    leftOperand = _syntaxFactory.ConditionalExpression(leftOperand, questionToken, colonLeft, colon, colonRight);
+                }
             }
 
             return leftOperand;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 : SyntaxFactory.Token(SyntaxKind.CloseBraceToken);
 
             var parsedText = Substring(text, interpolation.OpenBracePosition, interpolation.HasColon ? interpolation.ColonPosition - 1 : interpolation.CloseBracePosition - 1);
-            using (var tempLexer = new Lexer(Text.SourceText.From(parsedText), this.Options, allowPreprocessorDirectives: false))
+            using (var tempLexer = new Lexer(Text.SourceText.From(parsedText), this.Options, allowPreprocessorDirectives: false, followedByColon: interpolation.HasColon))
             {
                 // TODO: some of the trivia in the interpolation maybe should be trailing trivia of the openBraceToken
                 using (var tempParser = new LanguageParser(tempLexer, null, null))

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private DirectiveStack _directives;
         private readonly LexerCache _cache;
         private readonly bool _allowPreprocessorDirectives;
+        private readonly bool _followedByColon;
         private DocumentationCommentParser _xmlParser;
         private int _badTokenCount; // cumulative count of bad tokens produced
 
@@ -101,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             internal bool IsVerbatim;
         }
 
-        public Lexer(SourceText text, CSharpParseOptions options, bool allowPreprocessorDirectives = true)
+        public Lexer(SourceText text, CSharpParseOptions options, bool allowPreprocessorDirectives = true, bool followedByColon = false)
             : base(text)
         {
             Debug.Assert(options != null);
@@ -112,6 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _cache = new LexerCache();
             _createQuickTokenFunction = this.CreateQuickToken;
             _allowPreprocessorDirectives = allowPreprocessorDirectives;
+            _followedByColon = followedByColon;
         }
 
         public override void Dispose()
@@ -139,6 +141,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public DirectiveStack Directives
         {
             get { return _directives; }
+        }
+
+        public bool FollowedByColon
+        {
+            get
+            {
+                return _followedByColon;
+            }
         }
 
         public void Reset(int position, DirectiveStack directives)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -3742,5 +3742,48 @@ select t";
             }
             EOF();
         }
+
+        [Fact, WorkItem(12214, "https://github.com/dotnet/roslyn/issues/12214")]
+        public void ConditionalExpressionInInterpolation()
+        {
+            UsingExpression("$\"{a ? b : d}\"",
+                // (1,4): error CS8361: A conditional expression cannot be used directly in a string interpolation because the ':' ends the interpolation. Parenthesize the conditional expression.
+                // $"{a ? b : d}"
+                Diagnostic(ErrorCode.ERR_ConditionalInInterpolation, "a ? b ").WithLocation(1, 4)
+                );
+            N(SyntaxKind.InterpolatedStringExpression);
+            {
+                N(SyntaxKind.InterpolatedStringStartToken);
+                N(SyntaxKind.Interpolation);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ConditionalExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "a");
+                        }
+                        N(SyntaxKind.QuestionToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "b");
+                        }
+                        M(SyntaxKind.ColonToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.InterpolationFormatClause);
+                    {
+                        N(SyntaxKind.ColonToken);
+                        N(SyntaxKind.InterpolatedStringTextToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.InterpolatedStringEndToken);
+            }
+            EOF();
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

When using a conditional expression `e1 ? e2 : e3` inside of an interpolated string `$"{e1 ? e2 : e3}"` the compiler interprets the colon as the end of the interpolation and the beginning of the format string. That is by design and intentional. However, the error message for this situation is confusing: the syntax error points at the colon token and reports that a colon was expected. We need a more clear diagnostic. After this fix, the error message will be
`error CS8361: A conditional expression cannot be used directly in a string interpolation because the ':' ends the interpolation. Parenthesize the conditional expression.`

**Bugs this fixes:**

Fixes #12214

**Workarounds, if any**

Parenthesize the interpolated string fill-in.

**Risk**

Low. The fix is straightforward and merely changes the diagnostic under this particular circumstance.

**Performance impact**

None expected.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We simply did not have time to do a good job on the diagnostic for this situation when interpolated strings were first introduced.

**How was the bug found?**

This was a known shortcoming of the implementation.

**Test documentation updated?**

N/A

@dotnet/roslyn-compiler Please review.
