### PR TITLE
Emitting `foreach` over `Span` and `ReadOnlySpan` as a `for` loop

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return RewriteMultiDimensionalArrayForEachStatement(node);
                 }
             }
-            else if (CanRewriteForeachAsFor(node.Syntax, nodeExpressionType, out var indexerGet, out var lengthGetter))
+            else if (CanRewriteForEachAsFor(node.Syntax, nodeExpressionType, out var indexerGet, out var lengthGetter))
             {
                 return RewriteForEachStatementAsFor(node, indexerGet, lengthGetter);
             }
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool CanRewriteForeachAsFor(SyntaxNode forEachSyntax, TypeSymbol nodeExpressionType, out MethodSymbol indexerGet, out MethodSymbol lengthGet)
+        private bool CanRewriteForEachAsFor(SyntaxNode forEachSyntax, TypeSymbol nodeExpressionType, out MethodSymbol indexerGet, out MethodSymbol lengthGet)
         {
             lengthGet = indexerGet = null;
             var origDefinition = nodeExpressionType.OriginalDefinition;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///   RewriteEnumeratorForEachStatement
         ///   RewriteSingleDimensionalArrayForEachStatement
         ///   RewriteMultiDimensionalArrayForEachStatement
-        ///   RewriteStringForEachStatement
+        ///   CanRewriteForEachAsFor
         /// </summary>
         /// <remarks>
         /// We are diverging from the C# 4 spec (and Dev10) to follow the C# 5 spec.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -70,7 +70,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 lengthGet = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Span_T__get_Length, isOptional: true)?.SymbolAsMember(spanType);
                 indexerGet = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_Span_T__get_Item, isOptional: true)?.SymbolAsMember(spanType);
             }
-
+            else if ((object)origDefinition == this._compilation.GetWellKnownType(WellKnownType.System_ReadOnlySpan_T))
+            {
+                var spanType = (NamedTypeSymbol)nodeExpressionType;
+                lengthGet = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_ReadOnlySpan_T__get_Length, isOptional: true)?.SymbolAsMember(spanType);
+                indexerGet = (MethodSymbol)_factory.WellKnownMember(WellKnownMember.System_ReadOnlySpan_T__get_Item, isOptional: true)?.SymbolAsMember(spanType);
+            }
             return lengthGet != null && indexerGet != null;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -929,6 +929,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return parameter.RefKind != RefKind.None;
             }
 
+            protected override bool IsByRefMethod(MethodSymbol method)
+            {
+                return method.RefKind != RefKind.None;
+            }
+
             protected override bool IsGenericMethodTypeParam(TypeSymbol type, int paramPosition)
             {
                 if (type.Kind != SymbolKind.TypeParameter)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
@@ -357,6 +357,56 @@ class Test
         }
 
         [Fact]
