### PR TITLE
Simplified using directive comparer

### DIFF
--- a/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesDirectiveComparer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesDirectiveComparer.cs
@@ -66,8 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             var extern1 = directive1 as ExternAliasDirectiveSyntax;
             var extern2 = directive2 as ExternAliasDirectiveSyntax;
 
-            UsingKind directive1Kind = GetUsingKind(using1, extern1);
-            UsingKind directive2Kind = GetUsingKind(using2, extern2);
+            var directive1Kind = GetUsingKind(using1, extern1);
+            var directive2Kind = GetUsingKind(using2, extern2);
 
             // different types of usings get broken up into groups.
             //  * externs


### PR DESCRIPTION
Simplified `UsingsAndExternAliasesDirectiveComparer` by creating a `private enum` to help with sorting the different kinds of `using`s.

This PR makes the code shorter, less repetitive and I think also easier to understand. It also remove some unnecessary `else`s.

Though this doesn't improve functionality in any way, so feel free to close this PR if you think it's not worth it.