### PR TITLE
Begin work on Range

### DIFF
--- a/docs/features/range.work.md
+++ b/docs/features/range.work.md
@@ -1,0 +1,7 @@
+Remaining work for Range
+===
+
+* Add two Range operators, if LDM decides as such
+* Make `..` nonassociative (cannot write `x..y..z`)
+* Tie in the feature to `/langver`/`/feature`
+* Ensure IDE experience is functional

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -402,6 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SubtractExpression:
                 case SyntaxKind.DivideExpression:
                 case SyntaxKind.ModuloExpression:
+                case SyntaxKind.RangeExpression:
                 case SyntaxKind.EqualsExpression:
                 case SyntaxKind.NotEqualsExpression:
                 case SyntaxKind.GreaterThanExpression:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -376,6 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SubtractExpression:
                 case SyntaxKind.DivideExpression:
                 case SyntaxKind.ModuloExpression:
+                case SyntaxKind.RangeExpression:
                 case SyntaxKind.EqualsExpression:
                 case SyntaxKind.NotEqualsExpression:
                 case SyntaxKind.GreaterThanExpression:
@@ -627,6 +628,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void ReportBinaryOperatorError(ExpressionSyntax node, DiagnosticBag diagnostics, SyntaxToken operatorToken, BoundExpression left, BoundExpression right, LookupResultKind resultKind)
         {
+            if (resultKind == LookupResultKind.Empty && operatorToken.Kind() == SyntaxKind.DotDotToken)
+            {
+                // Diagnostics will already have been reported (when searching for an appropriate method)
+                return;
+            }
+
             if ((operatorToken.Kind() == SyntaxKind.EqualsEqualsToken || operatorToken.Kind() == SyntaxKind.ExclamationEqualsToken) &&
                 (left.IsLiteralDefault() && right.IsLiteralDefault()))
             {
@@ -1879,6 +1886,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.AddExpression: return BinaryOperatorKind.Addition;
                 case SyntaxKind.SubtractAssignmentExpression:
                 case SyntaxKind.SubtractExpression: return BinaryOperatorKind.Subtraction;
+                case SyntaxKind.RangeExpression: return BinaryOperatorKind.Range;
                 case SyntaxKind.RightShiftAssignmentExpression:
                 case SyntaxKind.RightShiftExpression: return BinaryOperatorKind.RightShift;
                 case SyntaxKind.LeftShiftAssignmentExpression:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -632,11 +632,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var leftSpecialType = left.Type.SpecialType;
                 var rightSpecialType = right.Type.SpecialType;
-                if (leftSpecialType.IsIntegralType() && rightSpecialType.IsIntegralType())
+                if (leftSpecialType.IsIntegralType() && rightSpecialType.IsIntegralType() &&
+                    leftSpecialType != SpecialType.System_UInt64 && rightSpecialType != SpecialType.System_UInt64)
                 {
                     // User meant to use the built-in range type, but it was missing
-                    if (leftSpecialType == SpecialType.System_Int64 || leftSpecialType == SpecialType.System_UInt64 ||
-                        rightSpecialType == SpecialType.System_Int64 || rightSpecialType == SpecialType.System_UInt64)
+                    if (leftSpecialType == SpecialType.System_Int64 || leftSpecialType == SpecialType.System_UInt32 ||
+                        rightSpecialType == SpecialType.System_Int64 || rightSpecialType == SpecialType.System_UInt32)
                     {
                         Error(diagnostics, ErrorCode.ERR_RangeNotFound, node, WellKnownTypes.GetMetadataName(WellKnownType.System_LongRange));
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //
                 // Example: int & int is legal, but int && int is not, so we can't use the same
                 // table for both operators.
-                if (!kind.IsLogical() || (leftIndex == (int)BinaryOperatorKind.Bool && rightIndex == (int)BinaryOperatorKind.Bool))
+                if ((!kind.IsLogical() || (leftIndex == (int)BinaryOperatorKind.Bool && rightIndex == (int)BinaryOperatorKind.Bool)) && kind != BinaryOperatorKind.Range)
                 {
                     result = s_opkind[kind.OperatorIndex()][leftIndex.Value, rightIndex.Value];
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -33,6 +33,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            if (underlyingKind == BinaryOperatorKind.Range)
+            {
+                var method = (MethodSymbol)Compilation.GetWellKnownTypeMember(WellKnownMember.System_Range__Create);
+                if (method == null)
+                {
+                    if (useSiteDiagnostics == null)
+                    {
+                        useSiteDiagnostics = new HashSet<DiagnosticInfo>();
+                    }
+
+                    var memberDescriptor = WellKnownMembers.GetDescriptor(WellKnownMember.System_Range__Create);
+                    useSiteDiagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_RangeNotFound, memberDescriptor.DeclaringTypeMetadataName));
+                    return;
+                }
+
+                var signature = new BinaryOperatorSignature(BinaryOperatorKind.UserDefined | BinaryOperatorKind.Range, method.ParameterTypes[0], method.ParameterTypes[1], method.ReturnType, method);
+
+                Conversion leftConversion = Conversions.FastClassifyConversion(left.Type, signature.LeftType);
+                Conversion rightConversion = Conversions.FastClassifyConversion(right.Type, signature.RightType);
+
+                Debug.Assert(leftConversion.Exists && leftConversion.IsImplicit);
+                Debug.Assert(rightConversion.Exists && rightConversion.IsImplicit);
+
+                result.Results.Add(BinaryOperatorAnalysisResult.Applicable(signature, leftConversion, rightConversion));
+                return;
+            }
+
             // The following is a slight rewording of the specification to emphasize that not all
             // operands of a binary operation need to have a type.
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -33,33 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            if (underlyingKind == BinaryOperatorKind.Range)
-            {
-                var method = (MethodSymbol)Compilation.GetWellKnownTypeMember(WellKnownMember.System_Range__Create);
-                if (method == null)
-                {
-                    if (useSiteDiagnostics == null)
-                    {
-                        useSiteDiagnostics = new HashSet<DiagnosticInfo>();
-                    }
-
-                    var memberDescriptor = WellKnownMembers.GetDescriptor(WellKnownMember.System_Range__Create);
-                    useSiteDiagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_RangeNotFound, memberDescriptor.DeclaringTypeMetadataName));
-                    return;
-                }
-
-                var signature = new BinaryOperatorSignature(BinaryOperatorKind.UserDefined | BinaryOperatorKind.Range, method.ParameterTypes[0], method.ParameterTypes[1], method.ReturnType, method);
-
-                Conversion leftConversion = Conversions.FastClassifyConversion(left.Type, signature.LeftType);
-                Conversion rightConversion = Conversions.FastClassifyConversion(right.Type, signature.RightType);
-
-                Debug.Assert(leftConversion.Exists && leftConversion.IsImplicit);
-                Debug.Assert(rightConversion.Exists && rightConversion.IsImplicit);
-
-                result.Results.Add(BinaryOperatorAnalysisResult.Applicable(signature, leftConversion, rightConversion));
-                return;
-            }
-
             // The following is a slight rewording of the specification to emphasize that not all
             // operands of a binary operation need to have a type.
 
@@ -143,6 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.LessThanOrEqual:
                 case BinaryOperatorKind.LogicalAnd:
                 case BinaryOperatorKind.LogicalOr:
+                case BinaryOperatorKind.Range:
                     return;
 
                 case BinaryOperatorKind.Addition:
@@ -400,6 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.LeftShift:
                 case BinaryOperatorKind.LogicalAnd:
                 case BinaryOperatorKind.LogicalOr:
+                case BinaryOperatorKind.Range:
                     return;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorFacts.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.AsteriskToken: return WellKnownMemberNames.MultiplyOperatorName;
                 case SyntaxKind.SlashToken: return WellKnownMemberNames.DivisionOperatorName;
                 case SyntaxKind.PercentToken: return WellKnownMemberNames.ModulusOperatorName;
+                case SyntaxKind.DotDotToken: return WellKnownMemberNames.RangeOperatorName;
                 case SyntaxKind.CaretToken: return WellKnownMemberNames.ExclusiveOrOperatorName;
                 case SyntaxKind.AmpersandToken: return WellKnownMemberNames.BitwiseAndOperatorName;
                 case SyntaxKind.BarToken: return WellKnownMemberNames.BitwiseOrOperatorName;
@@ -175,6 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.Multiplication: return WellKnownMemberNames.MultiplyOperatorName;
                 case BinaryOperatorKind.Or: return WellKnownMemberNames.BitwiseOrOperatorName;
                 case BinaryOperatorKind.NotEqual: return WellKnownMemberNames.InequalityOperatorName;
+                case BinaryOperatorKind.Range: return WellKnownMemberNames.RangeOperatorName;
                 case BinaryOperatorKind.Remainder: return WellKnownMemberNames.ModulusOperatorName;
                 case BinaryOperatorKind.RightShift: return WellKnownMemberNames.RightShiftOperatorName;
                 case BinaryOperatorKind.Subtraction: return WellKnownMemberNames.SubtractionOperatorName;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorKind.cs
@@ -658,5 +658,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         LiftedBoolXor = Lifted | Bool | Xor,
         LiftedUserDefinedXor = Lifted | UserDefined | Xor,
         DynamicXor = Dynamic | Xor,
+
+        UserDefinedRange = UserDefined | Range,
+        LiftedUserDefinedRange = Lifted | UserDefined | Range,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/OperatorKind.cs
@@ -313,6 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         And = 0x00001D00,
         Xor = 0x00001E00,
         Or = 0x00001F00,
+        Range = 0x00002000,
 
         Lifted = UnaryOperatorKind.Lifted,
         Logical = UnaryOperatorKind._Logical,

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9341,6 +9341,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected character sequence &apos;...&apos;.
+        /// </summary>
+        internal static string ERR_TripleDotNotAllowed {
+            get {
+                return ResourceManager.GetString("ERR_TripleDotNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tuple element names must be unique..
         /// </summary>
         internal static string ERR_TupleDuplicateElementName {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8216,6 +8216,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot create a range value because the compiler required type &apos;{0}&apos; cannot be found. Are you missing a reference?.
+        /// </summary>
+        internal static string ERR_RangeNotFound {
+            get {
+                return ResourceManager.GetString("ERR_RangeNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to } expected.
         /// </summary>
         internal static string ERR_RbraceExpected {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5238,4 +5238,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_RangeNotFound" xml:space="preserve">
     <value>Cannot create a range value because the compiler required type '{0}' cannot be found. Are you missing a reference?</value>
   </data>
+  <data name="ERR_TripleDotNotAllowed" xml:space="preserve">
+    <value>Unexpected character sequence '...'</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5235,4 +5235,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_FilterIsConstantFalseRedundantTryCatch_Title" xml:space="preserve">
     <value>Filter expression is a constant 'false'. </value>
   </data>
+  <data name="ERR_RangeNotFound" xml:space="preserve">
+    <value>Cannot create a range value because the compiler required type '{0}' cannot be found. Are you missing a reference?</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1551,6 +1551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region diagnostics introduced for C# 7.3
         ERR_RangeNotFound = 8380,
+        ERR_TripleDotNotAllowed = 8381,
         #endregion diagnostics introduced for C# 7.3
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1548,5 +1548,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_FilterIsConstantFalse = 8359,
         WRN_FilterIsConstantFalseRedundantTryCatch = 8360,
         #endregion diagnostics for FilterIsConstant warning message fix
+
+        #region diagnostics introduced for C# 7.3
+        ERR_RangeNotFound = 8380,
+        #endregion diagnostics introduced for C# 7.3
     }
 }

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -42406,6 +42406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarToken:
@@ -49333,6 +49334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarToken:

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -38203,6 +38203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.MultiplyExpression:
         case SyntaxKind.DivideExpression:
         case SyntaxKind.ModuloExpression:
+        case SyntaxKind.RangeExpression:
         case SyntaxKind.LeftShiftExpression:
         case SyntaxKind.RightShiftExpression:
         case SyntaxKind.LogicalOrExpression:
@@ -38235,6 +38236,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarBarToken:
@@ -45128,6 +45130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.MultiplyExpression:
         case SyntaxKind.DivideExpression:
         case SyntaxKind.ModuloExpression:
+        case SyntaxKind.RangeExpression:
         case SyntaxKind.LeftShiftExpression:
         case SyntaxKind.RightShiftExpression:
         case SyntaxKind.LogicalOrExpression:
@@ -45160,6 +45163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarBarToken:

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -4882,6 +4882,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         case SyntaxKind.MultiplyExpression:
         case SyntaxKind.DivideExpression:
         case SyntaxKind.ModuloExpression:
+        case SyntaxKind.RangeExpression:
         case SyntaxKind.LeftShiftExpression:
         case SyntaxKind.RightShiftExpression:
         case SyntaxKind.LogicalOrExpression:
@@ -4911,6 +4912,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarBarToken:
@@ -4957,6 +4959,8 @@ namespace Microsoft.CodeAnalysis.CSharp
           return SyntaxKind.SlashToken;
         case SyntaxKind.ModuloExpression:
           return SyntaxKind.PercentToken;
+        case SyntaxKind.RangeExpression:
+          return SyntaxKind.DotDotToken;
         case SyntaxKind.LeftShiftExpression:
           return SyntaxKind.LessThanLessThanToken;
         case SyntaxKind.RightShiftExpression:

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -8943,6 +8943,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         case SyntaxKind.AsteriskToken:
         case SyntaxKind.SlashToken:
         case SyntaxKind.PercentToken:
+        case SyntaxKind.DotDotToken:
         case SyntaxKind.LessThanLessThanToken:
         case SyntaxKind.GreaterThanGreaterThanToken:
         case SyntaxKind.BarToken:

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8715,6 +8715,7 @@ tryAgain:
             Equality,
             Relational,
             Shift,
+            Range,
             Additive,
             Mutiplicative,
             Unary,
@@ -8766,6 +8767,8 @@ tryAgain:
                 case SyntaxKind.LeftShiftExpression:
                 case SyntaxKind.RightShiftExpression:
                     return Precedence.Shift;
+                case SyntaxKind.RangeExpression:
+                    return Precedence.Range;
                 case SyntaxKind.AddExpression:
                 case SyntaxKind.SubtractExpression:
                     return Precedence.Additive;
@@ -10142,6 +10145,7 @@ tryAgain:
                 case SyntaxKind.AsteriskToken:
                 case SyntaxKind.SlashToken:
                 case SyntaxKind.PercentToken:
+                case SyntaxKind.DotDotToken:
                 case SyntaxKind.PlusPlusToken:
                 case SyntaxKind.MinusMinusToken:
                 case SyntaxKind.OpenBracketToken:

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -452,13 +452,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 // Triple-dot: explicitly reject this, to allow triple-dot
                                 // to be added to the language without a breaking change.
                                 // (without this, 0...2 would parse as (0)..(.2), i.e. a range from 0 to 0.2)
-                                TextWindow.Reset(startingPosition);
-                                goto default;
+                                this.AddError(ErrorCode.ERR_TripleDotNotAllowed);
                             }
-                            else
-                            {
-                                info.Kind = SyntaxKind.DotDotToken;
-                            }
+
+                            info.Kind = SyntaxKind.DotDotToken;
                         }
                         else
                         {
@@ -3945,12 +3942,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         if (TextWindow.PeekChar() == '.')
                         {
                             // See documentation in ScanSyntaxToken
-                            break;
+                            this.AddCrefError(ErrorCode.ERR_UnexpectedCharacter, ".");
                         }
-                        else
-                        {
-                            info.Kind = SyntaxKind.DotDotToken;
-                        }
+
+                        info.Kind = SyntaxKind.DotDotToken;
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -3940,8 +3940,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     info.Kind = SyntaxKind.CommaToken;
                     break;
                 case '.':
-                    if (AdvanceIfMatches('.')) info.Kind = SyntaxKind.DotDotToken;
-                    else info.Kind = SyntaxKind.DotToken;
+                    if (AdvanceIfMatches('.'))
+                    {
+                        if (TextWindow.PeekChar() == '.')
+                        {
+                            // See documentation in ScanSyntaxToken
+                            break;
+                        }
+                        else
+                        {
+                            info.Kind = SyntaxKind.DotDotToken;
+                        }
+                    }
+                    else
+                    {
+                        info.Kind = SyntaxKind.DotToken;
+                    }
+
                     break;
                 case '?':
                     info.Kind = SyntaxKind.QuestionToken;

--- a/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
+++ b/src/Compilers/CSharp/Portable/Parser/QuickScanner.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 (byte)QuickScanState.Done,                // Letter
                 (byte)QuickScanState.Number,              // Digit
                 (byte)QuickScanState.Done,                // Punct
-                (byte)QuickScanState.Done,                // Dot
+                (byte)QuickScanState.Bad,                 // Dot
                 (byte)QuickScanState.Done,                // Compound
                 (byte)QuickScanState.Bad,                 // Slash
                 (byte)QuickScanState.Bad,                 // Complex

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -14,6 +14,8 @@ Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.DotDotToken = 8222 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.RangeExpression = 8692 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.AssignmentExpressionSyntax assignment) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this Microsoft.CodeAnalysis.SemanticModel semanticModel, Microsoft.CodeAnalysis.CSharp.Syntax.ForEachVariableStatementSyntax foreach) -> Microsoft.CodeAnalysis.CSharp.DeconstructionInfo

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -549,6 +549,7 @@
     <Kind Name="MultiplyExpression"/>
     <Kind Name="DivideExpression"/>
     <Kind Name="ModuloExpression"/>
+    <Kind Name="RangeExpression"/>
     <Kind Name="LeftShiftExpression"/>
     <Kind Name="RightShiftExpression"/>
     <Kind Name="LogicalOrExpression"/>
@@ -576,6 +577,7 @@
       <Kind Name="AsteriskToken"/>
       <Kind Name="SlashToken"/>
       <Kind Name="PercentToken"/>
+      <Kind Name="DotDotToken"/>
       <Kind Name="LessThanLessThanToken"/>
       <Kind Name="GreaterThanGreaterThanToken"/>
       <Kind Name="BarBarToken"/>

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -3265,6 +3265,7 @@
       <Kind Name="AsteriskToken"/>
       <Kind Name="SlashToken"/>
       <Kind Name="PercentToken"/>
+      <Kind Name="DotDotToken"/>
       <Kind Name="LessThanLessThanToken"/>
       <Kind Name="GreaterThanGreaterThanToken"/>
       <Kind Name="BarToken"/>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         QuestionToken = 8219,
         HashToken = 8220,
         SlashToken = 8221,
+        DotDotToken = 8222,
 
         // additional xml tokens
         SlashGreaterThanToken = 8232, // xml empty element end
@@ -357,6 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         SimpleMemberAccessExpression = 8689,  // dot access:   a.b
         PointerMemberAccessExpression = 8690,  // arrow access:   a->b
         ConditionalAccessExpression = 8691,    // question mark access:   a?.b , a?[1]
+        RangeExpression = 8692,
 
         // binding expressions
         MemberBindingExpression = 8707,

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -449,6 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.AsteriskToken:
                 case SyntaxKind.SlashToken:
                 case SyntaxKind.PercentToken:
+                case SyntaxKind.DotDotToken:
                 case SyntaxKind.CaretToken:
                 case SyntaxKind.AmpersandToken:
                 case SyntaxKind.BarToken:
@@ -612,6 +613,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.DivideExpression;
                 case SyntaxKind.PercentToken:
                     return SyntaxKind.ModuloExpression;
+                case SyntaxKind.DotDotToken:
+                    return SyntaxKind.RangeExpression;
                 case SyntaxKind.AmpersandAmpersandToken:
                     return SyntaxKind.LogicalAndExpression;
                 case SyntaxKind.BarBarToken:
@@ -985,6 +988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case WellKnownMemberNames.ModulusOperatorName: return SyntaxKind.PercentToken;
                 case WellKnownMemberNames.MultiplyOperatorName: return SyntaxKind.AsteriskToken;
                 case WellKnownMemberNames.OnesComplementOperatorName: return SyntaxKind.TildeToken;
+                case WellKnownMemberNames.RangeOperatorName: return SyntaxKind.DotDotToken;
                 case WellKnownMemberNames.RightShiftOperatorName: return SyntaxKind.GreaterThanGreaterThanToken;
                 case WellKnownMemberNames.SubtractionOperatorName: return SyntaxKind.MinusToken;
                 case WellKnownMemberNames.TrueOperatorName: return SyntaxKind.TrueKeyword;
@@ -1254,6 +1258,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ">";
                 case SyntaxKind.DotToken:
                     return ".";
+                case SyntaxKind.DotDotToken:
+                    return "..";
                 case SyntaxKind.QuestionToken:
                     return "?";
                 case SyntaxKind.HashToken:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
@@ -151,15 +151,9 @@ class C
                 // (6,20): error CS1002: ; expected
                 //         var a = 0. .1;
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, ".1").WithLocation(6, 20),
-                // (7,18): error CS1056: Unexpected character '.'
+                // (7,18): error CS8381: Unexpected character sequence '...'
                 //         var b = 0...1;
-                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "").WithArguments(".").WithLocation(7, 18),
-                // (7,19): error CS1002: ; expected
-                //         var b = 0...1;
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "..").WithLocation(7, 19),
-                // (7,19): error CS1525: Invalid expression term '..'
-                //         var b = 0...1;
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "..").WithArguments("..").WithLocation(7, 19),
+                Diagnostic(ErrorCode.ERR_TripleDotNotAllowed, "").WithLocation(7, 18),
                 // (8,20): error CS1525: Invalid expression term '='
                 //         var c = 0..=1;
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(8, 20),
@@ -168,7 +162,10 @@ class C
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "<").WithArguments("<").WithLocation(9, 20),
                 // (6,20): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
                 //         var a = 0. .1;
