### PR TITLE
Ensure that we make operation callbacks into analyzers for operations within attributes

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27102.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -146,6 +146,10 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "BasicCodeStyleFixes", "src\
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "BasicCodeStyleTests", "src\CodeStyle\VisualBasic\Tests\BasicCodeStyleTests.vbproj", "{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CSharpAnalyzerDriver", "src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.shproj", "{54E08BF5-F819-404F-A18D-0AB9EA81EA04}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "BasicAnalyzerDriver", "src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.shproj", "{E8F0BAA5-7327-43D1-9A51-644E81AE55F1}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
@@ -156,6 +160,7 @@ Global
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		src\Compilers\Server\ServerShared\ServerShared.projitems*{32691768-af9c-4cae-9d0f-10721091b9aa}*SharedItemsImports = 13
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
+		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{54e08bf5-f819-404f-a18d-0ab9ea81ea04}*SharedItemsImports = 13
 		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
@@ -168,6 +173,7 @@ Global
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{d73adf7d-2c1c-42ae-b2ab-edc9497e4b71}*SharedItemsImports = 13
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 4
+		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{e8f0baa5-7327-43d1-9a51-644e81ae55f1}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -469,6 +475,8 @@ Global
 		{2531A8C4-97DD-47BC-A79C-B7846051E137} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
 		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{54E08BF5-F819-404F-A18D-0AB9EA81EA04} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
+		{E8F0BAA5-7327-43D1-9A51-644E81AE55F1} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F599E08-A9EA-4FAA-897F-5D824B0210E6}

--- a/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
+++ b/src/Compilers/CSharp/CSharpAnalyzerDriver/CSharpDeclarationComputer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return GetAttributes(((InterfaceDeclarationSyntax)typeDeclaration).AttributeLists);
 
                 default:
-                    return SpecializedCollections.EmptyEnumerable<SyntaxNode>();
+                    throw ExceptionUtilities.UnexpectedValue(typeDeclaration.Kind());
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
@@ -20,10 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var source = TestResource.AllInOneCSharpCode;
 
-            // AllInOneCSharpCode has no properties with initializers or named types with primary constructors.
+            // AllInOneCSharpCode has no properties with initializers/attributes.
             var symbolKindsWithNoCodeBlocks = new HashSet<SymbolKind>();
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.Property);
-            symbolKindsWithNoCodeBlocks.Add(SymbolKind.NamedType);
 
             var analyzer = new CSharpTrackingDiagnosticAnalyzer();
             CreateCompilationWithMscorlib45(source).VerifyAnalyzerDiagnostics(new[] { analyzer });

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1160,6 +1160,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 case SymbolKind.Event:
                 case SymbolKind.Property:
                 case SymbolKind.NamedType:
+                case SymbolKind.Namespace: // We are exposing assembly/module attributes on global namespace symbol.
                     return true;
 
                 case SymbolKind.Field:

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -857,17 +857,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
-        /// Method body and/or expressions subject to analysis.
+        /// One or more operation blocks that are the subject of the analysis.
+        /// This includes all blocks associated with the <see cref="OwningSymbol"/>,
+        /// such as method body, field/property/constructor/parameter initializer(s), attributes, etc.
         /// </summary>
+        /// <remarks>Note that the operation blocks are not in any specific order.</remarks>
         public ImmutableArray<IOperation> OperationBlocks => _operationBlocks;
 
         /// <summary>
-        /// <see cref="ISymbol"/> for which the code block provides a definition or value.
+        /// <see cref="ISymbol"/> for which the <see cref="OperationBlocks"/> provides a definition or value.
         /// </summary>
         public ISymbol OwningSymbol => _owningSymbol;
 
         /// <summary>
-        /// <see cref="CodeAnalysis.Compilation"/> containing the operation block.
+        /// <see cref="CodeAnalysis.Compilation"/> containing the <see cref="OperationBlocks"/>.
         /// </summary>
         public Compilation Compilation => _compilation;
 
@@ -934,17 +937,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly CancellationToken _cancellationToken;
 
         /// <summary>
-        /// Code block that is the subject of the analysis.
+        /// One or more operation blocks that are the subject of the analysis.
+        /// This includes all blocks associated with the <see cref="OwningSymbol"/>,
+        /// such as method body, field/property/constructor/parameter initializer(s), attributes, etc.
         /// </summary>
