### PR TITLE
Making sure that "in" matches exactly in method group conversions.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -10036,5 +10036,158 @@ public static class Extensions
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "1").WithLocation(14, 10)
                 );
         }
+
+        [Fact]
+        public void MethodGroupConversionVal2In()
+        {
+            var code = @"
+using System;
+
+class Program
+{
+    static void F(in DateTime x)
+    {
+        Console.WriteLine(x);
+    }
+
+    static void Main()
+    {
+        Action<DateTime> a = F;
+        a(DateTime.MaxValue);
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (13,30): error CS0123: No overload for 'F' matches delegate 'Action<DateTime>'
+                //         Action<DateTime> a = F;
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "F").WithArguments("F", "System.Action<System.DateTime>").WithLocation(13, 30)
+            );
+        }
+
+        [Fact]
+        public void MethodGroupConversionVal2Overloaded()
+        {
+            var code = @"
+using System;
+
+class Program
+{
+    static void F(in DateTime x)
+    {
+        Console.WriteLine('1');
+    }
+
+    static void F(DateTime x)
+    {
+        Console.WriteLine('2');
+    }
+
+    static void Main()
+    {
+        Action<DateTime> a = F;
+        a(DateTime.MaxValue);
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+            );
+        }
+
+        [Fact]
+        public void MethodGroupConversionIn2Overloaded()
+        {
+            var code = @"
+using System;
+
+class Program
+{
+    delegate void D(in DateTime d);
+
+    static void F(in DateTime x)
+    {
+        Console.WriteLine('1');
+    }
+
+    static void F(DateTime x)
+    {
+        Console.WriteLine('2');
+    }
+
+    static void Main()
+    {
+        D a = F;
+        a(DateTime.MaxValue);
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void MethodGroupConversionRoReadonlyReturn()
+        {
+            var code = @"
+using System;
+
+class Program
+{
+    delegate int D(in DateTime d);
+
+    static ref readonly int F(in DateTime x)
+    {
+        Console.WriteLine('1');
+        return ref (new int[1])[0];
+    }
+
+    static void Main()
+    {
+        D a = F;
+        a(DateTime.MaxValue);
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics
+            (
+                // (16,15): error CS8189: Ref mismatch between 'Program.F(in DateTime)' and delegate 'Program.D'
+                //         D a = F;
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "F").WithArguments("Program.F(in System.DateTime)", "Program.D").WithLocation(16, 15)
+            );
+        }
+
+        [Fact]
+        public void MethodGroupConversionRoReadonlyReturnType()
+        {
+            var code = @"
+using System;
+
+class Program
+{
+    delegate ref readonly object D(in DateTime d);
+
+    static ref readonly string F(in DateTime x)
+    {
+        Console.WriteLine('1');
+        return ref (new string[1])[0];
+    }
+
+    static void Main()
+    {
+        D a = F;
+        a(DateTime.MaxValue);
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics
+            (
+                // (16,15): error CS0407: 'string Program.F(in DateTime)' has the wrong return type
+                //         D a = F;
+                Diagnostic(ErrorCode.ERR_BadRetType, "F").WithArguments("Program.F(in System.DateTime)", "string").WithLocation(16, 15)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -10091,8 +10091,7 @@ class Program
 }
 ";
 
-            CreateStandardCompilation(code).VerifyDiagnostics(
-            );
+            CompileAndVerify(code, expectedOutput: @"2");
         }
 
         [Fact]
@@ -10123,7 +10122,8 @@ class Program
 }
 ";
 
-            CreateStandardCompilation(code).VerifyDiagnostics();
+            CompileAndVerify(code, expectedOutput: @"1", verify: Verification.Fails);
+
         }
 
         [Fact]


### PR DESCRIPTION
It looks like method group conversions apply regular method overload resolution when resolving target method group.
However we know that in such scenario, unlike the regular argument passing, "byval" cannot match "in".

We should reject candidates with in/val mismatches when doing overload resolution for group conversion purposes. Otherwise we may encounter false ambiguity errors or even pick wrong candidates that crash at run time.

Fixes:#23319

### Customer scenario

Customer uses code that converts a method group with `in` parameters to a delegate that uses ordinary byval parameters in the same positions. 
It is expected that C# compiler rejects such assignment ans it is not permitted by CLR. (ref and val parameters are not compatible, during delegate creation).

Because of the bug, code compiles and crashes at run time.

### Bugs this fixes

Fixes:#23319

### Workarounds, if any

Not using the described scenario that results in broken code.

### Risk

Low. 
The change is mostly about propagating "isMethodConversion" further, so that conversion machinery could reject candidates with `in` --> `byval` parameter match when performing resolution for the purpose of method group conversions. 

### Performance impact

Low.

### Is this a regression from a previous update?

No.

### Root cause analysis

Similar rules govern lambda conversions and were implemented and tested. The case with method group conversions goes on a different path (since it needs to do overload resolution form multiple candidates) and thus the scenario was missed.

### How was the bug found?

Reported by external customer.

### Test documentation updated?

N/A