### PR TITLE
Accept PE Operator Symbols having in parameters

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1947,6 +1947,68 @@ class Program
 
         [Fact]
         [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
+        public void OperatorsWithInParametersFromMetadata_Binary_Right()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(Test a, in Test b)
+    {
+        return a.Value + b.Value;
+    }
+}");
+
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new Test { Value = 3 };
+        var b = new Test { Value = 6 };
+
+        System.Console.WriteLine(a + b);
+    }
+}";
+
+            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "9");
+            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "9");
+        }
+
+        [Fact]
+        [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
+        public void OperatorsWithInParametersFromMetadata_Binary_Left()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(in Test a, Test b)
+    {
+        return a.Value + b.Value;
+    }
+}");
+
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new Test { Value = 3 };
+        var b = new Test { Value = 6 };
+
+        System.Console.WriteLine(a + b);
+    }
+}";
+
+            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "9");
+            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "9");
+        }
+
+        [Fact]
+        [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
         public void OperatorsWithInParametersFromMetadata_Unary()
         {
             var reference = CreateStandardCompilation(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -1917,6 +1912,97 @@ struct S1
   IL_0028:  call       ""void System.Console.Write(object)""
   IL_002d:  ret
 }");
+        }
+
+        [Fact]
+        [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
+        public void OperatorsWithInParametersFromMetadata_Binary()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(in Test a, in Test b)
+    {
+        return a.Value + b.Value;
+    }
+}");
+
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new Test { Value = 3 };
+        var b = new Test { Value = 6 };
+
+        System.Console.WriteLine(a + b);
+    }
+}";
+
+            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "9");
+            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "9");
+        }
+
+        [Fact]
+        [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
+        public void OperatorsWithInParametersFromMetadata_Unary()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test
+{
+    public bool Value { get; set; }
+
+    public static bool operator !(in Test a)
+    {
+        return !a.Value;
+    }
+}");
+
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new Test { Value = true };
+
+        System.Console.WriteLine(!a);
+    }
+}";
+
+            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "False");
+            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "False");
+        }
+
+        [Fact]
+        [WorkItem(530136, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=530136")]
+        public void OperatorsWithInParametersFromMetadata_Conversion()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test
+{
+    public bool Value { get; set; }
+
+    public static explicit operator int(in Test a)
+    {
+        return a.Value ? 3 : 5;
+    }
+}");
+
+            var code = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new Test { Value = true };
+
+        System.Console.WriteLine((int)a);
+    }
+}";
+
+            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "3");
+            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "3");
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
@@ -702,6 +702,184 @@ BC30657: 'EndInvoke' has a return type that is not supported or parameter types 
         End Sub
 
         <Fact>
+        Public Sub InOperatorsAreNotSupported_Binary()
+            Dim reference = CreateCSharpCompilation("
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(in Test a, in Test b)
+    {
+        return a.Value + b.Value;
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Program
+    Shared Sub Main() 
+        Dim a = New Test With { .Value = 3 }
+        Dim b = New Test With { .Value = 6 }
+        
+        System.Console.WriteLine(a + b)
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30452: Operator '+' is not defined for types 'Test' and 'Test'.
+        System.Console.WriteLine(a + b)
+                                 ~~~~~
+                                                </expected>)
+        End Sub
+
+        <Fact>
+        Public Sub InOperatorsAreNotSupported_Binary_Left()
+            Dim reference = CreateCSharpCompilation("
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(in Test a, Test b)
+    {
+        return a.Value + b.Value;
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Program
+    Shared Sub Main() 
+        Dim a = New Test With { .Value = 3 }
+        Dim b = New Test With { .Value = 6 }
+        
+        System.Console.WriteLine(a + b)
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30452: Operator '+' is not defined for types 'Test' and 'Test'.
+        System.Console.WriteLine(a + b)
+                                 ~~~~~
+                                                </expected>)
+        End Sub
+
+        <Fact>
+        Public Sub InOperatorsAreNotSupported_Binary_Right()
+            Dim reference = CreateCSharpCompilation("
+public class Test
+{
+    public int Value { get; set; }
+
+    public static int operator +(Test a, in Test b)
+    {
+        return a.Value + b.Value;
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Program
+    Shared Sub Main() 
+        Dim a = New Test With { .Value = 3 }
+        Dim b = New Test With { .Value = 6 }
+        
+        System.Console.WriteLine(a + b)
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30452: Operator '+' is not defined for types 'Test' and 'Test'.
+        System.Console.WriteLine(a + b)
+                                 ~~~~~
+                                                </expected>)
+        End Sub
+
+        <Fact>
+        Public Sub InOperatorsAreNotSupported_Unary()
+            Dim reference = CreateCSharpCompilation("
+public class Test
+{
+    public bool Value { get; set; }
+
+    public static bool operator !(in Test a)
+    {
+        return !a.Value;
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Program
+    Shared Sub Main() 
+        Dim a = New Test With { .Value = True }
+        
+        System.Console.WriteLine(Not a)
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30487: Operator 'Not' is not defined for type 'Test'.
+        System.Console.WriteLine(Not a)
+                                 ~~~~~
+                                                </expected>)
+        End Sub
+
+        <Fact>
+        Public Sub InOperatorsAreNotSupported_Conversion()
+            Dim reference = CreateCSharpCompilation("
+public class Test
+{
+    public bool Value { get; set; }
+
+    public static explicit operator int(in Test a)
+    {
+        return a.Value ? 3 : 5;
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Program
+    Shared Sub Main() 
+        Dim a = New Test With { .Value = True }
+        
+        System.Console.WriteLine(CType(a, Integer))
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30311: Value of type 'Test' cannot be converted to 'Integer'.
+        System.Console.WriteLine(CType(a, Integer))
+                                       ~
+                                                </expected>)
+        End Sub
+
+        <Fact>
         Public Sub OverloadResolutionShouldBeAbleToPickOverloadsWithNoModreqsOverOnesWithModreq_Methods_Parameters()
             Dim reference = CreateCSharpCompilation("
 public class TestRef


### PR DESCRIPTION
## Customer scenario

```csharp
// ref.dll
public class Test
 {
     public int Value { get; set; }
 
     public static int operator +(in Test a, in Test b)
     {
         return a.Value + b.Value;
     }
 }
 ```
```csharp
// main.exe
 class Program
 {
     static void Main(string[] args)
     {
         var a = new Test { Value = 3 };
         var b = new Test { Value = 6 };
 
         System.Console.WriteLine(a + b);
     }
 }
```

**Expected**: prints 9
**Actual**: CS0019: Operator '+' cannot be applied to operands of type 'Test' and 'Test'

## Bugs this fixes

Fixes devdiv bug 530136 ([feedback link](https://developercommunity.visualstudio.com/content/problem/156730/c-in-modifier-in-parameters-of-an-operator-method.html))

## Workarounds, if any

None needed

## Risk

Low.

## Performance impact

None.

## Is this a regression from a previous update?

No.

## Root cause analysis

 It was an implementation detail in how C# compiler imports symbols from other binaries. Now fixed.
The compiler would ignore operators that have parameters with any ref kind.

## How was the bug found?

Customer report.

## Test documentation updated?

No.