+        /// <remarks>Note that the operation blocks are not in any specific order.</remarks>
         public ImmutableArray<IOperation> OperationBlocks => _operationBlocks;
 
         /// <summary>
-        /// <see cref="ISymbol"/> for which the code block provides a definition or value.
+        /// <see cref="ISymbol"/> for which the <see cref="OperationBlocks"/> provides a definition or value.
         /// </summary>
         public ISymbol OwningSymbol => _owningSymbol;
 
         /// <summary>
-        /// <see cref="CodeAnalysis.Compilation"/> containing the operation block.
+        /// <see cref="CodeAnalysis.Compilation"/> containing the <see cref="OperationBlocks"/>.
         /// </summary>
         public Compilation Compilation => _compilation;
 

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTrackingDiagnosticAnalyzer.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTrackingDiagnosticAnalyzer.vb
@@ -11,7 +11,6 @@ Public Class BasicTrackingDiagnosticAnalyzer
 
     Protected Overrides Function IsOnCodeBlockSupported(symbolKind As SymbolKind, methodKind As MethodKind, returnsVoid As Boolean) As Boolean
         Return MyBase.IsOnCodeBlockSupported(symbolKind, methodKind, returnsVoid) AndAlso
-            symbolKind <> SymbolKind.Event AndAlso
             methodKind <> MethodKind.Destructor AndAlso
             methodKind <> MethodKind.ExplicitInterfaceImplementation
     End Function

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If methodBlock IsNot Nothing Then
                         Dim paramInitializers = GetParameterInitializers(methodBlock.BlockStatement.ParameterList)
                         Dim attributes = GetAttributes(methodBlock.BlockStatement.AttributeLists)
-                        Dim codeBlocks = paramInitializers.Concat(attributes)
+                        Dim codeBlocks = paramInitializers.Concat(methodBlock).Concat(attributes)
                         builder.Add(GetDeclarationInfo(model, node, getSymbol, codeBlocks, cancellationToken))
                         Return
                     End If

--- a/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
+++ b/src/Compilers/VisualBasic/BasicAnalyzerDriver/VisualBasicDeclarationComputer.vb
@@ -177,8 +177,44 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared Function GetMethodBaseCodeBlocks(methodBase As MethodBaseSyntax) As IEnumerable(Of SyntaxNode)
             Dim paramInitializers = GetParameterListInitializersAndAttributes(methodBase.ParameterList)
-            Dim attributes = GetAttributes(methodBase.AttributeLists).Concat(GetReturnTypeAttributes(methodBase.AsClauseInternal))
+            Dim attributes = GetAttributes(methodBase.AttributeLists).Concat(GetReturnTypeAttributes(GetAsClause(methodBase)))
             Return paramInitializers.Concat(attributes)
