### PR TITLE
Avoid skewing analysis time when logging analyzer times

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -244,13 +244,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             };
 
-            if (analysisOptions.LogAnalyzerExecutionTime)
-            {
-                // If we are reporting detailed analyzer performance numbers, then do a dummy invocation of Compilation.GetTypeByMetadataName API upfront.
-                // This API seems to cause a severe hit for the first analyzer invoking it and hence introduces lot of noise in the computed analyzer execution times.
-                var unused = compilation.GetTypeByMetadataName("System.Object");
-            }
-
             var analyzerExecutor = AnalyzerExecutor.Create(
                 compilation, analysisOptions.Options ?? AnalyzerOptions.Empty, addNotCategorizedDiagnosticOpt, newOnAnalyzerException, analysisOptions.AnalyzerExceptionFilter,
                 IsCompilerAnalyzer, analyzerManager, ShouldSkipAnalysisOnGeneratedCode, ShouldSuppressGeneratedCodeDiagnostic, IsGeneratedOrHiddenCodeLocation, GetAnalyzerGate,


### PR DESCRIPTION
### Customer scenario

A user attempts to run analyzers through the Roslyn API for performance testing. The measured performance overhead is significantly greater than the observed overhead for the analyzer in other cases.

### Bugs this fixes

N/A

### Workarounds, if any

None

### Risk

Low. The code was only intended to add stability to analyzer performance testing. After running the code through AnalyzerRunner, measurements indicated that the approach caused substantial performance overhead which obscured the true performance of the analyzers. The issue was most apparent during document edit testing (#23104).

### Performance impact

For applications like Visual Studio, no change in performance. For some applications using the Roslyn API, e.g. AnalyzerRunner, performance is either unchanged or improved.

### Is this a regression from a previous update?

No.

### Root cause analysis

Analyzer performance was only tested in limited scenarios previously.

### How was the bug found?

AnalyzerRunner

### Test documentation updated?

No.