### PR TITLE
Added support for pattern matching syntax to smart variable completion provider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -706,6 +706,72 @@ class Test
             await VerifyItemExistsAsync(markup, "tokens");
         }
 
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching1()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static void Main()
+    {
+        object obj = null;
+        if (obj is CancellationToken $$) { }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "cancellation");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching2()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static bool Foo()
+    {
+        object obj = null;
+        return obj is CancellationToken $$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "cancellation");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching3()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static void Main()
+    {
+        object obj = null;
+        switch(obj)
+        {
+            case CancellationToken $$
+        }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "cancellation");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void DisabledByOption()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -772,6 +772,69 @@ public class C
             await VerifyItemExistsAsync(markup, "token");
         }
 
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching4()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static void Main()
+    {
+        object obj = null;
+        if (obj is CancellationToken ca$$) { }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "cancellation");
+        }
+
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching5()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static bool Foo()
+    {
+        object obj = null;
+        return obj is CancellationToken to$$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
+        [WorkItem(23497, "https://github.com/dotnet/roslyn/issues/23497")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void InPatternMatching6()
+        {
+            var markup = @"
+using System.Threading;
+
+public class C
+{
+    public static void Main()
+    {
+        object obj = null;
+        switch(obj)
+        {
+            case CancellationToken to$$
+        }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void DisabledByOption()
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     {
         internal struct NameDeclarationInfo
         {
+            private static readonly ImmutableArray<SymbolKind> parameterSyntaxKind = ImmutableArray.Create(SymbolKind.Parameter);
+
             public NameDeclarationInfo(
                 ImmutableArray<SymbolKind> possibleSymbolKinds,
                 Accessibility accessibility,
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 result = IsLastTokenOfType<ExpressionStatementSyntax>(
                     token, semanticModel,
                     e => e.Expression,
-                    _ => default(SyntaxTokenList),
+                    _ => default,
                     _ => ImmutableArray.Create(SymbolKind.Local),
                     cancellationToken);
                 return result.Type != null;
@@ -192,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 SyntaxToken token,
                 SemanticModel semanticModel,
                 Func<TSyntaxNode, SyntaxNode> typeSyntaxGetter,
-                Func<TSyntaxNode, SyntaxTokenList?> modifierGetter,
+                Func<TSyntaxNode, SyntaxTokenList> modifierGetter,
                 Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
                 CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
             {
@@ -214,15 +216,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
 
                 var modifiers = modifierGetter(target);
-                if (modifiers == null)
-                {
-                    return default;
-                }
 
                 return new NameDeclarationInfo(
-                    possibleDeclarationComputer(GetDeclarationModifiers(modifiers.Value)),
-                    GetAccessibility(modifiers.Value),
-                    GetDeclarationModifiers(modifiers.Value),
+                    possibleDeclarationComputer(GetDeclarationModifiers(modifiers)),
+                    GetAccessibility(modifiers),
+                    GetDeclarationModifiers(modifiers),
                     semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type,
                     semanticModel.GetAliasInfo(typeSyntax, cancellationToken));
             }
@@ -286,8 +284,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 result = IsLastTokenOfType<ParameterSyntax>(
                     token, semanticModel,
                     p => p.Type,
-                    _ => default(SyntaxTokenList),
-                    _ => ImmutableArray.Create(SymbolKind.Parameter),
+                    _ => default,
+                    _ => parameterSyntaxKind,
                     cancellationToken);
                 return result.Type != null;
             }
@@ -301,8 +299,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     result = IsLastTokenOfType<BinaryExpressionSyntax>(
                         token, semanticModel,
                         b => b.Right,
-                        _ => default(SyntaxTokenList),
-                        _ => ImmutableArray.Create(SymbolKind.Parameter),
+                        _ => default,
+                        _ => parameterSyntaxKind,
                         cancellationToken);
                 }
                 else if (token.Parent.IsParentKind(SyntaxKind.CaseSwitchLabel))
@@ -310,8 +308,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     result = IsLastTokenOfType<CaseSwitchLabelSyntax>(
                         token, semanticModel,
                         b => b.Value,
-                        _ => default(SyntaxTokenList),
-                        _ => ImmutableArray.Create(SymbolKind.Parameter),
+                        _ => default,
+                        _ => parameterSyntaxKind,
                         cancellationToken);
                 }
                 else if (token.Parent.IsParentKind(SyntaxKind.DeclarationPattern))
@@ -319,8 +317,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     result = IsLastTokenOfType<DeclarationPatternSyntax>(
                         token, semanticModel,
                         b => b.Type,
-                        _ => default(SyntaxTokenList),
-                        _ => ImmutableArray.Create(SymbolKind.Parameter),
+                        _ => default,
+                        _ => parameterSyntaxKind,
                         cancellationToken);
                 }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     {
         internal struct NameDeclarationInfo
         {
-            private static readonly ImmutableArray<SymbolKind> parameterSyntaxKind = ImmutableArray.Create(SymbolKind.Parameter);
+            private static readonly ImmutableArray<SymbolKind> s_parameterSyntaxKind = ImmutableArray.Create(SymbolKind.Parameter);
 
             public NameDeclarationInfo(
                 ImmutableArray<SymbolKind> possibleSymbolKinds,
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     token, semanticModel,
                     p => p.Type,
                     _ => default,
-                    _ => parameterSyntaxKind,
+                    _ => s_parameterSyntaxKind,
                     cancellationToken);
                 return result.Type != null;
             }
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         token, semanticModel,
                         b => b.Right,
                         _ => default,
-                        _ => parameterSyntaxKind,
+                        _ => s_parameterSyntaxKind,
                         cancellationToken);
                 }
                 else if (token.Parent.IsParentKind(SyntaxKind.CaseSwitchLabel))
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         token, semanticModel,
                         b => b.Value,
                         _ => default,
-                        _ => parameterSyntaxKind,
+                        _ => s_parameterSyntaxKind,
                         cancellationToken);
                 }
                 else if (token.Parent.IsParentKind(SyntaxKind.DeclarationPattern))
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         token, semanticModel,
                         b => b.Type,
                         _ => default,
-                        _ => parameterSyntaxKind,
+                        _ => s_parameterSyntaxKind,
                         cancellationToken);
                 }
 


### PR DESCRIPTION
### Customer scenario

The pattern matching syntax is used with an explicit type name, but code completion does not assist the user in typing the name of the new variable.

### Bugs this fixes

Fixes #23497

### Workarounds, if any

Type the variable name.

### Risk

Low. The new code has many tests and only applies to pattern matching cases.

### Performance impact

Negligible. The algorithm used for pattern matching syntax is the same as the one used for other declaration locations.

### Is this a regression from a previous update?

No.

### Root cause analysis

Lack of testing for this case of declaring variables. Tests are now in place.

### How was the bug found?

Reported by external user.

### Test documentation updated?

No.