+        End Function
+
+        Private Shared Function GetAsClause(methodBase As MethodBaseSyntax) As AsClauseSyntax
+            Select Case methodBase.Kind
+                Case SyntaxKind.SubStatement, SyntaxKind.FunctionStatement
+                    Return DirectCast(methodBase, MethodStatementSyntax).AsClause
+
+                Case SyntaxKind.SubLambdaHeader, SyntaxKind.FunctionLambdaHeader
+                    Return DirectCast(methodBase, LambdaHeaderSyntax).AsClause
+
+                Case SyntaxKind.DeclareSubStatement, SyntaxKind.DeclareFunctionStatement
+                    Return DirectCast(methodBase, DeclareStatementSyntax).AsClause
+
+                Case SyntaxKind.DelegateSubStatement, SyntaxKind.DelegateFunctionStatement
+                    Return DirectCast(methodBase, DelegateStatementSyntax).AsClause
+
+                Case SyntaxKind.EventStatement
+                    Return DirectCast(methodBase, EventStatementSyntax).AsClause
+
+                Case SyntaxKind.OperatorStatement
+                    Return DirectCast(methodBase, OperatorStatementSyntax).AsClause
+
+                Case SyntaxKind.PropertyStatement
+                    Return DirectCast(methodBase, PropertyStatementSyntax).AsClause
+
+                Case SyntaxKind.SubNewStatement,
+                        SyntaxKind.GetAccessorStatement,
+                        SyntaxKind.SetAccessorStatement,
+                        SyntaxKind.AddHandlerAccessorStatement,
+                        SyntaxKind.RemoveHandlerAccessorStatement,
+                        SyntaxKind.RaiseEventAccessorStatement
+                    Return Nothing
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(methodBase.Kind)
+            End Select
         End Function
 
         Private Shared Function GetReturnTypeAttributes(asClause As AsClauseSyntax) As IEnumerable(Of SyntaxNode)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -1269,6 +1269,9 @@ End Class
                                  <![CDATA[
 Imports System
 
+<Assembly: MyAttribute(C.FieldForAssembly)>
+<Module: MyAttribute(C.FieldForModule)>
+
 Friend Class MyAttribute
     Inherits Attribute
     Public Sub New(f As Integer)
@@ -1285,7 +1288,9 @@ Friend Class C
     Friend Const FieldForClass As Integer = 1, FieldForStruct As Integer = 2, FieldForInterface As Integer = 3, FieldForField As Integer = 4, FieldForMethod As Integer = 5,
         FieldForEnum As Integer = 6, FieldForEnumMember As Integer = 7, FieldForDelegateSub As Integer = 8, FieldForDelegateFunction As Integer = 9, FieldForEventField As Integer = 10,
         FieldForEvent As Integer = 11, FieldForAddHandler As Integer = 12, FieldForRemoveHandler As Integer = 13, FieldForRaiseHandler As Integer = 14, FieldForProperty As Integer = 15,
-        FieldForPropertyGetter As Integer = 16, FieldForPropertySetter As Integer = 17, FieldForIndexer As Integer = 18, FieldForIndexerGetter As Integer = 19, FieldForIndexerSetter As Integer = 20
+        FieldForPropertyGetter As Integer = 16, FieldForPropertySetter As Integer = 17, FieldForIndexer As Integer = 18, FieldForIndexerGetter As Integer = 19, FieldForIndexerSetter As Integer = 20,
+        FieldForMethodParameter As Integer = 21, FieldForEventParameter As Integer = 22, FieldForDelegateSubParameter As Integer = 23, FieldForDelegateFunctionParameter As Integer = 24, FieldForIndexerParameter As Integer = 25,
+        FieldForAssembly As Integer = 26, FieldForModule As Integer = 27
 
     <MyAttribute(FieldForStruct)>
     Private Structure S
@@ -1299,7 +1304,7 @@ Friend Class C
     Private field2 As Integer = 0, field3 As Integer = 0
 
     <MyAttribute(FieldForMethod)>
-    Private Sub M1()
+    Private Sub M1(<MyAttribute(FieldForMethodParameter)> p1 As Integer)
     End Sub
 
     <MyAttribute(FieldForEnum)>
@@ -1309,13 +1314,13 @@ Friend Class C
     End Enum
 
     <MyAttribute(FieldForDelegateSub)>
-    Public Delegate Sub [Delegate]()
+    Public Delegate Sub [Delegate](<MyAttribute(FieldForDelegateSubParameter)> p1 As Integer)
 
     <MyAttribute(FieldForDelegateFunction)>
-    Public Delegate Function Delegate2()
+    Public Delegate Function Delegate2(<MyAttribute(FieldForDelegateFunctionParameter)> p1 As Integer)
 
     <MyAttribute(FieldForEventField)>
-    Public Event MyEvent As [Delegate]
+    Public Event MyEvent(<MyAttribute(FieldForEventParameter)> p1 As Integer)
 
     <MyAttribute(FieldForEvent)>
     Private Custom Event MyEvent2 As EventHandler Implements MyInterface.MyEvent
@@ -1342,7 +1347,7 @@ Friend Class C
     End Property
 
     <MyAttribute(FieldForIndexer)>
-    Default Property Item(index As Integer) As Integer
+    Default Property Item(<MyAttribute(FieldForIndexerParameter)> index As Integer) As Integer
         <MyAttribute(FieldForIndexerGetter)>
         Get
             Return 0
@@ -1368,27 +1373,34 @@ End Class
 
         Private Shared Sub TestFieldReferenceAnalyzer_InAttributes_Core(comp As Compilation, doOperationBlockAnalysis As Boolean)
             comp.VerifyAnalyzerDiagnostics({New FieldReferenceOperationAnalyzer(doOperationBlockAnalysis)}, Nothing, Nothing, False,
-                Diagnostic("ID", "C.FieldForClass").WithArguments("FieldForClass", "1").WithLocation(13, 14),
-                Diagnostic("ID", "FieldForStruct").WithArguments("FieldForStruct", "2").WithLocation(21, 18),
-                Diagnostic("ID", "FieldForInterface").WithArguments("FieldForInterface", "3").WithLocation(25, 18),
-                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(29, 18),
-                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(29, 18),
-                Diagnostic("ID", "FieldForMethod").WithArguments("FieldForMethod", "5").WithLocation(32, 18),
-                Diagnostic("ID", "FieldForEnum").WithArguments("FieldForEnum", "6").WithLocation(36, 18),
-                Diagnostic("ID", "FieldForEnumMember").WithArguments("FieldForEnumMember", "7").WithLocation(38, 22),
-                Diagnostic("ID", "FieldForDelegateSub").WithArguments("FieldForDelegateSub", "8").WithLocation(42, 18),
-                Diagnostic("ID", "FieldForDelegateFunction").WithArguments("FieldForDelegateFunction", "9").WithLocation(45, 18),
-                Diagnostic("ID", "FieldForEventField").WithArguments("FieldForEventField", "10").WithLocation(48, 18),
-                Diagnostic("ID", "FieldForEvent").WithArguments("FieldForEvent", "11").WithLocation(51, 18),
-                Diagnostic("ID", "FieldForAddHandler").WithArguments("FieldForAddHandler", "12").WithLocation(53, 22),
-                Diagnostic("ID", "FieldForRemoveHandler").WithArguments("FieldForRemoveHandler", "13").WithLocation(56, 22),
-                Diagnostic("ID", "FieldForRaiseHandler").WithArguments("FieldForRaiseHandler", "14").WithLocation(59, 22),
-                Diagnostic("ID", "FieldForProperty").WithArguments("FieldForProperty", "15").WithLocation(64, 18),
-                Diagnostic("ID", "FieldForPropertyGetter").WithArguments("FieldForPropertyGetter", "16").WithLocation(66, 22),
-                Diagnostic("ID", "FieldForPropertySetter").WithArguments("FieldForPropertySetter", "17").WithLocation(70, 22),
-                Diagnostic("ID", "FieldForIndexer").WithArguments("FieldForIndexer", "18").WithLocation(75, 18),
-                Diagnostic("ID", "FieldForIndexerGetter").WithArguments("FieldForIndexerGetter", "19").WithLocation(77, 22),
-                Diagnostic("ID", "FieldForIndexerSetter").WithArguments("FieldForIndexerSetter", "20").WithLocation(81, 22))
+                Diagnostic("ID", "C.FieldForClass").WithArguments("FieldForClass", "1").WithLocation(16, 14),
+                Diagnostic("ID", "FieldForStruct").WithArguments("FieldForStruct", "2").WithLocation(26, 18),
+                Diagnostic("ID", "FieldForInterface").WithArguments("FieldForInterface", "3").WithLocation(30, 18),
+                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(34, 18),
+                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(34, 18),
+                Diagnostic("ID", "FieldForMethod").WithArguments("FieldForMethod", "5").WithLocation(37, 18),
+                Diagnostic("ID", "FieldForEnum").WithArguments("FieldForEnum", "6").WithLocation(41, 18),
+                Diagnostic("ID", "FieldForEnumMember").WithArguments("FieldForEnumMember", "7").WithLocation(43, 22),
+                Diagnostic("ID", "FieldForDelegateSub").WithArguments("FieldForDelegateSub", "8").WithLocation(47, 18),
+                Diagnostic("ID", "FieldForDelegateFunction").WithArguments("FieldForDelegateFunction", "9").WithLocation(50, 18),
+                Diagnostic("ID", "FieldForEventField").WithArguments("FieldForEventField", "10").WithLocation(53, 18),
+                Diagnostic("ID", "FieldForEvent").WithArguments("FieldForEvent", "11").WithLocation(56, 18),
+                Diagnostic("ID", "FieldForAddHandler").WithArguments("FieldForAddHandler", "12").WithLocation(58, 22),
+                Diagnostic("ID", "FieldForRemoveHandler").WithArguments("FieldForRemoveHandler", "13").WithLocation(61, 22),
+                Diagnostic("ID", "FieldForRaiseHandler").WithArguments("FieldForRaiseHandler", "14").WithLocation(64, 22),
+                Diagnostic("ID", "FieldForProperty").WithArguments("FieldForProperty", "15").WithLocation(69, 18),
+                Diagnostic("ID", "FieldForPropertyGetter").WithArguments("FieldForPropertyGetter", "16").WithLocation(71, 22),
+                Diagnostic("ID", "FieldForPropertySetter").WithArguments("FieldForPropertySetter", "17").WithLocation(75, 22),
+                Diagnostic("ID", "FieldForIndexer").WithArguments("FieldForIndexer", "18").WithLocation(80, 18),
+                Diagnostic("ID", "FieldForIndexerGetter").WithArguments("FieldForIndexerGetter", "19").WithLocation(82, 22),
+                Diagnostic("ID", "FieldForIndexerSetter").WithArguments("FieldForIndexerSetter", "20").WithLocation(86, 22),
+                Diagnostic("ID", "FieldForMethodParameter").WithArguments("FieldForMethodParameter", "21").WithLocation(38, 33),
+                Diagnostic("ID", "FieldForEventParameter").WithArguments("FieldForEventParameter", "22").WithLocation(54, 39),
+                Diagnostic("ID", "FieldForDelegateSubParameter").WithArguments("FieldForDelegateSubParameter", "23").WithLocation(48, 49),
+                Diagnostic("ID", "FieldForDelegateFunctionParameter").WithArguments("FieldForDelegateFunctionParameter", "24").WithLocation(51, 53),
+                Diagnostic("ID", "FieldForIndexerParameter").WithArguments("FieldForIndexerParameter", "25").WithLocation(81, 40),
+                Diagnostic("ID", "C.FieldForAssembly").WithArguments("FieldForAssembly", "26").WithLocation(3, 24),
+                Diagnostic("ID", "C.FieldForModule").WithArguments("FieldForModule", "27").WithLocation(4, 22))
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -1290,7 +1290,8 @@ Friend Class C
         FieldForEvent As Integer = 11, FieldForAddHandler As Integer = 12, FieldForRemoveHandler As Integer = 13, FieldForRaiseHandler As Integer = 14, FieldForProperty As Integer = 15,
         FieldForPropertyGetter As Integer = 16, FieldForPropertySetter As Integer = 17, FieldForIndexer As Integer = 18, FieldForIndexerGetter As Integer = 19, FieldForIndexerSetter As Integer = 20,
         FieldForMethodParameter As Integer = 21, FieldForEventParameter As Integer = 22, FieldForDelegateSubParameter As Integer = 23, FieldForDelegateFunctionParameter As Integer = 24, FieldForIndexerParameter As Integer = 25,
-        FieldForAssembly As Integer = 26, FieldForModule As Integer = 27
+        FieldForAssembly As Integer = 26, FieldForModule As Integer = 27, FieldForMethodReturnType As Integer = 28, FieldForDelegateFunctionReturnType As Integer = 29, FieldForPropertyReturnType As Integer = 30,
+        FieldForIndexerReturnType = 31
 
     <MyAttribute(FieldForStruct)>
     Private Structure S
@@ -1304,8 +1305,9 @@ Friend Class C
     Private field2 As Integer = 0, field3 As Integer = 0
 
     <MyAttribute(FieldForMethod)>
-    Private Sub M1(<MyAttribute(FieldForMethodParameter)> p1 As Integer)
-    End Sub
+    Private Function M1(<MyAttribute(FieldForMethodParameter)> p1 As Integer) As <MyAttribute(FieldForMethodReturnType)> Integer
+        Return 0
+    End Function
 
     <MyAttribute(FieldForEnum)>
     Private Enum E
@@ -1317,7 +1319,7 @@ Friend Class C
     Public Delegate Sub [Delegate](<MyAttribute(FieldForDelegateSubParameter)> p1 As Integer)
 
     <MyAttribute(FieldForDelegateFunction)>
-    Public Delegate Function Delegate2(<MyAttribute(FieldForDelegateFunctionParameter)> p1 As Integer)
+    Public Delegate Function Delegate2(<MyAttribute(FieldForDelegateFunctionParameter)> p1 As Integer) As <MyAttribute(FieldForDelegateFunctionReturnType)> Integer
 
     <MyAttribute(FieldForEventField)>
     Public Event MyEvent(<MyAttribute(FieldForEventParameter)> p1 As Integer)
@@ -1336,7 +1338,7 @@ Friend Class C
     End Event
 
     <MyAttribute(FieldForProperty)>
-    Private Property P1() As Integer
+    Private Property P1() As <MyAttribute(FieldForPropertyReturnType)> Integer
         <MyAttribute(FieldForPropertyGetter)>
         Get
             Return 0
@@ -1347,7 +1349,7 @@ Friend Class C
     End Property
 
     <MyAttribute(FieldForIndexer)>
-    Default Property Item(<MyAttribute(FieldForIndexerParameter)> index As Integer) As Integer
+    Default Property Item(<MyAttribute(FieldForIndexerParameter)> index As Integer) As <MyAttribute(FieldForIndexerReturnType)> Integer
         <MyAttribute(FieldForIndexerGetter)>
         Get
             Return 0
@@ -1374,33 +1376,37 @@ End Class
         Private Shared Sub TestFieldReferenceAnalyzer_InAttributes_Core(comp As Compilation, doOperationBlockAnalysis As Boolean)
             comp.VerifyAnalyzerDiagnostics({New FieldReferenceOperationAnalyzer(doOperationBlockAnalysis)}, Nothing, Nothing, False,
                 Diagnostic("ID", "C.FieldForClass").WithArguments("FieldForClass", "1").WithLocation(16, 14),
-                Diagnostic("ID", "FieldForStruct").WithArguments("FieldForStruct", "2").WithLocation(26, 18),
-                Diagnostic("ID", "FieldForInterface").WithArguments("FieldForInterface", "3").WithLocation(30, 18),
-                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(34, 18),
-                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(34, 18),
-                Diagnostic("ID", "FieldForMethod").WithArguments("FieldForMethod", "5").WithLocation(37, 18),
-                Diagnostic("ID", "FieldForEnum").WithArguments("FieldForEnum", "6").WithLocation(41, 18),
-                Diagnostic("ID", "FieldForEnumMember").WithArguments("FieldForEnumMember", "7").WithLocation(43, 22),
-                Diagnostic("ID", "FieldForDelegateSub").WithArguments("FieldForDelegateSub", "8").WithLocation(47, 18),
-                Diagnostic("ID", "FieldForDelegateFunction").WithArguments("FieldForDelegateFunction", "9").WithLocation(50, 18),
-                Diagnostic("ID", "FieldForEventField").WithArguments("FieldForEventField", "10").WithLocation(53, 18),
-                Diagnostic("ID", "FieldForEvent").WithArguments("FieldForEvent", "11").WithLocation(56, 18),
-                Diagnostic("ID", "FieldForAddHandler").WithArguments("FieldForAddHandler", "12").WithLocation(58, 22),
-                Diagnostic("ID", "FieldForRemoveHandler").WithArguments("FieldForRemoveHandler", "13").WithLocation(61, 22),
-                Diagnostic("ID", "FieldForRaiseHandler").WithArguments("FieldForRaiseHandler", "14").WithLocation(64, 22),
-                Diagnostic("ID", "FieldForProperty").WithArguments("FieldForProperty", "15").WithLocation(69, 18),
-                Diagnostic("ID", "FieldForPropertyGetter").WithArguments("FieldForPropertyGetter", "16").WithLocation(71, 22),
-                Diagnostic("ID", "FieldForPropertySetter").WithArguments("FieldForPropertySetter", "17").WithLocation(75, 22),
-                Diagnostic("ID", "FieldForIndexer").WithArguments("FieldForIndexer", "18").WithLocation(80, 18),
-                Diagnostic("ID", "FieldForIndexerGetter").WithArguments("FieldForIndexerGetter", "19").WithLocation(82, 22),
-                Diagnostic("ID", "FieldForIndexerSetter").WithArguments("FieldForIndexerSetter", "20").WithLocation(86, 22),
-                Diagnostic("ID", "FieldForMethodParameter").WithArguments("FieldForMethodParameter", "21").WithLocation(38, 33),
-                Diagnostic("ID", "FieldForEventParameter").WithArguments("FieldForEventParameter", "22").WithLocation(54, 39),
-                Diagnostic("ID", "FieldForDelegateSubParameter").WithArguments("FieldForDelegateSubParameter", "23").WithLocation(48, 49),
-                Diagnostic("ID", "FieldForDelegateFunctionParameter").WithArguments("FieldForDelegateFunctionParameter", "24").WithLocation(51, 53),
-                Diagnostic("ID", "FieldForIndexerParameter").WithArguments("FieldForIndexerParameter", "25").WithLocation(81, 40),
+                Diagnostic("ID", "FieldForStruct").WithArguments("FieldForStruct", "2").WithLocation(27, 18),
+                Diagnostic("ID", "FieldForInterface").WithArguments("FieldForInterface", "3").WithLocation(31, 18),
+                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(35, 18),
+                Diagnostic("ID", "FieldForField").WithArguments("FieldForField", "4").WithLocation(35, 18),
+                Diagnostic("ID", "FieldForMethod").WithArguments("FieldForMethod", "5").WithLocation(38, 18),
+                Diagnostic("ID", "FieldForEnum").WithArguments("FieldForEnum", "6").WithLocation(43, 18),
+                Diagnostic("ID", "FieldForEnumMember").WithArguments("FieldForEnumMember", "7").WithLocation(45, 22),
+                Diagnostic("ID", "FieldForDelegateSub").WithArguments("FieldForDelegateSub", "8").WithLocation(49, 18),
+                Diagnostic("ID", "FieldForDelegateFunction").WithArguments("FieldForDelegateFunction", "9").WithLocation(52, 18),
+                Diagnostic("ID", "FieldForEventField").WithArguments("FieldForEventField", "10").WithLocation(55, 18),
+                Diagnostic("ID", "FieldForEvent").WithArguments("FieldForEvent", "11").WithLocation(58, 18),
+                Diagnostic("ID", "FieldForAddHandler").WithArguments("FieldForAddHandler", "12").WithLocation(60, 22),
+                Diagnostic("ID", "FieldForRemoveHandler").WithArguments("FieldForRemoveHandler", "13").WithLocation(63, 22),
+                Diagnostic("ID", "FieldForRaiseHandler").WithArguments("FieldForRaiseHandler", "14").WithLocation(66, 22),
+                Diagnostic("ID", "FieldForProperty").WithArguments("FieldForProperty", "15").WithLocation(71, 18),
+                Diagnostic("ID", "FieldForPropertyGetter").WithArguments("FieldForPropertyGetter", "16").WithLocation(73, 22),
+                Diagnostic("ID", "FieldForPropertySetter").WithArguments("FieldForPropertySetter", "17").WithLocation(77, 22),
+                Diagnostic("ID", "FieldForIndexer").WithArguments("FieldForIndexer", "18").WithLocation(82, 18),
+                Diagnostic("ID", "FieldForIndexerGetter").WithArguments("FieldForIndexerGetter", "19").WithLocation(84, 22),
+                Diagnostic("ID", "FieldForIndexerSetter").WithArguments("FieldForIndexerSetter", "20").WithLocation(88, 22),
+                Diagnostic("ID", "FieldForMethodParameter").WithArguments("FieldForMethodParameter", "21").WithLocation(39, 38),
+                Diagnostic("ID", "FieldForEventParameter").WithArguments("FieldForEventParameter", "22").WithLocation(56, 39),
+                Diagnostic("ID", "FieldForDelegateSubParameter").WithArguments("FieldForDelegateSubParameter", "23").WithLocation(50, 49),
+                Diagnostic("ID", "FieldForDelegateFunctionParameter").WithArguments("FieldForDelegateFunctionParameter", "24").WithLocation(53, 53),
+                Diagnostic("ID", "FieldForIndexerParameter").WithArguments("FieldForIndexerParameter", "25").WithLocation(83, 40),
                 Diagnostic("ID", "C.FieldForAssembly").WithArguments("FieldForAssembly", "26").WithLocation(3, 24),
-                Diagnostic("ID", "C.FieldForModule").WithArguments("FieldForModule", "27").WithLocation(4, 22))
+                Diagnostic("ID", "C.FieldForModule").WithArguments("FieldForModule", "27").WithLocation(4, 22),
+                Diagnostic("ID", "FieldForMethodReturnType").WithArguments("FieldForMethodReturnType", "28").WithLocation(39, 95),
+                Diagnostic("ID", "FieldForDelegateFunctionReturnType").WithArguments("FieldForDelegateFunctionReturnType", "29").WithLocation(53, 120),
+                Diagnostic("ID", "FieldForPropertyReturnType").WithArguments("FieldForPropertyReturnType", "30").WithLocation(72, 43),
+                Diagnostic("ID", "FieldForIndexerReturnType").WithArguments("FieldForIndexerReturnType", "31").WithLocation(83, 101))
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -67,7 +67,7 @@ class C
                 {
                     Assert.False(ideEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.MethodKind == MethodKind.DelegateInvoke && e.ReturnsVoid));
                     Assert.False(ideEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.MethodKind == MethodKind.DelegateInvoke && !e.ReturnsVoid));
