### PR TITLE
Infer nested nullability in flow analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2697,9 +2697,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var bestType = BestTypeInferrer.InferBestType(
                 boundInitializerExpressions,
                 this.Conversions,
-                this.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking),
-                out hadMultipleCandidates,
-                ref useSiteDiagnostics);
+                includeNullability: false,
+                hadMultipleCandidates: out hadMultipleCandidates,
+                useSiteDiagnostics: ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
             if ((object)bestType == null || bestType.SpecialType == SpecialType.System_Void) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3581,9 +3581,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     trueExpr,
                     falseExpr,
                     this.Conversions,
-                    this.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking),
-                    out hadMultipleCandidates,
-                    ref useSiteDiagnostics);
+                    includeNullability: false,
+                    hadMultipleCandidates: out hadMultipleCandidates,
+                    useSiteDiagnostics: ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
 
                 if ((object)bestType == null)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _conversions = conversions;
         }
 
+        // PROTOTYPE(NullableReferenceTypes): Remove includeNullability parameter. Nullability should be calculated in flow analysis.
         public static TypeSymbolWithAnnotations InferBestType(ImmutableArray<TypeSymbolWithAnnotations> types, Conversions conversions, bool includeNullability, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             var inferrer = new BestTypeInferrer(conversions);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -108,6 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static MethodTypeInferenceResult Infer(
             Binder binder,
+            ConversionsBase conversions,
             ImmutableArray<TypeParameterSymbol> methodTypeParameters,
             // We are attempting to build a map from method type parameters 
             // to inferred type arguments.
@@ -213,7 +214,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<RefKind> formalParameterRefKinds, // Optional; assume all value if missing.
             ImmutableArray<BoundExpression> arguments,// Required; in scenarios like method group conversions where there are
                                                       // no arguments per se we cons up some fake arguments.
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+            bool includeNullability = false)
         {
             Debug.Assert(!methodTypeParameters.IsDefault);
             Debug.Assert(methodTypeParameters.Length > 0);
@@ -232,13 +234,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var inferrer = new MethodTypeInferrer(
-                binder.Conversions,
+                conversions,
                 methodTypeParameters,
                 constructedContainingTypeOfMethod,
                 formalParameterTypes,
                 formalParameterRefKinds,
                 arguments,
-                binder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureStaticNullChecking));
+                includeNullability);
             return inferrer.InferTypeArgs(binder, ref useSiteDiagnostics);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2937,6 +2937,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var inferenceResult = MethodTypeInferrer.Infer(
                 _binder,
+                _binder.Conversions,
                 originalTypeParameters,
                 method.ContainingType,
                 originalEffectiveParameters.ParameterTypes,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2499,7 +2499,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out ImmutableArray<RefKind> parameterRefKinds)
         {
             bool hasAnyRefOmittedArgument;
-            var effectiveParameters = expanded ?
+            EffectiveParameters effectiveParameters = expanded ?
                 GetEffectiveParametersInExpandedForm(method, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument) :
                 GetEffectiveParametersInNormalForm(method, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument);
             parameterTypes = effectiveParameters.ParameterTypes;
@@ -2557,7 +2557,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
                 var parameter = parameters[parm];
-                types.Add(binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter));
+                types.Add(parameter.Type);
 
                 RefKind argRefKind = hasAnyRefArg ? argumentRefKinds[arg] : RefKind.None;
                 RefKind paramRefKind = GetEffectiveParameterRefKind(parameter, argRefKind, allowRefOmittedArguments, binder, ref hasAnyRefOmittedArgument);
@@ -2624,7 +2624,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var parm = argToParamMap.IsDefault ? arg : argToParamMap[arg];
                 var parameter = parameters[parm];
-                var type = binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter);
+                var type = parameter.Type;
 
                 types.Add(parm == parameters.Length - 1 ? ((ArrayTypeSymbol)type.TypeSymbol).ElementType : type);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -356,7 +356,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return MemberAnalysisResult.UseSiteError();
             }
 
-            var effectiveParameters = GetEffectiveParametersInNormalForm(constructor, arguments.Arguments.Count, argumentAnalysis.ArgsToParamsOpt, arguments.RefKinds, allowRefOmittedArguments: false);
+            var effectiveParameters = GetEffectiveParametersInNormalForm(constructor, arguments.Arguments.Count, argumentAnalysis.ArgsToParamsOpt, arguments.RefKinds, allowRefOmittedArguments: false, binder: _binder, hasAnyRefOmittedArgument: out _);
 
             return IsApplicable(
                 constructor,
@@ -388,7 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return MemberAnalysisResult.UseSiteError();
             }
 
-            var effectiveParameters = GetEffectiveParametersInExpandedForm(constructor, arguments.Arguments.Count, argumentAnalysis.ArgsToParamsOpt, arguments.RefKinds, allowRefOmittedArguments: false);
+            var effectiveParameters = GetEffectiveParametersInExpandedForm(constructor, arguments.Arguments.Count, argumentAnalysis.ArgsToParamsOpt, arguments.RefKinds, allowRefOmittedArguments: false, binder: _binder, hasAnyRefOmittedArgument: out _);
 
             // A vararg ctor is never applicable in its expanded form because
             // it is never a params method.
