### PR TITLE
Two fixes for F# quick info

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/QuickInfoDisplayDeferredContent.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/QuickInfoDisplayDeferredContent.cs
@@ -7,14 +7,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal class QuickInfoDisplayDeferredContent : IDeferredQuickInfoContent
     {
-        private readonly IDeferredQuickInfoContent _symbolGlyph;
-        private readonly IDeferredQuickInfoContent _mainDescription;
-        private readonly IDeferredQuickInfoContent _documentation;
-        private readonly IDeferredQuickInfoContent _typeParameterMap;
-        private readonly IDeferredQuickInfoContent _anonymousTypes;
-        private readonly IDeferredQuickInfoContent _usageText;
-        private readonly IDeferredQuickInfoContent _exceptionText;
-        private readonly IDeferredQuickInfoContent _warningGlyph;
+        public IDeferredQuickInfoContent SymbolGlyph { get; }
+        public IDeferredQuickInfoContent MainDescription { get; }
+        public IDeferredQuickInfoContent Documentation { get; }
+        public IDeferredQuickInfoContent TypeParameterMap { get; }
+        public IDeferredQuickInfoContent AnonymousTypes { get; }
+        public IDeferredQuickInfoContent UsageText { get; }
+        public IDeferredQuickInfoContent ExceptionText { get; }
+        public IDeferredQuickInfoContent WarningGlyph { get; }
 
         public QuickInfoDisplayDeferredContent(
             IDeferredQuickInfoContent symbolGlyph,
@@ -26,72 +26,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             IDeferredQuickInfoContent usageText,
             IDeferredQuickInfoContent exceptionText)
         {
-            _symbolGlyph = symbolGlyph;
-            _warningGlyph = warningGlyph;
-            _mainDescription = mainDescription;
-            _documentation = documentation;
-            _typeParameterMap = typeParameterMap;
-            _anonymousTypes = anonymousTypes;
-            _usageText = usageText;
-            _exceptionText = exceptionText;
-        }
-
-        internal ClassifiableDeferredContent MainDescription
-        {
-            get
-            {
-                return (ClassifiableDeferredContent)_mainDescription;
-            }
-        }
-
-        internal IDeferredQuickInfoContent Documentation => _documentation;
-
-        internal ClassifiableDeferredContent TypeParameterMap
-        {
-            get
-            {
-                return (ClassifiableDeferredContent)_typeParameterMap;
-            }
-        }
-
-        internal ClassifiableDeferredContent AnonymousTypes
-        {
-            get
-            {
-                return (ClassifiableDeferredContent)_anonymousTypes;
-            }
-        }
-
-        internal ClassifiableDeferredContent UsageText
-        {
-            get
-            {
-                return (ClassifiableDeferredContent)_usageText;
-            }
-        }
-
-        internal ClassifiableDeferredContent ExceptionText
-        {
-            get
-            {
-                return (ClassifiableDeferredContent)_exceptionText;
-            }
-        }
-
-        internal SymbolGlyphDeferredContent SymbolGlyph
-        {
-            get
-            {
-                return (SymbolGlyphDeferredContent)_symbolGlyph;
-            }
-        }
-
-        internal SymbolGlyphDeferredContent WarningGlyph
-        {
-            get
-            {
-                return (SymbolGlyphDeferredContent)_warningGlyph;
-            }
+            SymbolGlyph = symbolGlyph;
+            WarningGlyph = warningGlyph;
+            MainDescription = mainDescription;
+            Documentation = documentation;
+            TypeParameterMap = typeParameterMap;
+            AnonymousTypes = anonymousTypes;
+            UsageText = usageText;
+            ExceptionText = exceptionText;
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Classification/ClassificationTestHelper.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/ClassificationTestHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             return "(" + tuple.TextSpan + ", " + tuple.ClassificationType + ")";
         }
 
-        internal static void Verify(
+        internal static void VerifyTextAndClassifications(
             string expectedText,
             IEnumerable<Tuple<string, string>> expectedClassifications,
             string actualText,
@@ -59,12 +59,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             }
         }
 
-        internal static void Verify(
+        internal static void VerifyTextAndClassifications(
             string expectedText,
             IEnumerable<Tuple<string, string>> expectedClassifications,
             IList<TaggedText> actualContent)
         {
-            Verify(
+            VerifyTextAndClassifications(
                 expectedText,
                 expectedClassifications,
                 actualText: actualContent.GetFullText(),

--- a/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/TestUtilities/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
@@ -160,6 +160,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
             return null;
         }
 
+        private static void AssertTextAndClassifications(string expectedText, Tuple<string, string>[] expectedClassifications, IDeferredQuickInfoContent actualContent)
+        {
+            var actualClassifications = ((ClassifiableDeferredContent)actualContent).ClassifiableContent;
+
+            ClassificationTestHelper.VerifyTextAndClassifications(expectedText, expectedClassifications, actualClassifications);
+        }
+
         protected void WaitForDocumentationComment(object content)
         {
             if (content is QuickInfoDisplayDeferredContent deferredContent)
@@ -175,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
         {
             return content =>
             {
-                var actualIcon = ((QuickInfoDisplayDeferredContent)content).SymbolGlyph;
+                var actualIcon = (SymbolGlyphDeferredContent)((QuickInfoDisplayDeferredContent)content).SymbolGlyph;
                 Assert.Equal(expectedGlyph, actualIcon.Glyph);
             };
         }
@@ -190,15 +197,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
                 {
                     case QuickInfoDisplayDeferredContent qiContent:
                         {
-                            var actualContent = qiContent.MainDescription.ClassifiableContent;
-                            ClassificationTestHelper.Verify(expectedText, expectedClassifications, actualContent);
+                            AssertTextAndClassifications(expectedText, expectedClassifications, (ClassifiableDeferredContent)qiContent.MainDescription);
                         }
                         break;
 
                     case ClassifiableDeferredContent classifiable:
                         {
                             var actualContent = classifiable.ClassifiableContent;
-                            ClassificationTestHelper.Verify(expectedText, expectedClassifications, actualContent);
+                            ClassificationTestHelper.VerifyTextAndClassifications(expectedText, expectedClassifications, actualContent);
                         }
                         break;
                 }
@@ -224,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
                         {
                             var actualContent = classifiable.ClassifiableContent;
                             Assert.Equal(expectedText, actualContent.GetFullText());
-                            ClassificationTestHelper.Verify(expectedText, expectedClassifications, actualContent);
+                            ClassificationTestHelper.VerifyTextAndClassifications(expectedText, expectedClassifications, actualContent);
                         }
                         break;
                 }
@@ -237,14 +243,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
         {
             return content =>
             {
-                var actualContent = ((QuickInfoDisplayDeferredContent)content).TypeParameterMap.ClassifiableContent;
-
-                // The type parameter map should have an additional line break at the beginning. We
-                // create a copy here because we've captured expectedText and this delegate might be
-                // executed more than once (e.g. with different parse options).
-
-                // var expectedTextCopy = "\r\n" + expectedText;
-                ClassificationTestHelper.Verify(expectedText, expectedClassifications, actualContent);
+                AssertTextAndClassifications(expectedText, expectedClassifications, ((QuickInfoDisplayDeferredContent)content).TypeParameterMap);
             };
         }
 
@@ -254,16 +253,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
         {
             return content =>
             {
-                var actualContent = ((QuickInfoDisplayDeferredContent)content).AnonymousTypes.ClassifiableContent;
-
-                // The type parameter map should have an additional line break at the beginning. We
-                // create a copy here because we've captured expectedText and this delegate might be
-                // executed more than once (e.g. with different parse options).
-
-                // var expectedTextCopy = "\r\n" + expectedText;
-                ClassificationTestHelper.Verify(expectedText, expectedClassifications, actualContent);
+                AssertTextAndClassifications(expectedText, expectedClassifications, ((QuickInfoDisplayDeferredContent)content).AnonymousTypes);
             };
         }
+
 
         protected Action<object> NoTypeParameterMap
         {
@@ -271,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
             {
                 return content =>
                 {
-                    Assert.Equal(string.Empty, ((QuickInfoDisplayDeferredContent)content).TypeParameterMap.ClassifiableContent.GetFullText());
+                    AssertTextAndClassifications("", NoClassifications(), ((QuickInfoDisplayDeferredContent)content).TypeParameterMap);
                 };
             }
         }
@@ -281,8 +274,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
             return content =>
             {
                 var quickInfoContent = (QuickInfoDisplayDeferredContent)content;
-                Assert.Equal(expectedText, quickInfoContent.UsageText.ClassifiableContent.GetFullText());
-                Assert.Equal(expectsWarningGlyph, quickInfoContent.WarningGlyph != null && quickInfoContent.WarningGlyph.Glyph == Glyph.CompletionWarning);
+                Assert.Equal(expectedText, ((ClassifiableDeferredContent)quickInfoContent.UsageText).ClassifiableContent.GetFullText());
+                var warningGlyph = quickInfoContent.WarningGlyph as SymbolGlyphDeferredContent;
+                Assert.Equal(expectsWarningGlyph, warningGlyph != null && warningGlyph.Glyph == Glyph.CompletionWarning);
             };
         }
 
@@ -290,8 +284,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
         {
             return content =>
             {
-                var quickInfoContent = (QuickInfoDisplayDeferredContent)content;
-                Assert.Equal(expectedText, quickInfoContent.ExceptionText.ClassifiableContent.GetFullText());
+                AssertTextAndClassifications(expectedText, expectedClassifications: null, actualContent: ((QuickInfoDisplayDeferredContent)content).ExceptionText);
             };
         }
 

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -132,6 +132,10 @@ string[] NonRedistPackageNames = {
     "Microsoft.NETCore.Compilers",
     "Microsoft.VisualStudio.IntegrationTest.Utilities",
     "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient",
+
+    // Right now there is no public surface area in this assembly, and the expectation is it will be able to go away
+    // as the editor continues to refactor its surface area better.
+    "Microsoft.CodeAnalysis.EditorFeatures.Wpf"
 };
 
 string[] TestPackageNames = {

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Wpf.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Wpf.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.CodeAnalysis.EditorFeatures.Wpf</id>
+    <summary>
+      .NET Compiler Platform ("Roslyn") support for WPF-dependent editor features inside the Visual Studio editor.
+    </summary>
+    <description>
+      .NET Compiler Platform ("Roslyn") support for WPF-dependent editor features inside the Visual Studio editor.
+
+      Supported Platforms:
+      - .NET Framework 4.6
+      
+      More details at https://aka.ms/roslyn-packages
+
+      $commitPathMessage$
+    </description>
+    <dependencies>
+      <dependency id="Microsoft.CodeAnalysis.EditorFeatures" version="[$version$]" />
+    </dependencies>
+
+    <language>en-US</language>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+  </metadata>
+  <files>
+    <file src="Dlls\EditorFeatures.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll" target="lib\net46" />
+    <file src="Dlls\EditorFeatures.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.xml" target="lib\net46" />
+  </files>
+</package>


### PR DESCRIPTION
Two changes for F# quick info that we ran into:

- I accidentally created an assumption that quick info deferred content wouldn't have an F# derived type used, which I've fixed.
- They need a package of EditorFeatures.Wpf to use as well.