### PR TITLE
Merge pull request #23529 from agocke/fix-signing

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -140,8 +140,9 @@
             <PublicKey>$(RoslynInternalKey)</PublicKey>
             <PublicKeyToken>fc793a00266884fb</PublicKeyToken>
           </PropertyGroup>
-          <!-- Real-signing is only supported cross-platform in the boostrap toolset -->
-          <PropertyGroup Condition="'$(OS)' != 'Windows_NT' AND '$(BootstrapBuildPath)' == ''">
+          <!-- Real-signing cross-platform currently has a blocking bug:
+               https://github.com/dotnet/roslyn/issues/23521 -->
+          <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
               <PublicSign>true</PublicSign>
           </PropertyGroup>
         </Otherwise>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5826,7 +5826,7 @@ public class C
             Assert.Equal(1, peHeaders.PEHeader.MinorSubsystemVersion);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/23529")]
         public void CreateCompilationWithKeyFile()
         {
             string source = @"

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -284,12 +284,10 @@ namespace Microsoft.CodeAnalysis
 
         internal StrongNameProvider GetStrongNameProvider(StrongNameFileSystem fileSystem)
         {
-            bool fallback = 
-                ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
-                CompilationOptionsCore.CryptoKeyContainer != null;
-            return fallback ?
-                (StrongNameProvider)new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem) :
-                (StrongNameProvider)new PortableStrongNameProvider(KeyFileSearchPaths, fileSystem);
+            // https://github.com/dotnet/roslyn/issues/23521
+            // Disable the portable strong name provider until we can find and fix the
+            // root cause of the bug
+            return new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem);
         }
 
         internal CommandLineArguments()

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -107,7 +107,7 @@ End Module
             Assert.Equal("", output.ToString().Trim())
         End Sub
 
-        <Fact>
+        <Fact(Skip:= "https://github.com/dotnet/roslyn/pull/23529")>
         Public Sub CreateCompilationWithKeyFile()
             Dim source = "
 Public Class C


### PR DESCRIPTION
Quick fix for signing failures

(cherry picked from commit 0fb61ed4e2817fa373e51e726bfb9838609eddf2)

### Customer scenario

The full scope is unknown, but signing is almost entirely broken for the C# and VB compilers. This change reverts the compiler to always use the old signing system until the bug in the new signing system can be understood and fixed.

### Bugs this fixes

Fix for https://github.com/dotnet/roslyn/issues/23521

### Workarounds, if any

The user could use an internal feature flag to manually fall-back to the old signing. This change forces that feature flag to always be enabled.

### Risk

Very small. The revert continues to use the old signing code that Roslyn has always relied upon. The change itself is simply hardcoding the use of the flag requiring the old signing mechanism, instead of leaving it optional.

### Performance impact

None. This is a revert to the original code.

### Is this a regression from a previous update?

No.

### Root cause analysis

The Roslyn unit tests check to see if a binary has the signed bit set, but do not actually verify that the signed assembly is cryptographically valid. These tests would have caught the failure.

### How was the bug found?

Dogfooding by VS and partner teams.
