### PR TITLE
Batch up and flatten diagnostic updates, third approach.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 lock (_gate)
                 {
-                    if (_idToBatchedUpdates.TryGetValue(e.Id, out var batchedUpdates))
+                    if (!_idToBatchedUpdates.TryGetValue(e.Id, out var batchedUpdates))
                     {
                         batchedUpdates = (removeArgs: null, createArgs: s_documentPool.Allocate());
                     }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -312,6 +312,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 try
                 {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
                     // Do some quick checks to avoid doing any further work for diagnostics  we don't
                     // care about.
                     var ourDocument = _subjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 {
                     if (_idToUpdateArgs.TryGetValue(e.Id, out var updateArgs))
                     {
-                        updateArgs = (null, null);
+                        updateArgs = (removeArgs: null, createArgs: null);
                     }
 
                     if (e.Kind == DiagnosticsUpdatedKind.DiagnosticsRemoved)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -240,8 +240,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         batchedUpdates = (removeArgs: null, createArgs: s_documentPool.Allocate());
                     }
 
-                    if (e.Kind == DiagnosticsUpdatedKind.DiagnosticsRemoved)
+                    switch (e.Kind)
                     {
+                    case DiagnosticsUpdatedKind.DiagnosticsRemoved:
                         // we're being told about diagnostics going away because a document/project
                         // was removed.  This supercedes all previous removes and creates for this
                         // id.
@@ -249,16 +250,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                         // Clear all all creates for this provider. 
                         batchedUpdates.createArgs.Clear();
-                    }
-                    else if (e.Kind == DiagnosticsUpdatedKind.DiagnosticsCreated)
-                    {
+                        break;
+                    case DiagnosticsUpdatedKind.DiagnosticsCreated:
                         // We're creating diagnostics. This supercedes all existing creations for
                         // this id.  However, any existing removal for this id will still happen.
                         var document = e.Solution.GetDocument(e.DocumentId);
                         batchedUpdates.createArgs[document] = e;
-                    }
-                    else
-                    {
+                        break;
+                    default:
                         throw ExceptionUtilities.UnexpectedValue(e);
                     }
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -252,13 +252,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     case DiagnosticsUpdatedKind.DiagnosticsRemoved:
                         // we're being told about diagnostics going away because a document/project
                         // was removed.  This supercedes all previous removes and creates for this
-                        // document id.
+                        // provider+docid.
                         batchedUpdates.removeArgs[document] = e;
                         batchedUpdates.createArgs.Remove(document);
                         break;
                     case DiagnosticsUpdatedKind.DiagnosticsCreated:
-                        // We're creating diagnostics. This supercedes all existing creations for
-                        // this id.  However, any existing removal for this id will still happen.
+                        // We're creating diagnostics. This supercedes all existing creations for this
+                        // provider +docid.  However, any existing removal for this provider+docid will 
+                        // still happen.
                         batchedUpdates.createArgs[document] = e;
                         break;
                     default:

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         // we're being told about diagnostics going away because a document/project
                         // was removed.  This supercedes all previous removes and creates for this
                         // id.
-                        batchedUpdates = (removeArgs: e, batchedUpdates.createArgs);
+                        batchedUpdates.removeArgs = e;
 
                         // Clear all all creates for this provider. 
                         batchedUpdates.createArgs.Clear();

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -264,6 +264,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                     _idToBatchedUpdates[e.Id] = batchedUpdates;
 
+                    // Check if there's already an in-flight update task.  If so, there's nothing we
+                    // need to do.  The in-flight task will pick up the work we enqueued.  Otherwise,
+                    // create a task to process this work (and anything else that comes in) for 50ms
+                    // from now.
                     if (_updateTask == null)
                     {
                         var token = _owner._listener.BeginAsyncOperation(GetType().Name + "OnDiagnosticsUpdatedOnBackground");

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -453,11 +453,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             {
                 this.AssertIsForeground();
 
-                if (e == null)
-                {
-                    return;
-                }
-
                 Debug.Assert(!_disposed);
                 Debug.Assert(e.Kind == DiagnosticsUpdatedKind.DiagnosticsCreated);
                 Debug.Assert(providerId == e.Id);

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -429,8 +429,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                             continue;
                         }
 
-                        // Process removes for this provider first, then process the creates for it for
-                        // our document.
                         if (updateArgs.Kind == DiagnosticsUpdatedKind.DiagnosticsRemoved)
                         {
                             OnDiagnosticsRemovedOnForeground(updateArgs);

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -142,7 +142,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 Contract.ThrowIfFalse(document == null || document.Project.Solution.Workspace == _workspace);
 
                 // Safe to read _currentDocumentId here, we are the fg thread.
-                if (document.Id == _currentDocumentId)
+                if (document.Id == _currentDocumentId &&
+                    document.Project.Solution.Workspace == _workspace)
                 {
                     // Nothing changed.
                     return;

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -38,11 +38,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
+            // Data that is used from both threads and needs to be protected by _gate.
+            private readonly object _gate = new object();
+
             // Use a chain of tasks to make sure that we process each diagnostic event serially.
             // This also ensures that the first diagnostic event we hear about will be processed
             // after the initial background work to get the first group of diagnostics.
-            private readonly object _gate = new object();
-
             private Task _taskChain;
 
             /// <summary>

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     }
                 }
 
+                // We started tracking another document.  Clear out everything we've stored up so far.
                 ResetCurrentDocumentIdIfNecessary();
             }
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                             return;
                         }
 
-                OnDiagnosticsUpdatedOnForeground(providerId, e, sourceText, editorSnapshot);
+                OnDiagnosticsUpdatedOnForeground(e, sourceText, editorSnapshot);
             }
 
             private void OnDiagnosticsRemovedOnForeground(object providerId)
