### PR TITLE
Avoid TryReplaceWithAlias logic for documents without using alias directives

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// Indicates that a code element is performance sensitive under a known scenario.
+    /// </summary>
+    /// <remarks>
+    /// <para>When applying this attribute, only explicitly set the values for properties specifically indicated by the
+    /// test/measurement technique described in the associated <see cref="Uri"/>.</para>
+    /// </remarks>
+    [Conditional("EMIT_CODE_ANALYSIS_ATTRIBUTES")]
+    [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    internal sealed class PerformanceSensitiveAttribute : Attribute
+    {
+        public PerformanceSensitiveAttribute(string uri)
+        {
+            Uri = uri;
+        }
+
+        /// <summary>
+        /// Gets the location where the original problem is documented, likely with steps to reproduce the issue and/or
+        /// validate performance related to a change in the method.
+        /// </summary>
+        public string Uri
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets or sets a description of the constraint imposed by the original performance issue.
+        /// </summary>
+        /// <remarks>
+        /// <para>Constraints are normally specified by other specific properties that allow automated validation of the
+        /// constraint. This property supports documenting constraints which cannot be described in terms of other
+        /// constraint properties.</para>
+        /// </remarks>
+        public string Constraint
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether captures are allowed.
+        /// </summary>
+        public bool AllowCaptures
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enumeration of a generic <see cref="IEnumerable{T}"/> is allowed.
+        /// </summary>
+        public bool AllowGenericEnumeration
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the asynchronous state machine typically completes synchronously.
+        /// </summary>
+        /// <remarks>
+        /// <para>When <see langword="true"/>, validation of this performance constraint typically involves analyzing
+        /// the method to ensure synchronous completion of the state machine does not require the allocation of a
+        /// <see cref="Task"/>, either through caching the result or by using ValueTask.</para>
+        /// </remarks>
+        public bool OftenCompletesSynchronously
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this is an entry point to a parallel algorithm.
+        /// </summary>
+        /// <remarks>
+        /// <para>Parallelization APIs and algorithms, e.g. <c>Parallel.ForEach</c>, may be efficient for parallel entry
+        /// points (few direct calls but large amounts of iterative work), but are problematic when called inside the
+        /// iterations themselves. Performance-sensitive code should avoid the use of heavy parallization APIs except
+        /// for known entry points to the parallel portion of code.</para>
+        /// </remarks>
+        public bool IsParallelEntry
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -1013,9 +1013,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             // might be a speculative node (not fully rooted in a tree), we use the position of the evaluation to find
             // the equivalent node in the original tree, and from there determine if the tree has any using alias
             // directives.
-            if (semanticModel.SyntaxTree.TryGetRoot(out var root))
+            var originalModel = semanticModel;
+            var originalPosition = node.SpanStart;
+            while (originalModel.IsSpeculativeSemanticModel)
             {
-                var token = root.FindTokenOnLeftOfPosition(node.SpanStart);
+                originalPosition = originalModel.OriginalPositionForSpeculation;
+                originalModel = originalModel.ParentModel;
+            }
+
+            if (originalModel.SyntaxTree.TryGetRoot(out var root))
+            {
+                var token = root.FindTokenOnLeftOfPosition(originalPosition);
                 var tokenParent = token.Parent;
                 var aliasContainer = tokenParent?.FirstAncestorOrSelf<SyntaxNode>(
                     syntax =>

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -118,6 +118,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\OneOrMany.cs">
       <Link>InternalUtilities\OneOrMany.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs">
+      <Link>InternalUtilities\PerformanceSensitiveAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs">
       <Link>InternalUtilities\PlatformInformation.cs</Link>
     </Compile>


### PR DESCRIPTION
### Customer scenario

Running analyzers is slower than it should be. In this case, the primary impacted analyzer is Simplify Type Name, but other analyzers using the simplifier could be affected.

### Bugs this fixes

Fixes #23461

### Workarounds, if any

None needed

### Risk

This poses a small maintainability risk by special-casing a particular style of code. The risk is mitigated by a comment explaining the new constraint, and justified by AnalyzerRunner indicating the code lies on a particularly hot path.

Extremely deeply nested namespaces in a single document could result in a StackOverflowException. @CyrusNajmabadi indicated that this is not the only code to suffer from this, and believes it will not be a problem.

### Performance impact

AnalyzerRunner indicates allocation savings of 4.93GiB (5.7%) running IDE analyzers.

### Is this a regression from a previous update?

No.

### Root cause analysis

AnalyzerRunner is a new tool for helping us test analyzer performance in isolation.

### How was the bug found?

AnalyzerRunner.

### Test documentation updated?

No.

