### PR TITLE
Make anonymous type's GetHashCode not depend on compilation environment

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -166,10 +167,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //  Method body:
                 //
                 //  HASH_FACTOR = 0xa5555529;
-                //  INIT_HASH = (...((0 * HASH_FACTOR) + backingFld_1.Name.GetHashCode()) * HASH_FACTOR
-                //                                     + backingFld_2.Name.GetHashCode()) * HASH_FACTOR
+                //  INIT_HASH = (...((0 * HASH_FACTOR) + GetFNVHashCode(backingFld_1.Name)) * HASH_FACTOR
+                //                                     + GetFNVHashCode(backingFld_2.Name)) * HASH_FACTOR
                 //                                     + ...
-                //                                     + backingFld_N.Name.GetHashCode()
+                //                                     + GetFNVHashCode(backingFld_N.Name)
                 //
                 //  {
                 //      return (...((INITIAL_HASH * HASH_FACTOR) + EqualityComparer<T_1>.Default.GetHashCode(this.backingFld_1)) * HASH_FACTOR
@@ -177,6 +178,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //                                               ...
                 //                                               + EqualityComparer<T_N>.Default.GetHashCode(this.backingFld_N)
                 //  }
+                //
+                // Where GetFNVHashCode is the FNV-1a hash code.
 
                 const int HASH_FACTOR = -1521134295; // (int)0xa5555529
 
@@ -187,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 int initHash = 0;
                 foreach (var property in anonymousType.Properties)
                 {
-                    initHash = unchecked(initHash * HASH_FACTOR + property.BackingField.Name.GetHashCode());
+                    initHash = unchecked(initHash * HASH_FACTOR + Hash.GetFNVHashCode(property.BackingField.Name));
                 }
 
                 //  Generate expression for return statement

--- a/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
@@ -746,7 +746,7 @@ class Query
                 expectedOutput: "{ ToString = Field }-Field");
         }
 
-        [ClrOnlyFact(ClrOnlyReason.Unknown)]
+        [Fact]
         public void AnonymousTypeSymbol_StandardNames3()
         {
             var source = @"
@@ -846,11 +846,7 @@ class Query
 @"{
   // Code size       75 (0x4b)
   .maxstack  3
-" +
-  (IntPtr.Size == 4 ?
-    "  IL_0000:  ldc.i4     0x78ce6eb1" :
-    "  IL_0000:  ldc.i4     0x983c2cef") +
-@"
+  IL_0000:  ldc.i4     0x3711624
   IL_0005:  ldc.i4     0xa5555529
   IL_000a:  mul
   IL_000b:  call       ""System.Collections.Generic.EqualityComparer<<ToString>j__TPar> System.Collections.Generic.EqualityComparer<<ToString>j__TPar>.Default.get""
@@ -1003,7 +999,7 @@ class Query
             int init = 0;
             foreach (var name in names)
             {
-                init = unchecked(init * HASH_FACTOR + name.GetHashCode());
+                init = unchecked(init * HASH_FACTOR + Hash.GetFNVHashCode(name));
             }
             return "0x" + init.ToString("X").ToLower();
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -241,7 +241,10 @@ namespace Roslyn.Utilities
             return hashCode;
         }
 
-#if WORKSPACE
+        internal static int GetCaseInsensitiveFNVHashCode(string text)
+        {
+            return GetCaseInsensitiveFNVHashCode(text, 0, text.Length);
+        }
 
         internal static int GetCaseInsensitiveFNVHashCode(string text, int start, int length)
         {
@@ -255,8 +258,6 @@ namespace Roslyn.Utilities
 
             return hashCode;
         }
-
-#endif
 
         /// <summary>
         /// Compute the hashcode of a sub-string using FNV-1a

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/CRC32.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/CRC32.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim crc32 As UInt32 = &HFFFFFFFF
 
             For Each name In names
-                crc32 = Crc32Update(crc32, s_encoding.GetBytes(name.ToLowerInvariant()))
+                crc32 = Crc32Update(crc32, s_encoding.GetBytes(CaseInsensitiveComparison.ToLower(name)))
             Next
 
             Return crc32

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/AnonymousTypesCodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/AnonymousTypesCodeGenTests.vb
@@ -700,6 +700,35 @@ False
         End Sub
 
         <Fact()>
+        Public Sub TestAnonymousType_GetHashCode03()
+            CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module Program
+
+    Sub Main()
+        Dim at1 As Object = New With {.Ǉ1 = 123, Key .Ǉ2 = 456, Key .Ǉ3 = "XXX", .Ǉ4 = 123.456!}
+        ' Value changes in non-key fields, casing changes in all fields that require a recent unicode version
+        Dim at2 As Object = New With {.ǈ1 = "YYY", Key .ǈ2 = 456, Key .ǈ3 = "XXX", .ǈ4 = Nothing }
+        ' Value changes in Key fields
+        Dim at3 As Object = New With {.Ǉ1 = 123, Key .Ǉ2 = 455, Key .Ǉ3 = "XXX", .Ǉ4 = 123.456!}
+
+        Dim hc1 = at1.GetHashCode()      
+        Console.WriteLine(hc1 = at2.GetHashCode )
+        Console.WriteLine(hc1 = at3.GetHashCode)
+    
+    End Sub
+End Module
+    </file>
+</compilation>,
+expectedOutput:=<![CDATA[
+True
+False
+]]>)
+        End Sub
+
+        <Fact()>
         Public Sub TestAnonymousType_SequenceOfInitializers()
             CompileAndVerify(
 <compilation>


### PR DESCRIPTION
We stop calling string.GetHashCode() at compile time and placing the value in the
generated code because that is not deterministic. Instead we use FNV1a hash code.

For VB, which does not have this bug, we update the implementation to use a more
reliable case-mapping method (see #2116)

### Customer scenario

Compile source code in two different compilation environments, expecting the result to be the same. But the generated GetHashCode varies from one to another because it depends on string.GetHashCode in the compilation environment. When compiling in an environment with [randomized string hashing](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/userandomizedstringhashalgorithm-element), the compiler will produce a different assembly nearly every time.

### Bugs this fixes

Fixes #23020

### Workarounds, if any

Don't compile in different environments and expect deterministic compiler output.

### Risk

Very low. Replaces one hash code computation with another.

### Performance impact

Very low for the same reason.

### Is this a regression from a previous update?

No.

### Root cause analysis

We've been improving our determinism since we started working on it a couple of years ago. This particular issue was detected and diagnosed by a customer.

### How was the bug found?

Customer reported.

### Test documentation updated?

N/A

@dotnet/roslyn-compiler Please review.