### PR TITLE
Use binary log in microbuild

### DIFF
--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -125,7 +125,7 @@ try {
     $configDir = Join-Path $binariesDir $config
     $setupDir = Join-Path $repoDir "src\Setup"
 
-    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -cibuild:$cibuild -official:$official -msbuildDir $msbuildDir -release:$release -sign -signType $signType -pack -testDesktop:$testDesktop }
+    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -cibuild:$cibuild -official:$official -msbuildDir $msbuildDir -release:$release -sign -signType $signType -pack -testDesktop:$testDesktop -binaryLog }
     Copy-InsertionItems
 
     # Insertion scripts currently look for a sentinel file on the drop share to determine that the build was green


### PR DESCRIPTION
This enables the generation of binary logs for our build when running in Microbuild.
Having the logs available helps in post-build debugging of errors. We tend to get a
number of microbuild only failures that are impossible to track down without logging
like this.

Once this is merged i will be adding a task to our VSTS build definition to publish
these post build.

