### PR TITLE
Fix System.InvalidOperationException in IOperation factory for an Option statement inside a method body

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -318,7 +318,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      SyntaxKind.RaiseEventStatement,
                      SyntaxKind.ExpressionStatement,
                      SyntaxKind.YieldStatement,
-                     SyntaxKind.PrintStatement
+                     SyntaxKind.PrintStatement,
+                     SyntaxKind.OptionStatement
                     Return True
 
                 Case SyntaxKind.IfStatement,

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests.vb
@@ -872,5 +872,42 @@ End Class
             ' Verify we return null operation for child nodes of member access expression.
             Assert.Null(model.GetOperation(expr.Name))
         End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <WorkItem(23283, "https://github.com/dotnet/roslyn/issues/23283")>
+        <Fact()>
+        Public Sub TestOptionStatement_01()
+            Dim source = <![CDATA[
+Class Test
+    Sub Method()
+        Option Strict On 'BIND:"Option Strict On"
+    End Sub
+End Class
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'Option Strict On')
+  Children(0)
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30024: Statement is not valid inside a method.
+        Option Strict On 'BIND:"Option Strict On"
+        ~~~~~~~~~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of StatementSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <WorkItem(23283, "https://github.com/dotnet/roslyn/issues/23283")>
+        <Fact()>
+        Public Sub TestOptionStatement_02()
+            Dim source = <![CDATA[
+Option Strict On 'BIND:"Option Strict On"
+]]>.Value
+
+            VerifyNoOperationTreeForTest(Of StatementSyntax)(source)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #23283.

**Customer scenario**

Request IOperation tree for an Option statement like the one below:
```
    Sub Method()
        Option Strict On 'BIND:"Option Strict On"
    End Sub
```

An InvalidOperationException is thrown by IOperation factory.

**Bugs this fixes:**

Fixes #23283.

**Workarounds, if any**

No

**Risk**

Low

**Performance impact**

Low perf impact because no extra allocations/no complexity changes

**Is this a regression from a previous update?**

No

**Root cause analysis:**

A test gap. Unit-tests are added.

**How was the bug found?**

Running existing compiler tests with IOperation validation test hook enabled.
