### PR TITLE
Wrap completion providers logic in exception filters

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/AttributeNamedParameterCompletionProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -34,55 +35,62 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var cancellationToken = context.CancellationToken;
-
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            if (syntaxTree.IsInNonUserCode(position, cancellationToken))
+            try
             {
-                return;
+                var document = context.Document;
+                var position = context.Position;
+                var cancellationToken = context.CancellationToken;
+
+                var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                if (syntaxTree.IsInNonUserCode(position, cancellationToken))
+                {
+                    return;
+                }
+
+                var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+                token = token.GetPreviousTokenIfTouchingWord(position);
+
+                if (!token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+                {
+                    return;
+                }
+
+                var attributeArgumentList = token.Parent as AttributeArgumentListSyntax;
+                var attributeSyntax = token.Parent.Parent as AttributeSyntax;
+                if (attributeSyntax == null || attributeArgumentList == null)
+                {
+                    return;
+                }
+
+                if (IsAfterNameColonArgument(token) || IsAfterNameEqualsArgument(token))
+                {
+                    context.IsExclusive = true;
+                }
+
+                // We actually want to collect two sets of named parameters to present the user.  The
+                // normal named parameters that come from the attribute constructors.  These will be
+                // presented like "goo:".  And also the named parameters that come from the writable
+                // fields/properties in the attribute.  These will be presented like "bar =".  
+
+                var existingNamedParameters = GetExistingNamedParameters(attributeArgumentList, position);
+
+                var workspace = document.Project.Solution.Workspace;
+                var semanticModel = await document.GetSemanticModelForNodeAsync(attributeSyntax, cancellationToken).ConfigureAwait(false);
+                var nameColonItems = await GetNameColonItemsAsync(context, semanticModel, token, attributeSyntax, existingNamedParameters).ConfigureAwait(false);
+                var nameEqualsItems = await GetNameEqualsItemsAsync(context, semanticModel, token, attributeSyntax, existingNamedParameters).ConfigureAwait(false);
+
+                context.AddItems(nameEqualsItems);
+
+                // If we're after a name= parameter, then we only want to show name= parameters.
+                // Otherwise, show name: parameters too.
+                if (!IsAfterNameEqualsArgument(token))
+                {
+                    context.AddItems(nameColonItems);
+                }
             }
-
-            var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
-            token = token.GetPreviousTokenIfTouchingWord(position);
-
-            if (!token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
-                return;
-            }
-
-            var attributeArgumentList = token.Parent as AttributeArgumentListSyntax;
-            var attributeSyntax = token.Parent.Parent as AttributeSyntax;
-            if (attributeSyntax == null || attributeArgumentList == null)
-            {
-                return;
-            }
-
-            if (IsAfterNameColonArgument(token) || IsAfterNameEqualsArgument(token))
-            {
-                context.IsExclusive = true;
-            }
-
-            // We actually want to collect two sets of named parameters to present the user.  The
-            // normal named parameters that come from the attribute constructors.  These will be
-            // presented like "goo:".  And also the named parameters that come from the writable
-            // fields/properties in the attribute.  These will be presented like "bar =".  
-
-            var existingNamedParameters = GetExistingNamedParameters(attributeArgumentList, position);
-
-            var workspace = document.Project.Solution.Workspace;
-            var semanticModel = await document.GetSemanticModelForNodeAsync(attributeSyntax, cancellationToken).ConfigureAwait(false);
-            var nameColonItems = await GetNameColonItemsAsync(context, semanticModel, token, attributeSyntax, existingNamedParameters).ConfigureAwait(false);
-            var nameEqualsItems = await GetNameEqualsItemsAsync(context, semanticModel, token, attributeSyntax, existingNamedParameters).ConfigureAwait(false);
-
-            context.AddItems(nameEqualsItems);
-
-            // If we're after a name= parameter, then we only want to show name= parameters.
-            // Otherwise, show name: parameters too.
-            if (!IsAfterNameEqualsArgument(token))
-            {
-                context.AddItems(nameColonItems);
+                // nop
             }
         }
 
