### PR TITLE
Relax ordering constraints around 'ref' and 'partial' modifiers

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8341,15 +8341,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;partial&apos; modifier can only appear immediately before &apos;class&apos;, &apos;struct&apos;, &apos;interface&apos;, or &apos;void&apos;.
-        /// </summary>
-        internal static string ERR_PartialMisplaced {
-            get {
-                return ResourceManager.GetString("ERR_PartialMisplaced", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Partial declarations of &apos;{0}&apos; have conflicting accessibility modifiers.
         /// </summary>
         internal static string ERR_PartialModifierConflict {
@@ -11740,6 +11731,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureRefLocalsReturns {
             get {
                 return ResourceManager.GetString("IDS_FeatureRefLocalsReturns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ref and partial modifier ordering.
+        /// </summary>
+        internal static string IDS_FeatureRefPartialModOrdering {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefPartialModOrdering", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1089,9 +1089,6 @@
   <data name="ERR_NoImplicitConvCast" xml:space="preserve">
     <value>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</value>
   </data>
-  <data name="ERR_PartialMisplaced" xml:space="preserve">
-    <value>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</value>
-  </data>
   <data name="ERR_ImportedCircularBase" xml:space="preserve">
     <value>Imported type '{0}' is invalid. It contains a circular base class dependency.</value>
   </data>
@@ -5932,5 +5929,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_InternalError" xml:space="preserve">
     <value>Internal error in the C# compiler.</value>
+  </data>
+  <data name="IDS_FeatureRefPartialModOrdering" xml:space="preserve">
+    <value>ref and partial modifier ordering</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_PartialWrongTypeParams = 264,
         ERR_PartialWrongConstraints = 265,
         ERR_NoImplicitConvCast = 266, // Requires SymbolDistinguisher.
-        ERR_PartialMisplaced = 267,
+        // ERR_PartialMisplaced = 267, // We now give BadMemberFlag since the order is relaxed
         ERR_ImportedCircularBase = 268,
         ERR_UseDefViolationOut = 269,
         ERR_ArraySizeInDeclaration = 270,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -181,6 +181,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_OverrideWithConstraints = MessageBase + 12761,
         IDS_FeatureNestedStackalloc = MessageBase + 12762,
         IDS_FeatureSwitchExpression = MessageBase + 12763,
+
+        IDS_FeatureRefPartialModOrdering = MessageBase + 12764,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -324,6 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureExpressionVariablesInQueriesAndInitializers: // semantic check
                 case MessageID.IDS_FeatureExtensibleFixedStatement:  // semantic check
                 case MessageID.IDS_FeatureIndexingMovableFixedBuffers: //semantic check
+                case MessageID.IDS_FeatureRefPartialModOrdering:
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -290,6 +290,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                case MessageID.IDS_FeatureRefPartialModOrdering:
+                    return LanguageVersion.Preview;
+
                 // C# 8.0 features.
                 case MessageID.IDS_FeatureAltInterpolatedVerbatimStrings:
                 case MessageID.IDS_FeatureCoalesceAssignmentExpression:
@@ -326,7 +329,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureExpressionVariablesInQueriesAndInitializers: // semantic check
                 case MessageID.IDS_FeatureExtensibleFixedStatement:  // semantic check
                 case MessageID.IDS_FeatureIndexingMovableFixedBuffers: //semantic check
-                case MessageID.IDS_FeatureRefPartialModOrdering:
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1031,10 +1031,12 @@ tryAgain:
 
                             modTok = CheckFeatureAvailability(modTok,
                                 flags == ScanPartialFlags.PartialType
-                                    ? IsTypeDeclarationStart(this.CurrentToken.Kind) // pre-7.3 requirement.
+                                    ? IsTypeDeclarationStart(this.CurrentToken.Kind) // pre-8.0 requirement.
                                         ? MessageID.IDS_FeaturePartialTypes
                                         : MessageID.IDS_FeatureRefPartialModOrdering
-                                    : MessageID.IDS_FeaturePartialMethod);
+                                    : this.CurrentToken.Kind == SyntaxKind.VoidKeyword // pre-8.0 requirement.
+                                        ? MessageID.IDS_FeaturePartialMethod
+                                        : MessageID.IDS_FeatureRefPartialModOrdering);
 
                             break;
                         }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1108,7 +1108,7 @@ tryAgain:
         // For instance, we return true for both of these:
         //
         //    partial partial<T>()
-        //    partial partail<T> partial()
+        //    partial partial<T> partial()
         //
         // While, in fact, 'partial' is only a modifier on the second method.
         private bool IsPossibleModifier()
@@ -1133,11 +1133,11 @@ tryAgain:
         private enum ScanRefStructFlags
         {
             /// <summary>
-            /// Definitly a ref struct.
+            /// Definitely a ref struct.
             /// </summary>
             RefStruct,
             /// <summary>
-            /// Definitly a ref struct (C# 8.0)
+            /// Definitely a ref struct (C# 8.0)
             /// </summary>
             RefStructV8,
             /// <summary>
@@ -1177,19 +1177,19 @@ tryAgain:
         private enum ScanPartialFlags
         {
             /// <summary>
-            /// Definitly a partial type.
+            /// Definitely a partial type.
             /// </summary>
             PartialType,
             /// <summary>
-            /// Definitly a partial type (C# 8.0)
+            /// Definitely a partial type (C# 8.0)
             /// </summary>
             PartialTypeV8,
             /// <summary>
-            /// Definitly a partial member.
+            /// Definitely a partial member.
             /// </summary>
             PartialMember,
             /// <summary>
-            /// Definitly a partial member (C# 8.0)
+            /// Definitely a partial member (C# 8.0)
             /// </summary>
             PartialMemberV8,
             /// <summary>

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1207,12 +1207,13 @@ tryAgain:
             var point = this.GetResetPoint();
             try
             {
-                SyntaxToken firstMod = EatToken();
-                SyntaxToken lastMod = firstMod;
+                SyntaxToken lastMod = EatToken();
+                bool anyAdditionalModifiers = false;
                 // Skip over additional modifiers
                 while (IsPossibleModifier())
                 {
                     lastMod = EatToken();
+                    anyAdditionalModifiers = true;
                 }
 
                 switch (this.CurrentToken.Kind)
@@ -1235,9 +1236,9 @@ tryAgain:
                 if (this.ScanType() != ScanTypeFlags.NotType)
                 {
                     // If the last additional modifier was a contextual keyword, it could actually
-                    // be the return type of a generic method, in which case we have scanned for
-                    // the member name above, and therefore IsPossiblePartialMemberStart returns false.
-                    if (IsPossiblePartialMemberStart() || ((object)firstMod != (object)lastMod && IsContextualModifier(lastMod)))
+                    // be the return type of the member, in which case we have scanned for the member
+                    // name above, and therefore IsPossiblePartialMemberStart returns false.
+                    if (IsPossiblePartialMemberStart() || (anyAdditionalModifiers && IsContextualModifier(lastMod)))
                     {
                         return lastMod.ContextualKind == SyntaxKind.PartialKeyword
                             ? ScanPartialFlags.PartialMemberV8

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1160,7 +1160,8 @@ tryAgain:
                 {
                     SyntaxToken prevToken;
                     return currentToken.Kind == SyntaxKind.StructKeyword
-                        ? (prevToken = this.PeekToken(peekIndex - 1)).Kind == SyntaxKind.RefKeyword || prevToken.ContextualKind == SyntaxKind.PartialKeyword
+                        ? (prevToken = this.PeekToken(peekIndex - 1)).Kind == SyntaxKind.RefKeyword ||
+                           (this.PeekToken(peekIndex - 2).Kind == SyntaxKind.RefKeyword && prevToken.ContextualKind == SyntaxKind.PartialKeyword)
                             ? ScanRefStructFlags.RefStructV8
                             : ScanRefStructFlags.RefStruct
                         : IsPossibleStartOfTypeDeclaration(currentToken.Kind) || (forAccessors && this.IsPossibleAccessorModifier())
@@ -1210,10 +1211,14 @@ tryAgain:
                 SyntaxToken lastMod = EatToken();
                 bool anyAdditionalModifiers = false;
                 // Skip over additional modifiers
-                while (IsPossibleModifier())
+                if (IsPossibleModifier())
                 {
-                    lastMod = EatToken();
                     anyAdditionalModifiers = true;
+                    do
+                    {
+                        lastMod = EatToken();
+                    }
+                    while (IsPossibleModifier());
                 }
 
                 switch (this.CurrentToken.Kind)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Typ {0} nejde implicitně převést na typ {1}. Existuje explicitní převod. (Nechybí výraz přetypování?)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Modifikátor partial se smí objevit jenom bezprostředně před klíčovým slovem class, struct, interface nebo void.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Importovaný typ {0} je neplatný. Obsahuje cyklickou závislost základních tříd.</target>
@@ -9743,6 +9738,11 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">{0} nemůže implementovat člen rozhraní {1} v typu {2}, protože funkce {3} není v jazyce C# {4} k dispozici. Použijte prosím verzi jazyka {5} nebo vyšší.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Der Typ "{0}" kann nicht implizit in "{1}" konvertiert werden. Es ist bereits eine explizite Konvertierung vorhanden (möglicherweise fehlt eine Umwandlung).</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Der "partial"-Modifizierer kann nur unmittelbar vor "class", "struct", "interface" oder "void" verwendet werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Der importierte Typ "{0}" ist ungültig. Er enthält eine Basisklassen-Ringabhängigkeit.</target>
@@ -9743,6 +9738,11 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">"{0}" kann den Schnittstellenmember "{1}" im Typ "{2}" nicht implementieren, weil das Feature "{3}" in C# {4} nicht verfügbar ist. Verwenden Sie Sprachversion {5} oder höher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">No se puede convertir implícitamente el tipo '{0}' en '{1}'. Ya existe una conversión explícita (compruebe si le falta una conversión)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">El modificador 'partial' solo puede aparecer inmediatamente antes de 'class', 'struct', 'interface' o 'void'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">El tipo importado '{0}' no es válido. Contiene una dependencia de clase base circular.</target>
@@ -9743,6 +9738,11 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">"{0}" no puede implementar el miembro de interfaz "{1}" en el tipo "{2}" porque la característica "{3}" no está disponible en C# {4}. Use la versión de idioma "{5}" o una posterior.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Impossible de convertir implicitement le type '{0}' en '{1}'. Une conversion explicite existe (un cast est-il manquant ?)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Le modificateur 'partial' ne peut apparaître qu'immédiatement avant 'class', 'struct', 'interface' ou 'void'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Le type importé '{0}' n'est pas valide. Il contient une dépendance de classe de base circulaire.</target>
@@ -9743,6 +9738,11 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">'{0}' ne peut pas implémenter le membre d'interface '{1}' dans le type '{2}', car la fonctionnalité '{3}' n'est pas disponible en C# {4}. Utilisez la version de langage '{5}' ou une version ultérieure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Non è possibile convertire in modo implicito il tipo '{0}' in '{1}'. È presente una conversione esplicita. Probabilmente manca un cast.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Il modificatore 'partial' può trovarsi solo immediatamente prima di 'class', 'struct', 'interface' o 'void'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Il tipo importato '{0}' non è valido perché contiene una dipendenza circolare della classe base.</target>
@@ -9743,6 +9738,11 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">'{0}' non può implementare il membro di interfaccia '{1}' nel tipo '{2}' perché la funzionalità '{3}' non è disponibile in C# {4}. Usare la versione '{5}' o versioni successive del linguaggio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">型 '{0}' を '{1}' に暗黙的に変換できません。明示的な変換が存在します (cast が不足していないかどうかを確認してください)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">partial' 識別子は、'class'、'struct'、'interface'、または 'void' の直前にのみ指定できます</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">インポートされた型 '{0}' は無効です。この型には循環する基底クラスの依存関係が含まれています。</target>
@@ -9743,6 +9738,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">機能 '{3}' は C# {4} では使用できないため、'{0}' は型 '{2}' のインターフェイス メンバー '{1}' を実装できません。'{5}' 以上の言語バージョンをご使用ください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">암시적으로 '{0}' 형식을 '{1}' 형식으로 변환할 수 없습니다. 명시적 변환이 있습니다. 캐스트가 있는지 확인하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">partial' 한정자는 'class', 'struct', 'interface' 또는 'void' 바로 앞에만 올 수 있습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">가져온 '{0}' 형식이 잘못되었습니다. 이 형식에는 기본 클래스 순환 종속성이 포함되어 있습니다.</target>
@@ -9743,6 +9738,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">'{3}' 기능을 C# {4}에서 사용할 수 없으므로 '{0}'이(가) '{2}' 형식의 인터페이스 멤버 '{1}'을(를) 구현할 수 없습니다. 언어 버전 '{5}' 이상을 사용하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Nie można niejawnie przekonwertować typu „{0}” na „{1}”. Istnieje konwersja jawna (czy nie brakuje rzutu?).</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Modyfikator „partial” może się pojawić tylko bezpośrednio przed typem „class”, „struct”, „interface” lub „void”</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Importowany typ „{0}” jest nieprawidłowy. Zawiera on cykliczną zależność klasy bazowej.</target>
@@ -9743,6 +9738,11 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">Element „{0}” nie może implementować składowej interfejsu „{1}” w typie „{2}”, ponieważ funkcja „{3}” nie jest dostępna w języku C# {4}. Użyj wersji języka „{5}” lub nowszej.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Não é possível converter implicitamente tipo "{0}" em "{1}". Existe uma conversão explícita (há uma conversão ausente?)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">O modificador 'partial' só pode aparecer imediatamente antes de 'class', 'struct', 'interface' ou 'void'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Tipo importado "{0}" é inválido. Ele contém uma dependência de classe de base circular.</target>
@@ -9743,6 +9738,11 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">'{0}' não pode implementar o membro de interface '{1}' no tipo '{2}' porque o recurso '{3}' não está disponível no C# {4}. Use a versão de linguagem '{5}' ou superior.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">Не удается неявно преобразовать тип "{0}" в "{1}". Существует явное преобразование (возможно, пропущено приведение типов).</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">Модификатор "partial" может использоваться только перед "class", "struct", "interface" или "void".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">Недопустимый импортированный тип "{0}". Он содержит циклическую зависимость базового класса.</target>
@@ -9743,6 +9738,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">"{0}" не может реализовать член интерфейса "{1}" в типе "{2}", так как функция "{3}" недоступна в C# {4}. Используйте версию языка "{5}" или более позднюю.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">{0}' türü örtülü olarak '{1}' türüne dönüştürülemez. Açık bir dönüştürme var (eksik atamanız mı var?)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">partial' değiştiricisi yalnızca 'class', 'struct', 'interface' veya 'void' sözcüklerinden hemen önce gelebilir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">İçeri aktarılan '{0}' türü geçersiz. Döngüsel temel sınıf bağımlılığı içeriyor.</target>
@@ -9743,6 +9738,11 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">'{3}' özelliği C# {4} sürümünde kullanılamadığından '{0}', '{2}' türündeki '{1}' arabirim üyesini uygulayamaz. Lütfen '{5}' veya daha yüksek bir dil sürümü kullanın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -884,6 +884,11 @@
         <target state="translated">ref foreach 迭代变量</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeatureRefReassignment">
         <source>ref reassignment</source>
         <target state="translated">ref 赋值</target>
@@ -3037,11 +3042,6 @@
       <trans-unit id="ERR_NoImplicitConvCast">
         <source>Cannot implicitly convert type '{0}' to '{1}'. An explicit conversion exists (are you missing a cast?)</source>
         <target state="translated">无法将类型“{0}”隐式转换为“{1}”。存在一个显式转换(是否缺少强制转换?)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">"partial" 修饰符的后面只能紧跟 "class"、"struct"、"interface" 或 "void"</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -3039,11 +3039,6 @@
         <target state="translated">無法將類型 '{0}' 隱含轉換成 '{1}'。已存在明確轉換 (是否漏了轉型?)</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_PartialMisplaced">
-        <source>The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'</source>
-        <target state="translated">partial' 修飾詞只可緊接在 'class'、'struct'、'interface' 或 'void' 之前。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_ImportedCircularBase">
         <source>Imported type '{0}' is invalid. It contains a circular base class dependency.</source>
         <target state="translated">匯入的類型 '{0}' 無效。其包含循環基底類別相依性。</target>
@@ -9743,6 +9738,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
       <trans-unit id="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember">
         <source>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version '{5}' or greater.</source>
         <target state="translated">因為功能 '{3}' 不適用於 C# {4}，所以 '{0}' 無法在類型 '{2}' 中實作介面成員 '{1}'。請使用語言 '{5}' 版或更新版本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureRefPartialModOrdering">
+        <source>ref and partial modifier ordering</source>
+        <target state="new">ref and partial modifier ordering</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -9436,7 +9436,7 @@ public partial interface I1
 }
 ";
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
-                                                 parseOptions: TestOptions.Regular,
+                                                 parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: TargetFramework.NetStandardLatest);
 
             compilation1.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -38736,6 +38736,12 @@ interface I19
                 // (62,20): error CS0106: The modifier 'virtual' is not valid for this item
                 //     virtual static I13() => throw null;
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "I13").WithArguments("virtual").WithLocation(62, 20),
+                // (66,13): error CS1585: Member modifier 'static' must precede the member type and name
+                //     partial static I14();
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "static").WithArguments("static").WithLocation(66, 13),
+                // (66,20): error CS0501: 'I14.I14()' must declare a body because it is not marked abstract, extern, or partial
+                //     partial static I14();
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "I14").WithArguments("I14.I14()").WithLocation(66, 20),
                 // (70,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 //     static partial I15();
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(70, 12),
@@ -38745,6 +38751,9 @@ interface I19
                 // (70,20): error CS0542: 'I15': member names cannot be the same as their enclosing type
                 //     static partial I15();
                 Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I15").WithArguments("I15").WithLocation(70, 20),
+                // (74,13): error CS1585: Member modifier 'static' must precede the member type and name
+                //     partial static I16() {}
+                Diagnostic(ErrorCode.ERR_BadModifierLocation, "static").WithArguments("static").WithLocation(74, 13),
                 // (78,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 //     static partial I17() => throw null;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(78, 12),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -9445,10 +9445,7 @@ public partial interface I1
                 Diagnostic(ErrorCode.ERR_PartialMethodToDelegate, "M1").WithArguments("I1.M1()").WithLocation(9, 27),
                 // (10,27): error CS0762: Cannot create delegate from method 'I1.M2()' because it is a partial method without an implementing declaration
                 //         new System.Action(M2).Invoke();
-                Diagnostic(ErrorCode.ERR_PartialMethodToDelegate, "M2").WithArguments("I1.M2()").WithLocation(10, 27),
-                // (13,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial static void M4();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(13, 5)
+                Diagnostic(ErrorCode.ERR_PartialMethodToDelegate, "M2").WithArguments("I1.M2()").WithLocation(10, 27)
                 );
         }
 
@@ -38739,12 +38736,6 @@ interface I19
                 // (62,20): error CS0106: The modifier 'virtual' is not valid for this item
                 //     virtual static I13() => throw null;
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "I13").WithArguments("virtual").WithLocation(62, 20),
-                // (66,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial static I14();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(66, 5),
-                // (66,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial static I14();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(66, 5),
                 // (70,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 //     static partial I15();
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(70, 12),
@@ -38754,12 +38745,6 @@ interface I19
                 // (70,20): error CS0542: 'I15': member names cannot be the same as their enclosing type
                 //     static partial I15();
                 Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "I15").WithArguments("I15").WithLocation(70, 20),
-                // (74,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial static I16() {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(74, 5),
-                // (74,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial static I16() {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(74, 5),
                 // (78,12): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 //     static partial I17() => throw null;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(78, 12),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -13599,15 +13599,15 @@ partial class C
 ";
             var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (4,5): error CS0106: The modifier 'partial' is not valid for this item
                 //     partial int f;
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
-                // (5,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "partial").WithArguments("partial").WithLocation(4, 5),
+                // (5,5): error CS0106: The modifier 'partial' is not valid for this item
                 //     partial object P { get { return null; } }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(5, 5),
-                // (6,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "partial").WithArguments("partial").WithLocation(5, 5),
+                // (6,5): error CS0106: The modifier 'partial' is not valid for this item
                 //     partial int this[int index]
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(6, 5),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "partial").WithArguments("partial").WithLocation(6, 5),
                 // (4,17): warning CS0169: The field 'C.f' is never used
                 //     partial int f;
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "f").WithArguments("C.f").WithLocation(4, 17));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public partial class CompilationErrorTests : CompilingTestBase
     {
+        private static CSharpCompilation CreateCompilation(string source, CSharpParseOptions parseOptions = null)
+            => CompilingTestBase.CreateCompilation(source, parseOptions: parseOptions ?? TestOptions.RegularPreview);
+
         [Fact]
         public void UserDefinedOperatorCollisionErrors()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/UserDefinedOperatorErrorTests.cs
@@ -190,12 +190,9 @@ partial class C
 
             var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (4,5): error CS0106: The modifier 'partial' is not valid for this item
                 //     partial public static int operator + (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial public static int operator + (C c1, C c2) { return 0; }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "partial").WithArguments("partial").WithLocation(4, 5),
                 // (5,34): error CS0106: The modifier 'abstract' is not valid for this item
                 //     abstract public int operator - (C c1, C c2) { return 0; }
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "-").WithArguments("abstract").WithLocation(5, 34),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1428,7 +1428,7 @@ class C
 {
     async partial int operator
 ");
-            Check(SyntaxKind.IncompleteMember);
+            Check(SyntaxKind.OperatorDeclaration);
 
             // ... 'async' <typename> <membername> ...
             UsingTree(@"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5716,29 +5716,14 @@ partial class PartialPartial
     }
 }
 ";
