### PR TITLE
Optimize allocations in IsDefinedInSourceTree hot paths 

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/MergedTypeDeclaration.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly ImmutableArray<SingleTypeDeclaration> _declarations;
         private ImmutableArray<MergedTypeDeclaration> _lazyChildren;
+        private ImmutableArray<SyntaxReference> _lazySyntaxReferences;
         private ICollection<string> _lazyMemberNames;
 
         internal MergedTypeDeclaration(ImmutableArray<SingleTypeDeclaration> declarations)
@@ -36,7 +37,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _declarations.SelectAsArray(r => r.SyntaxReference);
+                if (_lazySyntaxReferences.IsDefault)
+                {
+                    ImmutableInterlocked.InterlockedInitialize(ref _lazySyntaxReferences, _declarations.SelectAsArray(r => r.SyntaxReference));
+                }
+
+                return _lazySyntaxReferences;
             }
         }
 


### PR DESCRIPTION
Fix for #23462
This solutions lazy caches the SyntaxReferences array in the same way the [Children](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Declarations/MergedTypeDeclaration.cs,196) property is cached a few lines down in the same class.

If this is the way to got the same solution can be adopted for the other property (SourceNamespaceSymbol.DeclaringSyntaxReferences) mentioned in the issue.

No additional tests are provided. See performance impact below for details on how I measured the impact of the change.

### Customer scenario

Avoid array allocations in hot path.

### Bugs this fixes

#23462

### Workarounds, if any

No.

### Risk

This solution avoids allocations by caching SyntaxReferences. The cache may increase memory usage. The cached array should be small (❓  0 to 1 references are the common case. More references are only stored for partial definitions).

### Performance impact

The performance impact was measured on solution load of a console app with only Program.cs and 100 lines of code (VS start -> Load Solution -> Wait a minute for warmup).
Before:
1.300 allocating calls of the now removed line
`return _declarations.SelectAsArray(r => r.SyntaxReference);` 
After:
2 allocating calls
```
    if (_lazySyntaxReferences.IsDefault) 
    {
        // Number of calls measured on next line
        ImmutableInterlocked.InterlockedInitialize(ref _lazySyntaxReferences, _declarations.SelectAsArray(r => r.SyntaxReference)); 
    } 
    return _lazySyntaxReferences; 
```

### Is this a regression from a previous update?

I don't know.

### Root cause analysis

I don't know.

### How was the bug found?

via Watson and AnalyzerWatcher. See #23462 and ask @sharwell for details.

### Test documentation updated?
