### PR TITLE
Enable Microsoft.CodeAnalysis.VisualBasic.UnitTests.GetExtendedSemanticInfoTests.GroupBy_Lookup1 unit-test.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_LookupSymbols.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/QueryExpressions_LookupSymbols.vb
@@ -490,7 +490,7 @@ End Module
             End If
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/23483")>
+        <Fact>
         <CompilerTrait(CompilerFeature.IOperation)>
         Public Sub GroupBy_Lookup1()
             Dim compilation = CreateCompilationWithMscorlib(
@@ -803,7 +803,7 @@ ITranslatedQueryOperation (OperationKind.TranslatedQuery, Type: ?, IsInvalid) (S
                 ReturnedValue: 
                   IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: <anonymous type: Key $315 As ?, Key $315 As ?>, IsInvalid, IsImplicit) (Syntax: 'Group ')
                     Initializers(2):
-                        IOperation:  (OperationKind.None, Type: null, IsInvalid, IsImplicit) (Syntax: '')
+                        IParameterReferenceOperation: $315 (OperationKind.ParameterReference, Type: ?, IsInvalid, IsImplicit) (Syntax: '')
                         IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid, IsImplicit) (Syntax: '')
                           Children(1):
                               IParameterReferenceOperation: $VB$ItAnonymous (OperationKind.ParameterReference, Type: ?, IsInvalid, IsImplicit) (Syntax: 'Group ')


### PR DESCRIPTION
Closes #23483.

@dotnet/roslyn-compiler Please review.