### PR TITLE
Avoid IEnumerable allocations when flusing data to sqlite.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -129,8 +129,13 @@ namespace Microsoft.CodeAnalysis.SQLite
                 // performed by FlushAllPendingWritesAsync.
                 using (await _writeQueueGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    // Get the writes we need to process.
-                    writesToProcess.AddRange(keyToWriteActions[key]);
+                    // Get the writes we need to process. 
+                    // Note: explicitly foreach so we operate on the struct enumerator for
+                    // MultiDictionary.ValueSet.
+                    foreach (var action in keyToWriteActions[key])
+                    {
+                        writesToProcess.Add(action);
+                    }
 
                     // and clear them from the queues so we don't process things multiple times.
                     keyToWriteActions.Remove(key);

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -132,7 +132,9 @@ namespace Microsoft.CodeAnalysis.SQLite
                     // Get the writes we need to process. 
                     // Note: explicitly foreach so we operate on the struct enumerator for
                     // MultiDictionary.ValueSet.
-                    foreach (var action in keyToWriteActions[key])
+                    var actions = keyToWriteActions[key];
+                    writesToProcess.EnsureCapacity(writesToProcess.Count + actions.Count);
+                    foreach (var action in actions)
                     {
                         writesToProcess.Add(action);
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/23425