@@ -542,14 +542,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             }
 
             private void OnDiagnosticsUpdatedOnForeground(
-                object providerId, DiagnosticsUpdatedArgs e, SourceText sourceText, ITextSnapshot editorSnapshot)
+                DiagnosticsUpdatedArgs e, SourceText sourceText, ITextSnapshot editorSnapshot)
             {
                 this.AssertIsForeground();
                 Debug.Assert(!_disposed);
 
                 // Find the appropriate async tagger for this diagnostics id, and let it know that
                 // there were new diagnostics produced for it.
-                if (!_idToProviderAndTagger.TryGetValue(providerId, out var providerAndTagger))
+                var id = e.Id;
+                if (!_idToProviderAndTagger.TryGetValue(id, out var providerAndTagger))
                 {
                     // We didn't have an existing tagger for this diagnostic id.  If there are no actual 
                     // diagnostics being reported, then don't bother actually doing anything.  This saves
@@ -566,7 +567,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     var tagger = taggerProvider.CreateTagger<TTag>(_subjectBuffer);
                     providerAndTagger = (taggerProvider, tagger);
 
-                    _idToProviderAndTagger[providerId] = providerAndTagger;
+                    _idToProviderAndTagger[id] = providerAndTagger;
 
                     // Register for changes from the underlying tagger.  When it tells us about
                     // changes, we'll let anyone know who is registered with us.

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -157,11 +157,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 this.AssertIsForeground();
 
                 var document = _subjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
-                Contract.ThrowIfFalse(document == null || document.Project.Solution.Workspace == _workspace);
 
                 // Safe to read _currentDocumentId here, we are the fg thread.
-                if (document.Id == _currentDocumentId &&
-                    document.Project.Solution.Workspace == _workspace)
+                if (document?.Id == _currentDocumentId &&
+                    document?.Project.Solution.Workspace == _workspace)
                 {
                     // Nothing changed.
                     return;

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             /// editor that we have changed).
             ///
             /// Because we're batching, we can optimize things such that we only store two pieces
-            /// of data per provider.  Specifically, if they were removing all diagnostics, and
-            /// per-document, the latest diagnostics we've created for it.
+            /// of data per provider and coument.  Specifically, if they were removing all diagnostics
+            /// and whatever the latest diagnostics are for for it.
             /// </summary>
             private ProviderAndDocumentToBatchedUpdates _idToBatchedUpdates = s_providerPool.Allocate();
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -79,6 +79,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             // nothing on the UI itself (we just push the data into our providers, and inform the
             // editor that we have changed).
             private ProviderAndDocumentToBatchedUpdates _idToBatchedUpdates = s_providerPool.Allocate();
+
+            /// <summary>
+            /// The task we use to actuall process all the diagnostic notifications we've gotten.
+            /// We only ever have one of these in flight at a time.  If the task is in flight and
+            /// we get new diagnostic events, we just add them to <see cref="_idToBatchedUpdates"/>
+            /// to be processed when the task finally executes.
+            /// </summary>
             private Task _updateTask = null;
 
             public AggregatingTagger(

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -508,42 +508,42 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 // Note: if the Solution or Document is null here, then that means the document
                 // was removed.  In that case, we do want to proceed so that we'll produce 0
                 // tags and we'll update the editor appropriately.
-                if (!diagnosticDocument.TryGetText(out var sourceText))
-                {
-                    return;
-                }
+                        if (!diagnosticDocument.TryGetText(out var sourceText))
+                        {
+                            return;
+                        }
 
-                var editorSnapshot = sourceText.FindCorrespondingEditorTextSnapshot();
-                if (editorSnapshot == null)
-                {
-                    return;
-                }
+                        var editorSnapshot = sourceText.FindCorrespondingEditorTextSnapshot();
+                        if (editorSnapshot == null)
+                        {
+                            return;
+                        }
 
-                // Make sure the editor we've got associated with these diagnostics is the 
-                // same one we're a tagger for.  It is possible for us to hear about diagnostics
-                // for the *same* Document that are not from the *same* buffer.  For example,
-                // say we have the following chain of events:
-                //
-                //      Document is opened.
-                //      Diagnostics start analyzing.
-                //      Document is closed.
-                //      Document is opened.
-                //      Diagnostics finish and report for document.
-                //
-                // We'll hear about diagnostics for the original Document/Buffer that was 
-                // opened.  But we'll be trying to apply them to this current Document/Buffer.
-                // That won't work since these will be different buffers (and thus, we won't
-                // be able to map the diagnostic spans appropriately).  
-                //
-                // Note: returning here is safe.  Because the file is closed/opened, The 
-                // Diagnostics Service will reanalyze it.  It will then report the new results
-                // which we will hear about and use.
-                if (editorSnapshot.TextBuffer != _subjectBuffer)
-                {
-                    return;
-                }
+                        // Make sure the editor we've got associated with these diagnostics is the 
+                        // same one we're a tagger for.  It is possible for us to hear about diagnostics
+                        // for the *same* Document that are not from the *same* buffer.  For example,
+                        // say we have the following chain of events:
+                        //
+                        //      Document is opened.
+                        //      Diagnostics start analyzing.
+                        //      Document is closed.
+                        //      Document is opened.
+                        //      Diagnostics finish and report for document.
+                        //
+                        // We'll hear about diagnostics for the original Document/Buffer that was 
+                        // opened.  But we'll be trying to apply them to this current Document/Buffer.
+                        // That won't work since these will be different buffers (and thus, we won't
+                        // be able to map the diagnostic spans appropriately).  
+                        //
+                        // Note: returning here is safe.  Because the file is closed/opened, The 
+                        // Diagnostics Service will reanalyze it.  It will then report the new results
+                        // which we will hear about and use.
+                        if (editorSnapshot.TextBuffer != _subjectBuffer)
+                        {
+                            return;
+                        }
 
-                OnDiagnosticsUpdatedOnForeground(providerId, e, sourceText, editorSnapshot);
+                        OnDiagnosticsUpdatedOnForeground(providerId, e, sourceText, editorSnapshot);
             }
 
             private void OnDiagnosticsRemovedOnForeground(

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -69,6 +69,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             private DocumentId _currentDocumentId;
             private Workspace _workspace;
 
+            // We may hear about diagnostics in a flurry. For example, we'll get notifications
+            // in batches as the diagnostics infrastructure runs all analyzers against a particular
+            // document.  To help lower overhead and not enqueue many UI thread requests, we batch
+            // notifications we hear about the document we're tracking and attempt to process them
+            // at the same time.  This means less notification allocations, and less UI timeslices
+            // needed.  This does mean we may spend a little more time on the UI processing all
+            // those notifications.  However, that time should still be very brief as we do almost
+            // nothing on the UI itself (we just push the data into our providers, and inform the
+            // editor that we have changed).
             private ProviderAndDocumentToBatchedUpdates _idToBatchedUpdates = s_providerPool.Allocate();
             private Task _updateTask = null;
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -513,12 +513,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 Debug.Assert(!_disposed);
 
-                // We're hearing about diagnostics for our document.  We may be hearing
-                // about new diagnostics coming, or existing diagnostics being cleared
-                // out.
-
-                // First see if this is a document/project removal.  If so, clear out any state we
-                // have associated with any analyzers we have for that document/project.
+                // This is a document removal.  Clear out any state we have associated with 
+                // this analyzer. 
                 var id = e.Id;
                 if (!_idToProviderAndTagger.TryGetValue(id, out var providerAndTagger))
                 {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -328,8 +328,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     return;
                 }
 
-                var document = e.Solution.GetDocument(e.DocumentId);
-                if (document == null)
+                if (e.DocumentId == null)
                 {
                     // Not a diagnostic event for a document.  Not something we can handle.
                     return;

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -435,7 +435,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         if (updateArgs.Kind == DiagnosticsUpdatedKind.DiagnosticsRemoved)
                         {
                             OnDiagnosticsRemovedOnForeground(providerId);
-                            continue;
                         }
                         else
                         {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                             return;
                         }
 
-                        OnDiagnosticsUpdatedOnForeground(providerId, e, sourceText, editorSnapshot);
+                OnDiagnosticsUpdatedOnForeground(providerId, e, sourceText, editorSnapshot);
             }
 
             private void OnDiagnosticsRemovedOnForeground(

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -47,9 +47,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             private Task _taskChain;
 
             /// <summary>
-            /// The current Document that our <see cref="_subjectBuffer"/> is associated with.
-            /// If our buffer becomes associated with another document, we will clear out any
-            /// cached diagnostic information we've collected so far as it's no longer valid.
+            /// The current Document and Workspace that our <see cref="_subjectBuffer"/> is 
+            /// associated with.  If our buffer becomes associated with another document or
+            /// workspace, we will clear out any cached diagnostic information we've collected 
+            /// so far as they're no longer valid.
             /// 
             /// Note: we fundamentally have a race condition here.  While we will update this
             /// whenever our ITextBuffer changes which document it is associated with, there

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -440,7 +440,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         if (diagnosticDocument.Id != ourDocument.Id ||
                             diagnosticDocument.Project.Solution.Workspace != ourDocument.Project.Solution.Workspace)
                         {
-                            // Notification for some other document.  Just ignore it.
+                            // Notification for some other document.  Just ignore it. This can happen
+                            // if the active document we were tracking changed between when we got
+                            // the diagnostic notification on the BG and now.
                             continue;
                         }
 


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/23409.

But with a simpler batching model where we only have to store the latest args for any id+doc pair.  