-                    Assert.False(ideEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.NamedType));
+                    Assert.True(ideEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.NamedType));
                     Assert.False(ideEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.Property));
                 }
             }
@@ -81,7 +81,7 @@ class C
                 {
                     Assert.False(compilerEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.MethodKind == MethodKind.DelegateInvoke && e.ReturnsVoid));
                     Assert.False(compilerEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.MethodKind == MethodKind.DelegateInvoke && !e.ReturnsVoid));
-                    Assert.False(compilerEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.NamedType));
+                    Assert.True(compilerEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.NamedType));
                     Assert.False(compilerEngineAnalyzer.CallLog.Any(e => e.CallerName == method && e.SymbolKind == SymbolKind.Property));
                 }
             }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -41,7 +41,7 @@ End Class
             Await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(ideEngineAnalyzer, ideEngineDocument, New TextSpan(0, ideEngineDocument.GetTextAsync().Result.Length))
             For Each method In methodNames
                 Assert.False(ideEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.Event, False)))
-                Assert.False(ideEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.NamedType, False)))
+                Assert.True(ideEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.NamedType, False)))
                 Assert.True(ideEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.Property, False)))
             Next method
         End Using
@@ -52,7 +52,7 @@ End Class
             compilerEngineCompilation.GetAnalyzerDiagnostics({compilerEngineAnalyzer})
             For Each method In methodNames
                 Assert.False(compilerEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.Event, False)))