-            // These errors aren't great.  Ideally we can improve things in the future.
+
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,13): error CS1525: Invalid expression term 'partial'
+                // (5,13): error CS1004: Duplicate 'partial' modifier
                 //     partial partial void PM();
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(5, 13),
-                // (5,13): error CS1002: ; expected
-                //     partial partial void PM();
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(5, 13),
-                // (6,13): error CS1525: Invalid expression term 'partial'
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(5, 13),
+                // (6,13): error CS1004: Duplicate 'partial' modifier
                 //     partial partial void PM()
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(6, 13),
-                // (6,13): error CS1002: ; expected
-                //     partial partial void PM()
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(6, 13),
-                // (6,13): error CS0102: The type 'PartialPartial' already contains a definition for ''
-                //     partial partial void PM()
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("PartialPartial", "").WithLocation(6, 13),
-                // (5,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
-                //     partial partial void PM();
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(5, 5),
-                // (6,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
-                //     partial partial void PM()
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(6, 5));
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(6, 13));
         }
 
         [Fact]
@@ -5746,12 +5731,9 @@ partial class PartialPartial
         {
             var text = @"partial enum E{}";
             CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
-                // (1,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (1,14): error CS0106: The modifier 'partial' is not valid for this item
                 // partial enum E{}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(1, 1),
-                // (1,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial enum E{}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(1, 14));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(1, 14));
         }
 
         [WorkItem(539120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539120")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -607,10 +607,7 @@ public class Test
 }
 ";
 
-            CreateCompilation(test).VerifyDiagnostics(
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial public class C  // CS0267
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1));
+            CreateCompilation(test).VerifyDiagnostics();
         }
 
         [Fact]
