### PR TITLE
Handle an empty span for 'introduce variable' refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -36,6 +36,80 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestEmptySpan1()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class C
+{
+    void M(Action action)
+    {
+        M(() [||]=> { });
+    }
+}",
+@"using System;
+class C
+{
+    void M(Action action)
+    {
+        Action {|Rename:action1|} = () => { };
+        M(action1);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestEmptySpan2()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class C
+{
+    void M(int a, int b)
+    {
+        var x = a [||]+ b + 3;
+    }
+}",
+@"using System;
+class C
+{
+    void M(int a, int b)
+    {
+        int {|Rename:v|} = a + b;
+        var x = v + 3;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestEmptySpan3()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    void M(int a)
+    {
+        var x = [||]a;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestEmptySpan4()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    void M(Action action)
+    {
+        M(() => { var x [||]= y; });
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestMethodFix1()
         {
             await TestInRegularAndScriptAsync(
@@ -4356,29 +4430,6 @@ struct TextSpan
     public TextSpan(int start, int length)
     {
 
-    }
-}");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
-        public async Task TestEmptySpan1()
-        {
-            await TestInRegularAndScriptAsync(
-@"using System;
-class C
-{
-    void M(Action action)
-    {
-        M(() [||]=> { });
-    }
-}",
-@"using System;
-class C
-{
-    void M(Action action)
-    {
-        Action {|Rename:action1|} = () => { };
-        M(action1);
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4359,5 +4359,28 @@ struct TextSpan
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestEmptySpan1()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+class C
+{
+    void M(Action action)
+    {
+        M(() [||]=> { });
+    }
+}",
+@"using System;
+class C
+{
+    void M(Action action)
+    {
+        Action {|Rename:action1|} = () => { };
+        M(action1);
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 var root = tree.GetRoot(cancellationToken);
                 if (textSpan.Length == 0)
                 {
-                    return root.FindToken(textSpan.Start).GetAncestor<TExpressionSyntax>();
+                    return root.FindToken(textSpan.Start).Parent as TExpressionSyntax;
                 }
 
                 var startToken = root.FindToken(textSpan.Start);

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -186,6 +186,11 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
             private TExpressionSyntax GetExpressionUnderSpan(SyntaxTree tree, TextSpan textSpan, CancellationToken cancellationToken)
             {
                 var root = tree.GetRoot(cancellationToken);
+                if (textSpan.Length == 0)
+                {
+                    return root.FindToken(textSpan.Start).GetAncestor<TExpressionSyntax>();
+                }
+
                 var startToken = root.FindToken(textSpan.Start);
                 var stopToken = root.FindToken(textSpan.End);
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/roslyn/issues/23310

