### PR TITLE
Remove * from CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,17 @@
 # More information: https://github.com/blog/2392-introducing-code-owners 
 
 *.groovy @dotnet/roslyn-infrastructure
-.github/* @dotnet/roslyn-infrastructure
-build/* @dotnet/roslyn-infrastructure
-src/CodeStyle/* @dotnet/roslyn-ide
-src/Compilers/* @dotnet/roslyn-compiler
-src/EditorFeatures/* @dotnet/roslyn-ide
-src/Features/* @dotnet/roslyn-ide
-src/Interactive/* @dotnet/roslyn-interactive
-src/NuGet/* @dotnet/roslyn-infrastructure
-src/Scripting/* @dotnet/roslyn-interactive
-src/Setup/* @dotnet/roslyn-infrastructure
-src/Tools/* @dotnet/roslyn-infrastructure
-src/VisualStudio/* @dotnet/roslyn-ide
-src/Workspaces/* @dotnet/roslyn-ide
+.github/ @dotnet/roslyn-infrastructure
+build/ @dotnet/roslyn-infrastructure
+src/CodeStyle/ @dotnet/roslyn-ide
+src/Compilers/ @dotnet/roslyn-compiler
+src/EditorFeatures/ @dotnet/roslyn-ide
+src/Features/ @dotnet/roslyn-ide
+src/Interactive/ @dotnet/roslyn-interactive
+src/NuGet/ @dotnet/roslyn-infrastructure
+src/Scripting/ @dotnet/roslyn-interactive
+src/Setup/ @dotnet/roslyn-infrastructure
+src/Tools/ @dotnet/roslyn-infrastructure
+src/VisualStudio/ @dotnet/roslyn-ide
+src/Workspaces/ @dotnet/roslyn-ide
 


### PR DESCRIPTION
Turns out the * only means the files in that immediate directory counts as being matched. That's not what we intended.

FYI to @jaredpar and @sharwell (who I suspect will notice the most) that this will auto-request reviews for PRs that match this. Great for community PRs, not so great for "in progress" PRs.