### PR TITLE
Enable execution of well known batch fixer from non-VS host

### DIFF
--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/DefaultDocumentTextDifferencingService.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/DefaultDocumentTextDifferencingService.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
+    [ExportWorkspaceService(typeof(IDocumentTextDifferencingService), ServiceLayer.Default), Shared]
     internal class DefaultDocumentTextDifferencingService : IDocumentTextDifferencingService
     {
         public async Task<ImmutableArray<TextChange>> GetTextChangesAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis
 
             // Automatically merge non-conflicting diffs while collecting the conflicting diffs
 
-            var textDifferencingService = _oldSolution.Workspace.Services.GetService<IDocumentTextDifferencingService>();
+            var textDifferencingService = _oldSolution.Workspace.Services.GetService<IDocumentTextDifferencingService>() ?? new DefaultDocumentTextDifferencingService();
             var appliedChanges = await textDifferencingService.GetTextChangesAsync(_oldSolution.GetDocument(linkedDocumentGroup.First()), _newSolution.GetDocument(linkedDocumentGroup.First()), cancellationToken).ConfigureAwait(false);
             var unmergedChanges = new List<UnmergedDocumentChanges>();
 

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis
 
             // Automatically merge non-conflicting diffs while collecting the conflicting diffs
 
-            var textDifferencingService = _oldSolution.Workspace.Services.GetService<IDocumentTextDifferencingService>() ?? new DefaultDocumentTextDifferencingService();
+            var textDifferencingService = _oldSolution.Workspace.Services.GetService<IDocumentTextDifferencingService>();
             var appliedChanges = await textDifferencingService.GetTextChangesAsync(_oldSolution.GetDocument(linkedDocumentGroup.First()), _newSolution.GetDocument(linkedDocumentGroup.First()), cancellationToken).ConfigureAwait(false);
             var unmergedChanges = new List<UnmergedDocumentChanges>();
 

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -661,5 +661,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.Equal(newPath, appliedDoc.FilePath);
             }
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestDefaultDocumentTextDifferencingService()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var service = ws.Services.GetService<IDocumentTextDifferencingService>();
+                Assert.NotNull(service);
+                Assert.Equal(service.GetType(), typeof(DefaultDocumentTextDifferencingService));
+            }
+        }
     }
 }


### PR DESCRIPTION
Well known batch fixer expects a MEF exported IDocumentTextDifferencingService, but we only have one in the EditorFeatures layer.
We already have a simple default differencing service in the workspace, this change exports it at the default service layer.
This change unblocks enabling FixAll testing in roslyn-analyzers repo: https://github.com/dotnet/roslyn-analyzers/issues/1420

<details><summary>Ask Mode template</summary>

### Customer scenario

Unable to write FixAll unit tests for fixers using well known batch fixer outside of Roslyn code base.

### Bugs this fixes

https://github.com/dotnet/roslyn-analyzers/issues/1420

### Workarounds, if any

None, except for not using the well known batch fixer.

### Risk

Low as we are just MEF exporting an existing service implementation.

### Performance impact

Low

### Is this a regression from a previous update?

No

### Root cause analysis

We do not have any FixAll unit tests in roslyn-analyzers repo currently. We are planning to add them this sprint.

### How was the bug found?

Attempting to implement https://github.com/dotnet/roslyn-analyzers/issues/1420

### Test documentation updated?

N/A

</details>
