### PR TITLE
Quick fix for signing failures

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -140,8 +140,9 @@
             <PublicKey>$(RoslynInternalKey)</PublicKey>
             <PublicKeyToken>fc793a00266884fb</PublicKeyToken>
           </PropertyGroup>
-          <!-- Real-signing is only supported cross-platform in the boostrap toolset -->
-          <PropertyGroup Condition="'$(OS)' != 'Windows_NT' AND '$(BootstrapBuildPath)' == ''">
+          <!-- Real-signing cross-platform currently has a blocking bug:
+               https://github.com/dotnet/roslyn/issues/23521 -->
+          <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
               <PublicSign>true</PublicSign>
           </PropertyGroup>
         </Otherwise>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5826,7 +5826,7 @@ public class C
             Assert.Equal(1, peHeaders.PEHeader.MinorSubsystemVersion);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/23529")]
         public void CreateCompilationWithKeyFile()
         {
             string source = @"

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -284,12 +284,10 @@ namespace Microsoft.CodeAnalysis
 
         internal StrongNameProvider GetStrongNameProvider(StrongNameFileSystem fileSystem)
         {
-            bool fallback = 
-                ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
-                CompilationOptionsCore.CryptoKeyContainer != null;
-            return fallback ?
-                (StrongNameProvider)new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem) :
-                (StrongNameProvider)new PortableStrongNameProvider(KeyFileSearchPaths, fileSystem);
+            // https://github.com/dotnet/roslyn/issues/23521
+            // Disable the portable strong name provider until we can find and fix the
+            // root cause of the bug
+            return new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem);
         }
 
         internal CommandLineArguments()

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -107,7 +107,7 @@ End Module
             Assert.Equal("", output.ToString().Trim())
         End Sub
 
-        <Fact>
+        <Fact(Skip = "https://github.com/dotnet/roslyn/pull/23529")>
         Public Sub CreateCompilationWithKeyFile()
             Dim source = "
 Public Class C

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -107,7 +107,7 @@ End Module
             Assert.Equal("", output.ToString().Trim())
         End Sub
 
-        <Fact(Skip = "https://github.com/dotnet/roslyn/pull/23529")>
+        <Fact(Skip:= "https://github.com/dotnet/roslyn/pull/23529")>
         Public Sub CreateCompilationWithKeyFile()
             Dim source = "
 Public Class C


### PR DESCRIPTION
Reverts the change to use the PortableStrongNameProvider and
switches us back to using the COM-based signing provider.