### PR TITLE
Fixed formatting for 'Use pattern matching code fix'

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -729,6 +729,62 @@ public static class C
 }");
         }
 
+        [WorkItem(23504, "https://github.com/dotnet/roslyn/issues/23504")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task DoNotChangeOriginalFormatting1()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        object obj = ""test"";
+
+        [|var|] str = obj as string;
+        var title = str != null
+            ? str
+            : "";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        object obj = ""test"";
+
+        var title = obj is string str
+            ? str
+            : "";
+    }
+}");
+        }
+
+        [WorkItem(23504, "https://github.com/dotnet/roslyn/issues/23504")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task DoNotChangeOriginalFormatting2()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        object obj = ""test"";
+
+        [|var|] str = obj as string;
+        var title = str != null ? str : "";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        object obj = ""test"";
+
+        var title = obj is string str ? str : "";
+    }
+}");
+        }
+
         [WorkItem(21172, "https://github.com/dotnet/roslyn/issues/21172")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         public async Task TestMissingWithDynamic()

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -76,12 +76,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             var targetStatement = (StatementSyntax)targetStatementLocation.FindNode(cancellationToken);
             var conditionPart = (BinaryExpressionSyntax)conditionLocation.FindNode(cancellationToken);
             var asExpression = (BinaryExpressionSyntax)asExpressionLocation.FindNode(cancellationToken);
+            var newIdentifier = localDeclaration.Declaration.Variables[0].Identifier
+                .WithoutTrivia().WithTrailingTrivia(conditionPart.Right.GetTrailingTrivia());
 
             var updatedConditionPart = SyntaxFactory.IsPatternExpression(
                 asExpression.Left, SyntaxFactory.DeclarationPattern(
                     ((TypeSyntax)asExpression.Right).WithoutTrivia(),
-                    SyntaxFactory.SingleVariableDesignation(
-                        localDeclaration.Declaration.Variables[0].Identifier.WithoutTrivia())));
+                    SyntaxFactory.SingleVariableDesignation(newIdentifier)));
 
             var currentCondition = GetCondition(targetStatement);
             var updatedCondition = currentCondition.ReplaceNode(conditionPart, updatedConditionPart);


### PR DESCRIPTION
Fixes #23504

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
