### PR TITLE
Publish NuGet packages for 15.6

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -14,7 +14,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta1</RoslynNuGetMoniker> 
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta2</RoslynNuGetMoniker> 
 
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>

--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -8,13 +8,13 @@
 
   <PropertyGroup>
     <!-- This is the assembly version of Roslyn from the .NET assembly perspective. It should only be revved during significant point releases. -->
-    <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.6.0</RoslynAssemblyVersionBase>
+    <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.7.0</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
-    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.6.0</RoslynFileVersionBase>
+    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.7.0</RoslynFileVersionBase>
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta3</RoslynNuGetMoniker> 
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta1</RoslynNuGetMoniker> 
 
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>

--- a/build/config/PublishData.json
+++ b/build/config/PublishData.json
@@ -1,6 +1,6 @@
 {
     "branches": {
-        "master": {
+        "master-vs-deps": {
             "nugetKind": "PerBuildPreRelease",
             "version": "2.7.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],

--- a/build/config/PublishData.json
+++ b/build/config/PublishData.json
@@ -1,18 +1,18 @@
 {
     "branches": {
+        "master": {
+            "nugetKind": "PerBuildPreRelease",
+            "version": "2.7.*",
+            "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+            "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
+            "channels": [ "dev15.6" ]
+        },
         "dev15.5.x": {
             "nugetKind": "PerBuildPreRelease",
             "version": "2.6.*",
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
             "channels": [ "dev15.5", "dev15.5p3" ]
-        },
-        "dev/jaredpar/fix-publish": {
-            "nugetKind": "PerBuildPreRelease",
-            "version": "2.6.*",
-            "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
-            "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-            "channels": [ "publish-test" ]
         },
         "features/readonly-ref": {
             "nugetKind": "PerBuildPreRelease",


### PR DESCRIPTION
Updating our publishing story for the 15.6 release:

- Moving to the 2.7 version number scheme
- Again publish packages out of master