### PR TITLE
Keep compilation alive in GetPartialSemanticModelAsync

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -181,7 +181,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (document.Project.TryGetCompilation(out var compilation))
             {
                 // We already have a compilation, so at this point it's fastest to just get a SemanticModel
-                return await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                // Make sure the compilation is kept alive so that GetSemanticModelAsync() doesn't become expensive
+                GC.KeepAlive(compilation);
+                return semanticModel;
             }
             else
             {


### PR DESCRIPTION
This keeps the compilation alive during `GetSemanticModelAsync` invocation. Separated from #23544.

<details><summary>Ask Mode template</summary>

### Customer scenario

Using completion might be unexpectedly slow. In one place we fetch a Compilation, and if we are holding it then call another workspace method under the assumption that would be fast. But a missing GC.KeepAlive means the compilation could have been GCed and the next call would still work but be much slower.

### Bugs this fixes

None, observed during code review.

### Workarounds, if any

None.

### Risk

Extremely low -- just a GC.KeepAlive in a small method.

### Performance impact

Might make an edge case better.

### Is this a regression from a previous update?

Nope.

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

Noticed during code review.

</details>