### PR TITLE
Disabled 'Replaces a method with property' refactoring for a method that overrides a metadata method.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -1898,24 +1898,15 @@ class C : IGoo
 }");
         }
 
-        [WorkItem(443523, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")]
+        [WorkItem(23593, "https://github.com/dotnet/roslyn/issues/23593")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
         public async Task TestMetadataOverride()
         {
-            await TestWithAllCodeStyleOff(
+            await TestMissingAsync(
 @"class C : System.Type
 {
     public override int [||]GetArrayRank()
     {
-    }
-}",
-@"class C : System.Type
-{
-    public override int {|Warning:ArrayRank|}
-    {
-        get
-        {
-        }
     }
 }");
         }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.vb
@@ -795,23 +795,15 @@ End Class")
 End class")
         End Function
 
-        <WorkItem(443523, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=443523")>
+        <WorkItem(23593, "https://github.com/dotnet/roslyn/issues/23593")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)>
         Public Async Function TestMetadataOverride() As Task
-            Await TestInRegularAndScriptAsync(
+            Await TestMissingAsync(
 "class C
     inherits system.type
 
     public overrides function [||]GetArrayRank() as integer
     End function
-End class",
-"class C
-    inherits system.type
-
-    public overrides ReadOnly Property {|Warning:ArrayRank|} as integer
-        Get
-        End Get
-    End Property
 End class")
         End Function
     End Class

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         {
             for (var current = method; current != null; current = current.OverriddenMethod)
             {
-                if (current.ContainingType.SpecialType == SpecialType.System_Object)
+                if (current.ContainingType.DeclaringSyntaxReferences.IsEmpty)
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes #23593
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