@@ -233,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private TextChange? GetTextChange(CompletionItem selectedItem, char? ch)
-        { 
+        {
             var displayText = selectedItem.DisplayText;
 
             if (ch != null)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -17,6 +17,7 @@ using Roslyn.Utilities;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using System;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
@@ -69,29 +70,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var options = context.Options;
-            var cancellationToken = context.CancellationToken;
-
-            var (token, semanticModel, symbols) = await GetSymbolsAsync(document, position, options, cancellationToken).ConfigureAwait(false);
-
-            if (symbols.Length == 0)
+            try
             {
-                return;
+                var document = context.Document;
+                var position = context.Position;
+                var options = context.Options;
+                var cancellationToken = context.CancellationToken;
+
+                var (token, semanticModel, symbols) = await GetSymbolsAsync(document, position, options, cancellationToken).ConfigureAwait(false);
+
+                if (symbols.Length == 0)
+                {
+                    return;
+                }
+
+                context.IsExclusive = true;
+
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var span = GetCompletionItemSpan(text, position);
+                var hideAdvancedMembers = options.GetOption(CompletionOptions.HideAdvancedMembers, semanticModel.Language);
+                var serializedOptions = ImmutableDictionary<string, string>.Empty.Add(HideAdvancedMembers, hideAdvancedMembers.ToString());
+
+                var items = CreateCompletionItems(document.Project.Solution.Workspace,
+                    semanticModel, symbols, token, span, position, serializedOptions);
+
+                context.AddItems(items);
             }
-
-            context.IsExclusive = true;
-
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var span = GetCompletionItemSpan(text, position);
-            var hideAdvancedMembers = options.GetOption(CompletionOptions.HideAdvancedMembers, semanticModel.Language);
-            var serializedOptions = ImmutableDictionary<string, string>.Empty.Add(HideAdvancedMembers, hideAdvancedMembers.ToString());
-
-            var items = CreateCompletionItems(document.Project.Solution.Workspace, 
-                semanticModel, symbols, token, span, position, serializedOptions);
-
-            context.AddItems(items);
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // nop
+            }
         }
 
         protected override async Task<(SyntaxToken, SemanticModel, ImmutableArray<ISymbol>)> GetSymbolsAsync(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
@@ -27,39 +28,46 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext completionContext)
         {
-            var position = completionContext.Position;
-            var document = completionContext.Document;
-            var cancellationToken = completionContext.CancellationToken;
-            var semanticModel = await document.GetSemanticModelForSpanAsync(new Text.TextSpan(position, 0), cancellationToken).ConfigureAwait(false);
-
-            if (!completionContext.Options.GetOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp))
+            try
             {
-                return;
-            }
+                var position = completionContext.Position;
+                var document = completionContext.Document;
+                var cancellationToken = completionContext.CancellationToken;
+                var semanticModel = await document.GetSemanticModelForSpanAsync(new Text.TextSpan(position, 0), cancellationToken).ConfigureAwait(false);
 
-            var context = CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken);
-            if (context.IsInNonUserCode)
+                if (!completionContext.Options.GetOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp))
+                {
+                    return;
+                }
+
+                var context = CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken);
+                if (context.IsInNonUserCode)
+                {
+                    return;
+                }
+
+                var nameInfo = await NameDeclarationInfo.GetDeclarationInfo(document, position, cancellationToken).ConfigureAwait(false);
+                var baseNames = GetBaseNames(semanticModel, nameInfo);
+                if (baseNames == default)
+                {
+                    return;
+                }
+
+                var recommendedNames = await GetRecommendedNamesAsync(baseNames, nameInfo, context, document, cancellationToken).ConfigureAwait(false);
+                int sortValue = 0;
+                foreach (var (name, kind) in recommendedNames)
+                {
+                    // We've produced items in the desired order, add a sort text to each item to prevent alphabetization
+                    completionContext.AddItem(CreateCompletionItem(name, GetGlyph(kind, nameInfo.DeclaredAccessibility), sortValue.ToString("D8")));
+                    sortValue++;
+                }
+
+                completionContext.SuggestionModeItem = CommonCompletionItem.Create(CSharpFeaturesResources.Name, CompletionItemRules.Default);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
-                return;
+                // nop
             }
-
-            var nameInfo = await NameDeclarationInfo.GetDeclarationInfo(document, position, cancellationToken).ConfigureAwait(false);
-            var baseNames = GetBaseNames(semanticModel, nameInfo);
-            if (baseNames == default)
-            {
-                return;
-            }
-
-            var recommendedNames = await GetRecommendedNamesAsync(baseNames, nameInfo, context, document, cancellationToken).ConfigureAwait(false);
-            int sortValue = 0;
-            foreach (var (name, kind) in recommendedNames)
-            {
-                // We've produced items in the desired order, add a sort text to each item to prevent alphabetization
-                completionContext.AddItem(CreateCompletionItem(name, GetGlyph(kind, nameInfo.DeclaredAccessibility), sortValue.ToString("D8")));
-                sortValue++;
-            }
-
-            completionContext.SuggestionModeItem = CommonCompletionItem.Create(CSharpFeaturesResources.Name, CompletionItemRules.Default);
         }
 
         private ImmutableArray<ImmutableArray<string>> GetBaseNames(SemanticModel semanticModel,  NameDeclarationInfo nameInfo)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -38,69 +40,76 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var options = context.Options;
-            var cancellationToken = context.CancellationToken;
-
-            var span = new TextSpan(position, length: 0);
-            var semanticModel = await document.GetSemanticModelForSpanAsync(span, cancellationToken).ConfigureAwait(false);
-            var syntaxTree = semanticModel.SyntaxTree;
-
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-            var semanticFacts = document.GetLanguageService<ISemanticFactsService>();
-
-            if (syntaxFacts.IsInNonUserCode(syntaxTree, position, cancellationToken) ||
-                semanticFacts.IsPreProcessorDirectiveContext(semanticModel, position, cancellationToken))
+            try
             {
-                return;
+                var document = context.Document;
+                var position = context.Position;
+                var options = context.Options;
+                var cancellationToken = context.CancellationToken;
+
+                var span = new TextSpan(position, length: 0);
+                var semanticModel = await document.GetSemanticModelForSpanAsync(span, cancellationToken).ConfigureAwait(false);
+                var syntaxTree = semanticModel.SyntaxTree;
+
+                var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+                var semanticFacts = document.GetLanguageService<ISemanticFactsService>();
+
+                if (syntaxFacts.IsInNonUserCode(syntaxTree, position, cancellationToken) ||
+                    semanticFacts.IsPreProcessorDirectiveContext(semanticModel, position, cancellationToken))
+                {
+                    return;
+                }
+
+                if (!syntaxTree.IsRightOfDotOrArrowOrColonColon(position, cancellationToken))
+                {
+                    return;
+                }
+
+                var node = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
+                                     .GetPreviousTokenIfTouchingWord(position)
+                                     .Parent;
+
+                if (node.Kind() != SyntaxKind.ExplicitInterfaceSpecifier)
+                {
+                    return;
+                }
+
+                // Bind the interface name which is to the left of the dot
+                var name = ((ExplicitInterfaceSpecifierSyntax)node).Name;
+
+                var symbol = semanticModel.GetSymbolInfo(name, cancellationToken).Symbol as ITypeSymbol;
+                if (symbol?.TypeKind != TypeKind.Interface)
+                {
+                    return;
+                }
+
+                var members = symbol.GetMembers();
+
+                // We're going to create a entry for each one, including the signature
+                var namePosition = name.SpanStart;
+
+                var text = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                foreach (var member in members)
+                {
+                    var displayText = member.ToMinimalDisplayString(
+                        semanticModel, namePosition, s_signatureDisplayFormat);
+                    var insertionText = displayText;
+
+                    var item = SymbolCompletionItem.CreateWithSymbolId(
+                        displayText,
+                        insertionText: insertionText,
+                        symbols: ImmutableArray.Create(member),
+                        contextPosition: position,
+                        rules: CompletionItemRules.Default);
+                    item = item.AddProperty(InsertionTextOnOpenParen, member.Name);
+
+                    context.AddItem(item);
+                }
             }
