### PR TITLE
Esnure the build target is called explicitly

### DIFF
--- a/src/Tools/MicroBuild/publish-blob.ps1
+++ b/src/Tools/MicroBuild/publish-blob.ps1
@@ -34,7 +34,7 @@ try {
         exit 1
     }
 
-    Exec-Console $msbuild "/p:ConfigDir=$configDir /p:ExpectedFeedUrl=$blobFeedUrl /p:AccountKey=$blobFeedKey /p:OutputPath=$configDir PublishBlobAssets.proj"
+    Exec-Console $msbuild "/p:ConfigDir=$configDir /p:ExpectedFeedUrl=$blobFeedUrl /p:AccountKey=$blobFeedKey /p:OutputPath=$configDir /t:Build PublishBlobAssets.proj"
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
The imported build tasks targets sets a nonexistent default target