-                Diagnostic(ErrorCode.ERR_IllegalStatement, ".1").WithLocation(6, 20)
+                Diagnostic(ErrorCode.ERR_IllegalStatement, ".1").WithLocation(6, 20),
+                // (7,17): error CS0019: Operator '..' cannot be applied to operands of type 'int' and 'double'
+                //         var b = 0...1;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "0...1").WithArguments("..", "int", "double").WithLocation(7, 17)
             );
         }
 
@@ -215,7 +212,6 @@ class C
 
             CompileAndVerify(new[] { RangeStruct, SlicableArray, source }, expectedOutput: "6,8,10;;6");
         }
-
 
         [Fact]
         public void RangeTypeMissing()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
@@ -216,6 +216,7 @@ class C
             CompileAndVerify(new[] { RangeStruct, SlicableArray, source }, expectedOutput: "6,8,10;;6");
         }
 
+
         [Fact]
         public void RangeTypeMissing()
         {
@@ -224,18 +225,55 @@ class C
 {
     static void Main()
     {
-        foreach (var x in 0..4)
-        {
-            System.Console.Write(x);
-        }
+        var a = false..true;
+        var b = ((sbyte)2)..((sbyte)4);
+        var c = ((byte)2)..((byte)4);
+        var d = ((short)2)..((short)4);
+        var e = ((ushort)2)..((ushort)4);
+        var f = ((int)2)..((int)4);
+        var g = ((uint)2)..((uint)4);
+        var h = ((long)2)..((long)4);
+        var i = ((ulong)2)..((ulong)4);
+        var j = ((float)2)..((float)4);
+        var k = ((double)2)..((double)4);
     }
 }
 ";
 
-            CreateCSharpCompilation(source).VerifyDiagnostics(
-                // (6,27): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
-                //         foreach (var x in 0..4)
-                Diagnostic(ErrorCode.ERR_RangeNotFound, "0..4").WithArguments("System.Range").WithLocation(6, 27)
+            CreateStandardCompilation(source).VerifyDiagnostics(
+                // (6,17): error CS0019: Operator '..' cannot be applied to operands of type 'bool' and 'bool'
+                //         var a = false..true;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "false..true").WithArguments("..", "bool", "bool").WithLocation(6, 17),
+                // (7,17): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         var b = ((sbyte)2)..((sbyte)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((sbyte)2)..((sbyte)4)").WithArguments("System.Range").WithLocation(7, 17),
+                // (8,17): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         var c = ((byte)2)..((byte)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((byte)2)..((byte)4)").WithArguments("System.Range").WithLocation(8, 17),
+                // (9,17): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         var d = ((short)2)..((short)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((short)2)..((short)4)").WithArguments("System.Range").WithLocation(9, 17),
+                // (10,17): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         var e = ((ushort)2)..((ushort)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((ushort)2)..((ushort)4)").WithArguments("System.Range").WithLocation(10, 17),
+                // (11,17): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         var f = ((int)2)..((int)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((int)2)..((int)4)").WithArguments("System.Range").WithLocation(11, 17),
+                // (12,17): error CS8380: Cannot create a range value because the compiler required type 'System.LongRange' cannot be found. Are you missing a reference?
+                //         var g = ((uint)2)..((uint)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((uint)2)..((uint)4)").WithArguments("System.LongRange").WithLocation(12, 17),
+                // (13,17): error CS8380: Cannot create a range value because the compiler required type 'System.LongRange' cannot be found. Are you missing a reference?
+                //         var h = ((long)2)..((long)4);
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "((long)2)..((long)4)").WithArguments("System.LongRange").WithLocation(13, 17),
+                // (14,17): error CS0019: Operator '..' cannot be applied to operands of type 'ulong' and 'ulong'
+                //         var i = ((ulong)2)..((ulong)4);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "((ulong)2)..((ulong)4)").WithArguments("..", "ulong", "ulong").WithLocation(14, 17),
+                // (15,17): error CS0019: Operator '..' cannot be applied to operands of type 'float' and 'float'
+                //         var j = ((float)2)..((float)4);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "((float)2)..((float)4)").WithArguments("..", "float", "float").WithLocation(15, 17),
+                // (16,17): error CS0019: Operator '..' cannot be applied to operands of type 'double' and 'double'
+                //         var k = ((double)2)..((double)4);
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "((double)2)..((double)4)").WithArguments("..", "double", "double").WithLocation(16, 17)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RangeTests.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class RangeTests : CompilingTestBase
+    {
+        private readonly string RangeStruct = @"
+using System.Collections;
+using System.Collections.Generic;
+namespace System
+{
+    public struct Range : IEnumerable<int>
+    {
+        public int Start { get; }
+        public int End { get; }
+        private Range(int start, int end)
+        {
+            Start = start;
+            End = end;
+        }
+        public static Range Create(int start, int end) => new Range(start, end);
+        public RangeEnumerable GetEnumerator() => new RangeEnumerable(Start, End);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator<int> IEnumerable<int>.GetEnumerator() => GetEnumerator();
+        public struct RangeEnumerable : IEnumerator<int>
+        {
+            public int Current { get; private set; }
+            public int End { get; }
+            public RangeEnumerable(int start, int end)
+            {
+                Current = start - 1;
+                End = end;
+            }
+            public bool MoveNext() => ++Current < End;
+            int IEnumerator<int>.Current => Current;
+            object IEnumerator.Current => Current;
+            void IDisposable.Dispose() { }
+            bool IEnumerator.MoveNext() => MoveNext();
+            void IEnumerator.Reset() => throw new NotSupportedException();
+        }
+    }
+}
+";
+
+        private readonly string SlicableArray = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+public struct SlicableArray<T> : IEnumerable<T>
+{
+    private readonly T[] _array;
+    public SlicableArray(params T[] array) => _array = array;
+    public T this[int index] => _array[index];
+    public SlicableArray<T> this[Range range]
+    {
+        get
+        {
+            var length = range.End - range.Start;
+            var result = new T[length];
+            Array.Copy(_array, range.Start, result, 0, length);
+            return new SlicableArray<T>(result);
+        }
+    }
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)_array).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+";
+
+        [Fact]
+        public void RangeHelloWorld()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in 0..4)
+        {
+            System.Console.Write(x);
+        }
+    }
+}
+";
+
+            CompileAndVerify(new[] { RangeStruct, source }, expectedOutput: "0123");
+        }
+
+        [Fact]
+        public void Lexing()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main()
+    {
+        var a = 0 .. 1;
+        var b =
+0
+..
+1
+;
+        var c =
+// comment
+ 0 // comment
+// comment
+ .. // comment
+// comment
+ 1 // comment
+// comment
+;
+        var d = /* comment */ 0 /* comment */ .. /* comment */ 1 /* comment */;
+        var e = /* comment */0/* comment */../* comment */1/* comment */;
+        Console.Write(string.Join("";"",
+            string.Join("","", a),
+            string.Join("","", b),
+            string.Join("","", c),
+            string.Join("","", d),
+            string.Join("","", e)
+        ));
+    }
+}
+";
+            CompileAndVerify(new[] { RangeStruct, source }, expectedOutput: "0;0;0;0;0");
+        }
+
+        [Fact]
+        public void LexingBad()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var a = 0. .1;
+        var b = 0...1;
+        var c = 0..=1;
+        var d = 0..<1;
+    }
+}
+";
+            CreateCSharpCompilation(source).VerifyDiagnostics(
+                // (6,20): error CS1001: Identifier expected
+                //         var a = 0. .1;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ".1").WithLocation(6, 20),
+                // (6,20): error CS1002: ; expected
+                //         var a = 0. .1;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ".1").WithLocation(6, 20),
+                // (7,18): error CS1056: Unexpected character '.'
+                //         var b = 0...1;
+                Diagnostic(ErrorCode.ERR_UnexpectedCharacter, "").WithArguments(".").WithLocation(7, 18),
+                // (7,19): error CS1002: ; expected
+                //         var b = 0...1;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "..").WithLocation(7, 19),
+                // (7,19): error CS1525: Invalid expression term '..'
+                //         var b = 0...1;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "..").WithArguments("..").WithLocation(7, 19),
+                // (8,20): error CS1525: Invalid expression term '='
+                //         var c = 0..=1;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(8, 20),
+                // (9,20): error CS1525: Invalid expression term '<'
+                //         var d = 0..<1;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "<").WithArguments("<").WithLocation(9, 20),
+                // (6,20): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
+                //         var a = 0. .1;
+                Diagnostic(ErrorCode.ERR_IllegalStatement, ".1").WithLocation(6, 20)
+            );
+        }
+
+        [Fact]
+        public void Typed()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main()
+    {
+        var a = 0..4;
+        System.Range b = 0..4;
+        Console.Write(string.Join("","", a) + "","" + string.Join("","", b));
+    }
+}
+";
+
+            CompileAndVerify(new[] { RangeStruct, source }, expectedOutput: "0,1,2,3,0,1,2,3");
+        }
+
+        [Fact]
+        public void Slice()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main()
+    {
+        var arr = new SlicableArray<int>(2, 4, 6, 8, 10);
+        Console.Write(""["" + string.Join("","", arr[2..4]) + ""]"");
+        Console.Write(""["" + string.Join("","", arr[2..2]) + ""]"");
+        Console.Write(""["" + string.Join("","", arr[1..3][1]) + ""]"");
+    }
+}
+";
+
+            CompileAndVerify(new[] { RangeStruct, SlicableArray, source }, expectedOutput: "[6,8][][6]");
+        }
+
+        [Fact]
+        public void RangeTypeMissing()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var x in 0..4)
+        {
+            System.Console.Write(x);
+        }
+    }
+}
+";
+
+            CreateCSharpCompilation(source).VerifyDiagnostics(
+                // (6,27): error CS8380: Cannot create a range value because the compiler required type 'System.Range' cannot be found. Are you missing a reference?
+                //         foreach (var x in 0..4)
+                Diagnostic(ErrorCode.ERR_RangeNotFound, "0..4").WithArguments("System.Range").WithLocation(6, 27)
+            );
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -561,6 +561,8 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute:
                     case WellKnownType.System_Span_T:
