### PR TITLE
Do not publish in tests.sh

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -146,6 +146,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "BasicCodeStyleFixes", "src\
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "BasicCodeStyleTests", "src\CodeStyle\VisualBasic\Tests\BasicCodeStyleTests.vbproj", "{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILAsm", "src\Tools\ILAsm\ILAsm.csproj", "{46B3E63A-C462-4133-9F27-3B85DA5E7D37}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
@@ -402,6 +404,10 @@ Global
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46B3E63A-C462-4133-9F27-3B85DA5E7D37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46B3E63A-C462-4133-9F27-3B85DA5E7D37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46B3E63A-C462-4133-9F27-3B85DA5E7D37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46B3E63A-C462-4133-9F27-3B85DA5E7D37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -469,6 +475,7 @@ Global
 		{2531A8C4-97DD-47BC-A79C-B7846051E137} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
 		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{46B3E63A-C462-4133-9F27-3B85DA5E7D37} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F599E08-A9EA-4FAA-897F-5D824B0210E6}

--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -359,6 +359,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "BasicCodeStyleTests", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoslynPublish", "src\Tools\RoslynPublish\RoslynPublish.csproj", "{2D36C343-BB6A-4CB5-902B-E2145ACCB58F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILAsm", "src\Tools\ILAsm\ILAsm.csproj", "{DA8522ED-02BC-499C-AC71-1DF884F63987}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
@@ -953,6 +955,10 @@ Global
 		{2D36C343-BB6A-4CB5-902B-E2145ACCB58F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D36C343-BB6A-4CB5-902B-E2145ACCB58F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D36C343-BB6A-4CB5-902B-E2145ACCB58F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA8522ED-02BC-499C-AC71-1DF884F63987}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA8522ED-02BC-499C-AC71-1DF884F63987}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA8522ED-02BC-499C-AC71-1DF884F63987}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA8522ED-02BC-499C-AC71-1DF884F63987}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1123,6 +1129,7 @@ Global
 		{5018D049-5870-465A-889B-C742CE1E31CB} = {DC014586-8D07-4DE6-B28E-C0540C59C085}
 		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510} = {DC014586-8D07-4DE6-B28E-C0540C59C085}
 		{2D36C343-BB6A-4CB5-902B-E2145ACCB58F} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