-
-            if (!syntaxTree.IsRightOfDotOrArrowOrColonColon(position, cancellationToken))
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
-                return;
-            }
-
-            var node = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
-                                 .GetPreviousTokenIfTouchingWord(position)
-                                 .Parent;
-
-            if (node.Kind() != SyntaxKind.ExplicitInterfaceSpecifier)
-            {
-                return;
-            }
-
-            // Bind the interface name which is to the left of the dot
-            var name = ((ExplicitInterfaceSpecifierSyntax)node).Name;
-
-            var symbol = semanticModel.GetSymbolInfo(name, cancellationToken).Symbol as ITypeSymbol;
-            if (symbol?.TypeKind != TypeKind.Interface)
-            {
-                return;
-            }
-
-            var members = symbol.GetMembers();
-
-            // We're going to create a entry for each one, including the signature
-            var namePosition = name.SpanStart;
-
-            var text = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            foreach (var member in members)
-            {
-                var displayText = member.ToMinimalDisplayString(
-                    semanticModel, namePosition, s_signatureDisplayFormat);
-                var insertionText = displayText;
-
-                var item = SymbolCompletionItem.CreateWithSymbolId(
-                    displayText,
-                    insertionText: insertionText,
-                    symbols: ImmutableArray.Create(member),
-                    contextPosition: position,
-                    rules: CompletionItemRules.Default);
-                item = item.AddProperty(InsertionTextOnOpenParen, member.Name);
-
-                context.AddItem(item);
+                // nop
             }
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
@@ -35,16 +37,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var completionCount = context.Items.Count;
-            await base.ProvideCompletionsAsync(context).ConfigureAwait(false);
-
-            if (completionCount < context.Items.Count)
+            try
             {
-                // If we added any items, then add a suggestion mode item as this is a location 
-                // where a member name could be written, and we should not interfere with that.
-                context.SuggestionModeItem = CreateSuggestionModeItem(
-                    CSharpFeaturesResources.member_name,
-                    CSharpFeaturesResources.Autoselect_disabled_due_to_member_declaration);
+                var completionCount = context.Items.Count;
+                await base.ProvideCompletionsAsync(context).ConfigureAwait(false);
+
+                if (completionCount < context.Items.Count)
+                {
+                    // If we added any items, then add a suggestion mode item as this is a location 
+                    // where a member name could be written, and we should not interfere with that.
+                    context.SuggestionModeItem = CreateSuggestionModeItem(
+                        CSharpFeaturesResources.member_name,
+                        CSharpFeaturesResources.Autoselect_disabled_due_to_member_declaration);
+                }
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // nop
             }
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExternAliasCompletionProvider.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -21,44 +23,51 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var cancellationToken = context.CancellationToken;
-
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
-            if (tree.IsInNonUserCode(position, cancellationToken))
+            try
             {
-                return;
-            }
+                var document = context.Document;
+                var position = context.Position;
+                var cancellationToken = context.CancellationToken;
 
-            var targetToken = tree
-                .FindTokenOnLeftOfPosition(position, cancellationToken)
-                .GetPreviousTokenIfTouchingWord(position);
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
-            if (targetToken.IsKind(SyntaxKind.AliasKeyword) && targetToken.Parent.IsKind(SyntaxKind.ExternAliasDirective))
-            {
-                var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var aliases = compilation.ExternalReferences.SelectMany(r => r.Properties.Aliases).ToSet();
-
-                if (aliases.Any())
+                if (tree.IsInNonUserCode(position, cancellationToken))
                 {
-                    var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-                    var usedAliases = root.ChildNodes().OfType<ExternAliasDirectiveSyntax>()
-                        .Where(e => !e.Identifier.IsMissing)
-                        .Select(e => e.Identifier.ValueText);
+                    return;
+                }
 
-                    aliases.RemoveRange(usedAliases);
-                    aliases.Remove(MetadataReferenceProperties.GlobalAlias);
+                var targetToken = tree
+                    .FindTokenOnLeftOfPosition(position, cancellationToken)
+                    .GetPreviousTokenIfTouchingWord(position);
 
-                    var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                if (targetToken.IsKind(SyntaxKind.AliasKeyword) && targetToken.Parent.IsKind(SyntaxKind.ExternAliasDirective))
+                {
+                    var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                    var aliases = compilation.ExternalReferences.SelectMany(r => r.Properties.Aliases).ToSet();
 
-                    foreach (var alias in aliases)
+                    if (aliases.Any())
                     {
-                        context.AddItem(CommonCompletionItem.Create(
-                            alias, CompletionItemRules.Default, glyph: Glyph.Namespace));
+                        var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+                        var usedAliases = root.ChildNodes().OfType<ExternAliasDirectiveSyntax>()
+                            .Where(e => !e.Identifier.IsMissing)
+                            .Select(e => e.Identifier.ValueText);
+
+                        aliases.RemoveRange(usedAliases);
+                        aliases.Remove(MetadataReferenceProperties.GlobalAlias);
+
+                        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                        foreach (var alias in aliases)
+                        {
+                            context.AddItem(CommonCompletionItem.Create(
+                                alias, CompletionItemRules.Default, glyph: Glyph.Namespace));
+                        }
                     }
                 }
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // nop
             }
         }
     }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -16,6 +16,8 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Completion.Providers;