+                    case WellKnownType.System_Range:
+                    case WellKnownType.System_LongRange:
                     // Not yet in the platform.
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
                         // Not always available.
@@ -860,6 +862,8 @@ namespace System
                         continue;
                     case WellKnownMember.System_Array__Empty:
                     case WellKnownMember.System_Span_T__ctor:
+                    case WellKnownMember.System_Range__Create:
+                    case WellKnownMember.System_LongRange__Create:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/BinaryExpression.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/BinaryExpression.cs
@@ -222,6 +222,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
                     return "/";
                 case SyntaxKind.ModuloExpression:
                     return "%";
+                case SyntaxKind.RangeExpression:
+                    return "..";
                 case SyntaxKind.LeftShiftExpression:
                     return "<<";
                 case SyntaxKind.RightShiftExpression:

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -503,6 +503,8 @@ abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.R
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation
 abstract Microsoft.CodeAnalysis.SemanticModel.RootCore.get -> Microsoft.CodeAnalysis.SyntaxNode
+const Microsoft.CodeAnalysis.WellKnownMemberNames.DeconstructMethodName = "Deconstruct" -> string
+const Microsoft.CodeAnalysis.WellKnownMemberNames.RangeOperatorName = "op_Range" -> string
 override Microsoft.CodeAnalysis.Operations.OperationWalker.DefaultVisit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Operations.OperationWalker.Visit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Optional<T>.ToString() -> string
