### PR TITLE
Variable misuse ML model found a bug where wrong variable is used to …

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             try
             {
-                outputFilePath = Path.GetDirectoryName(_filePath);
+                outputFilePath = Path.GetDirectoryName(filepath);
             }
             catch (ArgumentException)
             {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             }
 
             var currentSnapshot = textBuffer.CurrentSnapshot;
-            return GetLinePosition(snapshot, trackingPoint);
+            return GetLinePosition(currentSnapshot, trackingPoint);
         }
 
         private LinePosition GetLinePosition(ITextSnapshot snapshot, ITrackingPoint trackingPoint)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -87,8 +87,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             Contract.Requires(within is INamedTypeSymbol || within is IAssemblySymbol);
 
             failedThroughTypeCheck = false;
-            var withinAssembly = (within as IAssemblySymbol) ?? ((INamedTypeSymbol)within).ContainingAssembly;
-
             switch (symbol.Kind)
             {
                 case SymbolKind.Alias:


### PR DESCRIPTION
…call a method.

<detail>

### Customer scenario

Customer clicks on error list to navigate to an error and VS crash.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/23436

### Workarounds, if any

There is no workaround.

### Risk

Low risk. the code path is fallback code path, so not always exercised. and it will no longer throw an exception.

### Performance impact

N/A

### Is this a regression from a previous update?

No

### Root cause analysis

when we try to navigate to an error, we try our best to go to right location. since error list can contain staled error, location info can be wrong, so we try to get right snapshot to calculate right location. but it is not always guaranteed that we can get to right text snapshot from roslyn snapshot. when that is failed, we fallback to whatever latest text snapshot we have to calculate location. here code used wrong snapshot when it is supposed to use current snapshot which lead to null ref.

### How was the bug found?

Variable misuse ML model tool.

</details>