+using System;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
@@ -35,75 +37,82 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var cancellationToken = context.CancellationToken;
-
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            if (syntaxTree.IsInNonUserCode(position, cancellationToken))
+            try
             {
-                return;
+                var document = context.Document;
+                var position = context.Position;
+                var cancellationToken = context.CancellationToken;
+
+                var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                if (syntaxTree.IsInNonUserCode(position, cancellationToken))
+                {
+                    return;
+                }
+
+                var token = syntaxTree
+                    .FindTokenOnLeftOfPosition(position, cancellationToken)
+                    .GetPreviousTokenIfTouchingWord(position);
+
+                if (!token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.OpenBracketToken, SyntaxKind.CommaToken))
+                {
+                    return;
+                }
+
+                var argumentList = token.Parent as BaseArgumentListSyntax;
+                if (argumentList == null)
+                {
+                    return;
+                }
+
+                var semanticModel = await document.GetSemanticModelForNodeAsync(argumentList, cancellationToken).ConfigureAwait(false);
+                var parameterLists = GetParameterLists(semanticModel, position, argumentList.Parent, cancellationToken);
+                if (parameterLists == null)
+                {
+                    return;
+                }
+
+                var existingNamedParameters = GetExistingNamedParameters(argumentList, position);
+                parameterLists = parameterLists.Where(pl => IsValid(pl, existingNamedParameters));
+
+                var unspecifiedParameters = parameterLists.SelectMany(pl => pl)
+                                                          .Where(p => !existingNamedParameters.Contains(p.Name))
+                                                          .Distinct(this);
+
+                if (!unspecifiedParameters.Any())
+                {
+                    return;
+                }
+
+                // Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
+                // See https://github.com/dotnet/roslyn/issues/20657
+                var languageVersion = ((CSharpParseOptions)document.Project.ParseOptions).LanguageVersion;
+                if (languageVersion < LanguageVersion.CSharp7_2 && token.IsMandatoryNamedParameterPosition())
+                {
+                    context.IsExclusive = true;
+                }
+
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                var workspace = document.Project.Solution.Workspace;
+
+                foreach (var parameter in unspecifiedParameters)
+                {
+                    // Note: the filter text does not include the ':'.  We want to ensure that if 
+                    // the user types the name exactly (up to the colon) that it is selected as an
+                    // exact match.
+                    var escapedName = parameter.Name.ToIdentifierToken().ToString();
+
+                    context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
+                        displayText: escapedName + ColonString,
+                        symbols: ImmutableArray.Create(parameter),
+                        rules: s_rules.WithMatchPriority(SymbolMatchPriority.PreferNamedArgument),
+                        contextPosition: token.SpanStart,
+                        filterText: escapedName));
+                }
             }
