### PR TITLE
Move VS insertion item after signing

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -109,8 +109,7 @@
         "Vsix\\VisualStudioSetup.Next\\Roslyn.VisualStudio.Setup.Next.vsix",
         "Vsix\\VisualStudioSetup\\Roslyn.VisualStudio.Setup.vsix",
         "Vsix\\Roslyn\\RoslynDeployment.vsix",
-        "Vsix\\Templates\\Roslyn SDK.vsix",
-        "Vsix\\CodeAnalysisCompilers\\Microsoft.CodeAnalysis.Compilers.vsix"
+        "Vsix\\Templates\\Roslyn SDK.vsix"
       ]
     },
     {

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -183,14 +183,14 @@ function Build-Artifacts() {
 
     if ($pack) {
         Build-NuGetPackages
-
-        if ($cibuild -or $official) { 
-            Build-DeployToSymStore
-        }
     }
 
     if ($sign) {
         Run-SignTool
+    }
+
+    if ($pack -and ($cibuild -or $official)) { 
+        Build-DeployToSymStore
     }
 
     if ($buildAll) {

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -179,6 +179,21 @@ function Build-Artifacts() {
 
     if ($buildAll) {
         Build-ExtraSignArtifacts
+    }
+
+    if ($pack) {
+        Build-NuGetPackages
+
+        if ($cibuild -or $official) { 
+            Build-DeployToSymStore
+        }
+    }
+
+    if ($sign) {
+        Run-SignTool
+    }
+
+    if ($buildAll) {
         Build-InsertionItems
     }
 }
@@ -634,18 +649,6 @@ try {
 
     if ($build) {
         Build-Artifacts
-    }
-
-    if ($pack) {
-        Build-NuGetPackages
-
-        if ($cibuild -or $official) { 
-            Build-DeployToSymStore
-        }
-    }
-
-    if ($sign) {
-        Run-SignTool
     }
 
     if ($testDesktop -or $testCoreClr -or $testVsi -or $testVsiNetCore) {


### PR DESCRIPTION
The VS insertion items require a bit more work to be a part of batch
signing. In particular the VSMAN files because they contain checksums of
many of our other assets. These need to be rewritten during batch
signing to have the new correct values.

These assets though aren't actually required to be signed though. Hence
for now just moving the building of them till after signing completes.

