### PR TITLE
Fixed 'Qualify member access' analyzer for object initializer

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1240,5 +1240,43 @@ CodeStyleOptions.QualifyPropertyAccess);
 }",
 CodeStyleOptions.QualifyPropertyAccess);
         }
+
+        [WorkItem(22776, "https://github.com/dotnet/roslyn/issues/22776")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_InObjectInitializer1()
+        {
+            await TestMissingAsyncWithOption(
+@"public class C
+{
+    public string Foo { get; set; }
+    public void Bar()
+    {
+        var c = new C
+        {
+            [|Foo|] = string.Empty
+        };
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(22776, "https://github.com/dotnet/roslyn/issues/22776")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_InObjectInitializer2()
+        {
+            await TestMissingAsyncWithOption(
+@"public class C
+{
+    public string Foo;
+    public void Bar()
+    {
+        var c = new C
+        {
+            [|Foo|] = string.Empty
+        };
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -588,5 +588,35 @@ End Class
 ",
 CodeStyleOptions.QualifyFieldAccess)
         End Function
+
+        <WorkItem(22776, "https://github.com/dotnet/roslyn/issues/22776")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InObjectInitializer1() As Task
+            Await TestMissingAsyncWithOption("
+class C
+    Public Foo As Integer
+
+    Sub Bar()
+        Dim c = New C() With { [|.Foo = 1|] }
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(22776, "https://github.com/dotnet/roslyn/issues/22776")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_InObjectInitializer2() As Task
+            Await TestMissingAsyncWithOption("
+class C
+    Public Property Foo As Integer
+
+    Sub Bar()
+        Dim c = New C() With { [|.Foo|] = 1 }
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -18,7 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
 
         // If the member is already qualified with `base.`, it cannot be further qualified.
         protected override bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node)
-            => !(node.IsKind(SyntaxKind.BaseExpression) || IsInPropertyOrFieldInitialization(containingSymbol, node));
+            => !(node.IsKind(SyntaxKind.BaseExpression) ||
+                node.Parent.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||
+                IsInPropertyOrFieldInitialization(containingSymbol, node));
 
         private bool IsInPropertyOrFieldInitialization(ISymbol containingSymbol, SyntaxNode node)
         {

--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -16,7 +16,9 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
         protected override bool IsAlreadyQualifiedMemberAccess(SyntaxNode node)
             => node.IsKind(SyntaxKind.ThisExpression);
 
-        // If the member is already qualified with `base.`, it cannot be further qualified.
+        // If the member is already qualified with `base.`,
+        // or member is in object initialization context,
+        // or member in property or field initialization, it cannot be qualified.
         protected override bool CanMemberAccessBeQualified(ISymbol containingSymbol, SyntaxNode node)
             => !(node.IsKind(SyntaxKind.BaseExpression) ||
                 node.Parent.Parent.IsKind(SyntaxKind.ObjectInitializerExpression) ||

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -17,7 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
         End Function
 
         Protected Overrides Function CanMemberAccessBeQualified(containingSymbol As ISymbol, node As SyntaxNode) As Boolean
-            ' If the member is already qualified with `MyBase.`, or `MyClass.`, it cannot be further qualified.
+            ' If the member is already qualified with `MyBase.`, or `MyClass.`,
+            ' or member is in object initialization context, it cannot be qualified.
             Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression) OrElse node.IsKind(SyntaxKind.ObjectCreationExpression))
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
 
         Protected Overrides Function CanMemberAccessBeQualified(containingSymbol As ISymbol, node As SyntaxNode) As Boolean
             ' If the member is already qualified with `MyBase.`, or `MyClass.`, it cannot be further qualified.
-            Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression))
+            Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression) OrElse node.IsKind(SyntaxKind.ObjectCreationExpression))
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #22776
Fixes #23016

Regression from 15.4

VSO bug : [link](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/529870)