-
-            var token = syntaxTree
-                .FindTokenOnLeftOfPosition(position, cancellationToken)
-                .GetPreviousTokenIfTouchingWord(position);
-
-            if (!token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.OpenBracketToken, SyntaxKind.CommaToken))
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
-                return;
-            }
-
-            var argumentList = token.Parent as BaseArgumentListSyntax;
-            if (argumentList == null)
-            {
-                return;
-            }
-
-            var semanticModel = await document.GetSemanticModelForNodeAsync(argumentList, cancellationToken).ConfigureAwait(false);
-            var parameterLists = GetParameterLists(semanticModel, position, argumentList.Parent, cancellationToken);
-            if (parameterLists == null)
-            {
-                return;
-            }
-
-            var existingNamedParameters = GetExistingNamedParameters(argumentList, position);
-            parameterLists = parameterLists.Where(pl => IsValid(pl, existingNamedParameters));
-
-            var unspecifiedParameters = parameterLists.SelectMany(pl => pl)
-                                                      .Where(p => !existingNamedParameters.Contains(p.Name))
-                                                      .Distinct(this);
-
-            if (!unspecifiedParameters.Any())
-            {
-                return;
-            }
-
-            // Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
-            // See https://github.com/dotnet/roslyn/issues/20657
-            var languageVersion = ((CSharpParseOptions)document.Project.ParseOptions).LanguageVersion;
-            if (languageVersion < LanguageVersion.CSharp7_2 && token.IsMandatoryNamedParameterPosition())
-            {
-                context.IsExclusive = true;
-            }
-
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            var workspace = document.Project.Solution.Workspace;
-
-            foreach (var parameter in unspecifiedParameters)
-            {
-                // Note: the filter text does not include the ':'.  We want to ensure that if 
-                // the user types the name exactly (up to the colon) that it is selected as an
-                // exact match.
-                var escapedName = parameter.Name.ToIdentifierToken().ToString();
-
-                context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
-                    displayText: escapedName + ColonString,
-                    symbols: ImmutableArray.Create(parameter),
-                    rules: s_rules.WithMatchPriority(SymbolMatchPriority.PreferNamedArgument),
-                    contextPosition: token.SpanStart,
-                    filterText: escapedName));
+                // nop
             }
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
@@ -7,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -22,21 +24,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var document = context.Document;
-            var position = context.Position;
-            var cancellationToken = context.CancellationToken;
-
-            var showSpeculativeT = await document.IsValidContextForDocumentOrLinkedDocumentsAsync(
-                (doc, ct) => ShouldShowSpeculativeTCompletionItemAsync(doc, position, ct),
-                cancellationToken).ConfigureAwait(false);
-
-            if (showSpeculativeT)
+            try
             {
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var document = context.Document;
+                var position = context.Position;
+                var cancellationToken = context.CancellationToken;
 
-                const string T = nameof(T);
-                context.AddItem(CommonCompletionItem.Create(
-                    T, CompletionItemRules.Default, glyph: Glyph.TypeParameter));
+                var showSpeculativeT = await document.IsValidContextForDocumentOrLinkedDocumentsAsync(
+                    (doc, ct) => ShouldShowSpeculativeTCompletionItemAsync(doc, position, ct),
+                    cancellationToken).ConfigureAwait(false);
+
+                if (showSpeculativeT)
+                {
+                    var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                    const string T = nameof(T);
+                    context.AddItem(CommonCompletionItem.Create(
+                        T, CompletionItemRules.Default, glyph: Glyph.TypeParameter));
+                }
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // nop
             }
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -16,8 +18,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
-    using System;
-    using Microsoft.CodeAnalysis.ErrorReporting;
     using static DocumentationCommentXmlNames;
 
     internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompletionProvider<DocumentationCommentTriviaSyntax>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -16,6 +16,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
+    using System;
+    using Microsoft.CodeAnalysis.ErrorReporting;
     using static DocumentationCommentXmlNames;
 
     internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompletionProvider<DocumentationCommentTriviaSyntax>
@@ -34,110 +36,117 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             Document document, int position,
             CompletionTrigger trigger, CancellationToken cancellationToken)
         {
-            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
-            var parentTrivia = token.GetAncestor<DocumentationCommentTriviaSyntax>();
-
-            if (parentTrivia == null)
+            try
             {
-                return null;
-            }
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
+                var parentTrivia = token.GetAncestor<DocumentationCommentTriviaSyntax>();
 
-            var attachedToken = parentTrivia.ParentTrivia.Token;
-            if (attachedToken.Kind() == SyntaxKind.None)
-            {
-                return null;
-            }
-
-            var semanticModel = await document.GetSemanticModelForNodeAsync(attachedToken.Parent, cancellationToken).ConfigureAwait(false);
-
-            ISymbol declaredSymbol = null;
-            var memberDeclaration = attachedToken.GetAncestor<MemberDeclarationSyntax>();
-            if (memberDeclaration != null)
-            {
-                declaredSymbol = semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken);
-            }
-            else
-            {
-                var typeDeclaration = attachedToken.GetAncestor<TypeDeclarationSyntax>();
-                if (typeDeclaration != null)
+                if (parentTrivia == null)
                 {
-                    declaredSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken);
-                }
-            }
-
-            if (IsAttributeNameContext(token, position, out string elementName, out ISet<string> existingAttributes))
-            {
-                return GetAttributeItems(elementName, existingAttributes);
-            }
-
-            var wasTriggeredAfterSpace = trigger.Kind == CompletionTriggerKind.Insertion && trigger.Character == ' ';
-            if (wasTriggeredAfterSpace)
-            {
-                // Nothing below this point should triggered by a space character
-                // (only attribute names should be triggered by <SPACE>)
-                return null;
-            }
-
-            if (IsAttributeValueContext(token, out elementName, out string attributeName))
-            {
-                return GetAttributeValueItems(declaredSymbol, elementName, attributeName);
-            }
-
-            if (trigger.Kind == CompletionTriggerKind.Insertion && trigger.Character != '<')
-            {
-                // With the use of IsTriggerAfterSpaceOrStartOfWordCharacter, the code below is much
-                // too aggressive at suggesting tags, so exit early before degrading the experience
-                return null;
-            }
-
-            var items = new List<CompletionItem>();
-
-            if (token.Parent.Kind() == SyntaxKind.XmlEmptyElement || token.Parent.Kind() == SyntaxKind.XmlText ||
-                (token.Parent.IsKind(SyntaxKind.XmlElementEndTag) && token.IsKind(SyntaxKind.GreaterThanToken)) ||
-                (token.Parent.IsKind(SyntaxKind.XmlName) && token.Parent.IsParentKind(SyntaxKind.XmlEmptyElement)))
-            {
-                // The user is typing inside an XmlElement
-                if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement ||
-                    token.Parent.Parent.IsParentKind(SyntaxKind.XmlElement))
-                {
-                    // Avoid including language keywords when following < or <text, since these cases should only be
-                    // attempting to complete the XML name (which for language keywords is 'see'). While the parser
-                    // treats the 'name' in '< name' as an XML name, we don't treat it like that here so the completion
-                    // experience is consistent for '< ' and '< n'.
-                    var xmlNameOnly = token.IsKind(SyntaxKind.LessThanToken)
-                        || (token.Parent.IsKind(SyntaxKind.XmlName) && !token.HasLeadingTrivia);
-                    var includeKeywords = !xmlNameOnly;
-
-                    items.AddRange(GetNestedItems(declaredSymbol, includeKeywords));
+                    return null;
                 }
 
