### PR TITLE
Add details to output for IDE test failure

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.FindUsages
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.FindUsages
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.Test.Utilities.RemoteHost
 Imports Microsoft.CodeAnalysis.Text
@@ -202,7 +203,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                     Dim documentsWithAnnotatedSpans = workspace.Documents.Where(Function(d) d.AnnotatedSpans.Any())
                     Assert.Equal(Of String)(documentsWithAnnotatedSpans.Select(Function(d) GetFilePathAndProjectLabel(workspace, d)).Order(), actualDefinitions.Keys.Order())
                     For Each doc In documentsWithAnnotatedSpans
-                        Assert.Equal(Of Text.TextSpan)(doc.AnnotatedSpans(DefinitionKey).Order(), actualDefinitions(GetFilePathAndProjectLabel(workspace, doc)).Order())
+
+                        Dim expected = doc.AnnotatedSpans(DefinitionKey).Order()
+                        Dim actual = actualDefinitions(GetFilePathAndProjectLabel(workspace, doc)).Order()
+
+                        If Not TextSpansMatch(expected, actual) Then
+                            Assert.True(False, PrintSpans(expected, actual, workspace.CurrentSolution.GetDocument(doc.Id), "{|Definition:", "|}"))
+                        End If
                     Next
 
                     Dim actualReferences =
@@ -222,10 +229,78 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                         Dim expectedSpans = doc.SelectedSpans.Order()
                         Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(workspace, doc)).Order()
 
-                        AssertEx.Equal(expectedSpans, actualSpans)
+                        AssertEx.Equal(expectedSpans, actualSpans,
+                                       message:=PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), "[|", "|]", messageOnly:=True))
                     Next
                 Next
             End Using
+        End Function
+
+        Private Shared Function PrintSpans(expected As IOrderedEnumerable(Of TextSpan), actual As IOrderedEnumerable(Of TextSpan), doc As Document, prefix As String, suffix As String, Optional messageOnly As Boolean = False) As String
+            Debug.Assert(expected IsNot Nothing)
+            Debug.Assert(actual IsNot Nothing)
+
+            Dim instance = PooledStringBuilder.GetInstance()
+            Dim builder = instance.Builder
+
+            builder.AppendLine()
+            If Not messageOnly Then
+                builder.AppendLine($"Expected: {String.Join(", ", expected.Select(Function(e) e.ToString()))}")
+                builder.AppendLine($"Actual: {String.Join(", ", actual.Select(Function(a) a.ToString()))}")
+            End If
+
+            Dim text As SourceText = Nothing
+            doc.TryGetText(text)
+            Dim position = 0
+
+            For Each span In actual
+                builder.Append(text.GetSubText(New TextSpan(position, span.Start - position)))
+                builder.Append(prefix)
+                builder.Append(text.GetSubText(span))
+                builder.Append(suffix)
+                position = span.End
+            Next
+            builder.Append(text.GetSubText(New TextSpan(position, text.Length - position)))
+
+            Return instance.ToStringAndFree()
+        End Function
+
+        Private Shared Function TextSpansMatch(expected As IOrderedEnumerable(Of TextSpan), actual As IOrderedEnumerable(Of TextSpan)) As Boolean
+            Debug.Assert(expected IsNot Nothing)
+            Debug.Assert(actual IsNot Nothing)
+
+            Dim enumeratorExpected As IEnumerator(Of TextSpan) = Nothing
+            Dim enumeratorActual As IEnumerator(Of TextSpan) = Nothing
+            Try
+                enumeratorExpected = expected.GetEnumerator()
+                enumeratorActual = actual.GetEnumerator()
+
+                While True
+                    Dim hasNextExpected = enumeratorExpected.MoveNext()
+                    Dim hasNextActual = enumeratorActual.MoveNext()
+
+                    If Not hasNextExpected OrElse Not hasNextActual Then
+                        Return hasNextExpected = hasNextActual
+                    End If
+
+                    If Not enumeratorExpected.Current.Equals(enumeratorActual.Current) Then
+                        Return False
+                    End If
+                End While
+
+            Finally
+                Dim asDisposable = TryCast(enumeratorExpected, IDisposable)
+                If asDisposable IsNot Nothing Then
+                    asDisposable.Dispose()
+                End If
+
+                asDisposable = TryCast(enumeratorActual, IDisposable)
+                If asDisposable IsNot Nothing Then
+                    asDisposable.Dispose()
+                End If
+            End Try
+
+            Return True
         End Function
 
         Private Function IsImplicitNamespace(referencedSymbol As ReferencedSymbol) As Boolean


### PR DESCRIPTION
This is a part of closed PR https://github.com/dotnet/roslyn/pull/23276 that I think is still useful.

When running an IDE test that compares annotated spans, instead of printing something hard to decode such as:
```
Expected: [27..31)
Actual: [27..31), [81..85)
```

We now also print a visual representation of the actual spans. For instance:
```
interface I1
{
    int {|Definition:Area|} { get; }
}
 
class C1 : I1
{
    public int {|Definition:Area|} { get { return 1; } }
}
 
class C2 : C1
{
    public int Area
    {
        get
        {
            return base.Area;
        }
    }
}
```

Risk and performance impact:
None. This is a test-only change.

@CyrusNajmabadi @dotnet/roslyn-ide for review.