@@ -621,12 +618,9 @@ partial enum E { }
 ";
 
             CreateCompilation(test).VerifyDiagnostics(
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (2,14): error CS0106: The modifier 'partial' is not valid for this item
                 // partial enum E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
-                // (2,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial enum E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 14));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(2, 14));
         }
 
         [Fact]
@@ -638,9 +632,6 @@ partial delegate E { }
 
             // Extra errors
             CreateCompilation(test).VerifyDiagnostics(
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial delegate E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
                 // (2,20): error CS1001: Identifier expected
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(2, 20),
@@ -659,9 +650,9 @@ partial delegate E { }
                 // (2,22): error CS1022: Type or namespace definition, or end-of-file expected
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(2, 22),
-                // (2,20): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (2,20): error CS0106: The modifier 'partial' is not valid for this item
                 // partial delegate E { }
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "").WithLocation(2, 20),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "").WithArguments("partial").WithLocation(2, 20),
                 // (2,18): error CS0246: The type or namespace name 'E' could not be found (are you missing a using directive or an assembly reference?)
                 // partial delegate E { }
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "E").WithArguments("E").WithLocation(2, 18));
@@ -674,14 +665,10 @@ partial delegate E { }
 partial delegate void E();
 ";
 
-            // Extra errors
             CreateCompilation(test).VerifyDiagnostics(
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (2,23): error CS0106: The modifier 'partial' is not valid for this item
                 // partial delegate void E();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
-                // (2,23): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial delegate void E();
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "E").WithLocation(2, 23));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(2, 23));
         }
 
         // TODO: Extra errors

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -607,7 +607,7 @@ public class Test
 }
 ";
 