@@ -705,4 +707,3 @@ virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.V
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitVariableDeclarator(Microsoft.CodeAnalysis.Operations.IVariableDeclaratorOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitVariableInitializer(Microsoft.CodeAnalysis.Operations.IVariableInitializerOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitWhileLoop(Microsoft.CodeAnalysis.Operations.IWhileLoopOperation operation, TArgument argument) -> TResult
-const Microsoft.CodeAnalysis.WellKnownMemberNames.DeconstructMethodName = "Deconstruct" -> string

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -199,6 +199,11 @@ namespace Microsoft.CodeAnalysis
         public const string OnesComplementOperatorName = "op_OnesComplement";
 
         /// <summary>
+        /// The name assigned to the Modulus operator.
+        /// </summary>
+        public const string RangeOperatorName = "op_Range";
+
+        /// <summary>
         /// The name assigned to the RightShift operator.
         /// </summary>
         public const string RightShiftOperatorName = "op_RightShift";

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -425,6 +425,7 @@ namespace Microsoft.CodeAnalysis
         System_Span_T__ctor,
 
         System_Range__Create,
+        System_LongRange__Create,
 
         Count,
     }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -424,6 +424,8 @@ namespace Microsoft.CodeAnalysis
         System_ObsoleteAttribute__ctor,
         System_Span_T__ctor,
 
-        Count
+        System_Range__Create,
+
+        Count,
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2929,6 +2929,15 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.Pointer, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_Range__Create
+                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),                                               // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     2,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3294,6 +3303,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_ObsoleteAttribute__ctor
                 ".ctor",                                    // System_Span__ctor
