### PR TITLE
Reduce allocations in DeclarationTable.RootNamespaceLocationComparer.Compare

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2990,6 +2990,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return loc1.SourceSpan.Start - loc2.SourceSpan.Start;
         }
 
+        internal override int CompareSourceLocations(SyntaxReference loc1, SyntaxReference loc2)
+        {
+            var comparison = CompareSyntaxTreeOrdering(loc1.SyntaxTree, loc2.SyntaxTree);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            return loc1.Span.Start - loc2.Span.Start;
+        }
+
         /// <summary>
         /// Return true if there is a source declaration symbol name that meets given predicate.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.cs
@@ -148,9 +148,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _compilation = compilation;
             }
 
+            [PerformanceSensitive(
+                "https://github.com/dotnet/roslyn/issues/23582",
+                Constraint = "Avoid " + nameof(SingleNamespaceOrTypeDeclaration.Location) + " since it has a costly allocation on this fast path.")]
             public int Compare(SingleNamespaceDeclaration x, SingleNamespaceDeclaration y)
             {
-                return _compilation.CompareSourceLocations(x.Location, y.Location);
+                return _compilation.CompareSourceLocations(x.SyntaxReference, y.SyntaxReference);
             }
         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2824,6 +2824,12 @@ namespace Microsoft.CodeAnalysis
         internal abstract int CompareSourceLocations(Location loc1, Location loc2);
 
         /// <summary>
+        /// Compare two source locations, using their containing trees, and then by Span.First within a tree.
+        /// Can be used to get a total ordering on declarations, for example.
+        /// </summary>
+        internal abstract int CompareSourceLocations(SyntaxReference loc1, SyntaxReference loc2);
+
+        /// <summary>
         /// Return the lexically first of two locations.
         /// </summary>
         internal TLocation FirstSourceLocation<TLocation>(TLocation first, TLocation second)