-            CreateCompilation(test).VerifyDiagnostics();
+            CreateCompilation(test, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -29,42 +29,15 @@ class Program
     partial abstract struct S {}
 }");
             comp.VerifyDiagnostics(
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract class A {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5),
-                // (5,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract class A {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(5, 5),
-                // (7,13): error CS1525: Invalid expression term 'partial'
+                // (7,13): error CS1004: Duplicate 'partial' modifier
                 //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(7, 13),
-                // (7,13): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(7, 13),
+                // (8,13): error CS1004: Duplicate 'partial' modifier
                 //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(7, 13),
-                // (8,13): error CS1525: Invalid expression term 'partial'
-                //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(8, 13),
-                // (8,13): error CS1002: ; expected
-                //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(8, 13),
-                // (10,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract struct S {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(10, 5),
-                // (11,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                //     partial abstract struct S {}
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(11, 5),
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(8, 13),
                 // (10,29): error CS0106: The modifier 'abstract' is not valid for this item
                 //     partial abstract struct S {}
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("abstract").WithLocation(10, 29),
-                // (8,13): error CS0102: The type 'Program' already contains a definition for ''
-                //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("Program", "").WithLocation(8, 13),
-                // (8,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
-                //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(8, 5),
-                // (7,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
-                //     partial partial class B {}
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(7, 5));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "S").WithArguments("abstract").WithLocation(10, 29));
         }
 
         [WorkItem(540005, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540005")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
     public class ParserRegressionTests : CSharpTestBase
     {
+        private static CSharpCompilation CreateCompilation(string source, CSharpParseOptions parseOptions = null)
+            => ParsingTests.CreateCompilation(source, parseOptions: parseOptions ?? TestOptions.RegularPreview);
+
         [Fact]
         public void PartialLocationInModifierList()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -169,7 +169,7 @@ partial public struct S {}
             Assert.True(s1.IsPartial());
             Assert.True(s1.IsReadOnly);
             Assert.True(s1.IsRefLikeType);
-            Assert.Equal(s1.DeclaredAccessibility, Accessibility.Public);
+            Assert.Equal(Accessibility.Public, s1.DeclaredAccessibility);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ partial abstract class C {}
             var s1 = comp.GetTypeByMetadataName("C");
             Assert.True(s1.IsPartial());
             Assert.True(s1.IsAbstract);
-            Assert.Equal(s1.DeclaredAccessibility, Accessibility.Public);
+            Assert.Equal(Accessibility.Public, s1.DeclaredAccessibility);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -28,21 +28,21 @@ ref public partial struct S {}
                 // (2,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // ref partial struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(2, 1),
-                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // (3,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // ref partial public struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
-                // (3,5): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "ref").WithArguments("ref and partial modifier ordering").WithLocation(3, 1),
+                // (3,5): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // ref partial public struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 5),
-                // (4,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(3, 5),
+                // (4,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 1),
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(4, 1),
                 // (4,9): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // partial ref struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(4, 9),
-                // (5,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
-                // ref public partial struct S{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref and partial modifier ordering", "7.3")
+                // (5,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // ref public partial struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "ref").WithArguments("ref and partial modifier ordering").WithLocation(5, 1)
                 );
         }
 
@@ -57,15 +57,15 @@ partial public interface I {}
 
             var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
             tree.GetDiagnostics().Verify(
-                // (2,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // (2,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // partial public class C {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(2, 1),
-                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(2, 1),
+                // (3,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // partial public struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
-                // (4,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(3, 1),
+                // (4,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // partial public interface I {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 1)
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(4, 1)
                 );
         }
 
