### PR TITLE
Handle circular types for pluralize name completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -798,6 +798,7 @@ public class Container : IEnumerable<Container> { }
         {
             var markup = @"
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 public class Class1
 {
@@ -819,7 +820,7 @@ public class TaskType : Task<Container> { }
         public async void TypeImplementsTaskOfType()
         {
             var markup = @"
-using System.Collections.Generic;
+using System.Threading.Tasks;
 
 public class Class1
 {
@@ -840,7 +841,7 @@ public class ContainerBase : Task<ContainerBase> { }
         public async void TypeImplementsTaskOfType2()
         {
             var markup = @"
-using System.Collections.Generic;
+using System.Threading.Tasks;
 
 public class Class1
 {
@@ -862,6 +863,7 @@ public class ContainerBase : Container { }
         {
             var markup = @"
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 public class Class1
 {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -879,5 +879,24 @@ public class EnumerableType : IEnumerable<TaskType> { }
 ";
             await VerifyItemExistsAsync(markup, "taskTypes");
         }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeIsNullableOfNullable()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+      // This code isn't legal, but we want to ensure we don't crash in this broken code scenario
+      IEnumerable<Nullable<int?>> $$
+  }
+}
+";
+            await VerifyItemExistsAsync(markup, "nullables");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -729,5 +729,153 @@ class Test
                 workspace.Options = originalOptions;
             }
         }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsIEnumerableOfType()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+    Container $$
+  }
+}
+
+public class Container : ContainerBase { }
+public class ContainerBase : IEnumerable<ContainerBase> { }
+";
+            await VerifyItemExistsAsync(markup, "container");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsIEnumerableOfType2()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+     Container $$
+  }
+}
+
+public class ContainerBase : IEnumerable<Container> { }
+public class Container : ContainerBase { }
+";
+            await VerifyItemExistsAsync(markup, "container");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsIEnumerableOfType3()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+     Container $$
+  }
+}
+
+public class Container : IEnumerable<Container> { }
+";
+            await VerifyItemExistsAsync(markup, "container");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsIEnumerableOfType4()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+     TaskType $$
+  }
+}
+
+public class ContainerBase : IEnumerable<Container> { }
+public class Container : ContainerBase { }
+public class TaskType : Task<Container> { }
+";
+            await VerifyItemExistsAsync(markup, "taskType");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsTaskOfType()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+    Container $$
+  }
+}
+
+public class Container : ContainerBase { }
+public class ContainerBase : Task<ContainerBase> { }
+";
+            await VerifyItemExistsAsync(markup, "container");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsTaskOfType2()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+     Container $$
+  }
+}
+
+public class Container : Task<ContainerBase> { }
+public class ContainerBase : Container { }
+";
+            await VerifyItemExistsAsync(markup, "container");
+        }
+
+        [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TypeImplementsTaskOfType3()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Class1
+{
+  public void Method()
+  {
+    EnumerableType $$
+  }
+}
+
+public class TaskType : TaskTypeBase { }
+public class TaskTypeBase : Task<TaskTypeBase> { }
+public class EnumerableType : IEnumerable<TaskType> { }
+";
+            await VerifyItemExistsAsync(markup, "taskTypes");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed nder the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Fixes a stack overflow that would occur in name completion if a type implemented IEnumerable of itself.
The fix tracks the list of visited types and doesn't recurse if it encounters a previously visited type.

### Customer scenario

Customer types JObject &lt;space&gt; and VS crashes.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/23590
[DevDiv 533577](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_queries/edit/531437)

### Workarounds, if any

Disable the "show name suggestions" option

### Risk

Low--this fix only touches name suggestions.

### Performance impact

Low--this change prevents deeper recursion into a types type list.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

Didn't test against types that implemented interfaces that were generic over themselves. Unit tests have been added to prevent regressing the fix.

### How was the bug found?

Internal customer report (dogfooding)

### Test documentation updated?

N/A

