### PR TITLE
Mark Toolset projects non-shipping

### DIFF
--- a/build/ToolsetPackages/InternalToolset.csproj
+++ b/build/ToolsetPackages/InternalToolset.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Targets\SettingsSdk.props" />
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <NonShipping>true</NonShipping>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMerge)" />

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Targets\SettingsSdk.props" />
   <PropertyGroup>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
+    <NonShipping>true</NonShipping>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Sdk" Version="$(MicrosoftNetSdkVersion)" />


### PR DESCRIPTION
Mark InternalToolset.csproj and RoslynToolset.csproj as non-shipping. This prevents the projects
from pulling in a `PackageReference` to xliff-tasks, which they don't
need and, more to the point, may not be available in the NuGet feeds used to restore them.