### PR TITLE
Fix for #22690 NRE in GetAttributeSyntaxNodeOfToken

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractInternalsVisibleToCompletionProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             //[Attribute(""|
             //[Attribute("Text"|)
             var node = token.Parent;
-            if (syntaxFactsService.IsStringLiteralExpression(node))
+            if (node != null && syntaxFactsService.IsStringLiteralExpression(node))
             {
                 // Edge case: ElementAccessExpressionSyntax is present if the following statement is another attribute:
                 //   [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("|


### PR DESCRIPTION
:memo: This is a back-port of #22961 to **dev15.5.x**. The template below is copied from that issue.

**Customer scenario**

An NRE in AbstractInternalsVisibleToCompletionProvider causes a crash of VS. The NRE was not reproducible and seemed only to occur in the C# intermediate window. No tests are provided (see #22690 why).

**Bugs this fixes:**

Fixes #22690 
[DevDiv 525354](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/525354)

**Workarounds, if any**

None.

**Risk**

Bug was not reproducible and therefore no tests are given. The fix is a best guess effort and is based on looking at possible NRE places in the stacktrace given by #22690:

* `IsStringLiteralExpression` is only called at on place in `AbstractInternalsVisibleToCompletionProvider.GetAttributeSyntaxNodeOfToken`
* `CSharpSyntaxFactsService.IsStringLiteralExpression`  is defined as `=> node.Kind() == SyntaxKind.StringLiteralExpression;`
* `node.Kind()` causes the NRE most likely here: `var rawKind = node.RawKind;` if node is null.

If this analysis is not correct there might still be a bug that causes VS to crash.

**Performance impact**

None.

**Is this a regression from a previous update?**

No. New feature. Bug found in VS 15.5 Preview 1

**Root cause analysis:**

`var node = token.Parent;` returns `null` in some rare circumstances. This was discovered in VS 15.5 Preview 1.

**How was the bug found?**

Reported by @tmat in #22690.

**Test documentation updated?**

No.