--- a/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// Indicates that a code element is performance sensitive under a known scenario.
+    /// </summary>
+    /// <remarks>
+    /// <para>When applying this attribute, only explicitly set the values for properties specifically indicated by the
+    /// test/measurement technique described in the associated <see cref="Uri"/>.</para>
+    /// </remarks>
+    [Conditional("EMIT_CODE_ANALYSIS_ATTRIBUTES")]
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    internal sealed class PerformanceSensitiveAttribute : Attribute
+    {
+        public PerformanceSensitiveAttribute(string uri)
+        {
+            Uri = uri;
+        }
+
+        /// <summary>
+        /// Gets the location where the original problem is documented, likely with steps to reproduce the issue and/or
+        /// validate performance related to a change in the method.
+        /// </summary>
+        public string Uri
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets or sets a description of the constraint imposed by the original performance issue.
+        /// </summary>
+        /// <remarks>
+        /// <para>Constraints are normally specified by other specific properties that allow automated validation of the
+        /// constraint. This property supports documenting constraints which cannot be described in terms of other
+        /// constraint properties.</para>
+        /// </remarks>
+        public string Constraint
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether captures are allowed.
+        /// </summary>
+        public bool AllowCaptures
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enumeration of a generic <see cref="IEnumerable{T}"/> is allowed.
+        /// </summary>
+        public bool AllowGenericEnumeration
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the asynchronous state machine typically completes synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>When <see langword="true"/>, validation of this performance constraint typically involves analyzing
+        /// the method to ensure synchronous completion of the state machine does not require the allocation of a
+        /// <see cref="Task"/>, either through caching the result or by using ValueTask.</para>
+        /// </remarks>
+        public bool OftenCompletesSynchronously
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this is an entry point to a parallel algorithm.
+        /// </summary>
+        /// <remarks>
+        /// <para>Parallelization APIs and algorithms, e.g. <c>Parallel.ForEach</c>, may be efficient for parallel entry
+        /// points (few direct calls but large amounts of iterative work), but are problematic when called inside the
+        /// iterations themselves. Performance-sensitive code should avoid the use of heavy parallization APIs except
+        /// for known entry points to the parallel portion of code.</para>
+        /// </remarks>
+        public bool IsParallelEntry
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1154,6 +1154,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return LexicalSortKey.Compare(first, second, Me)
         End Function
 
+        ''' <summary>
+        ''' Compare two source locations, using their containing trees, and then by Span.First within a tree. 
+        ''' Can be used to get a total ordering on declarations, for example.
+        ''' </summary>
+        Friend Overrides Function CompareSourceLocations(first As SyntaxReference, second As SyntaxReference) As Integer
+            Return LexicalSortKey.Compare(first, second, Me)
+        End Function
+
         Friend Overrides Function GetSyntaxTreeOrdinal(tree As SyntaxTree) As Integer
             Debug.Assert(Me.ContainsSyntaxTree(tree))
             Return _syntaxTreeOrdinalMap(tree)

--- a/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.vb
+++ b/src/Compilers/VisualBasic/Portable/Declarations/DeclarationTable.vb
@@ -183,8 +183,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 _compilation = compilation
             End Sub
 
+            <PerformanceSensitive(
+                "https://github.com/dotnet/roslyn/issues/23582",
+                Constraint:="Avoid " + NameOf(SingleNamespaceOrTypeDeclaration.Location) + " since it probably also has a costly allocation on this fast path (VB equivalent of issue found in C# code).")>
             Public Function Compare(x As SingleNamespaceDeclaration, y As SingleNamespaceDeclaration) As Integer Implements IComparer(Of SingleNamespaceDeclaration).Compare
-                Return _compilation.CompareSourceLocations(x.Location, y.Location)
+                Return _compilation.CompareSourceLocations(x.SyntaxReference, y.SyntaxReference)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/LexicalSortKey.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/LexicalSortKey.vb
@@ -192,6 +192,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return LexicalSortKey.Compare(firstKey, secondKey)
         End Function
 
+        Public Shared Function Compare(first As SyntaxReference, second As SyntaxReference, compilation As VisualBasicCompilation) As Integer
+            ' This is a shortcut to avoid building complete keys for the case when both locations belong to the same tree.
+            ' Also saves us in some speculative SemanticModel scenarios when the tree we are dealing with doesn't belong to
+            ' the compilation and an attempt of building the LexicalSortKey will simply assert and crash.
+            If first.SyntaxTree IsNot Nothing AndAlso first.SyntaxTree Is second.SyntaxTree Then
+                Return first.Span.Start - second.Span.Start
+            End If
+
+            Dim firstKey = New LexicalSortKey(first, compilation)
+            Dim secondKey = New LexicalSortKey(second, compilation)
+            Return LexicalSortKey.Compare(firstKey, secondKey)
+        End Function
+
         Public Shared Function First(xSortKey As LexicalSortKey, ySortKey As LexicalSortKey) As LexicalSortKey
             Dim comparison As Integer = Compare(xSortKey, ySortKey)
             Return If(comparison > 0, ySortKey, xSortKey)

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -118,6 +118,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\OneOrMany.cs">
       <Link>InternalUtilities\OneOrMany.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs">
+      <Link>InternalUtilities\PerformanceSensitiveAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs">
       <Link>InternalUtilities\PlatformInformation.cs</Link>
     </Compile>


### PR DESCRIPTION
### Customer scenario

Running analyzer during a build is slower than it should be, with the analyzer driver contributing substantial overhead even when the analyzers themselves are lightweight.

### Bugs this fixes

Fixes #23464

### Workarounds, if any

None needed

### Risk

This poses a small maintainability risk by duplicating an existing algorithm into a new form for the sole benefit of reducing allocations. The risk is mitigated by a comment explaining the new constraint, and justified by AnalyzerRunner indicating the code lies on a particularly hot path.

### Performance impact

2% reduction in allocations for running IDE analyzers.

### Is this a regression from a previous update?

No.

### Root cause analysis

AnalyzerRunner is a new tool for helping us test analyzer performance in isolation.

### How was the bug found?

AnalyzerRunner.

### Test documentation updated?

No.