-                if (token.Parent.Parent is XmlElementSyntax xmlElement)
+                var attachedToken = parentTrivia.ParentTrivia.Token;
+                if (attachedToken.Kind() == SyntaxKind.None)
                 {
-                    AddXmlElementItems(items, xmlElement.StartTag);
+                    return null;
                 }
 
-                if (token.Parent.IsParentKind(SyntaxKind.XmlEmptyElement) && 
-                    token.Parent.Parent.Parent is XmlElementSyntax nestedXmlElement)
+                var semanticModel = await document.GetSemanticModelForNodeAsync(attachedToken.Parent, cancellationToken).ConfigureAwait(false);
+
+                ISymbol declaredSymbol = null;
+                var memberDeclaration = attachedToken.GetAncestor<MemberDeclarationSyntax>();
+                if (memberDeclaration != null)
                 {
-                    AddXmlElementItems(items, nestedXmlElement.StartTag);
+                    declaredSymbol = semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken);
+                }
+                else
+                {
+                    var typeDeclaration = attachedToken.GetAncestor<TypeDeclarationSyntax>();
+                    if (typeDeclaration != null)
+                    {
+                        declaredSymbol = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken);
+                    }
                 }
 
-                if (token.Parent.Parent is DocumentationCommentTriviaSyntax ||
-                    (token.Parent.Parent.IsKind(SyntaxKind.XmlEmptyElement) && token.Parent.Parent.Parent is DocumentationCommentTriviaSyntax))
+                if (IsAttributeNameContext(token, position, out string elementName, out ISet<string> existingAttributes))
                 {
-                    items.AddRange(GetTopLevelItems(declaredSymbol, parentTrivia));
+                    return GetAttributeItems(elementName, existingAttributes);
                 }
+
+                var wasTriggeredAfterSpace = trigger.Kind == CompletionTriggerKind.Insertion && trigger.Character == ' ';
+                if (wasTriggeredAfterSpace)
+                {
+                    // Nothing below this point should triggered by a space character
+                    // (only attribute names should be triggered by <SPACE>)
+                    return null;
+                }
+
+                if (IsAttributeValueContext(token, out elementName, out string attributeName))
+                {
+                    return GetAttributeValueItems(declaredSymbol, elementName, attributeName);
+                }
+
+                if (trigger.Kind == CompletionTriggerKind.Insertion && trigger.Character != '<')
+                {
+                    // With the use of IsTriggerAfterSpaceOrStartOfWordCharacter, the code below is much
+                    // too aggressive at suggesting tags, so exit early before degrading the experience
+                    return null;
+                }
+
+                var items = new List<CompletionItem>();
+
+                if (token.Parent.Kind() == SyntaxKind.XmlEmptyElement || token.Parent.Kind() == SyntaxKind.XmlText ||
+                    (token.Parent.IsKind(SyntaxKind.XmlElementEndTag) && token.IsKind(SyntaxKind.GreaterThanToken)) ||
+                    (token.Parent.IsKind(SyntaxKind.XmlName) && token.Parent.IsParentKind(SyntaxKind.XmlEmptyElement)))
+                {
+                    // The user is typing inside an XmlElement
+                    if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement ||
+                        token.Parent.Parent.IsParentKind(SyntaxKind.XmlElement))
+                    {
+                        // Avoid including language keywords when following < or <text, since these cases should only be
+                        // attempting to complete the XML name (which for language keywords is 'see'). While the parser
+                        // treats the 'name' in '< name' as an XML name, we don't treat it like that here so the completion
+                        // experience is consistent for '< ' and '< n'.
+                        var xmlNameOnly = token.IsKind(SyntaxKind.LessThanToken)
+                            || (token.Parent.IsKind(SyntaxKind.XmlName) && !token.HasLeadingTrivia);
+                        var includeKeywords = !xmlNameOnly;
+
+                        items.AddRange(GetNestedItems(declaredSymbol, includeKeywords));
+                    }
+
+                    if (token.Parent.Parent is XmlElementSyntax xmlElement)
+                    {
+                        AddXmlElementItems(items, xmlElement.StartTag);
+                    }
+
+                    if (token.Parent.IsParentKind(SyntaxKind.XmlEmptyElement) &&
+                        token.Parent.Parent.Parent is XmlElementSyntax nestedXmlElement)
+                    {
+                        AddXmlElementItems(items, nestedXmlElement.StartTag);
+                    }
+
+                    if (token.Parent.Parent is DocumentationCommentTriviaSyntax ||
+                        (token.Parent.Parent.IsKind(SyntaxKind.XmlEmptyElement) && token.Parent.Parent.Parent is DocumentationCommentTriviaSyntax))
+                    {
+                        items.AddRange(GetTopLevelItems(declaredSymbol, parentTrivia));
+                    }
+                }
+
+                if (token.Parent is XmlElementStartTagSyntax startTag &&
+                    token == startTag.GreaterThanToken)
+                {
+                    AddXmlElementItems(items, startTag);
+                }
+
+                items.AddRange(GetAlwaysVisibleItems());
+                return items;
             }
