### PR TITLE
Optimize ArrayBuilder<T>.ToImmutableAndFree

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1744,6 +1744,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // highestBoundNode: The highest node in the bound tree associated with node
         // boundNodeForSyntacticParent: The lowest node in the bound tree associated with node.Parent.
         // binderOpt: If this is null, then the one enclosing the bound node's syntax will be used (unsafe during speculative binding).
+        [PerformanceSensitive(
+            "https://github.com/dotnet/roslyn/issues/23582",
+            Constraint = "Provide " + nameof(ArrayBuilder<Symbol>) + " capacity to reduce number of allocations.")]
         internal SymbolInfo GetSymbolInfoForNode(
             SymbolInfoOptions options,
             BoundNode lowestBoundNode,
@@ -1817,7 +1820,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Caas clients don't want ErrorTypeSymbol in the symbols, but the best guess
                 // instead. If no best guess, then nothing is returned.
-                var builder = ArrayBuilder<Symbol>.GetInstance();
+                var builder = ArrayBuilder<Symbol>.GetInstance(symbols.Length);
                 foreach (Symbol symbol in symbols)
                 {
                     AddUnwrappingErrorTypes(builder, symbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -51,13 +51,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        [PerformanceSensitive(
+            "https://github.com/dotnet/roslyn/issues/23582",
+            Constraint = "Provide " + nameof(ArrayBuilder<Symbol>) + " capacity to reduce number of allocations.",
+            AllowGenericEnumeration = false)]
         public sealed override ImmutableArray<Symbol> GetMembers()
         {
             EnsureAllMembersLoaded();
 
-            var builder = ArrayBuilder<Symbol>.GetInstance();
-            builder.AddRange(GetMemberTypesPrivate());
-            builder.AddRange(GetMemberNamespacesPrivate());
+            var memberTypes = GetMemberTypesPrivate();
+            var builder = ArrayBuilder<Symbol>.GetInstance(memberTypes.Length + lazyNamespaces.Count);
+
+            builder.AddRange(memberTypes);
+            foreach (var pair in lazyNamespaces)
+            {
+                builder.Add(pair.Value);
+            }
+
             return builder.ToImmutableAndFree();
         }
 
@@ -71,11 +81,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
 
             return StaticCast<NamedTypeSymbol>.From(_lazyFlattenedTypes);
-        }
-
-        private IEnumerable<PENestedNamespaceSymbol> GetMemberNamespacesPrivate()
-        {
-            return lazyNamespaces.Values;
         }
 
         public sealed override ImmutableArray<Symbol> GetMembers(string name)

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PooledObjects
 {
@@ -271,9 +270,6 @@ namespace Microsoft.CodeAnalysis.PooledObjects
         /// <summary>
         /// Realizes the array and disposes the builder in one operation.
         /// </summary>
-        [PerformanceSensitive(
-            "https://github.com/dotnet/roslyn/issues/23582",
-            Constraint = "Callers creating arrays with known capacities need to be able to create an " + nameof(ImmutableArray<T>) + " without a full copy.")]
         public ImmutableArray<T> ToImmutableAndFree()
         {
             ImmutableArray<T> result;


### PR DESCRIPTION
### Customer scenario

Running analyzer during a build is slower than it should be, with the analyzer driver contributing substantial overhead even when the analyzers themselves are lightweight.

### Bugs this fixes

N/A

### Workarounds, if any

None needed

### Risk

Low. The new form of the code is straightforward, and each constraint implemented to address performance overhead is documented with a `PerformanceSensitive` attribute.

### Performance impact

AnalyzerRunner shows allocation reduction of 2.2%.

### Is this a regression from a previous update?

No.

### Root cause analysis

AnalyzerRunner is a new tool for helping us test analyzer performance in isolation.

### How was the bug found?

AnalyzerRunner.

### Test documentation updated?

No.