### PR TITLE
Avoid allocations in IsDefinedInSourceTree hot paths

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -866,6 +867,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return SyntaxReferences;
             }
+        }
+
+        // This method behaves the same was as the base class, but avoids allocations associated with DeclaringSyntaxReferences
+        internal override bool IsDefinedInSourceTree(SyntaxTree tree, TextSpan? definedWithinSpan, CancellationToken cancellationToken)
+        {
+            var declarations = declaration.Declarations;
+            if (IsImplicitlyDeclared && declarations.IsEmpty)
+            {
+                return ContainingSymbol.IsDefinedInSourceTree(tree, definedWithinSpan, cancellationToken);
+            }
+
+            foreach (var declaration in declarations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var syntaxRef = declaration.SyntaxReference;
+                if (syntaxRef.SyntaxTree == tree &&
+                    (!definedWithinSpan.HasValue || syntaxRef.Span.IntersectsWith(definedWithinSpan.Value)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -463,11 +463,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Check if any namespace declaration block intersects with the given tree/span.
-            foreach (var syntaxRef in this.DeclaringSyntaxReferences)
+            foreach (var declaration in _mergedDeclaration.Declarations)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (syntaxRef.SyntaxTree != tree)
+                var declarationSyntaxRef = declaration.SyntaxReference;
+                if (declarationSyntaxRef.SyntaxTree != tree)
                 {
                     continue;
                 }
@@ -477,7 +478,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 }
 
-                var syntax = syntaxRef.GetSyntax(cancellationToken);
+                var syntax = NamespaceDeclarationSyntaxReference.GetSyntax(declarationSyntaxRef, cancellationToken);
                 if (syntax.FullSpan.IntersectsWith(definedWithinSpan.Value))
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/Syntax/NamespaceDeclarationSyntaxReference.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/NamespaceDeclarationSyntaxReference.cs
@@ -2,8 +2,8 @@
 
 using System.Diagnostics;
 using System.Threading;
-using Microsoft.CodeAnalysis.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -19,6 +19,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected override SyntaxNode Translate(SyntaxReference reference, CancellationToken cancellationToken)
+        {
+            return GetSyntax(reference, cancellationToken);
+        }
+
+        internal static SyntaxNode GetSyntax(SyntaxReference reference, CancellationToken cancellationToken)
         {
             var node = (CSharpSyntaxNode)reference.GetSyntax(cancellationToken);
 


### PR DESCRIPTION
Fixes #23462

:memo: This is an alternate approach to the one seen in #23490. This approach has more code duplication, but further reduces memory usage and can't increase memory footprint due to caching.

### Customer scenario

Running analyzer during a build is slower than it should be, with the analyzer driver contributing substantial overhead even when the analyzers themselves are lightweight.

### Bugs this fixes

Fixes #23462

### Workarounds, if any

None needed

### Risk

This poses a small maintainability risk by duplicating an existing algorithm into a new form for the sole benefit of reducing allocations. The risk is partially mitigated by comment(s) in the source code, and justified by AnalyzerRunner indicating the code lies on a particularly hot path.

### Performance impact

6% reduction in allocations for running IDE analyzers.

### Is this a regression from a previous update?

No.

### Root cause analysis

AnalyzerRunner is a new tool for helping us test analyzer performance in isolation.

### How was the bug found?

AnalyzerRunner.

### Test documentation updated?

No.