-
-            if (token.Parent is XmlElementStartTagSyntax startTag &&
-                token == startTag.GreaterThanToken)
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
             {
-                AddXmlElementItems(items, startTag);
+                return SpecializedCollections.EmptyEnumerable<CompletionItem>();
             }
-
-            items.AddRange(GetAlwaysVisibleItems());
-            return items;
         }
 
         private void AddXmlElementItems(List<CompletionItem> items, XmlElementStartTagSyntax startTag)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -47,22 +48,29 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            var cancellationToken = context.CancellationToken;
-            var syntaxTree = await context.Document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxFactsService = context.Document.GetLanguageService<ISyntaxFactsService>();
-            if (syntaxFactsService.IsEntirelyWithinStringOrCharOrNumericLiteral(syntaxTree, context.Position, cancellationToken))
+            try
             {
-                var token = syntaxTree.FindTokenOnLeftOfPosition(context.Position, cancellationToken);
-                var attributeSyntaxNode = GetAttributeSyntaxNodeOfToken(syntaxFactsService, token);
-                if (attributeSyntaxNode == null)
+                var cancellationToken = context.CancellationToken;
+                var syntaxTree = await context.Document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var syntaxFactsService = context.Document.GetLanguageService<ISyntaxFactsService>();
+                if (syntaxFactsService.IsEntirelyWithinStringOrCharOrNumericLiteral(syntaxTree, context.Position, cancellationToken))
                 {
-                    return;
-                }
+                    var token = syntaxTree.FindTokenOnLeftOfPosition(context.Position, cancellationToken);
+                    var attributeSyntaxNode = GetAttributeSyntaxNodeOfToken(syntaxFactsService, token);
+                    if (attributeSyntaxNode == null)
+                    {
+                        return;
+                    }
 
-                if (await CheckTypeInfoOfAttributeAsync(context.Document, attributeSyntaxNode, context.CancellationToken).ConfigureAwait(false))
-                {
-                    await AddAssemblyCompletionItemsAsync(context, cancellationToken).ConfigureAwait(false);
+                    if (await CheckTypeInfoOfAttributeAsync(context.Document, attributeSyntaxNode, context.CancellationToken).ConfigureAwait(false))
+                    {
+                        await AddAssemblyCompletionItemsAsync(context, cancellationToken).ConfigureAwait(false);
+                    }
                 }
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
+            {
+                // nop
             }
         }
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.ErrorReporting
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class CrefCompletionProvider
@@ -34,44 +35,48 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Sub
 
         Public Overrides Async Function ProvideCompletionsAsync(context As CompletionContext) As Task
-            Dim document = context.Document
-            Dim position = context.Position
-            Dim cancellationToken = context.CancellationToken
+            Try
+                Dim document = context.Document
+                Dim position = context.Position
+                Dim cancellationToken = context.CancellationToken
 
-            Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
-            Dim token = tree.GetTargetToken(position, cancellationToken)
+                Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
+                Dim token = tree.GetTargetToken(position, cancellationToken)
 
-            If IsCrefTypeParameterContext(token) Then
-                Return
-            End If
+                If IsCrefTypeParameterContext(token) Then
+                    Return
+                End If
 
-            ' To get a Speculative SemanticModel (which is much faster), we need to 
-            ' walk up to the node the DocumentationTrivia is attached to.
-            Dim parentNode = token.Parent?.FirstAncestorOrSelf(Of DocumentationCommentTriviaSyntax)()?.ParentTrivia.Token.Parent
-            _testSpeculativeNodeCallbackOpt?.Invoke(parentNode)
-            If parentNode Is Nothing Then
-                Return
-            End If
+                ' To get a Speculative SemanticModel (which is much faster), we need to 
+                ' walk up to the node the DocumentationTrivia is attached to.
+                Dim parentNode = token.Parent?.FirstAncestorOrSelf(Of DocumentationCommentTriviaSyntax)()?.ParentTrivia.Token.Parent
+                _testSpeculativeNodeCallbackOpt?.Invoke(parentNode)
+                If parentNode Is Nothing Then
+                    Return
+                End If
 
-            Dim semanticModel = Await document.GetSemanticModelForNodeAsync(parentNode, cancellationToken).ConfigureAwait(False)
-            Dim workspace = document.Project.Solution.Workspace
+                Dim semanticModel = Await document.GetSemanticModelForNodeAsync(parentNode, cancellationToken).ConfigureAwait(False)
+                Dim workspace = document.Project.Solution.Workspace
 
-            Dim symbols = GetSymbols(token, semanticModel, cancellationToken)
-            If Not symbols.Any() Then
-                Return
-            End If
+                Dim symbols = GetSymbols(token, semanticModel, cancellationToken)
+                If Not symbols.Any() Then
+                    Return
+                End If
 
-            Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+                Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
 
-            Dim items = CreateCompletionItems(workspace, semanticModel, symbols, position)
-            context.AddItems(items)
+                Dim items = CreateCompletionItems(workspace, semanticModel, symbols, position)
+                context.AddItems(items)
 
-            If IsFirstCrefParameterContext(token) Then
-                ' Include Of in case they're typing a type parameter
-                context.AddItem(CreateOfCompletionItem())
-            End If
+                If IsFirstCrefParameterContext(token) Then
+                    ' Include Of in case they're typing a type parameter
+                    context.AddItem(CreateOfCompletionItem())
+                End If
 
