### PR TITLE
Enabled 'Use Local Function' refactoring for delegate which is invoked with Invoke

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
@@ -1436,25 +1436,41 @@ class Enclosing<T> where T : class
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseLocalFunction)]
-        [WorkItem(22672, "https://github.com/dotnet/roslyn/issues/22672")]
-        public async Task TestMissingIfUsedInMemberAccess()
+        [WorkItem(23150, "https://github.com/dotnet/roslyn/issues/23150")]
+        public async Task TestWithInvokeMethod()
         {
-            await TestMissingAsync(
+            await TestInRegularAndScript1Async(
 @"using System;
 
 class Enclosing<T> where T : class
 {
-  delegate T MyDelegate(T t = null);
+    delegate T MyDelegate(T t = null);
 
-  public class Class
-  {
-    public void Caller()
+    public class Class
     {
-      MyDelegate [||]local = x => x;
+        public void Caller()
+        {
+            MyDelegate [||]local = x => x;
 
-      local.Invoke();
+            local.Invoke();
+        }
     }
-  }
+}",
+@"using System;
+
+class Enclosing<T> where T : class
+{
+    delegate T MyDelegate(T t = null);
+
+    public class Class
+    {
+        public void Caller()
+        {
+            T local(T x = null) => x;
+
+            local();
+        }
+    }
 }");
         }
 


### PR DESCRIPTION
**Customer scenario**

Use Local Function refactoring doesn't work when delegate is invoked with Invoke

**Bugs this fixes:**

Fixes #23150
