### PR TITLE
Restore toolset packages to Obj directory

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -211,7 +211,9 @@
   <Import Project="$(RoslynDiagnosticsPropsFilePath)" Condition="'$(UseRoslynAnalyzers)' == 'true' AND Exists('$(RoslynDiagnosticsPropsFilePath)')" />
 
   <ImportGroup Label="WindowsImports" Condition="'$(OS)' == 'Windows_NT'">
-    <Import Project="$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props" />
+    <Import 
+      Project="$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props"
+      Condition="Exists('$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props')" />
   </ImportGroup>
 
   <!-- 

--- a/build/ToolsetPackages/BaseToolset.csproj
+++ b/build/ToolsetPackages/BaseToolset.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\Packages.props" />
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\FixedPackages.props" />
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Targets\SettingsSdk.props" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
@@ -30,4 +31,5 @@
     <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" />
     <PackageReference Include="pdb2pdb" Version="$(Pdb2PdbVersion)" />
   </ItemGroup>
+  <Import Project="..\Targets\Imports.targets" />
 </Project>

--- a/build/ToolsetPackages/CoreToolset.csproj
+++ b/build/ToolsetPackages/CoreToolset.csproj
@@ -1,10 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\Packages.props" />
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\FixedPackages.props" />
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Targets\SettingsSdk.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" />
   </ItemGroup>
+  <Import Project="..\Targets\Imports.targets" />
 </Project>

--- a/build/ToolsetPackages/InternalToolset.csproj
+++ b/build/ToolsetPackages/InternalToolset.csproj
@@ -1,10 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\Packages.props" />
-  <Import Project="$(MSBuildThisFileDirectory)..\Targets\FixedPackages.props" />
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Targets\SettingsSdk.props" />
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMerge)" />
   </ItemGroup>
+  <Import Project="..\Targets\Imports.targets" />
 </Project>

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -409,7 +409,7 @@ function Restore-Project([string]$fileName, [string]$nuget, [string]$msbuildDir)
         $filePath = Join-Path $repoDir $fileName
     }
 
-    Exec-Block { & $nuget restore -verbosity quiet -configfile $nugetConfig -MSBuildPath $msbuildDir -Project2ProjectTimeOut 1200 $filePath } | Write-Host
+    Exec-Console $nuget "restore $filePath -verbosity quiet -configfile $nugetConfig -MSBuildPath ""$msbuildDir"" -Project2ProjectTimeOut 1200"
 }
 
 # Restore all of the projects that the repo consumes


### PR DESCRIPTION
The toolset packages were all restoring to the source directory. This
violates our build principal of builds should never write to the source
directory.

Changed to restore to the Obj directory as the rest of our code does.
Temporarily went back to the old MSBuild syntax. This will move to the
new MSbuild syntax with the rest of the repo.