-            context.IsExclusive = True
+                context.IsExclusive = True
+            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+                ' nop
+            End Try
         End Function
         Protected Overrides Async Function GetSymbolsAsync(document As Document, position As Integer, options As OptionSet, cancellationToken As CancellationToken) As Task(Of (SyntaxToken, SemanticModel, ImmutableArray(Of ISymbol)))
             Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -1,16 +1,16 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Text
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.ErrorReporting
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class CrefCompletionProvider

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
+Imports Microsoft.CodeAnalysis.ErrorReporting
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class NamedParameterCompletionProvider
@@ -21,58 +22,62 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Function
 
         Public Overrides Async Function ProvideCompletionsAsync(context As CompletionContext) As Task
-            Dim document = context.Document
-            Dim position = context.Position
-            Dim cancellationToken = context.CancellationToken
+            Try
+                Dim document = context.Document
+                Dim position = context.Position
+                Dim cancellationToken = context.CancellationToken
 
-            Dim syntaxTree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
-            If syntaxTree.IsInNonUserCode(position, cancellationToken) OrElse
-                syntaxTree.IsInSkippedText(position, cancellationToken) Then
-                Return
-            End If
-
-            Dim token = syntaxTree.GetTargetToken(position, cancellationToken)
-
-            If Not token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken) Then
-                Return
-            End If
-
-            Dim argumentList = TryCast(token.Parent, ArgumentListSyntax)
-            If argumentList Is Nothing Then
-                Return
-            End If
-
-            If token.Kind = SyntaxKind.CommaToken Then
-                ' Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
-                ' See https://github.com/dotnet/roslyn/issues/20657
-                Dim languageVersion = DirectCast(document.Project.ParseOptions, VisualBasicParseOptions).LanguageVersion
-                If languageVersion < LanguageVersion.VisualBasic15_5 AndAlso token.IsMandatoryNamedParameterPosition() Then
-                    context.IsExclusive = True
+                Dim syntaxTree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
+                If syntaxTree.IsInNonUserCode(position, cancellationToken) OrElse
+                    syntaxTree.IsInSkippedText(position, cancellationToken) Then
+                    Return
                 End If
-            End If
 
-            Dim semanticModel = Await document.GetSemanticModelForNodeAsync(argumentList, cancellationToken).ConfigureAwait(False)
-            Dim parameterLists = GetParameterLists(semanticModel, position, argumentList.Parent, cancellationToken)
-            If parameterLists Is Nothing Then
-                Return
-            End If
+                Dim token = syntaxTree.GetTargetToken(position, cancellationToken)
 
-            Dim existingNamedParameters = GetExistingNamedParameters(argumentList, position)
-            parameterLists = parameterLists.Where(Function(p) IsValid(p, existingNamedParameters))
+                If Not token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken) Then
+                    Return
+                End If
 
-            Dim unspecifiedParameters = parameterLists.SelectMany(Function(pl) pl).
-                                                       Where(Function(p) Not existingNamedParameters.Contains(p.Name))
+                Dim argumentList = TryCast(token.Parent, ArgumentListSyntax)
+                If argumentList Is Nothing Then
+                    Return
+                End If
 
-            Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+                If token.Kind = SyntaxKind.CommaToken Then
+                    ' Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
+                    ' See https://github.com/dotnet/roslyn/issues/20657
+                    Dim languageVersion = DirectCast(document.Project.ParseOptions, VisualBasicParseOptions).LanguageVersion
+                    If languageVersion < LanguageVersion.VisualBasic15_5 AndAlso token.IsMandatoryNamedParameterPosition() Then
+                        context.IsExclusive = True
+                    End If
+                End If
 
-            For Each parameter In unspecifiedParameters
-                context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
-                    displayText:=parameter.Name & s_colonEquals,
-                    insertionText:=parameter.Name.ToIdentifierToken().ToString() & s_colonEquals,
-                    symbols:=ImmutableArray.Create(parameter),
-                    contextPosition:=position,
-                    rules:=s_itemRules))
-            Next
+                Dim semanticModel = Await document.GetSemanticModelForNodeAsync(argumentList, cancellationToken).ConfigureAwait(False)
+                Dim parameterLists = GetParameterLists(semanticModel, position, argumentList.Parent, cancellationToken)
+                If parameterLists Is Nothing Then
+                    Return
+                End If
+
+                Dim existingNamedParameters = GetExistingNamedParameters(argumentList, position)
+                parameterLists = parameterLists.Where(Function(p) IsValid(p, existingNamedParameters))
+
+                Dim unspecifiedParameters = parameterLists.SelectMany(Function(pl) pl).
+                                                           Where(Function(p) Not existingNamedParameters.Contains(p.Name))
+
+                Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+
+                For Each parameter In unspecifiedParameters
+                    context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
+                        displayText:=parameter.Name & s_colonEquals,
+                        insertionText:=parameter.Name.ToIdentifierToken().ToString() & s_colonEquals,
+                        symbols:=ImmutableArray.Create(parameter),
+                        contextPosition:=position,
+                        rules:=s_itemRules))
+                Next
+            Catch e As Exception When FatalError.ReportWithoutCrashUnlessCanceled(e)
+                ' nop
+            End Try
         End Function
 
         ' Typing : or = should not filter the list, but they should commit the list.


### PR DESCRIPTION
**Customer scenario**

Report NFW and recover on unexpected exception from completion providers instead of crashing VS when an unexpected exception occurs in completion providers.

**Bugs this fixes:**

**Workarounds, if any**

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**

Identified missing stack frames while investigating a crash dump.

**Test documentation updated?**