@@ -81,9 +81,10 @@ partial class C
 
             var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
             tree.GetDiagnostics().Verify(
-                // (4,5): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // (4,5): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     partial static void M();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 5));
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "partial").WithArguments("ref and partial modifier ordering").WithLocation(4, 5)
+                );
         }
 
         [Fact]
@@ -161,7 +162,7 @@ partial readonly ref struct S {}
 partial public struct S {}
 ";
 
-            var comp = CreateCompilation(text);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
             var s1 = comp.GetTypeByMetadataName("S");
@@ -180,7 +181,7 @@ partial public class C {}
 partial abstract class C {}
 ";
 
-            var comp = CreateCompilation(text);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
 
             var s1 = comp.GetTypeByMetadataName("C");
@@ -197,7 +198,7 @@ partial partial ref class C {}
 partial partial ref struct S {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
                 // (2,27): error CS0106: The modifier 'ref' is not valid for this item
                 // partial partial ref class C {}
@@ -219,7 +220,7 @@ partial ref ref class C {}
 partial ref ref struct S {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
                 // (2,23): error CS0106: The modifier 'ref' is not valid for this item
                 // partial ref ref class C {}
@@ -242,7 +243,7 @@ using System;
 partial class Test {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Regular7_3);
+            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.RegularPreview);
             tree.GetDiagnostics().Verify(
                 // (3,11): error CS1026: ) expected
                 // [Obsolete(
@@ -262,7 +263,7 @@ using System;
 partial public class Test {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Regular7_3);
+            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.RegularPreview);
             tree.GetDiagnostics().Verify(
                 // (3,11): error CS1026: ) expected
                 // [Obsolete(
@@ -283,7 +284,7 @@ class partial
 }
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 ref partial struct S {}
 ref partial public struct S {}
 partial ref struct S {}
+ref public partial struct S {}
 ";
 
             var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
@@ -38,7 +39,10 @@ partial ref struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 1),
                 // (4,9): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(4, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(4, 9),
