### PR TITLE
Fixed 'Generate Constructor' for sealed class.

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -865,6 +865,37 @@ class Derived : Base
 }");
         }
 
+        [WorkItem(22699, "https://github.com/dotnet/Roslyn/issues/22699")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestGenerateFromDerivedClass3()
+        {
+            await TestInRegularAndScriptAsync(
+@"abstract class Base
+{
+    protected Base(int value)
+    {
+    }
+}
+
+sealed class [||]Derived : Base
+{
+
+}",
+@"abstract class Base
+{
+    protected Base(int value)
+    {
+    }
+}
+
+sealed class Derived : Base
+{
+    public Derived(int value) : base(value)
+    {
+    }
+}");
+        }
+
         [WorkItem(19953, "https://github.com/dotnet/roslyn/issues/19953")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestNotOnEnum()

--- a/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -630,6 +630,37 @@ Public Class Derived
 End Class")
         End Function
 
+        <WorkItem(22699, "https://github.com/dotnet/Roslyn/issues/22699")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function TestGenerateInDerivedType3() As Task
+            Await TestInRegularAndScriptAsync(
+"
+MustInherit Class Base
+    Protected Sub New(value As Integer)
+
+    End Sub
+End Class
+
+NotInheritable Class [||]Derived
+    Inherits Base
+
+End Class",
+"
+MustInherit Class Base
+    Protected Sub New(value As Integer)
+
+    End Sub
+End Class
+
+NotInheritable Class Derived
+    Inherits Base
+
+    Public Sub New(value As Integer)
+        MyBase.New(value)
+    End Sub
+End Class")
+        End Function
+
         <WorkItem(19953, "https://github.com/dotnet/roslyn/issues/19953")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Async Function TestNotOnEnum() As Task

--- a/src/Features/Core/Portable/GenerateMember/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
 
                 return CodeGenerationSymbolFactory.CreateConstructorSymbol(
                     attributes: default,
-                    accessibility: constructor.DeclaredAccessibility,
+                    accessibility: _state.ClassType.IsSealed ? Accessibility.Public : constructor.DeclaredAccessibility,
                     modifiers: new DeclarationModifiers(),
                     typeName: _state.ClassType.Name,
                     parameters: constructor.Parameters,


### PR DESCRIPTION
Fixes #22699
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
