### PR TITLE
Escape curly braces in string literals when converting concatenation to interpolated string

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -499,5 +499,47 @@ public class C
 }");
             }
         }
+
+        [WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithVerbatimStringWithBraces()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = 1 + [||]@""{string}"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $@""{1}{{string}}"";
+    }
+}");
+        }
+
+        [WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithMultipleVerbatimStringsWithBraces()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class C
+{
+    void M()
+    {
+        var v = @""{"" + 1 + [||]@""}"";
+    }
+}",
+@"public class C
+{
+    void M()
+    {
+        var v = $@""{{{1}}}"";
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.cs
@@ -430,5 +430,74 @@ public class C
     }
 }");
         }
+
+        [WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithStringLiteralWithBraces()
+        {
+            {
+                await TestInRegularAndScriptAsync(
+    @"public class C
+{
+    void M()
+    {
+        var v = 1 + [||]""{string}"";
+    }
+}",
+    @"public class C
+{
+    void M()
+    {
+        var v = $""{1}{{string}}"";
+    }
+}");
+            }
+        }
+
+        [WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithStringLiteralWithDoubleBraces()
+        {
+            {
+                await TestInRegularAndScriptAsync(
+    @"public class C
+{
+    void M()
+    {
+        var v = 1 + [||]""{{string}}"";
+    }
+}",
+    @"public class C
+{
+    void M()
+    {
+        var v = $""{1}{{{{string}}}}"";
+    }
+}");
+            }
+        }
+
+        [WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestWithMultipleStringLiteralsWithBraces()
+        {
+            {
+                await TestInRegularAndScriptAsync(
+    @"public class C
+{
+    void M()
+    {
+        var v = ""{"" + 1 + [||]""}"";
+    }
+}",
+    @"public class C
+{
+    void M()
+    {
+        var v = $""{{{1}}}"";
+    }
+}");
+            }
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertToInterpolatedString/ConvertConcatenationToInterpolatedStringTests.vb
@@ -266,5 +266,59 @@ Public Class C
     End Sub
 End Class")
         End Function
+
+        <WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithStringLiteralWithBraces() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 1 & [||]""{string}""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{1}{{string}}""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithStringLiteralWithDoubleBraces() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = 1 & [||]""{{string}}""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{1}{{{{string}}}}""
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(23536, "https://github.com/dotnet/roslyn/issues/23536")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)>
+        Public Async Function TestWithMultipleStringLiteralsWithBraces() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Public Class C
+    Sub M()
+        dim v = ""{"" & 1 & [||]""}""
+    End Sub
+End Class",
+"
+Public Class C
+    Sub M()
+        dim v = $""{{{1}}}""
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -118,7 +118,8 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
                 if (currentContentIsStringLiteral)
                 {
                     var text = piece.GetFirstToken().Text;
-                    var textWithoutQuotes = GetTextWithoutQuotes(text, isVerbatimStringLiteral);
+                    var textWithEscapedBraces = text.Replace("{", "{{").Replace("}", "}}");
+                    var textWithoutQuotes = GetTextWithoutQuotes(textWithEscapedBraces, isVerbatimStringLiteral);
                     if (previousContentWasStringLiteralExpression)
                     {
                         // Last part we added to the content list was also an interpolated-string-text-node.


### PR DESCRIPTION
### Customer scenario

Customer has a string concatenation where the string literal contains curly braces. For example:
```cs
var firstExample = "Something {X} = " + 9;
var secondExample = "Something {" + 9 + "}";
```

Using the "Convert to interpolated string" refactoring does not escape the curly braces in the string literal(s). When applying the refactoring, this can lead to compile errors or unmeant escapes:

```cs
// results as of now:
var firstExample = $"Something {X} = {9}"; // compile error: {X} does not exist in context
var secondExample = $"Something {{9}}"; // '9' is escaped when it should not be
```

### Bugs this fixes
#23536 

### Workarounds, if any
Escape the braces manually in the string literal(s) before or after applying the refactoring.

### Risk
The scope of the fix is limited to this specific refactoring.

### Performance impact
Low, the fix only adds two extra string operations (which are only executed if necessary).

### Is this a regression from a previous update?
I don't know.

### Root cause analysis
This specific situation was not covered by unit tests yet. I added these tests now.

### How was the bug found?
Customer reported, see #23536.

### Test documentation updated?
No impact on test documentation.