### PR TITLE
Void type not allowed in __arglist

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -76,3 +76,4 @@ if (o is object res) { // warning CS0184: The given expression is never of the p
 In Visual Studio 2017 version 15.6 such conversions will be explicitly disallowed by the compiler and cause compile time errors.
 Example: `Func<int> f = default(TypedReference).GetHashCode; // new error CS0123: No overload for 'GetHashCode' matches delegate 'Func<int>'` 
    
+- https://github.com/dotnet/roslyn/pull/23416 Before Visual Studio 2017 version 15.6 (Roslyn version 2.8) the compiler accepted `__arglist(...)` expressions with void-typed arguments. For instance, `__arglist(Console.WriteLine())`. But such program would fail at runtime. In Visual Studio 2017 version 15.6, this causes a compile-time error.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -190,6 +190,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     analyzedArguments.Arguments[i] = GenerateConversionForAssignment(objType, argument, diagnostics);
                 }
+                else if (argument.Type.SpecialType == SpecialType.System_Void)
+                {
+                    Error(diagnostics, ErrorCode.ERR_CantUseVoidInArglist, argument.Syntax);
+                }
             }
 
             ImmutableArray<BoundExpression> arguments = analyzedArguments.Arguments.ToImmutable();

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2735,6 +2735,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to __arglist cannot have an argument of void type.
+        /// </summary>
+        internal static string ERR_CantUseVoidInArglist {
+            get {
+                return ResourceManager.GetString("ERR_CantUseVoidInArglist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The operation overflows at compile time in checked mode.
         /// </summary>
         internal static string ERR_CheckedOverflow {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1554,6 +1554,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_PropertyWithNoAccessors" xml:space="preserve">
     <value>'{0}': property or indexer must have at least one accessor</value>
   </data>
+  <data name="ERR_CantUseVoidInArglist" xml:space="preserve">
+    <value>__arglist cannot have an argument of void type</value>
+  </data>
   <data name="ERR_NewVirtualInSealed" xml:space="preserve">
     <value>'{0}' is a new virtual member in sealed class '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1539,7 +1539,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_OutAttrOnInParam = 8355,
         #endregion diagnostics introduced for `ref readonly`, `ref ternary` and `ref-like` features in C# 7.2
 
-        #region diagnostics introduced for C# 7.3
         ERR_PredefinedValueTupleTypeAmbiguous3 = 8356,
         ERR_InvalidVersionFormatDeterministic = 8357,
 
@@ -1551,6 +1550,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion diagnostics for FilterIsConstant warning message fix
 
         ERR_ConditionalInInterpolation = 8361,
-        #endregion diagnostics introduced for C# 7.3
+        ERR_CantUseVoidInArglist = 8362,
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ArglistTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ArglistTests.cs
@@ -226,6 +226,30 @@ public struct C
         }
 
         [Fact]
+        [WorkItem(23369, "https://github.com/dotnet/roslyn/issues/23369")]
+        public void ArglistWithVoidMethod()
+        {
+            var text = @"
+public class C
+{
+    void M()
+    {
+        M2(__arglist(1, M()));
+    }
+    void M2(__arglist)
+    {
+    }
+}";
+
+            var comp = CreateStandardCompilation(text);
+            comp.VerifyDiagnostics(
+                // (6,25): error CS8361: __arglist cannot have an argument of void type
+                //         M2(__arglist(1, M()));
+                Diagnostic(ErrorCode.ERR_CantUseVoidInArglist, "M()").WithLocation(6, 25)
+                );
+        }
+
+        [Fact]
         public void RefValueUnsafeToReturn()
         {
             var text = @"


### PR DESCRIPTION
`__arglist(VoidReturningMethod())` should produce an error. It necessarily fails at runtime.

Fixes https://github.com/dotnet/roslyn/issues/23369

### Risk & Performance impact
Low. Just adding a simple check to `__arglist` arguments.

### Is this a regression from a previous update?
No

### How was the bug found?
Reshetnikov