-                Assert.False(compilerEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.NamedType, False)))
+                Assert.True(compilerEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.NamedType, False)))
                 Assert.True(compilerEngineAnalyzer.CallLog.Any(Function(e) e.CallerName = method AndAlso If(e.SymbolKind = SymbolKind.Property, False)))
             Next method
         End Using

--- a/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -126,7 +126,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.StaticConstructor, ReturnsVoid = true },
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.UserDefinedOperator, ReturnsVoid = false },
                 new { SymbolKind = SymbolKind.Property, MethodKind = InvalidMethodKind, ReturnsVoid = false },
-                new { SymbolKind = SymbolKind.NamedType, MethodKind = InvalidMethodKind, ReturnsVoid = false }
+                new { SymbolKind = SymbolKind.NamedType, MethodKind = InvalidMethodKind, ReturnsVoid = false },
+                new { SymbolKind = SymbolKind.Namespace, MethodKind = InvalidMethodKind, ReturnsVoid = false }
             }.AsEnumerable();
 
             if (symbolKindsWithNoCodeBlocks != null)

--- a/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             const MethodKind InvalidMethodKind = (MethodKind)(-1);
             var expectedArguments = new[]
             {
-                new { SymbolKind = SymbolKind.Event,  MethodKind = InvalidMethodKind, ReturnsVoid = false }, // C# only
+                new { SymbolKind = SymbolKind.Event,  MethodKind = InvalidMethodKind, ReturnsVoid = false },
                 new { SymbolKind = SymbolKind.Field,  MethodKind = InvalidMethodKind, ReturnsVoid = false },
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.Constructor, ReturnsVoid = true },
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.Conversion, ReturnsVoid = false },
@@ -126,6 +126,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.StaticConstructor, ReturnsVoid = true },
                 new { SymbolKind = SymbolKind.Method, MethodKind = MethodKind.UserDefinedOperator, ReturnsVoid = false },
                 new { SymbolKind = SymbolKind.Property, MethodKind = InvalidMethodKind, ReturnsVoid = false },
+                new { SymbolKind = SymbolKind.NamedType, MethodKind = InvalidMethodKind, ReturnsVoid = false }
             }.AsEnumerable();
 
             if (symbolKindsWithNoCodeBlocks != null)


### PR DESCRIPTION
**Customer scenario**

Executing any operation block analyzers on piece of code with attributes causes lot of false analyzer diagnostics

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/23309 

**Workarounds, if any**

Uninstall all operation block analyzers or suppress all warnings from such analyzers

**Risk**

Low. This change only affects the analyzer driver code that calls back into the analyzers. Now we ensure that operation callbacks happen for operations within attributes and we also return attribute operations as root operation blocks for analysis.

**Performance impact**

None. We are supposedly analyzing more code than before, but that is by design - we do want code within attributes to be part of analysis.

**Is this a regression from a previous update?**

No, this is for a new feature.

**Root cause analysis:**

Found during dogfooding of operation analyzers.

**How was the bug found?**

Found during dogfooding of operation analyzers.