@@ -2487,6 +2487,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal static void GetEffectiveParameterTypes(
+            MethodSymbol method,
+            int argumentCount,
+            ImmutableArray<int> argToParamMap,
+            ArrayBuilder<RefKind> argumentRefKinds,
+            bool allowRefOmittedArguments,
+            Binder binder,
+            bool expanded,
+            out ImmutableArray<TypeSymbolWithAnnotations> parameterTypes,
+            out ImmutableArray<RefKind> parameterRefKinds)
+        {
+            bool hasAnyRefOmittedArgument;
+            var effectiveParameters = expanded ?
+                GetEffectiveParametersInExpandedForm(method, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument) :
+                GetEffectiveParametersInNormalForm(method, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, binder, out hasAnyRefOmittedArgument);
+            parameterTypes = effectiveParameters.ParameterTypes;
+            parameterRefKinds = effectiveParameters.ParameterRefKinds;
+        }
+
         private struct EffectiveParameters
         {
             internal readonly ImmutableArray<TypeSymbolWithAnnotations> ParameterTypes;
@@ -2499,24 +2518,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private EffectiveParameters GetEffectiveParametersInNormalForm<TMember>(
-            TMember member,
-            int argumentCount,
-            ImmutableArray<int> argToParamMap,
-            ArrayBuilder<RefKind> argumentRefKinds,
-            bool allowRefOmittedArguments)
-            where TMember : Symbol
-        {
-            bool discarded;
-            return GetEffectiveParametersInNormalForm(member, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, hasAnyRefOmittedArgument: out discarded);
-        }
-
-        private EffectiveParameters GetEffectiveParametersInNormalForm<TMember>(
+        private static EffectiveParameters GetEffectiveParametersInNormalForm<TMember>(
             TMember member,
             int argumentCount,
             ImmutableArray<int> argToParamMap,
             ArrayBuilder<RefKind> argumentRefKinds,
             bool allowRefOmittedArguments,
+            Binder binder,
             out bool hasAnyRefOmittedArgument) where TMember : Symbol
         {
             Debug.Assert(argumentRefKinds != null);
@@ -2549,10 +2557,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
                 var parameter = parameters[parm];
-                types.Add(_binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter));
+                types.Add(binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter));
 
                 RefKind argRefKind = hasAnyRefArg ? argumentRefKinds[arg] : RefKind.None;
-                RefKind paramRefKind = GetEffectiveParameterRefKind(parameter, argRefKind, allowRefOmittedArguments, ref hasAnyRefOmittedArgument);
+                RefKind paramRefKind = GetEffectiveParameterRefKind(parameter, argRefKind, allowRefOmittedArguments, binder, ref hasAnyRefOmittedArgument);
 
                 if (refs == null)
                 {
@@ -2572,7 +2580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new EffectiveParameters(types.ToImmutableAndFree(), refKinds);
         }
 
-        private RefKind GetEffectiveParameterRefKind(ParameterSymbol parameter, RefKind argRefKind, bool allowRefOmittedArguments, ref bool hasAnyRefOmittedArgument)
+        private static RefKind GetEffectiveParameterRefKind(ParameterSymbol parameter, RefKind argRefKind, bool allowRefOmittedArguments, Binder binder, ref bool hasAnyRefOmittedArgument)
         {
             var paramRefKind = parameter.RefKind;
 
@@ -2585,7 +2593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Omit ref feature for COM interop: We can pass arguments by value for ref parameters if we are calling a method/property on an instance of a COM imported type.
             // We must ignore the 'ref' on the parameter while determining the applicability of argument for the given method call.
             // During argument rewriting, we will replace the argument value with a temporary local and pass that local by reference.
-            if (allowRefOmittedArguments && paramRefKind == RefKind.Ref && argRefKind == RefKind.None && !_binder.InAttributeArgument)
+            if (allowRefOmittedArguments && paramRefKind == RefKind.Ref && argRefKind == RefKind.None && !binder.InAttributeArgument)
             {
                 hasAnyRefOmittedArgument = true;
                 return RefKind.None;
@@ -2594,23 +2602,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return paramRefKind;
         }
 
-        private EffectiveParameters GetEffectiveParametersInExpandedForm<TMember>(
-            TMember member,
-            int argumentCount,
-            ImmutableArray<int> argToParamMap,
-            ArrayBuilder<RefKind> argumentRefKinds,
-            bool allowRefOmittedArguments) where TMember : Symbol
-        {
-            bool discarded;
-            return GetEffectiveParametersInExpandedForm(member, argumentCount, argToParamMap, argumentRefKinds, allowRefOmittedArguments, hasAnyRefOmittedArgument: out discarded);
-        }
-
-        private EffectiveParameters GetEffectiveParametersInExpandedForm<TMember>(
+        private static EffectiveParameters GetEffectiveParametersInExpandedForm<TMember>(
             TMember member,
             int argumentCount,
             ImmutableArray<int> argToParamMap,
             ArrayBuilder<RefKind> argumentRefKinds,
             bool allowRefOmittedArguments,
+            Binder binder,
             out bool hasAnyRefOmittedArgument) where TMember : Symbol
         {
             Debug.Assert(argumentRefKinds != null);
@@ -2626,12 +2624,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var parm = argToParamMap.IsDefault ? arg : argToParamMap[arg];
                 var parameter = parameters[parm];
-                var type = _binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter);
+                var type = binder.GetTypeOrReturnTypeWithAdjustedNullableAnnotations(parameter);
 
                 types.Add(parm == parameters.Length - 1 ? ((ArrayTypeSymbol)type.TypeSymbol).ElementType : type);
 
                 var argRefKind = hasAnyRefArg ? argumentRefKinds[arg] : RefKind.None;
-                var paramRefKind = GetEffectiveParameterRefKind(parameter, argRefKind, allowRefOmittedArguments, ref hasAnyRefOmittedArgument);
+                var paramRefKind = GetEffectiveParameterRefKind(parameter, argRefKind, allowRefOmittedArguments, binder, ref hasAnyRefOmittedArgument);
 
                 refs.Add(paramRefKind);
                 if (paramRefKind != RefKind.None)
@@ -2692,6 +2690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentAnalysis.ArgsToParamsOpt,
                 arguments.RefKinds,
                 allowRefOmittedArguments,
+                _binder,
                 out hasAnyRefOmittedArgument);
 
             Debug.Assert(!hasAnyRefOmittedArgument || allowRefOmittedArguments);
@@ -2702,7 +2701,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments.Arguments.Count,
                 argumentAnalysis.ArgsToParamsOpt,
                 arguments.RefKinds,
-                allowRefOmittedArguments);
+                allowRefOmittedArguments,
+                _binder,
+                out _);
 
             // The member passed to the following call is returned in the result (possibly a constructed version of it).
             // The applicability is checked based on effective parameters passed in.
@@ -2759,6 +2760,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentAnalysis.ArgsToParamsOpt,
                 arguments.RefKinds,
                 allowRefOmittedArguments,
+                _binder,
                 out hasAnyRefOmittedArgument);
 
             Debug.Assert(!hasAnyRefOmittedArgument || allowRefOmittedArguments);
@@ -2769,7 +2771,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 arguments.Arguments.Count,
                 argumentAnalysis.ArgsToParamsOpt,
                 arguments.RefKinds,
-                allowRefOmittedArguments);
+                allowRefOmittedArguments,
+                _binder,
+                out _);
 
             // The member passed to the following call is returned in the result (possibly a constructed version of it).
             // The applicability is checked based on effective parameters passed in.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -227,6 +227,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.Literal:
                 case BoundKind.UnboundLambda:
                     break;
+                case BoundKind.ValuePlaceholder:
+                    return ((BoundValuePlaceholder)expr).IsNullable;
                 default:
                     // PROTOTYPE(NullableReferenceTypes): Handle all expression kinds.
                     //Debug.Assert(false, "Unhandled expression: " + expr.Kind);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1652,6 +1652,7 @@
   </Node>
 
   <!-- Special node, used only during nullability flow analysis -->
+  <!-- PROTOTYPE(NullableReferenceTypes): Derive from BoundValuePlaceholderBase and give specific name. -->
   <Node Name="BoundValuePlaceholder" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="IsNullable" Type="bool?" Null="allow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1651,8 +1651,9 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
   </Node>
 
-  <!-- Special node, used only during Data Flow Pass -->
+  <!-- Special node, used only during nullability flow analysis -->
   <Node Name="BoundValuePlaceholder" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="IsNullable" Type="bool?" Null="allow"/>
   </Node>
 </Tree>

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -140,6 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                // PROTOTYPE(NullableReferenceTypes): Should pass includeNullability: false.
                 bestResultType = BestTypeInferrer.InferBestType(resultTypes, binder.Conversions, includeNullability, ref useSiteDiagnostics);
             }
 
@@ -200,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _types = types;
             }
 
+            // PROTOTYPE(NullableReferenceTypes): Remove includeNullability parameter.
             public static ImmutableArray<TypeSymbolWithAnnotations> GetReturnTypes(bool includeNullability, BoundBlock block, out RefKind refKind, out int numberOfDistinctReturns)
             {
                 var types = new HashSet<TypeSymbolWithAnnotations>(TypeSymbolWithAnnotations.EqualsComparer.Instance);

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1890,7 +1890,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt: ImmutableArray<int>.Empty,
                 resultKind: resultKind,
                 binderOpt: null,
-                type: baseType,
+                type: baseConstructor.ReturnType.TypeSymbol,
                 hasErrors: hasErrors)
             { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AlwaysAssignedWalker.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method, ParameterSymbol parameter)
+        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method)
         {
             // ref parameter does not "always" assign.
             if (refKind == RefKind.Out)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.VariableIdentifier.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Field || symbol.Kind == SymbolKind.Parameter ||
                     (symbol as MethodSymbol)?.MethodKind == MethodKind.LocalFunction ||
-                    symbol.Kind == SymbolKind.Property);
+                    symbol.Kind == SymbolKind.Property || symbol.Kind == SymbolKind.Event);
                 Symbol = symbol;
                 ContainingSlot = containingSlot;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1751,7 +1751,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method, ParameterSymbol parameter)