+		{DA8522ED-02BC-499C-AC71-1DF884F63987} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/build/scripts/obtain_dotnet.sh
+++ b/build/scripts/obtain_dotnet.sh
@@ -13,7 +13,7 @@ install_dotnet () {
     source "${THIS_DIR}"/build-utils.sh
 
     local DOTNET_VERSION="$(get_tool_version dotnetSdk)"
-    local DOTNET_PATH="${THIS_DIR}"/../../Binaries/dotnet-cli
+    local DOTNET_PATH="${THIS_DIR}"/../../Binaries/Tools/dotnet
 
     # check if the correct `dotnet` is already on the PATH
     if command -v dotnet >/dev/null 2>&1

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -29,30 +29,16 @@ else
     exit 1
 fi
 
+echo "Publishing ILAsm.csproj"
+dotnet publish "${root_path}/src/Tools/ILAsm" --no-restore --runtime ${runtime_id} --self-contained -o "${binaries_path}/Tools/ILAsm"
+
 echo "Using ${xunit_console}"
-
-# Need to publish projects that have runtime assets before running tests
-need_publish=(
-    'src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj'
-)
-
-for project in "${need_publish[@]}"
-do
-    echo "Publishing ${project}"
-    dotnet publish --no-restore "${root_path}"/"${project}" -r "${runtime_id}" -f "${target_framework}" -p:SelfContained=true
-done
 
 # Discover and run the tests
 mkdir -p "${log_dir}"
 
 for test_path in "${unittest_dir}"/*/"${target_framework}"
 do
-    publish_test_path="${test_path}"/"${runtime_id}"/publish
-    if [[ -d "${publish_test_path}" ]]
-    then
-        test_path="${publish_test_path}"
-    fi
-
     file_name=( "${test_path}"/*.UnitTests.dll )
     log_file="${log_dir}"/"$(basename "${file_name%.*}.xml")"
     deps_json="${file_name%.*}".deps.json

--- a/docs/infrastructure/cross-platform.md
+++ b/docs/infrastructure/cross-platform.md
@@ -14,7 +14,7 @@ cd <roslyn-git-directory>
 dotnet build Compilers.sln
 ```
 
-If you do not have a system-wide `dotnet` install, you can obtain one with `./build/scripts/obtain_dotnet.sh`. This will install a compatible version of the CLI to `./Binaries/dotnet-cli` - add this to your PATH before trying to build `Compilers.sln`. Alternatively, sourcing the script with `source ./build/scripts/obtain_dotnet.sh` will add it to your PATH for you.
+If you do not have a system-wide `dotnet` install, you can obtain one with `./build/scripts/obtain_dotnet.sh`. This will install a compatible version of the CLI to `./Binaries/Tools/dotnet` - add this to your PATH before trying to build `Compilers.sln`. Alternatively, sourcing the script with `source ./build/scripts/obtain_dotnet.sh` will add it to your PATH for you.
 
 ## Using the compiler
 

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -35,8 +35,6 @@
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.0'" />
   </ItemGroup>
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -29,7 +29,29 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
             else
             {
-                return Path.Combine(AppContext.BaseDirectory, "ilasm");
+                string ilasmExeName;
+                if (PlatformInformation.IsWindows)
+                {
+                    ilasmExeName = "ilasm.exe";
+                }
+                else
+                {
+                    ilasmExeName = "ilasm";
+                }
+
+                var directory = AppContext.BaseDirectory;
+                string path = null;
+                while (directory != null && !File.Exists(path = Path.Combine(directory, "Binaries", "Tools", "ILAsm", ilasmExeName)))
+                {
+                    directory = Path.GetDirectoryName(directory);
+                }
+
+                if (directory == null)
+                {
+                    throw new NotSupportedException("Unable to find CoreCLR ilasm tool. Has the Microsoft.NETCore.ILAsm package been published to ./Binaries/Tools?");
+                }
+
+                return path;
             }
         }
 

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -29,15 +29,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
             else
             {
-                string ilasmExeName;
-                if (PlatformInformation.IsWindows)
-                {
-                    ilasmExeName = "ilasm.exe";
-                }
-                else
-                {
-                    ilasmExeName = "ilasm";
-                }
+                var ilasmExeName = PlatformInformation.IsWindows ? "ilasm.exe" : "ilasm";
 
                 var directory = AppContext.BaseDirectory;
                 string path = null;

--- a/src/Tools/ILAsm/ILAsm.csproj
+++ b/src/Tools/ILAsm/ILAsm.csproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build\Targets\SettingsSdk.props" />
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />
+  </ItemGroup>
+  <Import Project="..\..\..\build\Targets\Imports.targets" />
+</Project>

--- a/src/Tools/ILAsm/ILAsm.csproj
+++ b/src/Tools/ILAsm/ILAsm.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" />


### PR DESCRIPTION
ILAsm is the only asset needed, so put that in CoreToolset

Ping @jaredpar 

Note that CoreToolset is currently publishing into `Binaries/Tools` directly. This makes sense for the binary paths (`Binaries/Tools/ilasm`), but it clutters the Tools directory immensely (lots of dlls, e.g. `System.IO.Pipes.dll`)

I also synced the location of `dotnet` to be the same as the place where the windows build installs it, which is `Binaries/Tools/dotnet`

I also tried running `dotnet-xunit.dll` directly out of `Binaries/Tools` instead of digging into `.nuget`, but that was giving super weird errors, so I left that for a later time.

Also note that https://github.com/dotnet/roslyn/pull/23316 would be super nice to have here, but that PR has super absurd errors, so that can go in separately.