+                "Create",                                   // System_Range__Create
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2938,6 +2938,15 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Range - WellKnownType.ExtSentinel),
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_LongRange__Create
+                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_LongRange - WellKnownType.ExtSentinel),                                               // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     2,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_LongRange - WellKnownType.ExtSentinel),
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int64,
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int64,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3304,6 +3313,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_ObsoleteAttribute__ctor
                 ".ctor",                                    // System_Span__ctor
                 "Create",                                   // System_Range__Create
+                "Create",                                   // System_LongRange__Create
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -271,6 +271,8 @@ namespace Microsoft.CodeAnalysis
         System_ObsoleteAttribute,
         System_Span_T,
 
+        System_Range,
+
         NextAvailable,
     }
 
@@ -535,6 +537,8 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.InteropServices.InAttribute",
             "System.ObsoleteAttribute",
             "System.Span`1",
+
+            "System.Range",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -272,6 +272,7 @@ namespace Microsoft.CodeAnalysis
         System_Span_T,
 
         System_Range,
+        System_LongRange,
 
         NextAvailable,
     }
@@ -539,6 +540,7 @@ namespace Microsoft.CodeAnalysis
             "System.Span`1",
 
             "System.Range",
+            "System.LongRange",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -502,7 +502,9 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Span_T
+                         WellKnownType.System_Span_T,
+                         WellKnownType.System_Range,
+                         WellKnownType.System_LongRange
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -540,7 +542,9 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Span_T
+                         WellKnownType.System_Span_T,
+                         WellKnownType.System_Range,
+                         WellKnownType.System_LongRange
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -584,7 +588,9 @@ End Namespace
                         ' Not a real value.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Span_T__ctor