+        public void TestSpanNoIndexer()
+        {
+            var comp = CreateCompilationWithMscorlibAndSpan(@"
+using System;
+
+class Test
+{
+    public static void Main()
+    {       
+        var sp = new Span<int>(new[] {1, 2, 3});
+        foreach(var i in sp)
+        {
+            Console.Write(i);
+        }
+    }
+}
+
+", TestOptions.ReleaseExe);
+
+            comp.MakeMemberMissing(WellKnownMember.System_Span_T__get_Item);
+
+            CompileAndVerify(comp, expectedOutput: "123").VerifyIL("Test.Main", @"
+{
+  // Code size       57 (0x39)
+  .maxstack  4
+  .locals init (System.Span<int> V_0, //sp
+                System.Span<int>.Enumerator V_1)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.3
+  IL_0003:  newarr     ""int""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0013:  call       ""System.Span<int>..ctor(int[])""
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  call       ""System.Span<int>.Enumerator System.Span<int>.GetEnumerator()""
+  IL_001f:  stloc.1
+  IL_0020:  br.s       IL_002f
+  IL_0022:  ldloca.s   V_1
+  IL_0024:  call       ""ref int System.Span<int>.Enumerator.Current.get""
+  IL_0029:  ldind.i4
+  IL_002a:  call       ""void System.Console.Write(int)""
+  IL_002f:  ldloca.s   V_1
+  IL_0031:  call       ""bool System.Span<int>.Enumerator.MoveNext()""
+  IL_0036:  brtrue.s   IL_0022
+  IL_0038:  ret
+}");
+        }
+
+        [Fact]
         public void TestSpanConvert()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
@@ -357,6 +357,59 @@ class Test
         }
 
         [Fact]
+        public void TestReadOnlySpan()
+        {
+            var comp = CreateCompilationWithMscorlibAndSpan(@"
+using System;
+
+class Test
+{
+    public static void Main()
+    {       
+        var sp = new ReadOnlySpan<int>(new[] {1, 2, 3});
+        foreach(var i in sp)
+        {
+            Console.Write(i);
+        }
+    }
+}
+
+", TestOptions.ReleaseExe);
+
+            CompileAndVerify(comp, expectedOutput: "123").VerifyIL("Test.Main", @"
+{
+  // Code size       56 (0x38)
+  .maxstack  3
+  .locals init (System.ReadOnlySpan<int> V_0,
+                int V_1)
+  IL_0000:  ldc.i4.3
+  IL_0001:  newarr     ""int""
+  IL_0006:  dup
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0011:  newobj     ""System.ReadOnlySpan<int>..ctor(int[])""
+  IL_0016:  stloc.0
+  IL_0017:  ldc.i4.0
+  IL_0018:  stloc.1
+  IL_0019:  br.s       IL_002d
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  ldloc.1
+  IL_001e:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+  IL_0023:  ldind.i4
+  IL_0024:  call       ""void System.Console.Write(int)""
+  IL_0029:  ldloc.1
+  IL_002a:  ldc.i4.1
+  IL_002b:  add
+  IL_002c:  stloc.1
+  IL_002d:  ldloc.1
+  IL_002e:  ldloca.s   V_0
+  IL_0030:  call       ""int System.ReadOnlySpan<int>.Length.get""
+  IL_0035:  blt.s      IL_001b
+  IL_0037:  ret
+}");
+        }
+
+        [Fact]
         public void TestSpanNoIndexer()
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -862,6 +862,8 @@ namespace System
                     case WellKnownMember.System_Span_T__ctor:
                     case WellKnownMember.System_Span_T__get_Item:
                     case WellKnownMember.System_Span_T__get_Length:
+                    case WellKnownMember.System_ReadOnlySpan_T__get_Item:
+                    case WellKnownMember.System_ReadOnlySpan_T__get_Length:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -561,6 +561,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute:
                     case WellKnownType.System_Span_T:
+                    case WellKnownType.System_ReadOnlySpan_T:
                     // Not yet in the platform.
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
                         // Not always available.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -860,6 +860,8 @@ namespace System
                         continue;
                     case WellKnownMember.System_Array__Empty:
                     case WellKnownMember.System_Span_T__ctor:
+                    case WellKnownMember.System_Span_T__get_Item:
+                    case WellKnownMember.System_Span_T__get_Length:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
             builder.Add((byte)paramCount);
 
             // Return type
-            ParseType(builder, stream);
+            ParseType(builder, stream, allowByRef: true);
 
             // Parameters
             for (int i = 0; i < paramCount; i++)

--- a/src/Compilers/Core/Portable/SignatureComparer.cs
+++ b/src/Compilers/Core/Portable/SignatureComparer.cs
@@ -91,6 +91,13 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
                 return false;
             }
 
+            bool isByRef = IsByRef(signature, ref position);
+
+            if (IsByRefMethod(method) != isByRef)
+            {
+                return false;
+            }
+
             // get the return type
             if (!MatchType(GetReturnType(method), signature, ref position))
             {
@@ -112,18 +119,7 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
 
         private bool MatchParameter(ParameterSymbol parameter, ImmutableArray<byte> signature, ref int position)
         {
-            SignatureTypeCode typeCode = (SignatureTypeCode)signature[position];
-            bool isByRef;
-
-            if (typeCode == SignatureTypeCode.ByReference)
-            {
-                isByRef = true;
-                position++;
-            }
-            else
-            {
-                isByRef = false;
-            }
+            bool isByRef = IsByRef(signature, ref position);
 
             if (IsByRefParam(parameter) != isByRef)
             {
@@ -131,6 +127,21 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
             }
 
             return MatchType(GetParamType(parameter), signature, ref position);
+        }
+
+        private static bool IsByRef(ImmutableArray<byte> signature, ref int position)
+        {
+            SignatureTypeCode typeCode = (SignatureTypeCode)signature[position];
+
+            if (typeCode == SignatureTypeCode.ByReference)
+            {
+                position++;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
 
@@ -273,7 +284,9 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
         protected abstract ImmutableArray<ParameterSymbol> GetParameters(PropertySymbol property);
 
         protected abstract TypeSymbol GetParamType(ParameterSymbol parameter);
+
         protected abstract bool IsByRefParam(ParameterSymbol parameter);
+        protected abstract bool IsByRefMethod(MethodSymbol method);
 
         protected abstract TypeSymbol GetFieldType(FieldSymbol field);
     }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -423,6 +423,8 @@ namespace Microsoft.CodeAnalysis
 
         System_ObsoleteAttribute__ctor,
         System_Span_T__ctor,
+        System_Span_T__get_Item,
+        System_Span_T__get_Length,
 
         Count
     }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -422,9 +422,13 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor,
 
         System_ObsoleteAttribute__ctor,
+
         System_Span_T__ctor,
         System_Span_T__get_Item,
         System_Span_T__get_Length,
+
+        System_ReadOnlySpan_T__get_Item,
+        System_ReadOnlySpan_T__get_Length,
 
         Count
     }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2944,6 +2944,21 @@ namespace Microsoft.CodeAnalysis
                  0,                                                                                                                                             // Arity
                     0,                                                                                                                                          // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_ReadOnlySpan__get_Item
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    1,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_ReadOnlySpan__get_Length
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    0,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3311,6 +3326,8 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Span__ctor
                 "get_Item",                                 // System_Span__get_Item
                 "get_Length",                               // System_Span__get_Length
+                "get_Item",                                 // System_ReadOnlySpan__get_Item
+                "get_Length",                               // System_ReadOnlySpan__get_Length
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2947,7 +2947,7 @@ namespace Microsoft.CodeAnalysis
 
                  // System_ReadOnlySpan__get_Item
                  (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
-                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                      // DeclaringTypeId
                  0,                                                                                                                                             // Arity
                     1,                                                                                                                                          // Method Signature
                     (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericTypeParameter, 0,
@@ -2955,7 +2955,7 @@ namespace Microsoft.CodeAnalysis
 
                  // System_ReadOnlySpan__get_Length
                  (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
-                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                      // DeclaringTypeId
                  0,                                                                                                                                             // Arity
                     0,                                                                                                                                          // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2929,6 +2929,21 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.Pointer, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_Span__get_Item
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Span_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    1,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_Span__get_Length
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Span_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    0,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3294,6 +3309,8 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_ObsoleteAttribute__ctor
                 ".ctor",                                    // System_Span__ctor
+                "get_Item",                                 // System_Span__get_Item
+                "get_Length",                               // System_Span__get_Length
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -270,6 +270,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_InteropServices_InAttribute,
         System_ObsoleteAttribute,
         System_Span_T,
+        System_ReadOnlySpan_T,
 
         NextAvailable,
     }
@@ -535,6 +536,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.InteropServices.InAttribute",
             "System.ObsoleteAttribute",
             "System.Span`1",
+            "System.ReadOnlySpan`1",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1227,38 +1227,130 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private static string spanSource = @"
 namespace System
-{
-    public readonly ref struct Span<T> 
     {
-        public ref T this[int i] => throw null;
-        public override int GetHashCode() => 1;
-        public int Length { get; }
-
-        unsafe public Span(void* pointer, int length)
+        public readonly ref struct Span<T>
         {
-            this.Length = length;
+            private readonly T[] arr;
+
+            public ref T this[int i] => ref arr[i];
+            public override int GetHashCode() => 1;
+            public int Length { get; }
+
+            unsafe public Span(void* pointer, int length)
+            {
+                this.arr = null;
+                this.Length = length;
+            }
+
+            public Span(T[] arr)
+            {
+                this.arr = arr;
+                this.Length = arr.Length;
+            }
+
+            public void CopyTo(Span<T> other) { }
+
+            /// <summary>Gets an enumerator for this span.</summary>
+            public Enumerator GetEnumerator() => new Enumerator(this);
+
+            /// <summary>Enumerates the elements of a <see cref=""Span{T}""/>.</summary>
+            public ref struct Enumerator
+            {
+                /// <summary>The span being enumerated.</summary>
+                private readonly Span<T> _span;
+                /// <summary>The next index to yield.</summary>
+                private int _index;
+
+                /// <summary>Initialize the enumerator.</summary>
+                /// <param name=""span"">The span to enumerate.</param>
+                internal Enumerator(Span<T> span)
+                {
+                    _span = span;
+                    _index = -1;
+                }
+
+                /// <summary>Advances the enumerator to the next element of the span.</summary>
+                public bool MoveNext()
+                {
+                    int index = _index + 1;
+                    if (index < _span.Length)
+                    {
+                        _index = index;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                /// <summary>Gets the element at the current position of the enumerator.</summary>
+                public ref T Current
+                {
+                    get => ref _span[_index];
+                }
+            }
         }
-        public Span(T[] arr)
+
+        public readonly ref struct ReadOnlySpan<T>
         {
-            this.Length = arr.Length;
+            private readonly T[] arr;
+
+            public ref readonly T this[int i] => ref arr[i];
+            public override int GetHashCode() => 2;
+            public int Length { get; }
+
+            public ReadOnlySpan(T[] arr)
+            {
+                this.arr = arr;
+                this.Length = arr.Length;
+            }
+
+            public void CopyTo(Span<T> other) { }
+
+            /// <summary>Gets an enumerator for this span.</summary>
+            public Enumerator GetEnumerator() => new Enumerator(this);
+
+            /// <summary>Enumerates the elements of a <see cref=""Span{T}""/>.</summary>
+            public ref struct Enumerator
+            {
+                /// <summary>The span being enumerated.</summary>
+                private readonly ReadOnlySpan<T> _span;
+                /// <summary>The next index to yield.</summary>
+                private int _index;
+
+                /// <summary>Initialize the enumerator.</summary>
+                /// <param name=""span"">The span to enumerate.</param>
+                internal Enumerator(ReadOnlySpan<T> span)
+                {
+                    _span = span;
+                    _index = -1;
+                }
+
+                /// <summary>Advances the enumerator to the next element of the span.</summary>
+                public bool MoveNext()
+                {
+                    int index = _index + 1;
+                    if (index < _span.Length)
+                    {
+                        _index = index;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                /// <summary>Gets the element at the current position of the enumerator.</summary>
+                public ref readonly T Current
+                {
+                    get => ref _span[_index];
+                }
+            }
         }
 
-        public void CopyTo(Span<T> other){}
-    }
-
-    public readonly ref struct ReadOnlySpan<T>
-    {
-        public ref readonly T this[int i] => throw null;
-        public override int GetHashCode() => 2;
-
-        public void CopyTo(Span<T> other){}
-    }
-
-    public readonly ref struct SpanLike<T>
-    {
-        public readonly Span<T> field;
-    }
-}";
+        public readonly ref struct SpanLike<T>
+        {
+            public readonly Span<T> field;
+        }
+    }";
         #endregion
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -624,6 +624,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return parameter.IsByRef
             End Function
 
+            Protected Overrides Function IsByRefMethod(ByVal method As MethodSymbol) As Boolean
+                Return method.ReturnsByRef
+            End Function
+
             Protected Overrides Function IsGenericMethodTypeParam(type As TypeSymbol, paramPosition As Integer) As Boolean
                 If type.Kind <> SymbolKind.TypeParameter Then
                     Return False

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -584,7 +584,9 @@ End Namespace
                         ' Not a real value.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Span_T__ctor
+                         WellKnownMember.System_Span_T__ctor,
+                        WellKnownMember.System_Span_T__get_Item,
+                        WellKnownMember.System_Span_T__get_Length
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -668,7 +670,9 @@ End Namespace
                         ' The type is not embedded, so the member is not available.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Span_T__ctor
+                         WellKnownMember.System_Span_T__ctor,
+                         WellKnownMember.System_Span_T__get_Item,
+                         WellKnownMember.System_Span_T__get_Length
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -502,7 +502,8 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Span_T
+                         WellKnownType.System_Span_T,
+                         WellKnownType.System_ReadOnlySpan_T
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -540,7 +541,8 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Span_T
+                         WellKnownType.System_Span_T,
+                         WellKnownType.System_ReadOnlySpan_T
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -585,8 +585,10 @@ End Namespace
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
                          WellKnownMember.System_Span_T__ctor,
-                        WellKnownMember.System_Span_T__get_Item,
-                        WellKnownMember.System_Span_T__get_Length
+                         WellKnownMember.System_Span_T__get_Item,
+                         WellKnownMember.System_Span_T__get_Length,
+                         WellKnownMember.System_ReadOnlySpan_T__get_Item,
+                         WellKnownMember.System_ReadOnlySpan_T__get_Length
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -672,7 +674,9 @@ End Namespace
                     Case WellKnownMember.System_Array__Empty,
                          WellKnownMember.System_Span_T__ctor,
                          WellKnownMember.System_Span_T__get_Item,
-                         WellKnownMember.System_Span_T__get_Length
+                         WellKnownMember.System_Span_T__get_Length,
+                         WellKnownMember.System_ReadOnlySpan_T__get_Item,
+                         WellKnownMember.System_ReadOnlySpan_T__get_Length
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
Fixes:https://github.com/dotnet/roslyn/issues/23091

The implementation slightly generalizes lowering of `foreach` for `System.String` and now supports spans as well.

NOTE: Successful binding of `foreach` loop for spans does not technically guarantee that the loop can be emitted as `for`. In fact there are older implementations of ReadOnlySpan that vary in terms of indexer. 

We will probe for necessary APIs (need an indexer and Length). 
If both are present then we emit `for` loop.
Otherwise we emit ordinary `foreach` loop. 


### Customer scenario

Customer uses `foreach` statement with `Span` or `ReadOnySpan`.
The IL emitted by C# compiler could use indexing as in `for` loop, which would be faster.

### Bugs this fixes

Fixes:https://github.com/dotnet/roslyn/issues/23091

### Workarounds, if any

If this optimization is not done by the compiler and user wants all the efficiency, a `for` loop can be used directly, but that is not as expressive as `foreach`

### Risk

Very low. The same code handles similar optimization for `System.String`

### Performance impact

Very low for the same reason.

### Is this a regression from a previous update?

No.

### Root cause analysis

Not really a bug. Code Quality improvement.

### How was the bug found?

Planned change. Was discussed and vetted by LDM.

### Test documentation updated?

N/A
