### PR TITLE
Enable concurrent execution for all built-in C# analyzers

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -72,6 +72,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
         {
             context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKindsOfInterest);
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
         }
 
         protected void AnalyzeNode(SyntaxNodeAnalysisContext context)

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
@@ -29,6 +29,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.RemoveUnnecessaryCast
         public sealed override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
             context.RegisterSyntaxNodeAction(
                 nodeContext =>
                     {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterSyntaxNodeAction(AnalyzeNode, this.SyntaxKindsOfInterest.ToArray());
         }
 

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -72,6 +72,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterSemanticModelAction(this.AnalyzeSemanticModel);
         }
 

--- a/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
+
             context.RegisterCompilationStartAction(startContext =>
             {
                 var formatProviderType = startContext.Compilation.GetTypeByMetadataName(typeof(System.IFormatProvider).FullName);


### PR DESCRIPTION
Eliminates a large amount of unnecessary performance overhead due to serializing analyzers when running in the OOP host.

### Customer scenario

A user attempts to use a Fix All operation, and the initial analysis phase to find all diagnostics to fix is very slow. Alternately, a user turns on Full Solution Analysis, and the time taken to run the analyzers is very slow.

### Bugs this fixes

N/A

### Workarounds, if any

* Wait longer
* Leave Full Solution Analysis disabled

### Risk

Low:

1. All of our analyzers were designed to be stateless so concurrent analysis *could* be enabled.
2. The primary performance concern - overwhelming devenv.exe with analysis operations - is not likely to result in problems because the in-process analyzer driver never uses multiple threads.

### Performance impact

Improves performance by reducing monitor contention. The difference is most apparent on analyzers that are register callbacks for a large number of syntax nodes, but have an early return fast path that applies to the majority of cases. The performance improvement was measured at up to 30% for some lightweight analyzers.

Note that for some analysis situations, performance is not improved by this change in isolation. This tends to impact cases where large numbers of analyzers are used in a manner that causes substantial GC overhead. Profiling indicates that these are "downstream" issues and I would not consider them a contraindication for this change.

### Is this a regression from a previous update?

No.

### Root cause analysis

* No performance testing of analyzers at scale.
* No unit tests to ensure analyzers are registered as concurrent.

### How was the bug found?

Found with AnalyzerRunner, verified with profiling.

### Test documentation updated?

N/A
