### PR TITLE
Pool the Stopwatch instance used in the analyzer driver

### DIFF
--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.projitems
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ObjectPool`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PooledDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PooledHashSet.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PooledStopwatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PooledStringBuilder.cs" />
   </ItemGroup>
 </Project>

--- a/src/Dependencies/PooledObjects/PooledStopwatch.cs
+++ b/src/Dependencies/PooledObjects/PooledStopwatch.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.PooledObjects
+{
+    internal class PooledStopwatch : Stopwatch
+    {
+        private static readonly ObjectPool<PooledStopwatch> s_poolInstance = CreatePool();
+
+        private readonly ObjectPool<PooledStopwatch> _pool;
+
+        private PooledStopwatch(ObjectPool<PooledStopwatch> pool)
+        {
+            _pool = pool;
+            UpdateValueFactory = (_, accumulated) => accumulated + Elapsed;
+        }
+
+        public Func<object, TimeSpan, TimeSpan> UpdateValueFactory
+        {
+            get;
+        }
+
+        public void Free()
+        {
+            Reset();
+            _pool?.Free(this);
+        }
+
+        public static ObjectPool<PooledStopwatch> CreatePool()
+        {
+            ObjectPool<PooledStopwatch> pool = null;
+            pool = new ObjectPool<PooledStopwatch>(() => new PooledStopwatch(pool), 128);
+            return pool;
+        }
+
+        public static PooledStopwatch StartInstance()
+        {
+            var instance = s_poolInstance.Allocate();
+            instance.Restart();
+            return instance;
+        }
+    }
+}


### PR DESCRIPTION
### Customer scenario

Running analyzer during a build is slower than it should be, with the analyzer driver contributing substantial overhead even when the analyzers themselves are lightweight.

### Bugs this fixes

N/A

### Workarounds, if any

None needed

### Risk

Low. A `PerformanceSensitive` attribute is added to aid in preventing regressions.

### Performance impact

AnalyzerRunner on an FXCop scenario indicates overall allocation savings of 7-8%. About 1% is due to the `Stopwatch` instance itself, while the rest is due to the closure and delegate which can now be cached.

### Is this a regression from a previous update?

No.

### Root cause analysis

AnalyzerRunner is a new tool for helping us test analyzer performance in isolation.

### How was the bug found?

AnalyzerRunner.

### Test documentation updated?

No.