+        protected override void WriteArgument(BoundExpression arg, RefKind refKind, MethodSymbol method)
         {
             if (refKind == RefKind.Ref)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPassBase.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VariableIdentifier variableId = variableBySlot[slot];
             while (variableId.ContainingSlot > 0)
             {
-                Debug.Assert(variableId.Symbol.Kind == SymbolKind.Field || variableId.Symbol.Kind == SymbolKind.Property);
+                Debug.Assert(variableId.Symbol.Kind == SymbolKind.Field || variableId.Symbol.Kind == SymbolKind.Property || variableId.Symbol.Kind == SymbolKind.Event);
                 variableId = variableBySlot[variableId.ContainingSlot];
             }
             return variableId.Symbol;
@@ -269,6 +269,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
                 case SymbolKind.Property:
                     return ((PropertySymbol)s).Type;
+                case SymbolKind.Event:
+                    return ((EventSymbol)s).Type;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(s.Kind);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -793,7 +793,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
         {
             Debug.Assert(!IsConditionalState);
-            this.State.ResultType = _invalidType;
+            this.State.ResultType = _invalidType; // PROTOTYPE(NullableReferenceTypes): Move to `Visit` method?
             var result = base.VisitExpressionWithoutStackGuard(node);
 #if DEBUG
             // Verify Visit method set ResultType.
@@ -859,7 +859,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitObjectCreationInitializer(receiver, slot, initializerOpt);
             }
 
-            this.State.Result = Result.Create(TypeSymbolWithAnnotations.Create(node.Type), slot);
+            this.State.Result = Result.Create(TypeSymbolWithAnnotations.Create(type), slot);
         }
 
         private void VisitObjectCreationInitializer(Symbol containingSymbol, int containingSlot, BoundExpression node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1223,6 +1223,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool? isNullable = this.State.ResultType?.IsNullable & savedState.ResultType?.IsNullable;
             IntersectWith(ref this.State, ref savedState);
+            // PROTOTYPE(NullableReferenceTypes): Use flow analysis type rather than node.Type
+            // so that nested nullability is inferred from flow analysis. See VisitConditionalOperator.
             this.State.ResultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: isNullable);
             Debug.Assert(!IsConditionalState);
             return null;
@@ -1261,6 +1263,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitRvalue(node.AccessExpression);
 
             IntersectWith(ref this.State, ref savedState);
+            // PROTOTYPE(NullableReferenceTypes): Use flow analysis type rather than node.Type
+            // so that nested nullability is inferred from flow analysis. See VisitConditionalOperator.
             this.State.ResultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: savedState.ResultType?.IsNullable | this.State.ResultType?.IsNullable);
             // PROTOTYPE(NullableReferenceTypes): Report conversion warnings.
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1129,6 +1129,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if ((object)methodOpt != null && methodOpt.ParameterCount == 2)
                 {
+                    // PROTOTYPE(NullableReferenceTypes): Should return methodOpt.ReturnType
+                    // since that type might include nested nullability inferred from this flow analysis.
                     return IsResultNullable(methodOpt);
                 }
                 else
@@ -1314,6 +1316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.HasErrors)
             {
+                // PROTOTYPE(NullableReferenceTypes): Can we set resultType correctly in some error situations?
                 resultType = TypeSymbolWithAnnotations.Create(node.Type, isNullableIfReferenceType: null);
             }
             else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1411,12 +1411,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 VisitConditionalOperand(consequenceState, node.Consequence, isByRef);
-                var consequenceType = this.State.ResultType;
                 Unsplit();
+                var consequenceType = this.State.ResultType;
                 consequenceState = this.State;
                 VisitConditionalOperand(alternativeState, node.Alternative, isByRef);
-                var alternativeType = this.State.ResultType;
                 Unsplit();
+                var alternativeType = this.State.ResultType;
                 IntersectWith(ref this.State, ref consequenceState);
                 if ((object)consequenceType == null || (object)alternativeType == null || !consequenceType.Equals(alternativeType, TypeCompareKind.ConsiderEverything))
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1411,11 +1411,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 VisitConditionalOperand(consequenceState, node.Consequence, isByRef);
-                var consequenceType = consequenceState.ResultType;
+                var consequenceType = this.State.ResultType;
                 Unsplit();
                 consequenceState = this.State;
                 VisitConditionalOperand(alternativeState, node.Alternative, isByRef);
-                var alternativeType = alternativeState.ResultType;
+                var alternativeType = this.State.ResultType;
                 Unsplit();
                 IntersectWith(ref this.State, ref consequenceState);
                 if ((object)consequenceType == null || (object)alternativeType == null || !consequenceType.Equals(alternativeType, TypeCompareKind.ConsiderEverything))

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1707,7 +1707,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private Symbol AsMemberOfResultType(Symbol symbol)
         {
             var containingType = this.State.Result.Type?.TypeSymbol as NamedTypeSymbol;
-            if ((object)containingType == null)
+            if ((object)containingType == null || containingType.IsErrorType())
             {
                 return symbol;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2943,21 +2943,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
-            var result = base.VisitEventAssignmentOperator(node);
-            SetUnknownResultNullability();
-            return result;
-        }
-
-        protected override void VisitReceiverOfEventAssignmentAsRvalue(BoundEventAssignmentOperator node)
-        {
-            base.VisitReceiverOfEventAssignmentAsRvalue(node);
-
+            VisitRvalue(node.ReceiverOpt);
             Debug.Assert(!IsConditionalState);
             var receiverOpt = node.ReceiverOpt;
             if (!node.Event.IsStatic)
             {
                 CheckPossibleNullReceiver(receiverOpt);
             }
+            VisitRvalue(node.Argument);
+            SetUnknownResultNullability();
+            return null;
         }
 
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1267,15 +1267,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
-            VisitReceiverOfEventAssignmentAsRvalue(node);
+            VisitRvalue(node.ReceiverOpt);
             VisitRvalue(node.Argument);
             if (_trackExceptions) NotePossibleException(node);
             return null;
-        }
-
-        protected virtual void VisitReceiverOfEventAssignmentAsRvalue(BoundEventAssignmentOperator node)
-        {
-            VisitRvalue(node.ReceiverOpt);
         }
 
         private void VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
