### PR TITLE
Skip IOperation test GroupBy_Lookup1 until it is investigated

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_LookupSymbols.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_LookupSymbols.vb
@@ -490,7 +490,7 @@ End Module
             End If
         End Sub
 
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/23483")>
         <CompilerTrait(CompilerFeature.IOperation)>
         Public Sub GroupBy_Lookup1()
             Dim compilation = CreateCompilationWithMscorlib(


### PR DESCRIPTION
This PR skips a single test that has been failing frequently in code flow from master to other branches. See, for example, 

- https://github.com/dotnet/roslyn/pull/23419
- https://github.com/dotnet/roslyn/pull/23420
- https://github.com/dotnet/roslyn/pull/23454
- https://github.com/dotnet/roslyn/pull/23455

Issue #23483 has been filed to investigate the underlying failure.

### Risk

No product code change.

### Performance impact

No product code change.

### Root cause analysis

#23483 has been filed to analyze the root cause.

### How was the bug found?

Automated testing of integration branches.

### Test documentation updated?

N/A

@dotnet/roslyn-compiler @dotnet/roslyn-infrastructure May I please have a review of this?