+                         WellKnownMember.System_Span_T__ctor,
+                         WellKnownMember.System_Range__Create,
+                         WellKnownMember.System_LongRange__Create
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -668,7 +674,9 @@ End Namespace
                         ' The type is not embedded, so the member is not available.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Span_T__ctor
+                         WellKnownMember.System_Span_T__ctor,
+                         WellKnownMember.System_Range__Create,
+                         WellKnownMember.System_LongRange__Create
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -301,6 +301,7 @@ namespace My
                 1.1f
             };
             var (tuple, _) = (named: 1, 2);
+            var range = 1..2;
             int[, ,] cube = { { { 111, 112, }, { 121, 122 } }, { { 211, 212 }, { 221, 222 } } };
             int[][] jagged = { { 111 }, { 121, 122 } };
             int[][,] arr = new int[5][,]; // as opposed to new int[][5,5]

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3856,6 +3856,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return CreateBinaryExpression(SyntaxKind.ModuloExpression, left, right);
         }
 
+        public SyntaxNode RangeExpression(SyntaxNode left, SyntaxNode right)
+        {
+            return CreateBinaryExpression(SyntaxKind.RangeExpression, left, right);
+        }
+
         public override SyntaxNode BitwiseAndExpression(SyntaxNode left, SyntaxNode right)
         {
             return CreateBinaryExpression(SyntaxKind.BitwiseAndExpression, left, right);

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2573,6 +2573,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                     return OperatorPrecedence.Additive;
 
+                case SyntaxKind.RangeExpression:
+                    return OperatorPrecedence.Range;
+
                 case SyntaxKind.LeftShiftExpression:
                 case SyntaxKind.RightShiftExpression:
                     // From C# spec, 7.3.1:

--- a/src/Workspaces/CSharp/Portable/Extensions/OperatorPrecedence.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/OperatorPrecedence.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         Equality,
         RelationalAndTypeTesting,
         Shift,
+        Range,
         Additive,
         Multiplicative,
         Unary,

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOperatorKind.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOperatorKind.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         Subtraction = 24,
         True = 25,
         UnaryPlus = 26,
-        UnaryNegation = 27
+        UnaryNegation = 27,
+        Range = 28,
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 case CodeGenerationOperatorKind.Like:
                 case CodeGenerationOperatorKind.Modulus:
                 case CodeGenerationOperatorKind.Multiplication:
+                case CodeGenerationOperatorKind.Range:
                 case CodeGenerationOperatorKind.RightShift:
                 case CodeGenerationOperatorKind.Subtraction:
                     return 2;
@@ -100,6 +101,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 case CodeGenerationOperatorKind.Modulus: return WellKnownMemberNames.ModulusOperatorName;
                 case CodeGenerationOperatorKind.Multiplication: return WellKnownMemberNames.MultiplyOperatorName;
                 case CodeGenerationOperatorKind.OnesComplement: return WellKnownMemberNames.OnesComplementOperatorName;
+                case CodeGenerationOperatorKind.Range: return WellKnownMemberNames.RangeOperatorName;
                 case CodeGenerationOperatorKind.RightShift: return WellKnownMemberNames.RightShiftOperatorName;
                 case CodeGenerationOperatorKind.Subtraction: return WellKnownMemberNames.SubtractionOperatorName;
                 case CodeGenerationOperatorKind.True: return WellKnownMemberNames.TrueOperatorName;

--- a/src/Workspaces/Core/Portable/Editing/OperatorKind.cs
+++ b/src/Workspaces/Core/Portable/Editing/OperatorKind.cs
@@ -134,5 +134,10 @@ namespace Microsoft.CodeAnalysis.Editing
         /// The name assigned to the UnaryPlus operator.
         /// </summary>
         UnaryPlus,
+
+        /// <summary>
+        /// The name assigned to the Range operator.
+        /// </summary>
+        Range,
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -241,6 +241,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 case WellKnownMemberNames.ModulusOperatorName: return OperatorKind.Modulus;
                 case WellKnownMemberNames.MultiplyOperatorName: return OperatorKind.Multiply;
                 case WellKnownMemberNames.OnesComplementOperatorName: return OperatorKind.OnesComplement;
+                case WellKnownMemberNames.RangeOperatorName: return OperatorKind.Range;
                 case WellKnownMemberNames.RightShiftOperatorName: return OperatorKind.RightShift;
                 case WellKnownMemberNames.SubtractionOperatorName: return OperatorKind.Subtraction;
                 case WellKnownMemberNames.TrueOperatorName: return OperatorKind.True;

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsRef.get -> bool
+Microsoft.CodeAnalysis.Editing.OperatorKind.Range = 26 -> Microsoft.CodeAnalysis.Editing.OperatorKind
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleElementExpression(Microsoft.CodeAnalysis.ITypeSymbol type, string name = null) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleTypeExpression(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ITypeSymbol> elementTypes, System.Collections.Generic.IEnumerable<string> elementNames = null) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TupleTypeExpression(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> elements) -> Microsoft.CodeAnalysis.SyntaxNode


### PR DESCRIPTION
Contents of this PR:

* Syntax for both the expression and `operator ..` method
* Binding for built-in operators
  * Lookup for `System.Range`
  * Lookup for `System.LongRange`
* Binding for user-defined operators
* A very small number of tests (broad testing area suggestions would be appreciated)

Features lacking:
* Not tying into langver or `/feature`
* Only has one operator (depends on if LDM wants one or two operators)
* Nonassociativity of `..`

Note: this is going into the branch `features/range`, not `master`.