+                // (5,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // ref public partial struct S{}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref and partial modifier ordering", "7.3")
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -13,6 +13,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
     {
         public RefPartialModOrderingParsingTests(ITestOutputHelper output) : base(output) { }
 
+        private static CSharpCompilation CreateCompilation(string source, CSharpParseOptions parseOptions = null)
+            => ParsingTests.CreateCompilation(source, parseOptions: parseOptions ?? TestOptions.RegularPreview);
+
+        private new static SyntaxTree ParseTree(string text, CSharpParseOptions options = null)
+            => SyntaxFactory.ParseSyntaxTree(text, options ?? TestOptions.RegularPreview);
+
         [Fact]
         public void TestLangVersion_PartialRef()
         {
@@ -23,7 +29,7 @@ partial ref struct S {}
 ref public partial struct S {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            var tree = ParseTree(text, options: TestOptions.Regular7);
             tree.GetDiagnostics().Verify(
                 // (2,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // ref partial struct S {}
@@ -55,7 +61,7 @@ partial public struct S {}
 partial public interface I {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            var tree = ParseTree(text, options: TestOptions.Regular7);
             tree.GetDiagnostics().Verify(
                 // (2,1): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 // partial public class C {}
@@ -79,7 +85,7 @@ partial class C
 }
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            var tree = ParseTree(text, options: TestOptions.Regular7);
             tree.GetDiagnostics().Verify(
                 // (4,5): error CS8652: The feature 'ref and partial modifier ordering' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                 //     partial static void M();
@@ -162,7 +168,7 @@ partial readonly ref struct S {}
 partial public struct S {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics();
 
             var s1 = comp.GetTypeByMetadataName("S");
@@ -181,7 +187,7 @@ partial public class C {}
 partial abstract class C {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics();
 
             var s1 = comp.GetTypeByMetadataName("C");
@@ -198,7 +204,7 @@ partial partial ref class C {}
 partial partial ref struct S {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (2,27): error CS0106: The modifier 'ref' is not valid for this item
                 // partial partial ref class C {}
@@ -220,7 +226,7 @@ partial ref ref class C {}
 partial ref ref struct S {}
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics(
                 // (2,23): error CS0106: The modifier 'ref' is not valid for this item
                 // partial ref ref class C {}
@@ -243,7 +249,7 @@ using System;
 partial class Test {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.RegularPreview);
+            var tree = ParseTree(test);
             tree.GetDiagnostics().Verify(
                 // (3,11): error CS1026: ) expected
                 // [Obsolete(
@@ -263,7 +269,7 @@ using System;
 partial public class Test {}
 ";
 
-            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.RegularPreview);
+            var tree = ParseTree(test);
             tree.GetDiagnostics().Verify(
                 // (3,11): error CS1026: ) expected
                 // [Obsolete(
@@ -284,7 +290,7 @@ class partial
 }
 ";
 
-            var comp = CreateCompilation(text, parseOptions: TestOptions.RegularPreview);
+            var comp = CreateCompilation(text);
             comp.VerifyDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -59,6 +59,23 @@ partial public interface I {}
         }
 
         [Fact]
+        public void TestLangVersion_PartialMethod()
+        {
+            var text = @"
+partial class C
+{
+    partial static void M();
+}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            tree.GetDiagnostics().Verify(
+                // (4,5): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                //     partial static void M();
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 5));
+        }
+
+        [Fact]
         public void TestBadTypeKind_PartialPublic()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
         {
             var text = @"
 ref partial struct S {}
+ref partial public struct S {}
 partial ref struct S {}
 ";
 
@@ -26,12 +27,18 @@ partial ref struct S {}
                 // (2,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // ref partial struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(2, 1),
-                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // (3,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
+                // ref partial public struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(3, 1),
+                // (3,5): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // ref partial public struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 5),
+                // (4,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
                 // partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
-                // (3,9): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 1),
+                // (4,9): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(3, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(4, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -27,9 +27,9 @@ partial ref struct S {}
                 // (2,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
                 // ref partial struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(2, 1),
-                // (3,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
+                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
                 // ref partial public struct S {}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(3, 1),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
                 // (3,5): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
                 // ref partial public struct S {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 5),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefPartialModOrderingParsingTests.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit.Abstractions;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
+{
+    [CompilerTrait(CompilerFeature.RefPartialModOrdering)]
+    public class RefPartialModOrderingParsingTests : ParsingTests
+    {
+        public RefPartialModOrderingParsingTests(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public void TestLangVersion_PartialRef()
+        {
+            var text = @"
+ref partial struct S {}
+partial ref struct S {}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            tree.GetDiagnostics().Verify(
+                // (2,1): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
+                // ref partial struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(2, 1),
+                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
+                // (3,9): error CS8107: Feature 'ref structs' is not available in C# 7.0. Please use language version 7.2 or greater.
+                // partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(3, 9)
+                );
+        }
+
+        [Fact]
+        public void TestLangVersion_Partial()
+        {
+            var text = @"
+partial public class C {}
+partial public struct S {}
+partial public interface I {}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular7);
+            tree.GetDiagnostics().Verify(
+                // (2,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // partial public class C {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(2, 1),
+                // (3,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // partial public struct S {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(3, 1),
+                // (4,1): error CS8107: Feature 'ref and partial modifier ordering' is not available in C# 7.0. Please use language version 7.3 or greater.
+                // partial public interface I {}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "partial").WithArguments("ref and partial modifier ordering", "7.3").WithLocation(4, 1)
+                );
+        }
+
+        [Fact]
+        public void TestBadTypeKind_PartialPublic()
+        {
+            var text = @"
+partial public enum E {}
+partial public delegate void D();
+";
+
+            var comp = CreateCompilation(text);
+            comp.VerifyDiagnostics(
+                // (2,21): error CS0106: The modifier 'partial' is not valid for this item
+                // partial public enum E {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(2, 21),
+                // (3,30): error CS0106: The modifier 'partial' is not valid for this item
+                // partial public delegate void D();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "D").WithArguments("partial").WithLocation(3, 30)
+                );
+        }
+
+        [Fact]
+        public void TestBadTypeKind_Partial()
+        {
+            var text = @"
+partial enum E {}
+partial delegate void D();
+";
+
+            var comp = CreateCompilation(text);
+            comp.VerifyDiagnostics(
+                // (2,14): error CS0106: The modifier 'partial' is not valid for this item
+                // partial enum E {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(2, 14),
+                // (3,23): error CS0106: The modifier 'partial' is not valid for this item
+                // partial delegate void D();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "D").WithArguments("partial").WithLocation(3, 23)
+                );
+        }
+
+        [Fact]
+        public void TestBadTypeKind_PartialPartial()
+        {
+            var text = @"
+partial partial enum E {}
+partial partial delegate void D();
+";
+
+            var comp = CreateCompilation(text);
+            comp.VerifyDiagnostics(
+                // (2,22): error CS0106: The modifier 'partial' is not valid for this item
+                // partial partial enum E {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "E").WithArguments("partial").WithLocation(2, 22),
+                // (2,9): error CS1004: Duplicate 'partial' modifier
+                // partial partial enum E {}
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(2, 9),
+                // (3,31): error CS0106: The modifier 'partial' is not valid for this item
+                // partial partial delegate void D();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "D").WithArguments("partial").WithLocation(3, 31),
+                // (3,9): error CS1004: Duplicate 'partial' modifier
+                // partial partial delegate void D();
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(3, 9)
+                );
+        }
+
+        [Fact]
+        public void TestPartialRefStruct_Symbols()
+        {
+            var text = @"
+partial struct S {}
+partial ref struct S {}
+ref partial struct S {}
+partial ref readonly struct S {}
+partial readonly ref struct S {}
+partial public struct S {}
+";
+
+            var comp = CreateCompilation(text);
+            comp.VerifyDiagnostics();
+
+            var s1 = comp.GetTypeByMetadataName("S");
+            Assert.True(s1.IsPartial());
+            Assert.True(s1.IsReadOnly);
+            Assert.True(s1.IsRefLikeType);
+            Assert.Equal(s1.DeclaredAccessibility, Accessibility.Public);
+        }
+
+        [Fact]
+        public void TestPartialClass_Symbols()
+        {
+            var text = @"
+partial class C {}
+partial public class C {}
+partial abstract class C {}
+";
+
+            var comp = CreateCompilation(text);
+            comp.VerifyDiagnostics();
+
+            var s1 = comp.GetTypeByMetadataName("C");
+            Assert.True(s1.IsPartial());
+            Assert.True(s1.IsAbstract);
+            Assert.Equal(s1.DeclaredAccessibility, Accessibility.Public);
+        }
+
+        [Fact]
+        public void TestPartialPartialRef()
+        {
+            var text = @"
+partial partial ref class C {}
+partial partial ref struct S {}
+";
+
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics(
+                // (2,27): error CS0106: The modifier 'ref' is not valid for this item
+                // partial partial ref class C {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "C").WithArguments("ref").WithLocation(2, 27),
+                // (2,9): error CS1004: Duplicate 'partial' modifier
+                // partial partial ref class C {}
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(2, 9),
+                // (3,9): error CS1004: Duplicate 'partial' modifier
+                // partial partial ref struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(3, 9)
+                );
+        }
+
+        [Fact]
+        public void TestPartialRefRef()
+        {
+            var text = @"
+partial ref ref class C {}
+partial ref ref struct S {}
+";
+
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics(
+                // (2,23): error CS0106: The modifier 'ref' is not valid for this item
+                // partial ref ref class C {}
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "C").WithArguments("ref").WithLocation(2, 23),
+                // (2,13): error CS1004: Duplicate 'ref' modifier
+                // partial ref ref class C {}
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "ref").WithArguments("ref").WithLocation(2, 13),
+                // (3,13): error CS1004: Duplicate 'ref' modifier
+                // partial ref ref struct S {}
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "ref").WithArguments("ref").WithLocation(3, 13)
+                );
+        }
+
+        [Fact]
+        public void TestPartialAfterIncompleteAttribute_PartialClass()
+        {
+            var test = @"
+using System;
+[Obsolete(
+partial class Test {}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Regular7_3);
+            tree.GetDiagnostics().Verify(
+                // (3,11): error CS1026: ) expected
+                // [Obsolete(
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(3, 11),
+                // (3,11): error CS1003: Syntax error, ']' expected
+                // [Obsolete(
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]", "").WithLocation(3, 11)
+                );
+        }
+
+        [Fact]
+        public void TestPartialAfterIncompleteAttribute_PartialPublicClass()
+        {
+            var test = @"
+using System;
+[Obsolete(
+partial public class Test {}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(test, options: TestOptions.Regular7_3);
+            tree.GetDiagnostics().Verify(
+                // (3,11): error CS1026: ) expected
+                // [Obsolete(
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(3, 11),
+                // (3,11): error CS1003: Syntax error, ']' expected
+                // [Obsolete(
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]", "").WithLocation(3, 11)
+                );
+        }
+
+        [Fact]
+        public void TestNoRegressionOnRefPartialMember()
+        {
+            var text = @"
+class partial
+{
+    ref partial M() => throw null;
+}
+";
+
+            var comp = CreateCompilation(text, parseOptions: TestOptions.Regular7_3);
+            comp.VerifyDiagnostics();
+        }
+    }
+}
+

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -14,10 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
     {
         public RefStructs(ITestOutputHelper output) : base(output) { }
 
-        protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
-        {
-            return SyntaxFactory.ParseSyntaxTree(text, options: options);
-        }
+        private static CSharpCompilation CreateCompilation(string source, CSharpParseOptions parseOptions = null)
+            => ParsingTests.CreateCompilation(source, parseOptions: parseOptions ?? TestOptions.RegularPreview);
 
         [Fact]
         public void RefStructSimple()
@@ -74,7 +72,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (4,15): error CS0106: The modifier 'ref' is not valid for this item
                 //     ref class S1{}

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -76,21 +76,18 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
-                // (4,9): error CS1031: Type expected
+                // (4,15): error CS0106: The modifier 'ref' is not valid for this item
                 //     ref class S1{}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "class"),
-                // (6,16): error CS1031: Type expected
-                //     public ref unsafe struct S2{}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "unsafe"),
-                // (8,9): error CS1031: Type expected
-                //     ref interface I1{};
-                Diagnostic(ErrorCode.ERR_TypeExpected, "interface").WithLocation(8, 9),
-                // (10,16): error CS1031: Type expected
-                //     public ref delegate ref int D1();
-                Diagnostic(ErrorCode.ERR_TypeExpected, "delegate").WithLocation(10, 16),
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "S1").WithArguments("ref").WithLocation(4, 15),
                 // (6,30): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 //     public ref unsafe struct S2{}
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "S2")
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "S2").WithLocation(6, 30),
+                // (8,19): error CS0106: The modifier 'ref' is not valid for this item
+                //     ref interface I1{};
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("ref").WithLocation(8, 19),
+                // (10,33): error CS0106: The modifier 'ref' is not valid for this item
+                //     public ref delegate ref int D1();
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "D1").WithArguments("ref").WithLocation(10, 33)
             );
         }
 
@@ -105,16 +102,7 @@ class Program
 }
 ";
             var comp = CreateCompilation(text);
-            comp.VerifyDiagnostics(
-                // (4,13): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 13),
-                // (5,13): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 13),
-                // (5,24): error CS0102: The type 'Program' already contains a definition for 'S'
-                //     partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("Program", "S").WithLocation(5, 24));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -138,20 +126,11 @@ class C
     ref partial readonly struct S {}
     ref partial readonly struct S {}
 }");
-            comp.VerifyDiagnostics(
-                // (4,17): error CS1585: Member modifier 'readonly' must precede the member type and name
-                //     ref partial readonly struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "readonly").WithArguments("readonly").WithLocation(4, 17),
-                // (5,17): error CS1585: Member modifier 'readonly' must precede the member type and name
-                //     ref partial readonly struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "readonly").WithArguments("readonly").WithLocation(5, 17),
-                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
-                //     ref partial readonly struct S {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
-        public void RefReadonlyPartialStruct()
+        public void PartialRefReadonlyStruct()
         {
             var comp = CreateCompilation(@"
 class C
@@ -159,22 +138,7 @@ class C
     partial ref readonly struct S {}
     partial ref readonly struct S {}
 }");
-            comp.VerifyDiagnostics(
-                // (4,13): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     partial ref readonly struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 13),
-                // (4,26): error CS1031: Type expected
-                //     partial ref readonly struct S {}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "struct").WithLocation(4, 26),
-                // (5,13): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     partial ref readonly struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 13),
-                // (5,26): error CS1031: Type expected
-                //     partial ref readonly struct S {}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "struct").WithLocation(5, 26),
-                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
-                //     partial ref readonly struct S {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -186,16 +150,7 @@ class C
     readonly partial ref struct S {}
     readonly partial ref struct S {}
 }");
-            comp.VerifyDiagnostics(
-                // (4,22): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     readonly partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(4, 22),
-                // (5,22): error CS1585: Member modifier 'ref' must precede the member type and name
-                //     readonly partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_BadModifierLocation, "ref").WithArguments("ref").WithLocation(5, 22),
-                // (5,33): error CS0102: The type 'C' already contains a definition for 'S'
-                //     readonly partial ref struct S {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "S").WithArguments("C", "S").WithLocation(5, 33));
+            comp.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RoundTrippingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RoundTrippingTests.cs
@@ -398,7 +398,7 @@ partial class partial
         public void TestNegBug876575()
         {
             var text = @"partial enum E{}";
-            ParseAndRoundTripping(text, errorCount: 1);
+            ParseAndRoundTripping(text, errorCount: 0);
         }
 
         [Fact]
@@ -506,7 +506,7 @@ partial class PartialPartial
     }
 }
 ";
-            ParseAndRoundTripping(text, -1);
+            ParseAndRoundTripping(text, 0);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -1842,12 +1842,9 @@ partial void Goo(){};
 partial enum en {};
 ";
             CreateCompilation(test).VerifyDiagnostics(
-                // (2,1): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (2,14): error CS0106: The modifier 'partial' is not valid for this item
                 // partial enum en {};
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(2, 1),
-                // (2,14): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
-                // partial enum en {};
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "en").WithLocation(2, 14));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "en").WithArguments("partial").WithLocation(2, 14));
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -974,7 +974,7 @@ namespace System.Runtime.CompilerServices
                 allReferences = allReferences.Concat(references);
             }
 
