### PR TITLE
Fix flaky compiler server test

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -109,14 +109,18 @@ End Module")
 #endif
         }
 
+        private static readonly object s_createFilesLock = new object();
         private static void CreateFiles(TempDirectory currentDirectory, IEnumerable<KeyValuePair<string, string>> files)
         {
             if (files != null)
             {
-                foreach (var pair in files)
+                lock (s_createFilesLock)
                 {
-                    TempFile file = currentDirectory.CreateFile(pair.Key);
-                    file.WriteAllText(pair.Value);
+                    foreach (var pair in files)
+                    {
+                        TempFile file = currentDirectory.CreateFile(pair.Key);
+                        file.WriteAllText(pair.Value);
+                    }
                 }
             }
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -109,18 +109,14 @@ End Module")
 #endif
         }
 
-        private static readonly object s_createFilesLock = new object();
         private static void CreateFiles(TempDirectory currentDirectory, IEnumerable<KeyValuePair<string, string>> files)
         {
             if (files != null)
             {
-                lock (s_createFilesLock)
+                foreach (var pair in files)
                 {
-                    foreach (var pair in files)
-                    {
-                        TempFile file = currentDirectory.CreateFile(pair.Key);
-                        file.WriteAllText(pair.Value);
-                    }
+                    TempFile file = currentDirectory.CreateFile(pair.Key);
+                    file.WriteAllText(pair.Value);
                 }
             }
         }

--- a/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
+++ b/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         private readonly ConcurrentBag<IDisposable> _temps = new ConcurrentBag<IDisposable>();
         public static readonly string Root;
+        private bool _disposed;
 
         static TempRoot()
         {
@@ -20,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public void Dispose()
         {
+            _disposed = true;
             while (_temps.TryTake(out var temp))
             {
                 try
@@ -36,8 +38,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+        private void CheckDisposed()
+        {
+            if (this._disposed)
+            {
+                throw new ObjectDisposedException(nameof(TempRoot));
+            }
+        }
+
         public TempDirectory CreateDirectory()
         {
+            CheckDisposed();
             var dir = new DisposableDirectory(this);
             _temps.Add(dir);
             return dir;
@@ -45,11 +56,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public TempFile CreateFile(string prefix = null, string extension = null, string directory = null, [CallerFilePath]string callerSourcePath = null, [CallerLineNumber]int callerLineNumber = 0)
         {
+            CheckDisposed();
             return AddFile(new DisposableFile(prefix, extension, directory, callerSourcePath, callerLineNumber));
         }
 
         public DisposableFile AddFile(DisposableFile file)
         {
+            CheckDisposed();
             _temps.Add(file);
             return file;
         }

--- a/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
+++ b/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 {
     public sealed class TempRoot : IDisposable
     {
-        private readonly List<IDisposable> _temps = new List<IDisposable>();
+        private readonly ConcurrentBag<IDisposable> _temps = new ConcurrentBag<IDisposable>();
         public static readonly string Root;
 
         static TempRoot()
@@ -20,16 +20,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public void Dispose()
         {
-            if (_temps != null)
-            {
-                DisposeAll(_temps);
-                _temps.Clear();
-            }
-        }
-
-        private static void DisposeAll(IEnumerable<IDisposable> temps)
-        {
-            foreach (var temp in temps)
+            while (_temps.TryTake(out var temp))
             {
                 try
                 {


### PR DESCRIPTION
`MultipleSimultaneousCompiles` calls `RunCommandLineCompiler` on multiple
threads (using `Task.Run`), which in turn calls `CreateFiles` on multiple
threads, which in turn goes through `TempDirectory` and `TempRoot` and
eventually boils down to calling `List<T>.Add()`, which is not
thread-safe, and so occasionally crashes.

Solution: hit the problem with a hammer by throwing a lock around CreateFiles.

Fixes https://github.com/dotnet/roslyn/issues/22913