@@ -1585,7 +1580,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        protected void AdjustStateAfterReturnStatement(BoundReturnStatement node)
+        private void AdjustStateAfterReturnStatement(BoundReturnStatement node)
         {
             _pendingBranches.Add(new PendingBranch(node, this.State));
             SetUnreachable();
@@ -1648,7 +1643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // returns false if expression is not a property access 
         // or if the property has a backing field
         // and accessed in a corresponding constructor
-        protected bool RegularPropertyAccess(BoundExpression expr)
+        private bool RegularPropertyAccess(BoundExpression expr)
         {
             if (expr.Kind != BoundKind.PropertyAccess)
             {
@@ -1765,11 +1760,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 receiverOpt.Kind != BoundKind.TypeExpression &&
                 (object)receiverOpt.Type != null &&
                 !receiverOpt.Type.IsPrimitiveRecursiveStruct());
-            VisitFieldAccess(receiverOpt, fieldSymbol, asLvalue);
-        }
-
-        private void VisitFieldAccess(BoundExpression receiverOpt, FieldSymbol fieldSymbol, bool asLvalue)
-        {
             if (asLvalue)
             {
                 VisitLvalue(receiverOpt);
@@ -2708,15 +2698,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arguments = node.Arguments;
             if (!arguments.IsDefaultOrEmpty)
             {
-                MethodSymbol method = null;
-
-                if (node.MemberSymbol?.Kind == SymbolKind.Property)
+                foreach (var argument in arguments)
                 {
-                    var property = (PropertySymbol)node.MemberSymbol;
-                    method = GetReadMethod(property);
+                    VisitRvalue(argument);
                 }
-
-                VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, method);
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1214,7 +1214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        protected virtual void UpdateStateForCall(BoundCall node)
+        protected void UpdateStateForCall(BoundCall node)
         {
             if (_trackExceptions) NotePossibleException(node);
         }
@@ -1227,7 +1227,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void VisitReceiverAfterCall(BoundExpression receiverOpt, MethodSymbol method)
+        protected void VisitReceiverAfterCall(BoundExpression receiverOpt, MethodSymbol method)
         {
             NamedTypeSymbol containingType;
             if (receiverOpt != null && ((object)method == null || method.MethodKind == MethodKind.Constructor || (object)(containingType = method.ContainingType) != null && !method.IsStatic && !containingType.IsReferenceType && !TypeIsImmutable(containingType)))
@@ -1328,13 +1328,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void VisitArgumentAsRvalue(ImmutableArray<BoundExpression> arguments, int i, MethodSymbol method, ImmutableArray<int> argsToParamsOpt, bool expanded)
+        protected void VisitArgumentAsRvalue(ImmutableArray<BoundExpression> arguments, int i, MethodSymbol method, ImmutableArray<int> argsToParamsOpt, bool expanded)
         {
             ParameterSymbol parameter = GetCorrespondingParameter(i, method, argsToParamsOpt, ref expanded);
             VisitArgumentAsRvalue(arguments[i], parameter, expanded);
         }
 
-        private static ParameterSymbol GetCorrespondingParameter(int argumentOrdinal, MethodSymbol method, ImmutableArray<int> argsToParamsOpt, ref bool expanded)
+        protected static ParameterSymbol GetCorrespondingParameter(int argumentOrdinal, MethodSymbol method, ImmutableArray<int> argsToParamsOpt, ref bool expanded)
         {
             ParameterSymbol parameter;
             if ((object)method != null)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1273,10 +1273,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private void VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
+        protected virtual void VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
         {
-            Debug.Assert(!(this is NullableWalker));  // Should call NullableWalker.VisitArguments instead, for null warnings.
-
             // first value and ref parameters are read...
             for (int i = 0; i < arguments.Length; i++)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2698,7 +2698,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var argument in arguments)
                 {
-                    VisitRvalue(argument);
+                    MethodSymbol method = null;
+
+                    if (node.MemberSymbol?.Kind == SymbolKind.Property)
+                    {
+                        var property = (PropertySymbol)node.MemberSymbol;
+                        method = GetReadMethod(property);
+                    }
+
+                    VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, method);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -568,7 +568,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Visit a boolean condition expression.
         /// </summary>
         /// <param name="node"></param>
-        protected virtual void VisitCondition(BoundExpression node, bool inExpression = false)
+        protected void VisitCondition(BoundExpression node)
         {
             Visit(node);
             AdjustConditionalState(node);
@@ -1923,7 +1923,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(stack.Count > 0);
 
-            VisitCondition(child, inExpression: true);
+            VisitCondition(child);
 
             while (true)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2696,18 +2696,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             var arguments = node.Arguments;
             if (!arguments.IsDefaultOrEmpty)
             {
-                foreach (var argument in arguments)
+                MethodSymbol method = null;
+
+                if (node.MemberSymbol?.Kind == SymbolKind.Property)
                 {
-                    MethodSymbol method = null;
-
-                    if (node.MemberSymbol?.Kind == SymbolKind.Property)
-                    {
-                        var property = (PropertySymbol)node.MemberSymbol;
-                        method = GetReadMethod(property);
-                    }
-
-                    VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, method);
+                    var property = (PropertySymbol)node.MemberSymbol;
+                    method = GetReadMethod(property);
                 }
+
+                VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, method);
             }
 
             return null;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6187,33 +6187,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundValuePlaceholder : BoundExpression
     {
-        public BoundValuePlaceholder(SyntaxNode syntax, TypeSymbol type, bool hasErrors)
+        public BoundValuePlaceholder(SyntaxNode syntax, bool? isNullable, TypeSymbol type, bool hasErrors)
             : base(BoundKind.ValuePlaceholder, syntax, type, hasErrors)
         {
 
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            this.IsNullable = isNullable;
         }
 
-        public BoundValuePlaceholder(SyntaxNode syntax, TypeSymbol type)
+        public BoundValuePlaceholder(SyntaxNode syntax, bool? isNullable, TypeSymbol type)
             : base(BoundKind.ValuePlaceholder, syntax, type)
         {
 
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            this.IsNullable = isNullable;
         }
 
+
+        public bool? IsNullable { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitValuePlaceholder(this);
         }
 
-        public BoundValuePlaceholder Update(TypeSymbol type)
+        public BoundValuePlaceholder Update(bool? isNullable, TypeSymbol type)
         {
-            if (type != this.Type)
+            if (isNullable != this.IsNullable || type != this.Type)
             {
-                var result = new BoundValuePlaceholder(this.Syntax, type, this.HasErrors);
+                var result = new BoundValuePlaceholder(this.Syntax, isNullable, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -9441,7 +9445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitValuePlaceholder(BoundValuePlaceholder node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(type);
+            return node.Update(node.IsNullable, type);
         }
     }
 
@@ -11023,6 +11027,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new TreeDumperNode("valuePlaceholder", null, new TreeDumperNode[]
             {
+                new TreeDumperNode("isNullable", node.IsNullable, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19234,7 +19234,10 @@ public class Cls
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(14, 30),
                 // (18,58): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             var list2 = new Dictionary<int, long> { [out _] = 6 };
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(18, 58)
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(18, 58),
+                // (9,18): error CS0165: Use of unassigned local variable 'x1'
+                //             [out var x1] = 3,
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "var x1").WithArguments("x1").WithLocation(9, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19234,10 +19234,7 @@ public class Cls
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(14, 30),
                 // (18,58): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             var list2 = new Dictionary<int, long> { [out _] = 6 };
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(18, 58),
-                // (9,18): error CS0165: Use of unassigned local variable 'x1'
-                //             [out var x1] = 3,
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "var x1").WithArguments("x1").WithLocation(9, 18)
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(18, 58)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -8869,6 +8869,25 @@ class C
         }
 
         [Fact]
+        public void DynamicMemberAccess_02()
+        {
+            // PROTOTYPE(NullableReferenceTypes): Consider adding test infrastructure to verify
+            // nullability based on /*[...]*/ annotations such as [dynamic], [dynamic!], [dynamic?].
+            var source =
+@"class C
+{
+    static void M(dynamic x)
+    {
+        x.F/*[dynamic]*/.ToString();
+        var y/*[dynamic]*/ = x.F;
+        y = null;
+    }
+}";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void DynamicObjectCreationExpression_01()
         {
             CSharpCompilation c = CreateStandardCompilation(@"
@@ -17244,6 +17263,26 @@ class C
                 // (6,37): error CS1628: Cannot use ref or out parameter 'i' inside an anonymous method, lambda expression, or query expression
                 //         return await Task.Run(() => i++);
                 Diagnostic(ErrorCode.ERR_AnonDelegateCantUse, "i").WithArguments("i").WithLocation(6, 37));
+        }
+
+        [Fact]
+        public void NullCastToValueType()
+        {
+            var source =
+@"struct S { }
+class C
+{
+    static void M()
+    {
+        S s = (S)null;
+        s.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,15): error CS0037: Cannot convert null to 'S' because it is a non-nullable value type
+                //         S s = (S)null;
+                Diagnostic(ErrorCode.ERR_ValueCantBeNull, "(S)null").WithArguments("S").WithLocation(6, 15));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -5812,21 +5812,24 @@ class CL1
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (13,14): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
-                 //         u1 = new [] { y1, z1 };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { y1, z1 }").WithArguments("CL1?[]", "CL1[]").WithLocation(13, 14),
-                 // (14,14): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
-                 //         v1 = new [,] { {y1}, {z1} };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [,] { {y1}, {z1} }").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(14, 14),
-                 // (25,14): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
-                 //         u2 = a2;
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a2").WithArguments("CL1?[]", "CL1[]").WithLocation(25, 14),
-                 // (31,21): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
-                 //         CL1 [] x8 = new [] { y8, z8 };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { y8, z8 }").WithArguments("CL1?[]", "CL1[]").WithLocation(31, 21),
-                 // (36,22): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
-                 //         CL1 [,] x9 = new [,] { {y9}, {z9} };
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [,] { {y9}, {z9} }").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(36, 22)
+                // (13,14): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
+                //         u1 = new [] { y1, z1 };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { y1, z1 }").WithArguments("CL1?[]", "CL1[]").WithLocation(13, 14),
+                // (14,14): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
+                //         v1 = new [,] { {y1}, {z1} };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [,] { {y1}, {z1} }").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(14, 14),
+                // (25,14): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
+                //         u2 = a2;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a2").WithArguments("CL1?[]", "CL1[]").WithLocation(25, 14),
+                // (26,14): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
+                //         v2 = b2;
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b2").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(26, 14),
+                // (31,21): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
+                //         CL1 [] x8 = new [] { y8, z8 };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { y8, z8 }").WithArguments("CL1?[]", "CL1[]").WithLocation(31, 21),
+                // (36,22): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
+                //         CL1 [,] x9 = new [,] { {y9}, {z9} };
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [,] { {y9}, {z9} }").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(36, 22)
                 );
         }
 
@@ -8425,9 +8428,12 @@ class CL1
 ", new[] { CSharpRef, SystemCoreRef }, parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (15,17): warning CS8601: Possible null reference assignment.
-                 //         z2[0] = y2;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17)
+                // (14,26): warning CS8601: Possible null reference assignment.
+                //         x2[(dynamic)0] = y2;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(14, 26),
+                // (15,17): warning CS8601: Possible null reference assignment.
+                //         z2[0] = y2;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y2").WithLocation(15, 17)
                 );
         }
 
@@ -9564,12 +9570,6 @@ class CL0
 ", parseOptions: TestOptions.Regular8);
 
             c.VerifyDiagnostics(
-                 // (10,19): warning CS8604: Possible null reference argument for parameter 'x' in 'bool CL0.operator true(CL0 x)'.
-                 //         CL0? u1 = x1 && y1 || z1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1 && y1").WithArguments("x", "bool CL0.operator true(CL0 x)").WithLocation(10, 19),
-                 // (10,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator |(CL0 x, CL0? y)'.
-                 //         CL0? u1 = x1 && y1 || z1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1 && y1").WithArguments("x", "CL0 CL0.operator |(CL0 x, CL0? y)").WithLocation(10, 19)
                 );
         }
 
@@ -11260,7 +11260,9 @@ class Test
                 );
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Events are not tracked for structs.
+        // (This should be fixed if/when struct member state is populated lazily.)
+        [Fact(Skip = "TODO")]
         public void Events_02()
         {
             CSharpCompilation c = CreateStandardCompilation(@"
@@ -11314,7 +11316,9 @@ struct TS1
                 );
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Events are not tracked for structs.
+        // (This should be fixed if/when struct member state is populated lazily.)
+        [Fact(Skip = "TODO")]
         public void Events_03()
         {
             CSharpCompilation c = CreateStandardCompilation(@"
@@ -17203,6 +17207,43 @@ namespace System
                 // (16,22): warning CS8602: Possible dereference of a null reference.
                 //             _value = _f.GetHashCode();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "_f").WithLocation(16, 22));
+        }
+
+        [Fact]
+        public void Pointer()
+        {
+            var source =
+@"class C
+{
+    static unsafe void F(int* p)
+    {
+        *p = 0;
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8, options: TestOptions.UnsafeReleaseDll);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void IncrementWithErrors()
+        {
+            var source =
+@"using System.Threading.Tasks;
+class C
+{
+    static async Task<int> F(ref int i)
+    {
+        return await Task.Run(() => i++);
+    }
+}";
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (4,38): error CS1988: Async methods cannot have ref or out parameters
+                //     static async Task<int> F(ref int i)
+                Diagnostic(ErrorCode.ERR_BadAsyncArgType, "i").WithLocation(4, 38),
+                // (6,37): error CS1628: Cannot use ref or out parameter 'i' inside an anonymous method, lambda expression, or query expression
+                //         return await Task.Run(() => i++);
+                Diagnostic(ErrorCode.ERR_AnonDelegateCantUse, "i").WithArguments("i").WithLocation(6, 37));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking.cs
@@ -5824,9 +5824,6 @@ class CL1
                  // (25,14): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
                  //         u2 = a2;
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "a2").WithArguments("CL1?[]", "CL1[]").WithLocation(25, 14),
-                 // (26,14): warning CS8619: Nullability of reference types in value of type 'CL1?[*,*]' doesn't match target type 'CL1[*,*]'.
-                 //         v2 = b2;
-                 Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "b2").WithArguments("CL1?[*,*]", "CL1[*,*]").WithLocation(26, 14),
                  // (31,21): warning CS8619: Nullability of reference types in value of type 'CL1?[]' doesn't match target type 'CL1[]'.
                  //         CL1 [] x8 = new [] { y8, z8 };
                  Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "new [] { y8, z8 }").WithArguments("CL1?[]", "CL1[]").WithLocation(31, 21),
@@ -9309,9 +9306,6 @@ class CL0
                  // (10,19): warning CS8604: Possible null reference argument for parameter 'x' in 'CL0 CL0.operator &(CL0 x, CL0? y)'.
                  //         CL0? z1 = x1 && y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x1").WithArguments("x", "CL0 CL0.operator &(CL0 x, CL0? y)").WithLocation(10, 19),
-                 // (11,18): warning CS8601: Possible null reference assignment.
-                 //         CL0 u1 = z1;
-                 Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "z1").WithLocation(11, 18),
                  // (17,18): hidden CS8607: Expression is probably never null.
                  //         CL0 u2 = z2 ?? new CL0();
                  Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "z2").WithLocation(17, 18)
@@ -9708,6 +9702,48 @@ class CL0
                  // (10,25): warning CS8604: Possible null reference argument for parameter 'y' in 'CL0 CL0.operator &(CL0? x, CL0 y)'.
                  //         CL0? u1 = x1 && !y1;
                  Diagnostic(ErrorCode.WRN_NullReferenceArgument, "!y1").WithArguments("y", "CL0 CL0.operator &(CL0? x, CL0 y)").WithLocation(10, 25)
+                );
+        }
+
+        [Fact]
+        public void BinaryOperator_13()
+        {
+            CSharpCompilation c = CreateStandardCompilation(@"
+class C
+{
+    static void Main()
+    {
+    }
+
+    void Test1(CL0 x1, CL0 y1)
+    {
+        CL0 z1 = x1 && y1;
+    }
+}
+
+class CL0
+{
+    public static CL0? operator &(CL0 x, CL0 y)
+    {
+        return new CL0();
+    }
+
+    public static bool operator true(CL0 x)
+    {
+        return false;
+    }
+
+    public static bool operator false(CL0? x)
+    {
+        return false;
+    }
+}
+", parseOptions: TestOptions.Regular8);
+
+            c.VerifyDiagnostics(
+                // (10,18): warning CS8601: Possible null reference assignment.
+                //         CL0 z1 = x1 && y1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "x1 && y1").WithLocation(10, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -690,6 +690,46 @@ class C
         }
 
         [Fact]
+        public void TypeInference_01()
+        {
+            var source =
+@"class C<T>
+{
+    internal T F;
+}
+class C
+{
+    static C<T> Create<T>(T t)
+    {
+        return new C<T>();
+    }
+    static void F(object? x)
+    {
+        if (x == null)
+        {
+            Create(x).F = null;
+            var y = Create(x);
+            y.F = null;
+        }
+        else
+        {
+            Create(x).F = null;
+            var y = Create(x);
+            y.F = null;
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (21,27): warning CS8600: Cannot convert null to non-nullable reference.
+                //             Create(x).F = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(21, 27),
+                // (23,19): warning CS8600: Cannot convert null to non-nullable reference.
+                //             y.F = null;
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(23, 19));
+        }
+
+        [Fact]
         public void LambdaReturnValue_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -16,21 +16,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
     static void F(object x, object? y)
     {
         var a = new[] { x, x };
+        a.ToString();
         a[0].ToString();
         var b = new[] { x, y };
+        b.ToString();
         b[0].ToString();
         var c = new[] { b };
+        c[0].ToString();
         c[0][0].ToString();
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (8,9): warning CS8602: Possible dereference of a null reference.
-                //         b[0].ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
                 // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(10, 9),
+                // (13,9): warning CS8602: Possible dereference of a null reference.
                 //         c[0][0].ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0][0]").WithLocation(10, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0][0]").WithLocation(13, 9));
         }
 
         [Fact]
@@ -47,6 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
         b[0].ToString();
         var c = new[] { a, b };
         c[0][0].ToString();
+        var d = new[] { a, b! };
+        d[0][0].ToString();
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
@@ -289,6 +294,8 @@ class C
         a[0].ToString();
         var b = new object?[] { x, y };
         b[0].ToString();
+        var c = new object[] { x, y! };
+        c[0].ToString();
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -568,6 +568,44 @@ class C
         }
 
         [Fact]
+        public void NullCoalescingOperator_06()
+        {
+            var source =
+@"class C
+{
+    static void F(object? o, object[]? a, object?[]? b)
+    {
+        if (o == null)
+        {
+            var c = new[] { o };
+            (a ?? c)[0].ToString();
+            (b ?? c)[0].ToString();
+        }
+        else
+        {
+            var c = new[] { o };
+            (a ?? c)[0].ToString();
+            (b ?? c)[0].ToString();
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,19): warning CS8619: Nullability of reference types in value of type 'object?[]' doesn't match target type 'object[]'.
+                //             (a ?? c)[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c").WithArguments("object?[]", "object[]").WithLocation(8, 19),
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             (b ?? c)[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ?? c)[0]").WithLocation(9, 13),
+                // (15,19): warning CS8619: Nullability of reference types in value of type 'object[]' doesn't match target type 'object?[]'.
+                //             (b ?? c)[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInAssignment, "c").WithArguments("object[]", "object?[]").WithLocation(15, 19),
+                // (15,13): warning CS8602: Possible dereference of a null reference.
+                //             (b ?? c)[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ?? c)[0]").WithLocation(15, 13));
+        }
+
+        [Fact]
         public void LambdaReturnValue_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -1,0 +1,660 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Nullable
+{
+    public class StaticNullChecking_FlowAnalysis : CSharpTestBase
+    {
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_01()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        var a = new[] { x, x };
+        a[0].ToString();
+        var b = new[] { x, y };
+        b[0].ToString();
+        var c = new[] { b };
+        c[0][0].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         c[0][0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0][0]").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_02()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        var a = new[] { x };
+        a[0].ToString();
+        var b = new[] { y };
+        b[0].ToString();
+        var c = new[] { a, b };
+        c[0][0].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_03()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        (new[] { x, x })[1].ToString();
+        (new[] { y, x })[1].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         (new[] { y, x })[1].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(new[] { y, x })[1]").WithLocation(6, 9));
+        }
+
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_04()
+        {
+            var source =
+@"class C
+{
+    static void F()
+    {
+        object? o = new object();
+        var a = new[] { o };
+        a[0].ToString();
+        var b = new[] { a };
+        b[0][0].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_05()
+        {
+            var source =
+@"class C
+{
+    static void F(int n)
+    {
+        object? o = new object();
+        while (n-- > 0)
+        {
+            var a = new[] { o };
+            a[0].ToString();
+            var b = new[] { a };
+            b[0][0].ToString();
+            o = null;
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,13): warning CS8602: Possible dereference of a null reference.
+                //             a[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(9, 13),
+                // (11,13): warning CS8602: Possible dereference of a null reference.
+                //             b[0][0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0][0]").WithLocation(11, 13));
+        }
+
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_06()
+        {
+            var source =
+@"class C
+{
+    static void F()
+    {
+        var a = new[] { new object(), (string)null };
+        a[0].ToString();
+        var b = new[] { (object)null, string.Empty };
+        b[0].ToString();
+        var c = new[] { string.Empty, (object)null };
+        c[0].ToString();
+        var d = new[] { (string)null, new object() };
+        d[0].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         a[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a[0]").WithLocation(6, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         c[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "c[0]").WithLocation(10, 9),
+                // (12,9): warning CS8602: Possible dereference of a null reference.
+                //         d[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0]").WithLocation(12, 9));
+        }
+
+        // PROTOTYPE(NullableReferenceTypes): Should report nullability mismatch warnings.
+        [Fact]
+        public void ImplicitlyTypedArrayCreation_07()
+        {
+            var source =
+@"#pragma warning disable 0649
+class A<T>
+{
+    internal T F;
+}
+class B1 : A<object?> { }
+class B2 : A<object> { }
+class C
+{
+    static void F()
+    {
+        var a = new[] { new A<object>(), new B1() };
+        a[0].F.ToString();
+        var b = new[] { new A<object?>(), new B2() };
+        b[0].F.ToString();
+        var c = new[] { new B1(), new A<object>() };
+        c[0].F.ToString();
+        var d = new[] { new B2(), new A<object?>() };
+        d[0].F.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (15,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0].F").WithLocation(15, 9),
+                // (19,9): warning CS8602: Possible dereference of a null reference.
+                //         d[0].F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "d[0].F").WithLocation(19, 9));
+        }
+
+        [Fact]
+        public void ExplicitlyTypedArrayCreation()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        var a = new object[] { x, y };
+        a[0].ToString();
+        var b = new object?[] { x, y };
+        b[0].ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,35): warning CS8601: Possible null reference assignment.
+                //         var a = new object[] { x, y };
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "y").WithLocation(5, 35),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         b[0].ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b[0]").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void ConditionalOperator_01()
+        {
+            var source =
+@"class C
+{
+    static void F(bool b, object x, object? y)
+    {
+        var z = b ? x : y;
+        z.ToString();
+        var w = b ? y : x;
+        w.ToString();
+        var v = true ? y : x;
+        v.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(6, 9),
+                // (8,9): warning CS8602: Possible dereference of a null reference.
+                //         w.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "w").WithLocation(8, 9),
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         v.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v").WithLocation(10, 9));
+        }
+
+        [Fact]
+        public void ConditionalOperator_02()
+        {
+            var source =
+@"class C
+{
+    static void F(bool b, object x, object? y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+        if (y != null) (b ? x : y).ToString();
+        if (y != null) (b ? y : x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(5, 10),
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(6, 10));
+        }
+
+        [Fact]
+        public void ConditionalOperator_03()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        (false ? x : y).ToString();
+        (false ? y : x).ToString();
+        (true ? x : y).ToString();
+        (true ? y : x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (false ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "false ? x : y").WithLocation(5, 10),
+                // (8,10): warning CS8602: Possible dereference of a null reference.
+                //         (true ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "true ? y : x").WithLocation(8, 10));
+        }
+
+        [Fact]
+        public void ConditionalOperator_04()
+        {
+            var source =
+@"class C
+{
+    static void F(bool b, object x, string? y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+    static void G(bool b, object? x, string y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(5, 10),
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(6, 10),
+                // (10,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(10, 10),
+                // (11,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(11, 10));
+        }
+
+        // PROTOTYPE(NullableReferenceTypes): Should report nullability mismatch warnings.
+        [Fact]
+        public void ConditionalOperator_05()
+        {
+            var source =
+@"#pragma warning disable 0649
+class A<T>
+{
+    internal T F;
+}
+class B1 : A<object?> { }
+class B2 : A<object> { }
+class C
+{
+    static void F(bool b, A<object> x, B1 y)
+    {
+        (b ? x : y).F.ToString();
+        (b ? y : x).F.ToString();
+    }
+    static void G(bool b, A<object?> x, B2 y)
+    {
+        (b ? x : y).F.ToString();
+        (b ? y : x).F.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (17,9): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? x : y).F").WithLocation(17, 9),
+                // (18,9): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).F.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "(b ? y : x).F").WithLocation(18, 9));
+        }
+
+        [Fact]
+        public void ConditionalOperator_06()
+        {
+            var source =
+@"class C
+{
+    static void F(bool b, object x, string? y)
+    {
+        (b ? null : x).ToString();
+        (b ? null : y).ToString();
+        (b ? x: null).ToString();
+        (b ? y: null).ToString();
+        (b ? null: null).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between '<null>' and '<null>'
+                //         (b ? null: null).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? null: null").WithArguments("<null>", "<null>").WithLocation(9, 10),
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? null : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : x").WithLocation(5, 10),
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? null : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : y").WithLocation(6, 10),
+                // (7,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x: null).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x: null").WithLocation(7, 10),
+                // (8,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y: null).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y: null").WithLocation(8, 10),
+                // (9,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? null: null).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null: null").WithLocation(9, 10));
+        }
+
+        [Fact]
+        public void ConditionalOperator_07()
+        {
+            var source =
+@"class C
+{
+    static void F(bool b, Unknown x, Unknown? y)
+    {
+        (b ? null : x).ToString();
+        (b ? null : y).ToString();
+        (b ? x: null).ToString();
+        (b ? y: null).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,27): error CS0246: The type or namespace name 'Unknown' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F(bool b, Unknown x, Unknown? y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unknown").WithArguments("Unknown").WithLocation(3, 27),
+                // (3,38): error CS0246: The type or namespace name 'Unknown' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F(bool b, Unknown x, Unknown? y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Unknown").WithArguments("Unknown").WithLocation(3, 38),
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? null : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : x").WithLocation(5, 10),
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? null : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? null : y").WithLocation(6, 10),
+                // (7,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x: null).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x: null").WithLocation(7, 10),
+                // (8,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y: null).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y: null").WithLocation(8, 10));
+        }
+
+        [Fact]
+        public void NullCoalescingOperator_01()
+        {
+            var source =
+@"class C
+{
+    static void F(object? x, object? y)
+    {
+        var z = x ?? y;
+        z.ToString();
+        if (y == null) return;
+        var w = x ?? y;
+        w.ToString();
+        var v = null ?? x;
+        v.ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,9): warning CS8602: Possible dereference of a null reference.
+                //         z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(6, 9),
+                // (11,9): warning CS8602: Possible dereference of a null reference.
+                //         v.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "v").WithLocation(11, 9));
+        }
+
+        [Fact]
+        public void NullCoalescingOperator_02()
+        {
+            var source =
+@"class C
+{
+    static void F(object? x, object? y)
+    {
+        (x ?? y).ToString();
+        if (y != null) (x ?? y).ToString();
+        if (y != null) (y ?? x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (5,10): warning CS8602: Possible dereference of a null reference.
+                //         (x ?? y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x ?? y").WithLocation(5, 10),
+                // (7,25): hidden CS8607: Expression is probably never null.
+                //         if (y != null) (y ?? x).ToString();
+                Diagnostic(ErrorCode.HDN_ExpressionIsProbablyNeverNull, "y").WithLocation(7, 25));
+        }
+
+        [Fact]
+        public void NullCoalescingOperator_03()
+        {
+            var source =
+@"class C
+{
+    static void F(object x, object? y)
+    {
+        (null ?? x).ToString();
+        (null ?? y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (6,10): warning CS8602: Possible dereference of a null reference.
+                //         (null ?? y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "null ?? y").WithLocation(6, 10));
+        }
+
+        [Fact]
+        public void NullCoalescingOperator_04()
+        {
+            var source =
+@"class C
+{
+    static void F(string x, string? y)
+    {
+        ("""" ?? x).ToString();
+        ("""" ?? y).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LambdaReturnValue_01()
+        {
+            var source =
+@"using System;
+class C
+{
+    static void F(Func<object> f)
+    {
+    }
+    static void G(string x, object? y)
+    {
+        F(() => { if ((object)x == y) return x; return y; });
+        F(() => { if (y == null) return x; return y; });
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,56): warning CS8603: Possible null reference return.
+                //         F(() => { if ((object)x == y) return x; return y; });
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y").WithLocation(9, 56));
+        }
+
+        [Fact]
+        public void LambdaReturnValue_02()
+        {
+            var source =
+@"using System;
+class C
+{
+    static void F(Func<object> f)
+    {
+    }
+    static void G(bool b, object x, string? y)
+    {
+        F(() => { if (b) return x; return y; });
+        F(() => { if (b) return y; return x; });
+    }
+    static void H(bool b, object? x, string y)
+    {
+        F(() => { if (b) return x; return y; });
+        F(() => { if (b) return y; return x; });
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (9,43): warning CS8603: Possible null reference return.
+                //         F(() => { if (b) return x; return y; });
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y").WithLocation(9, 43),
+                // (10,33): warning CS8603: Possible null reference return.
+                //         F(() => { if (b) return y; return x; });
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y").WithLocation(10, 33),
+                // (14,33): warning CS8603: Possible null reference return.
+                //         F(() => { if (b) return x; return y; });
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "x").WithLocation(14, 33),
+                // (15,43): warning CS8603: Possible null reference return.
+                //         F(() => { if (b) return y; return x; });
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "x").WithLocation(15, 43));
+        }
+
+        [Fact]
+        public void LambdaReturnValue_03()
+        {
+            var source =
+@"using System;
+class C
+{
+    static T F<T>(Func<T> f)
+    {
+        return default(T);
+    }
+    static void G(bool b, object x, string? y)
+    {
+        F(() => { if (b) return x; return y; }).ToString();
+    }
+    static void H(bool b, object? x, string y)
+    {
+        F(() => { if (b) return x; return y; }).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (10,43): warning CS8603: Possible null reference return.
+                //         F(() => { if (b) return x; return y; }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReturn, "y").WithLocation(10, 43),
+                // (14,9): warning CS8602: Possible dereference of a null reference.
+                //         F(() => { if (b) return x; return y; }).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => { if (b) return x; return y; })").WithLocation(14, 9));
+        }
+
+        [Fact]
+        public void LambdaReturnValue_04()
+        {
+            var source =
+@"using System;
+class C
+{
+    static T F<T>(Func<T> f)
+    {
+        return default(T);
+    }
+    static void G(object? o)
+    {
+        F(() => o).ToString();
+        if (o != null) F(() => o).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Possible dereference of a null reference.
+                //         F(() => o).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o)").WithLocation(10, 9),
+                // (11,24): warning CS8602: Possible dereference of a null reference.
+                //         if (o != null) F(() => o).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(() => o)").WithLocation(11, 24));
+        }
+
+        [Fact]
+        public void LambdaReturnValue_05()
+        {
+            var source =
+@"using System;
+class C
+{
+    static T F<T>(Func<object?, T> f)
+    {
+        return default(T);
+    }
+    static void G()
+    {
+        F(o => { if (o == null) throw new ArgumentException(); return o; }).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_FlowAnalysis.cs
@@ -521,6 +521,114 @@ class C
         }
 
         [Fact]
+        public void ConditionalOperator_08()
+        {
+            var source =
+@"class C
+{
+    static void F1(bool b, UnknownA x, UnknownB y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+    static void F2(bool b, UnknownA? x, UnknownB y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+    static void F3(bool b, UnknownA? x, UnknownB? y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,28): error CS0246: The type or namespace name 'UnknownA' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F1(bool b, UnknownA x, UnknownB y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownA").WithArguments("UnknownA").WithLocation(3, 28),
+                // (3,40): error CS0246: The type or namespace name 'UnknownB' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F1(bool b, UnknownA x, UnknownB y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownB").WithArguments("UnknownB").WithLocation(3, 40),
+                // (8,28): error CS0246: The type or namespace name 'UnknownA' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F2(bool b, UnknownA? x, UnknownB y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownA").WithArguments("UnknownA").WithLocation(8, 28),
+                // (8,41): error CS0246: The type or namespace name 'UnknownB' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F2(bool b, UnknownA? x, UnknownB y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownB").WithArguments("UnknownB").WithLocation(8, 41),
+                // (13,28): error CS0246: The type or namespace name 'UnknownA' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F3(bool b, UnknownA? x, UnknownB? y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownA").WithArguments("UnknownA").WithLocation(13, 28),
+                // (13,41): error CS0246: The type or namespace name 'UnknownB' could not be found (are you missing a using directive or an assembly reference?)
+                //     static void F3(bool b, UnknownA? x, UnknownB? y)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "UnknownB").WithArguments("UnknownB").WithLocation(13, 41),
+                // (10,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(10, 10),
+                // (11,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(11, 10),
+                // (15,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(15, 10),
+                // (16,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(16, 10));
+        }
+
+        [Fact]
+        public void ConditionalOperator_09()
+        {
+            var source =
+@"struct A { }
+struct B { }
+class C
+{
+    static void F1(bool b, A x, B y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+    static void F2(bool b, A x, C y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+    static void F3(bool b, B x, C? y)
+    {
+        (b ? x : y).ToString();
+        (b ? y : x).ToString();
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (7,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'A' and 'B'
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? x : y").WithArguments("A", "B").WithLocation(7, 10),
+                // (8,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'B' and 'A'
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? y : x").WithArguments("B", "A").WithLocation(8, 10),
+                // (12,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'A' and 'C'
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? x : y").WithArguments("A", "C").WithLocation(12, 10),
+                // (13,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'C' and 'A'
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? y : x").WithArguments("C", "A").WithLocation(13, 10),
+                // (17,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'B' and 'C'
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? x : y").WithArguments("B", "C").WithLocation(17, 10),
+                // (18,10): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'C' and 'B'
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.ERR_InvalidQM, "b ? y : x").WithArguments("C", "B").WithLocation(18, 10),
+                // (17,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? x : y).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? x : y").WithLocation(17, 10),
+                // (18,10): warning CS8602: Possible dereference of a null reference.
+                //         (b ? y : x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "b ? y : x").WithLocation(18, 10));
+        }
+
+        [Fact]
         public void NullCoalescingOperator_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -1120,7 +1120,9 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y, y)").WithLocation(37, 9));
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Currently reporting WRN_NullabilityMismatchInArgument
+        // passing (string, string?) to (string?, string?).
+        [Fact(Skip = "TODO")]
         public void TupleTypeInference_01()
         {
             var source =
@@ -1140,15 +1142,9 @@ class C
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (7,11): warning CS8620: Nullability of reference types in argument of type '(string x, string? y)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
-                //         F((x, y)).Item2.ToString();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, y)").WithArguments("(string x, string? y)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(7, 11),
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         F((x, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((x, y)).Item2").WithLocation(7, 9),
-                // (8,11): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
-                //         F((y, x)).Item2.ToString();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(8, 11),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
@@ -1157,7 +1153,9 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, y)).Item2").WithLocation(9, 9));
         }
 
-        [Fact]
+        // PROTOTYPE(NullableReferenceTypes): Currently reporting WRN_NullabilityMismatchInArgument
+        // passing (string, string?) to (string?, string?).
+        [Fact(Skip = "TODO")]
         public void TupleTypeInference_02()
         {
             var source =
@@ -1177,12 +1175,6 @@ class C
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (6,11): warning CS8620: Nullability of reference types in argument of type '(string, string)' doesn't match target type '(string, string?)' for parameter 't' in '(string, string) C.F<string>((string, string?) t)'.
-                //         F((x, x)).Item2.ToString();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, x)").WithArguments("(string, string)", "(string, string?)", "t", "(string, string) C.F<string>((string, string?) t)").WithLocation(6, 11),
-                // (8,11): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
-                //         F((y, x)).Item2.ToString();
-                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(8, 11),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StaticNullChecking_TypeInference.cs
@@ -1140,9 +1140,15 @@ class C
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
+                // (7,11): warning CS8620: Nullability of reference types in argument of type '(string x, string? y)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
+                //         F((x, y)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, y)").WithArguments("(string x, string? y)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(7, 11),
                 // (7,9): warning CS8602: Possible dereference of a null reference.
                 //         F((x, y)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((x, y)).Item2").WithLocation(7, 9),
+                // (8,11): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
+                //         F((y, x)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(8, 11),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
@@ -1171,6 +1177,12 @@ class C
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
+                // (6,11): warning CS8620: Nullability of reference types in argument of type '(string, string)' doesn't match target type '(string, string?)' for parameter 't' in '(string, string) C.F<string>((string, string?) t)'.
+                //         F((x, x)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, x)").WithArguments("(string, string)", "(string, string?)", "t", "(string, string) C.F<string>((string, string?) t)").WithLocation(6, 11),
+                // (8,11): warning CS8620: Nullability of reference types in argument of type '(string? y, string x)' doesn't match target type '(string?, string?)' for parameter 't' in '(string?, string?) C.F<string?>((string?, string?) t)'.
+                //         F((y, x)).Item2.ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(y, x)").WithArguments("(string? y, string x)", "(string?, string?)", "t", "(string?, string?) C.F<string?>((string?, string?) t)").WithLocation(8, 11),
                 // (8,9): warning CS8602: Possible dereference of a null reference.
                 //         F((y, x)).Item2.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F((y, x)).Item2").WithLocation(8, 9),
@@ -1662,7 +1674,10 @@ class C
             comp.VerifyDiagnostics(
                 // (13,22): error CS1061: '(object?, int)' does not contain a definition for 'x' and no extension method 'x' accepting a first argument of type '(object?, int)' could be found (are you missing a using directive or an assembly reference?)
                 //         c.F((o, -1)).x.ToString();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "x").WithArguments("(object?, int)", "x").WithLocation(13, 22));
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "x").WithArguments("(object?, int)", "x").WithLocation(13, 22),
+                // (13,13): warning CS8620: Nullability of reference types in argument of type '(object o, int)' doesn't match target type '(object?, int)' for parameter 't' in '(object?, int) E.F<(object?, int)>(C<(object?, int)> c, (object?, int) t)'.
+                //         c.F((o, -1)).x.ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(o, -1)").WithArguments("(object o, int)", "(object?, int)", "t", "(object?, int) E.F<(object?, int)>(C<(object?, int)> c, (object?, int) t)").WithLocation(13, 13));
         }
 
         [Fact]
@@ -1721,7 +1736,10 @@ class C
                 source,
                 references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                 parseOptions: TestOptions.Regular8);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (13,13): warning CS8620: Nullability of reference types in argument of type '(dynamic x, object y)' doesn't match target type '(dynamic, object?)' for parameter 't' in '(dynamic, object?) E.F<(dynamic, object?)>(C<(dynamic, object?)> c, (dynamic, object?) t)'.
+                //         c.F((x, y)).Item1.G();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInArgument, "(x, y)").WithArguments("(dynamic x, object y)", "(dynamic, object?)", "t", "(dynamic, object?) E.F<(dynamic, object?)>(C<(dynamic, object?)> c, (dynamic, object?) t)").WithLocation(13, 13));
         }
 
         // Assert failure in ConversionsBase.IsValidExtensionMethodThisArgConversion.
@@ -1767,15 +1785,17 @@ class C
         object? y = x;
         F(x).ToString();
         F(y).ToString();
+        y = null;
+        F(y).ToString();
     }
 }";
             var comp = CreateStandardCompilation(
                 source,
                 parseOptions: TestOptions.Regular8);
             comp.VerifyDiagnostics(
-                // (9,9): warning CS8602: Possible dereference of a null reference.
+                // (11,9): warning CS8602: Possible dereference of a null reference.
                 //         F(y).ToString();
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(9, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F(y)").WithLocation(11, 9));
         }
 
         [Fact]


### PR DESCRIPTION
Infer nested nullability in flow analysis. To support nested nullability such as the cases below, it's necessary to track the entire type in flow analysis rather than just the top-level nullability.
```
static T F<T>(T[] a) => a[0];

static void M(object? o)
{
    if (o != null)
    {
        var a = new[] { o };
        a[0].ToString(); // no warning
        F(a).ToString(); // no warning    
    }
    else
    {
        var b = new[] { o };
        b[0].ToString(); // warning: b[0] may be null
        F(b).ToString(); // warning: F(b) may be null    
    }
}
```