-            return CreateCompilation(source, allReferences, options, parseOptions, TargetFramework.Empty, assemblyName, sourceFileName);
+            return CreateCompilation(source, allReferences, options, parseOptions ?? TestOptions.RegularPreview, TargetFramework.Empty, assemblyName, sourceFileName);
         }
 
         public static CSharpCompilation CreateCompilation(

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -6882,9 +6882,10 @@ partial class C
 ";
             var edits = GetTopEdits(src1, src2);
             edits.VerifySemanticDiagnostics(
-                // (4,5): error CS0267: The 'partial' modifier can only appear immediately before 'class', 'struct', 'interface', or 'void'
+                // (4,5): error CS0106: The modifier 'partial' is not valid for this item
                 //     partial int P => 1;
-                Diagnostic(ErrorCode.ERR_PartialMisplaced, "partial").WithLocation(4, 5));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "partial").WithArguments("partial").WithLocation(4, 5)
+                );
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/OrderModifiers/OrderModifiersCompilerErrorTests.cs
+++ b/src/EditorFeatures/CSharpTest/OrderModifiers/OrderModifiersCompilerErrorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.OrderModifiers
             => (null, new CSharpOrderModifiersCodeFixProvider());
 
         [WorkItem(30352, "https://github.com/dotnet/roslyn/issues/30352")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)]
+        [Fact(Skip = "PROTOTYPE(ref-partial)"), Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)]
         public async Task PartialAtTheEnd()
         {
             // Verify that the code fix claims it fixes the compiler error (CS0267) in addition to the analyzer diagnostic.

--- a/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
@@ -35,5 +35,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         AsyncStreams,
         NullableReferenceTypes,
         DefaultInterfaceImplementation,
+        RefPartialModOrdering,
     }
 }


### PR DESCRIPTION
Proposal: https://github.com/dotnet/csharplang/issues/946 (as part of C# 7.3)

Also related: https://github.com/dotnet/csharplang/issues/1022



