### PR TITLE
Simplify codegen for struct declaration patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -243,30 +243,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else // type parameter or value type
             {
-                // bool Is<T>(this object i, out T o)
+                // bool Is<T>(this object i, ref T o)
                 // {
                 //     // inefficient because it performs the type test twice, and also because it boxes the input.
-                //     bool s;
-                //     o = (s = i is T) ? (T)i : default(T);
-                //     return s;
+                //     return i is T && (o = (T)i; true);
                 // }
 
                 // Because a cast involving a type parameter is not necessarily a valid conversion (or, if it is, it might not
                 // be of a kind appropriate for pattern-matching), we use `object` as an intermediate type for the input expression.
                 var objectType = _factory.SpecialType(SpecialType.System_Object);
-                var s = _factory.SynthesizedLocal(_factory.SpecialType(SpecialType.System_Boolean), syntax);
                 var i = _factory.SynthesizedLocal(objectType, syntax); // we copy the input to avoid double evaluation
-                return _factory.Sequence(
-                    ImmutableArray.Create(s, i),
-                    ImmutableArray.Create<BoundExpression>(
-                        _factory.AssignmentExpression(_factory.Local(i), _factory.Convert(objectType, loweredInput)),
-                        _factory.AssignmentExpression(loweredTarget, _factory.Conditional(
-                            _factory.AssignmentExpression(_factory.Local(s), _factory.Is(_factory.Local(i), type)),
-                            _factory.Convert(type, _factory.Local(i)),
-                            _factory.Default(type), type))
-                        ),
-                    _factory.Local(s)
-                    );
+                return _factory.MakeSequence(i,
+                    _factory.AssignmentExpression(_factory.Local(i), _factory.Convert(objectType, loweredInput)),
+                    _factory.LogicalAnd(
+                        _factory.Is(_factory.Local(i), type),
+                        _factory.MakeSequence(
+                            _factory.AssignmentExpression(loweredTarget, _factory.Convert(type, _factory.Local(i))),
+                            _factory.Literal(true))));
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -240,12 +240,11 @@ class IdentityAccessor<T>
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("X<T>.Y<U>",
 @"{
-  // Code size       67 (0x43)
+  // Code size       56 (0x38)
   .maxstack  3
   .locals init (U V_0, //u
                 bool V_1,
-                object V_2,
-                U V_3)
+                object V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       ""System.Collections.Generic.IEnumerable<T> X<T>.GetT()""
@@ -257,23 +256,19 @@ class IdentityAccessor<T>
   IL_001d:  stloc.2
   IL_001e:  ldloc.2
   IL_001f:  isinst     ""U""
-  IL_0024:  ldnull
-  IL_0025:  cgt.un
-  IL_0027:  dup
-  IL_0028:  brtrue.s   IL_0035
-  IL_002a:  ldloca.s   V_3
-  IL_002c:  initobj    ""U""
-  IL_0032:  ldloc.3
-  IL_0033:  br.s       IL_003b
-  IL_0035:  ldloc.2
-  IL_0036:  unbox.any  ""U""
-  IL_003b:  stloc.0
-  IL_003c:  stloc.1
-  IL_003d:  ldloc.1
-  IL_003e:  brfalse.s  IL_0042
-  IL_0040:  nop
-  IL_0041:  nop
-  IL_0042:  ret
+  IL_0024:  brfalse.s  IL_0030
+  IL_0026:  ldloc.2
+  IL_0027:  unbox.any  ""U""
+  IL_002c:  stloc.0
+  IL_002d:  ldc.i4.1
+  IL_002e:  br.s       IL_0031
+  IL_0030:  ldc.i4.0
+  IL_0031:  stloc.1
+  IL_0032:  ldloc.1
+  IL_0033:  brfalse.s  IL_0037
+  IL_0035:  nop
+  IL_0036:  nop
+  IL_0037:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -240,11 +240,11 @@ class IdentityAccessor<T>
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("X<T>.Y<U>",
 @"{
-  // Code size       56 (0x38)
+  // Code size       61 (0x3d)
   .maxstack  3
   .locals init (U V_0, //u
                 bool V_1,
-                object V_2)
+                T V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  call       ""System.Collections.Generic.IEnumerable<T> X<T>.GetT()""
@@ -252,23 +252,24 @@ class IdentityAccessor<T>
   IL_0008:  ldftn      ""bool X<T>.<Y>b__1_0<U>(T)""
   IL_000e:  newobj     ""System.Func<T, bool>..ctor(object, System.IntPtr)""
   IL_0013:  call       ""T System.Linq.Enumerable.FirstOrDefault<T>(System.Collections.Generic.IEnumerable<T>, System.Func<T, bool>)""
-  IL_0018:  box        ""T""
-  IL_001d:  stloc.2
-  IL_001e:  ldloc.2
+  IL_0018:  dup
+  IL_0019:  stloc.2
+  IL_001a:  box        ""T""
   IL_001f:  isinst     ""U""
-  IL_0024:  brfalse.s  IL_0030
+  IL_0024:  brfalse.s  IL_0035
   IL_0026:  ldloc.2
-  IL_0027:  unbox.any  ""U""
-  IL_002c:  stloc.0
-  IL_002d:  ldc.i4.1
-  IL_002e:  br.s       IL_0031
-  IL_0030:  ldc.i4.0
-  IL_0031:  stloc.1
-  IL_0032:  ldloc.1
-  IL_0033:  brfalse.s  IL_0037
-  IL_0035:  nop
-  IL_0036:  nop
-  IL_0037:  ret
+  IL_0027:  box        ""T""
+  IL_002c:  unbox.any  ""U""
+  IL_0031:  stloc.0
+  IL_0032:  ldc.i4.1
+  IL_0033:  br.s       IL_0036
+  IL_0035:  ldc.i4.0
+  IL_0036:  stloc.1
+  IL_0037:  ldloc.1
+  IL_0038:  brfalse.s  IL_003c
+  IL_003a:  nop
+  IL_003b:  nop
+  IL_003c:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -7948,32 +7948,26 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size       38 (0x26)
-  .maxstack  2
+  // Code size       29 (0x1d)
+  .maxstack  1
   .locals init (object V_0,
                 int V_1,
                 object V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse.s  IL_0025
+  IL_0003:  brfalse.s  IL_001c
   IL_0005:  ldloc.0
   IL_0006:  stloc.2
   IL_0007:  ldloc.2
   IL_0008:  isinst     ""int""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_0016
-  IL_0013:  ldc.i4.0
-  IL_0014:  br.s       IL_001c
-  IL_0016:  ldloc.2
-  IL_0017:  unbox.any  ""int""
-  IL_001c:  stloc.1
-  IL_001d:  brfalse.s  IL_0025
-  IL_001f:  ldloc.1
-  IL_0020:  call       ""void System.Console.Write(int)""
-  IL_0025:  ret
+  IL_000d:  brfalse.s  IL_001c
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""int""
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  call       ""void System.Console.Write(int)""
+  IL_001c:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -7981,8 +7975,8 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size       57 (0x39)
-  .maxstack  2
+  // Code size       48 (0x30)
+  .maxstack  1
   .locals init (object V_0,
                 int V_1,
                 int V_2, //i
@@ -7995,31 +7989,25 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0029
+  IL_0008:  br.s       IL_0020
   IL_000a:  ldloc.0
   IL_000b:  stloc.s    V_4
   IL_000d:  ldloc.s    V_4
   IL_000f:  isinst     ""int""
-  IL_0014:  ldnull
-  IL_0015:  cgt.un
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_001d
-  IL_001a:  ldc.i4.0
-  IL_001b:  br.s       IL_0024
-  IL_001d:  ldloc.s    V_4
-  IL_001f:  unbox.any  ""int""
-  IL_0024:  stloc.1
-  IL_0025:  brfalse.s  IL_0029
-  IL_0027:  br.s       IL_002b
-  IL_0029:  br.s       IL_0038
-  IL_002b:  ldloc.1
-  IL_002c:  stloc.2
+  IL_0014:  brfalse.s  IL_0020
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  unbox.any  ""int""
+  IL_001d:  stloc.1
+  IL_001e:  br.s       IL_0022
+  IL_0020:  br.s       IL_002f
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.2
+  IL_0024:  br.s       IL_0026
+  IL_0026:  ldloc.2
+  IL_0027:  call       ""void System.Console.Write(int)""
+  IL_002c:  nop
   IL_002d:  br.s       IL_002f
-  IL_002f:  ldloc.2
-  IL_0030:  call       ""void System.Console.Write(int)""
-  IL_0035:  nop
-  IL_0036:  br.s       IL_0038
-  IL_0038:  ret
+  IL_002f:  ret
 }"
             );
         }
@@ -8054,36 +8042,27 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       51 (0x33)
-  .maxstack  2
+  // Code size       34 (0x22)
+  .maxstack  1
   .locals init (object V_0,
                 T V_1,
-                object V_2,
-                T V_3)
+                object V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse.s  IL_0032
+  IL_0003:  brfalse.s  IL_0021
   IL_0005:  ldloc.0
   IL_0006:  stloc.2
   IL_0007:  ldloc.2
   IL_0008:  isinst     ""T""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  initobj    ""T""
-  IL_001b:  ldloc.3
-  IL_001c:  br.s       IL_0024
-  IL_001e:  ldloc.2
-  IL_001f:  unbox.any  ""T""
-  IL_0024:  stloc.1
-  IL_0025:  brfalse.s  IL_0032
-  IL_0027:  ldloc.1
-  IL_0028:  box        ""T""
-  IL_002d:  call       ""void System.Console.Write(object)""
-  IL_0032:  ret
+  IL_000d:  brfalse.s  IL_0021
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""T""
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  box        ""T""
+  IL_001c:  call       ""void System.Console.Write(object)""
+  IL_0021:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8091,14 +8070,13 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       71 (0x47)
-  .maxstack  2
+  // Code size       53 (0x35)
+  .maxstack  1
   .locals init (object V_0,
                 T V_1,
                 T V_2, //i
                 object V_3,
-                object V_4,
-                T V_5)
+                object V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.3
@@ -8106,34 +8084,26 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0032
+  IL_0008:  br.s       IL_0020
   IL_000a:  ldloc.0
   IL_000b:  stloc.s    V_4
   IL_000d:  ldloc.s    V_4
   IL_000f:  isinst     ""T""
-  IL_0014:  ldnull
-  IL_0015:  cgt.un
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_0026
-  IL_001a:  ldloca.s   V_5
-  IL_001c:  initobj    ""T""
-  IL_0022:  ldloc.s    V_5
-  IL_0024:  br.s       IL_002d
-  IL_0026:  ldloc.s    V_4
-  IL_0028:  unbox.any  ""T""
-  IL_002d:  stloc.1
-  IL_002e:  brfalse.s  IL_0032
-  IL_0030:  br.s       IL_0034
-  IL_0032:  br.s       IL_0046
-  IL_0034:  ldloc.1
-  IL_0035:  stloc.2
-  IL_0036:  br.s       IL_0038
-  IL_0038:  ldloc.2
-  IL_0039:  box        ""T""
-  IL_003e:  call       ""void System.Console.Write(object)""
-  IL_0043:  nop
-  IL_0044:  br.s       IL_0046
-  IL_0046:  ret
+  IL_0014:  brfalse.s  IL_0020
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  unbox.any  ""T""
+  IL_001d:  stloc.1
+  IL_001e:  br.s       IL_0022
+  IL_0020:  br.s       IL_0034
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.2
+  IL_0024:  br.s       IL_0026
+  IL_0026:  ldloc.2
+  IL_0027:  box        ""T""
+  IL_002c:  call       ""void System.Console.Write(object)""
+  IL_0031:  nop
+  IL_0032:  br.s       IL_0034
+  IL_0034:  ret
 }"
             );
         }
@@ -8168,36 +8138,27 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       51 (0x33)
-  .maxstack  2
+  // Code size       34 (0x22)
+  .maxstack  1
   .locals init (System.IComparable V_0,
                 T V_1,
-                object V_2,
-                T V_3)
+                object V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse.s  IL_0032
+  IL_0003:  brfalse.s  IL_0021
   IL_0005:  ldloc.0
   IL_0006:  stloc.2
   IL_0007:  ldloc.2
   IL_0008:  isinst     ""T""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  initobj    ""T""
-  IL_001b:  ldloc.3
-  IL_001c:  br.s       IL_0024
-  IL_001e:  ldloc.2
-  IL_001f:  unbox.any  ""T""
-  IL_0024:  stloc.1
-  IL_0025:  brfalse.s  IL_0032
-  IL_0027:  ldloc.1
-  IL_0028:  box        ""T""
-  IL_002d:  call       ""void System.Console.Write(object)""
-  IL_0032:  ret
+  IL_000d:  brfalse.s  IL_0021
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""T""
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  box        ""T""
+  IL_001c:  call       ""void System.Console.Write(object)""
+  IL_0021:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8205,14 +8166,13 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       71 (0x47)
-  .maxstack  2
+  // Code size       53 (0x35)
+  .maxstack  1
   .locals init (System.IComparable V_0,
                 T V_1,
                 T V_2, //i
                 System.IComparable V_3,
-                object V_4,
-                T V_5)
+                object V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.3
@@ -8220,34 +8180,26 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0032
+  IL_0008:  br.s       IL_0020
   IL_000a:  ldloc.0
   IL_000b:  stloc.s    V_4
   IL_000d:  ldloc.s    V_4
   IL_000f:  isinst     ""T""
-  IL_0014:  ldnull
-  IL_0015:  cgt.un
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_0026
-  IL_001a:  ldloca.s   V_5
-  IL_001c:  initobj    ""T""
-  IL_0022:  ldloc.s    V_5
-  IL_0024:  br.s       IL_002d
-  IL_0026:  ldloc.s    V_4
-  IL_0028:  unbox.any  ""T""
-  IL_002d:  stloc.1
-  IL_002e:  brfalse.s  IL_0032
-  IL_0030:  br.s       IL_0034
-  IL_0032:  br.s       IL_0046
-  IL_0034:  ldloc.1
-  IL_0035:  stloc.2
-  IL_0036:  br.s       IL_0038
-  IL_0038:  ldloc.2
-  IL_0039:  box        ""T""
-  IL_003e:  call       ""void System.Console.Write(object)""
-  IL_0043:  nop
-  IL_0044:  br.s       IL_0046
-  IL_0046:  ret
+  IL_0014:  brfalse.s  IL_0020
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  unbox.any  ""T""
+  IL_001d:  stloc.1
+  IL_001e:  br.s       IL_0022
+  IL_0020:  br.s       IL_0034
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.2
+  IL_0024:  br.s       IL_0026
+  IL_0026:  ldloc.2
+  IL_0027:  box        ""T""
+  IL_002c:  call       ""void System.Console.Write(object)""
+  IL_0031:  nop
+  IL_0032:  br.s       IL_0034
+  IL_0034:  ret
 }"
             );
         }
@@ -8282,38 +8234,29 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T, U>",
 @"{
-  // Code size       61 (0x3d)
-  .maxstack  2
+  // Code size       44 (0x2c)
+  .maxstack  1
   .locals init (U V_0,
                 T V_1,
-                object V_2,
-                T V_3)
+                object V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  box        ""U""
-  IL_0008:  brfalse.s  IL_003c
+  IL_0008:  brfalse.s  IL_002b
   IL_000a:  ldloc.0
   IL_000b:  box        ""U""
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  isinst     ""T""
-  IL_0017:  ldnull
-  IL_0018:  cgt.un
-  IL_001a:  dup
-  IL_001b:  brtrue.s   IL_0028
-  IL_001d:  ldloca.s   V_3
-  IL_001f:  initobj    ""T""
-  IL_0025:  ldloc.3
-  IL_0026:  br.s       IL_002e
-  IL_0028:  ldloc.2
-  IL_0029:  unbox.any  ""T""
-  IL_002e:  stloc.1
-  IL_002f:  brfalse.s  IL_003c
-  IL_0031:  ldloc.1
-  IL_0032:  box        ""T""
-  IL_0037:  call       ""void System.Console.Write(object)""
-  IL_003c:  ret
+  IL_0017:  brfalse.s  IL_002b
+  IL_0019:  ldloc.2
+  IL_001a:  unbox.any  ""T""
+  IL_001f:  stloc.1
+  IL_0020:  ldloc.1
+  IL_0021:  box        ""T""
+  IL_0026:  call       ""void System.Console.Write(object)""
+  IL_002b:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8321,14 +8264,13 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T, U>",
 @"{
-  // Code size       81 (0x51)
-  .maxstack  2
+  // Code size       63 (0x3f)
+  .maxstack  1
   .locals init (U V_0,
                 T V_1,
                 T V_2, //i
                 U V_3,
-                object V_4,
-                T V_5)
+                object V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.3
@@ -8337,35 +8279,27 @@ public class Program
   IL_0005:  ldloc.0
   IL_0006:  box        ""U""
   IL_000b:  brtrue.s   IL_000f
-  IL_000d:  br.s       IL_003c
+  IL_000d:  br.s       IL_002a
   IL_000f:  ldloc.0
   IL_0010:  box        ""U""
   IL_0015:  stloc.s    V_4
   IL_0017:  ldloc.s    V_4
   IL_0019:  isinst     ""T""
-  IL_001e:  ldnull
-  IL_001f:  cgt.un
-  IL_0021:  dup
-  IL_0022:  brtrue.s   IL_0030
-  IL_0024:  ldloca.s   V_5
-  IL_0026:  initobj    ""T""
-  IL_002c:  ldloc.s    V_5
-  IL_002e:  br.s       IL_0037
-  IL_0030:  ldloc.s    V_4
-  IL_0032:  unbox.any  ""T""
-  IL_0037:  stloc.1
-  IL_0038:  brfalse.s  IL_003c
-  IL_003a:  br.s       IL_003e
-  IL_003c:  br.s       IL_0050
-  IL_003e:  ldloc.1
-  IL_003f:  stloc.2
-  IL_0040:  br.s       IL_0042
-  IL_0042:  ldloc.2
-  IL_0043:  box        ""T""
-  IL_0048:  call       ""void System.Console.Write(object)""
-  IL_004d:  nop
-  IL_004e:  br.s       IL_0050
-  IL_0050:  ret
+  IL_001e:  brfalse.s  IL_002a
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  unbox.any  ""T""
+  IL_0027:  stloc.1
+  IL_0028:  br.s       IL_002c
+  IL_002a:  br.s       IL_003e
+  IL_002c:  ldloc.1
+  IL_002d:  stloc.2
+  IL_002e:  br.s       IL_0030
+  IL_0030:  ldloc.2
+  IL_0031:  box        ""T""
+  IL_0036:  call       ""void System.Console.Write(object)""
+  IL_003b:  nop
+  IL_003c:  br.s       IL_003e
+  IL_003e:  ret
 }"
             );
         }
@@ -8472,8 +8406,8 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       46 (0x2e)
-  .maxstack  2
+  // Code size       31 (0x1f)
+  .maxstack  1
   .locals init (T V_0, //t
                 object V_1,
                 T V_2)
@@ -8481,30 +8415,23 @@ class Program
   IL_0001:  stloc.1
   IL_0002:  ldloc.1
   IL_0003:  isinst     ""T""
-  IL_0008:  ldnull
-  IL_0009:  cgt.un
-  IL_000b:  dup
-  IL_000c:  brtrue.s   IL_0019
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  initobj    ""T""
-  IL_0016:  ldloc.2
-  IL_0017:  br.s       IL_001f
-  IL_0019:  ldloc.1
-  IL_001a:  unbox.any  ""T""
-  IL_001f:  stloc.0
-  IL_0020:  brtrue.s   IL_002c
-  IL_0022:  ldloca.s   V_2
-  IL_0024:  initobj    ""T""
-  IL_002a:  ldloc.2
-  IL_002b:  ret
-  IL_002c:  ldloc.0
-  IL_002d:  ret
+  IL_0008:  brfalse.s  IL_0013
+  IL_000a:  ldloc.1
+  IL_000b:  unbox.any  ""T""
+  IL_0010:  stloc.0
+  IL_0011:  br.s       IL_001d
+  IL_0013:  ldloca.s   V_2
+  IL_0015:  initobj    ""T""
+  IL_001b:  ldloc.2
+  IL_001c:  ret
+  IL_001d:  ldloc.0
+  IL_001e:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       51 (0x33)
-  .maxstack  2
+  // Code size       34 (0x22)
+  .maxstack  1
   .locals init (System.ValueType V_0,
                 T V_1,
                 object V_2,
@@ -8512,29 +8439,21 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse.s  IL_0029
+  IL_0003:  brfalse.s  IL_0018
   IL_0005:  ldloc.0
   IL_0006:  stloc.2
   IL_0007:  ldloc.2
   IL_0008:  isinst     ""T""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  initobj    ""T""
-  IL_001b:  ldloc.3
-  IL_001c:  br.s       IL_0024
-  IL_001e:  ldloc.2
-  IL_001f:  unbox.any  ""T""
-  IL_0024:  stloc.1
-  IL_0025:  brfalse.s  IL_0029
-  IL_0027:  ldloc.1
-  IL_0028:  ret
-  IL_0029:  ldloca.s   V_3
-  IL_002b:  initobj    ""T""
-  IL_0031:  ldloc.3
-  IL_0032:  ret
+  IL_000d:  brfalse.s  IL_0018
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""T""
+  IL_0015:  stloc.1
+  IL_0016:  ldloc.1
+  IL_0017:  ret
+  IL_0018:  ldloca.s   V_3
+  IL_001a:  initobj    ""T""
+  IL_0020:  ldloc.3
+  IL_0021:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8543,8 +8462,8 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       52 (0x34)
-  .maxstack  2
+  // Code size       37 (0x25)
+  .maxstack  1
   .locals init (T V_0, //t
                 object V_1,
                 T V_2,
@@ -8554,33 +8473,26 @@ class Program
   IL_0002:  stloc.1
   IL_0003:  ldloc.1
   IL_0004:  isinst     ""T""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  dup
-  IL_000d:  brtrue.s   IL_001a
-  IL_000f:  ldloca.s   V_2
-  IL_0011:  initobj    ""T""
-  IL_0017:  ldloc.2
-  IL_0018:  br.s       IL_0020
-  IL_001a:  ldloc.1
-  IL_001b:  unbox.any  ""T""
-  IL_0020:  stloc.0
-  IL_0021:  brtrue.s   IL_002e
-  IL_0023:  ldloca.s   V_2
-  IL_0025:  initobj    ""T""
-  IL_002b:  ldloc.2
-  IL_002c:  br.s       IL_002f
-  IL_002e:  ldloc.0
-  IL_002f:  stloc.3
-  IL_0030:  br.s       IL_0032
-  IL_0032:  ldloc.3
-  IL_0033:  ret
+  IL_0009:  brfalse.s  IL_0014
+  IL_000b:  ldloc.1
+  IL_000c:  unbox.any  ""T""
+  IL_0011:  stloc.0
+  IL_0012:  br.s       IL_001f
+  IL_0014:  ldloca.s   V_2
+  IL_0016:  initobj    ""T""
+  IL_001c:  ldloc.2
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.0
+  IL_0020:  stloc.3
+  IL_0021:  br.s       IL_0023
+  IL_0023:  ldloc.3
+  IL_0024:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       78 (0x4e)
-  .maxstack  2
+  // Code size       60 (0x3c)
+  .maxstack  1
   .locals init (System.ValueType V_0,
                 T V_1,
                 T V_2, //t
@@ -8595,38 +8507,30 @@ class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0032
+  IL_0008:  br.s       IL_0020
   IL_000a:  ldloc.0
   IL_000b:  stloc.s    V_4
   IL_000d:  ldloc.s    V_4
   IL_000f:  isinst     ""T""
-  IL_0014:  ldnull
-  IL_0015:  cgt.un
-  IL_0017:  dup
-  IL_0018:  brtrue.s   IL_0026
-  IL_001a:  ldloca.s   V_5
-  IL_001c:  initobj    ""T""
-  IL_0022:  ldloc.s    V_5
-  IL_0024:  br.s       IL_002d
-  IL_0026:  ldloc.s    V_4
-  IL_0028:  unbox.any  ""T""
-  IL_002d:  stloc.1
-  IL_002e:  brfalse.s  IL_0032
-  IL_0030:  br.s       IL_0034
-  IL_0032:  br.s       IL_003d
-  IL_0034:  ldloc.1
-  IL_0035:  stloc.2
-  IL_0036:  br.s       IL_0038
-  IL_0038:  ldloc.2
-  IL_0039:  stloc.s    V_6
-  IL_003b:  br.s       IL_004b
-  IL_003d:  ldloca.s   V_5
-  IL_003f:  initobj    ""T""
-  IL_0045:  ldloc.s    V_5
-  IL_0047:  stloc.s    V_6
-  IL_0049:  br.s       IL_004b
-  IL_004b:  ldloc.s    V_6
-  IL_004d:  ret
+  IL_0014:  brfalse.s  IL_0020
+  IL_0016:  ldloc.s    V_4
+  IL_0018:  unbox.any  ""T""
+  IL_001d:  stloc.1
+  IL_001e:  br.s       IL_0022
+  IL_0020:  br.s       IL_002b
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.2
+  IL_0024:  br.s       IL_0026
+  IL_0026:  ldloc.2
+  IL_0027:  stloc.s    V_5
+  IL_0029:  br.s       IL_0039
+  IL_002b:  ldloca.s   V_6
+  IL_002d:  initobj    ""T""
+  IL_0033:  ldloc.s    V_6
+  IL_0035:  stloc.s    V_5
+  IL_0037:  br.s       IL_0039
+  IL_0039:  ldloc.s    V_5
+  IL_003b:  ret
 }"
             );
         }
@@ -8674,8 +8578,8 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       35 (0x23)
-  .maxstack  2
+  // Code size       28 (0x1c)
+  .maxstack  1
   .locals init (int V_0, //t
                 object V_1)
   IL_0000:  ldarg.0
@@ -8683,26 +8587,21 @@ class Program
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
   IL_0008:  isinst     ""int""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_0016
-  IL_0013:  ldc.i4.0
-  IL_0014:  br.s       IL_001c
-  IL_0016:  ldloc.1
-  IL_0017:  unbox.any  ""int""
-  IL_001c:  stloc.0
-  IL_001d:  brtrue.s   IL_0021
-  IL_001f:  ldc.i4.0
-  IL_0020:  ret
-  IL_0021:  ldloc.0
-  IL_0022:  ret
+  IL_000d:  brfalse.s  IL_0018
+  IL_000f:  ldloc.1
+  IL_0010:  unbox.any  ""int""
+  IL_0015:  stloc.0
+  IL_0016:  br.s       IL_001a
+  IL_0018:  ldc.i4.0
+  IL_0019:  ret
+  IL_001a:  ldloc.0
+  IL_001b:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       45 (0x2d)
-  .maxstack  2
+  // Code size       36 (0x24)
+  .maxstack  1
   .locals init (T V_0,
                 int V_1,
                 object V_2)
@@ -8710,26 +8609,20 @@ class Program
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  box        ""T""
-  IL_0008:  brfalse.s  IL_002b
+  IL_0008:  brfalse.s  IL_0022
   IL_000a:  ldloc.0
   IL_000b:  box        ""T""
   IL_0010:  stloc.2
   IL_0011:  ldloc.2
   IL_0012:  isinst     ""int""
-  IL_0017:  ldnull
-  IL_0018:  cgt.un
-  IL_001a:  dup
-  IL_001b:  brtrue.s   IL_0020
-  IL_001d:  ldc.i4.0
-  IL_001e:  br.s       IL_0026
-  IL_0020:  ldloc.2
-  IL_0021:  unbox.any  ""int""
-  IL_0026:  stloc.1
-  IL_0027:  brfalse.s  IL_002b
-  IL_0029:  ldloc.1
-  IL_002a:  ret
-  IL_002b:  ldc.i4.0
-  IL_002c:  ret
+  IL_0017:  brfalse.s  IL_0022
+  IL_0019:  ldloc.2
+  IL_001a:  unbox.any  ""int""
+  IL_001f:  stloc.1
+  IL_0020:  ldloc.1
+  IL_0021:  ret
+  IL_0022:  ldc.i4.0
+  IL_0023:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8738,8 +8631,8 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       41 (0x29)
-  .maxstack  2
+  // Code size       34 (0x22)
+  .maxstack  1
   .locals init (int V_0, //t
                 object V_1,
                 int V_2)
@@ -8749,29 +8642,24 @@ class Program
   IL_0007:  stloc.1
   IL_0008:  ldloc.1
   IL_0009:  isinst     ""int""
-  IL_000e:  ldnull
-  IL_000f:  cgt.un
-  IL_0011:  dup
-  IL_0012:  brtrue.s   IL_0017
-  IL_0014:  ldc.i4.0
-  IL_0015:  br.s       IL_001d
-  IL_0017:  ldloc.1
-  IL_0018:  unbox.any  ""int""
-  IL_001d:  stloc.0
-  IL_001e:  brtrue.s   IL_0023
-  IL_0020:  ldc.i4.0
-  IL_0021:  br.s       IL_0024
-  IL_0023:  ldloc.0
-  IL_0024:  stloc.2
-  IL_0025:  br.s       IL_0027
-  IL_0027:  ldloc.2
-  IL_0028:  ret
+  IL_000e:  brfalse.s  IL_0019
+  IL_0010:  ldloc.1
+  IL_0011:  unbox.any  ""int""
+  IL_0016:  stloc.0
+  IL_0017:  br.s       IL_001c
+  IL_0019:  ldc.i4.0
+  IL_001a:  br.s       IL_001d
+  IL_001c:  ldloc.0
+  IL_001d:  stloc.2
+  IL_001e:  br.s       IL_0020
+  IL_0020:  ldloc.2
+  IL_0021:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       70 (0x46)
-  .maxstack  2
+  // Code size       61 (0x3d)
+  .maxstack  1
   .locals init (T V_0,
                 int V_1,
                 int V_2, //t
@@ -8786,35 +8674,29 @@ class Program
   IL_0005:  ldloc.0
   IL_0006:  box        ""T""
   IL_000b:  brtrue.s   IL_000f
-  IL_000d:  br.s       IL_0033
+  IL_000d:  br.s       IL_002a
   IL_000f:  ldloc.0
   IL_0010:  box        ""T""
   IL_0015:  stloc.s    V_4
   IL_0017:  ldloc.s    V_4
   IL_0019:  isinst     ""int""
-  IL_001e:  ldnull
-  IL_001f:  cgt.un
-  IL_0021:  dup
-  IL_0022:  brtrue.s   IL_0027
-  IL_0024:  ldc.i4.0
-  IL_0025:  br.s       IL_002e
-  IL_0027:  ldloc.s    V_4
-  IL_0029:  unbox.any  ""int""
-  IL_002e:  stloc.1
-  IL_002f:  brfalse.s  IL_0033
-  IL_0031:  br.s       IL_0035
-  IL_0033:  br.s       IL_003e
-  IL_0035:  ldloc.1
-  IL_0036:  stloc.2
-  IL_0037:  br.s       IL_0039
-  IL_0039:  ldloc.2
-  IL_003a:  stloc.s    V_5
-  IL_003c:  br.s       IL_0043
-  IL_003e:  ldc.i4.0
-  IL_003f:  stloc.s    V_5
-  IL_0041:  br.s       IL_0043
-  IL_0043:  ldloc.s    V_5
-  IL_0045:  ret
+  IL_001e:  brfalse.s  IL_002a
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  unbox.any  ""int""
+  IL_0027:  stloc.1
+  IL_0028:  br.s       IL_002c
+  IL_002a:  br.s       IL_0035
+  IL_002c:  ldloc.1
+  IL_002d:  stloc.2
+  IL_002e:  br.s       IL_0030
+  IL_0030:  ldloc.2
+  IL_0031:  stloc.s    V_5
+  IL_0033:  br.s       IL_003a
+  IL_0035:  ldc.i4.0
+  IL_0036:  stloc.s    V_5
+  IL_0038:  br.s       IL_003a
+  IL_003a:  ldloc.s    V_5
+  IL_003c:  ret
 }"
             );
         }
@@ -9167,7 +9049,7 @@ None
 Generic<object>.Color.Red");
             compVerifier.VerifyIL("Program.M2",
 @"{
-  // Code size      148 (0x94)
+  // Code size      130 (0x82)
   .maxstack  2
   .locals init (object V_0,
                 Generic<long>.Color V_1,
@@ -9184,68 +9066,56 @@ Generic<object>.Color.Red");
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  brtrue.s   IL_000c
-  IL_000a:  br.s       IL_005c
+  IL_000a:  br.s       IL_004a
   IL_000c:  ldloc.0
   IL_000d:  stloc.s    V_5
   IL_000f:  ldloc.s    V_5
   IL_0011:  isinst     ""Generic<long>.Color""
-  IL_0016:  ldnull
-  IL_0017:  cgt.un
-  IL_0019:  dup
-  IL_001a:  brtrue.s   IL_001f
-  IL_001c:  ldc.i4.0
-  IL_001d:  br.s       IL_0026
-  IL_001f:  ldloc.s    V_5
-  IL_0021:  unbox.any  ""Generic<long>.Color""
-  IL_0026:  stloc.1
-  IL_0027:  brfalse.s  IL_002b
-  IL_0029:  br.s       IL_005e
-  IL_002b:  ldloc.0
-  IL_002c:  stloc.s    V_5
+  IL_0016:  brfalse.s  IL_0022
+  IL_0018:  ldloc.s    V_5
+  IL_001a:  unbox.any  ""Generic<long>.Color""
+  IL_001f:  stloc.1
+  IL_0020:  br.s       IL_004c
+  IL_0022:  ldloc.0
+  IL_0023:  stloc.s    V_5
+  IL_0025:  ldloc.s    V_5
+  IL_0027:  isinst     ""Generic<object>.Color""
+  IL_002c:  brfalse.s  IL_004a
   IL_002e:  ldloc.s    V_5
-  IL_0030:  isinst     ""Generic<object>.Color""
-  IL_0035:  ldnull
-  IL_0036:  cgt.un
-  IL_0038:  dup
-  IL_0039:  brtrue.s   IL_003e
-  IL_003b:  ldc.i4.0
-  IL_003c:  br.s       IL_0045
-  IL_003e:  ldloc.s    V_5
-  IL_0040:  unbox.any  ""Generic<object>.Color""
-  IL_0045:  stloc.2
-  IL_0046:  brfalse.s  IL_005c
-  IL_0048:  ldloc.2
-  IL_0049:  stloc.s    V_6
-  IL_004b:  ldloc.s    V_6
-  IL_004d:  brfalse.s  IL_0058
-  IL_004f:  br.s       IL_0051
-  IL_0051:  ldloc.s    V_6
-  IL_0053:  ldc.i4.1
-  IL_0054:  beq.s      IL_005a
-  IL_0056:  br.s       IL_005c
-  IL_0058:  br.s       IL_0076
-  IL_005a:  br.s       IL_007f
-  IL_005c:  br.s       IL_0088
-  IL_005e:  ldloc.1
-  IL_005f:  stloc.3
-  IL_0060:  br.s       IL_0062
-  IL_0062:  ldstr      ""Generic<long>.Color.""
-  IL_0067:  ldloc.3
-  IL_0068:  box        ""Generic<long>.Color""
-  IL_006d:  call       ""string string.Concat(object, object)""
+  IL_0030:  unbox.any  ""Generic<object>.Color""
+  IL_0035:  stloc.2
+  IL_0036:  ldloc.2
+  IL_0037:  stloc.s    V_6
+  IL_0039:  ldloc.s    V_6
+  IL_003b:  brfalse.s  IL_0046
+  IL_003d:  br.s       IL_003f
+  IL_003f:  ldloc.s    V_6
+  IL_0041:  ldc.i4.1
+  IL_0042:  beq.s      IL_0048
+  IL_0044:  br.s       IL_004a
+  IL_0046:  br.s       IL_0064
+  IL_0048:  br.s       IL_006d
+  IL_004a:  br.s       IL_0076
+  IL_004c:  ldloc.1
+  IL_004d:  stloc.3
+  IL_004e:  br.s       IL_0050
+  IL_0050:  ldstr      ""Generic<long>.Color.""
+  IL_0055:  ldloc.3
+  IL_0056:  box        ""Generic<long>.Color""
+  IL_005b:  call       ""string string.Concat(object, object)""
+  IL_0060:  stloc.s    V_7
+  IL_0062:  br.s       IL_007f
+  IL_0064:  ldstr      ""Generic<object>.Color.Red""
+  IL_0069:  stloc.s    V_7
+  IL_006b:  br.s       IL_007f
+  IL_006d:  ldstr      ""Generic<dynamic>.Color.Blue""
   IL_0072:  stloc.s    V_7
-  IL_0074:  br.s       IL_0091
-  IL_0076:  ldstr      ""Generic<object>.Color.Red""
+  IL_0074:  br.s       IL_007f
+  IL_0076:  ldstr      ""None""
   IL_007b:  stloc.s    V_7
-  IL_007d:  br.s       IL_0091
-  IL_007f:  ldstr      ""Generic<dynamic>.Color.Blue""
-  IL_0084:  stloc.s    V_7
-  IL_0086:  br.s       IL_0091
-  IL_0088:  ldstr      ""None""
-  IL_008d:  stloc.s    V_7
-  IL_008f:  br.s       IL_0091
-  IL_0091:  ldloc.s    V_7
-  IL_0093:  ret
+  IL_007d:  br.s       IL_007f
+  IL_007f:  ldloc.s    V_7
+  IL_0081:  ret
 }"
             );
         }
@@ -9327,101 +9197,77 @@ public class Program
                 expectedOutput: "");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size      191 (0xbf)
-  .maxstack  2
+  // Code size      152 (0x98)
+  .maxstack  1
   .locals init (object V_0,
                 int V_1,
                 object V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse    IL_0088
-  IL_0008:  ldloc.0
-  IL_0009:  stloc.2
-  IL_000a:  ldloc.2
-  IL_000b:  isinst     ""int""
-  IL_0010:  ldnull
-  IL_0011:  cgt.un
-  IL_0013:  dup
-  IL_0014:  brtrue.s   IL_0019
-  IL_0016:  ldc.i4.0
-  IL_0017:  br.s       IL_001f
-  IL_0019:  ldloc.2
-  IL_001a:  unbox.any  ""int""
-  IL_001f:  stloc.1
-  IL_0020:  brfalse.s  IL_0088
-  IL_0022:  br.s       IL_0081
-  IL_0024:  ldloc.0
-  IL_0025:  brfalse.s  IL_0098
-  IL_0027:  ldloc.0
-  IL_0028:  stloc.2
-  IL_0029:  ldloc.2
-  IL_002a:  isinst     ""int""
-  IL_002f:  ldnull
-  IL_0030:  cgt.un
-  IL_0032:  dup
-  IL_0033:  brtrue.s   IL_0038
-  IL_0035:  ldc.i4.0
-  IL_0036:  br.s       IL_003e
-  IL_0038:  ldloc.2
-  IL_0039:  unbox.any  ""int""
-  IL_003e:  stloc.1
-  IL_003f:  brfalse.s  IL_0098
-  IL_0041:  br.s       IL_0091
-  IL_0043:  ldloc.0
-  IL_0044:  brfalse.s  IL_00a8
-  IL_0046:  ldloc.0
-  IL_0047:  stloc.2
-  IL_0048:  ldloc.2
-  IL_0049:  isinst     ""int""
-  IL_004e:  ldnull
-  IL_004f:  cgt.un
-  IL_0051:  dup
-  IL_0052:  brtrue.s   IL_0057
-  IL_0054:  ldc.i4.0
-  IL_0055:  br.s       IL_005d
-  IL_0057:  ldloc.2
-  IL_0058:  unbox.any  ""int""
-  IL_005d:  stloc.1
-  IL_005e:  brfalse.s  IL_00a8
-  IL_0060:  br.s       IL_00a1
-  IL_0062:  ldloc.0
-  IL_0063:  brfalse.s  IL_00b8
-  IL_0065:  ldloc.0
-  IL_0066:  stloc.2
-  IL_0067:  ldloc.2
-  IL_0068:  isinst     ""int""
-  IL_006d:  ldnull
-  IL_006e:  cgt.un
-  IL_0070:  dup
-  IL_0071:  brtrue.s   IL_0076
-  IL_0073:  ldc.i4.0
-  IL_0074:  br.s       IL_007c
-  IL_0076:  ldloc.2
-  IL_0077:  unbox.any  ""int""
-  IL_007c:  stloc.1
-  IL_007d:  brfalse.s  IL_00b8
-  IL_007f:  br.s       IL_00b1
+  IL_0003:  brfalse.s  IL_0061
+  IL_0005:  ldloc.0
+  IL_0006:  stloc.2
+  IL_0007:  ldloc.2
+  IL_0008:  isinst     ""int""
+  IL_000d:  brfalse.s  IL_0061
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""int""
+  IL_0015:  stloc.1
+  IL_0016:  br.s       IL_005a
+  IL_0018:  ldloc.0
+  IL_0019:  brfalse.s  IL_0071
+  IL_001b:  ldloc.0
+  IL_001c:  stloc.2
+  IL_001d:  ldloc.2
+  IL_001e:  isinst     ""int""
+  IL_0023:  brfalse.s  IL_0071
+  IL_0025:  ldloc.2
+  IL_0026:  unbox.any  ""int""
+  IL_002b:  stloc.1
+  IL_002c:  br.s       IL_006a
+  IL_002e:  ldloc.0
+  IL_002f:  brfalse.s  IL_0081
+  IL_0031:  ldloc.0
+  IL_0032:  stloc.2
+  IL_0033:  ldloc.2
+  IL_0034:  isinst     ""int""
+  IL_0039:  brfalse.s  IL_0081
+  IL_003b:  ldloc.2
+  IL_003c:  unbox.any  ""int""
+  IL_0041:  stloc.1
+  IL_0042:  br.s       IL_007a
+  IL_0044:  ldloc.0
+  IL_0045:  brfalse.s  IL_0091
+  IL_0047:  ldloc.0
+  IL_0048:  stloc.2
+  IL_0049:  ldloc.2
+  IL_004a:  isinst     ""int""
+  IL_004f:  brfalse.s  IL_0091
+  IL_0051:  ldloc.2
+  IL_0052:  unbox.any  ""int""
+  IL_0057:  stloc.1
+  IL_0058:  br.s       IL_008a
+  IL_005a:  ldsfld     ""bool Program.b""
+  IL_005f:  brtrue.s   IL_0097
+  IL_0061:  ldsfld     ""bool Program.b""
+  IL_0066:  brtrue.s   IL_0097
+  IL_0068:  br.s       IL_0018
+  IL_006a:  ldsfld     ""bool Program.b""
+  IL_006f:  brtrue.s   IL_0097
+  IL_0071:  ldsfld     ""bool Program.b""
+  IL_0076:  brtrue.s   IL_0097
+  IL_0078:  br.s       IL_002e
+  IL_007a:  ldsfld     ""bool Program.b""
+  IL_007f:  brtrue.s   IL_0097
   IL_0081:  ldsfld     ""bool Program.b""
-  IL_0086:  brtrue.s   IL_00be
-  IL_0088:  ldsfld     ""bool Program.b""
-  IL_008d:  brtrue.s   IL_00be
-  IL_008f:  br.s       IL_0024
+  IL_0086:  brtrue.s   IL_0097
+  IL_0088:  br.s       IL_0044
+  IL_008a:  ldsfld     ""bool Program.b""
+  IL_008f:  brtrue.s   IL_0097
   IL_0091:  ldsfld     ""bool Program.b""
-  IL_0096:  brtrue.s   IL_00be
-  IL_0098:  ldsfld     ""bool Program.b""
-  IL_009d:  brtrue.s   IL_00be
-  IL_009f:  br.s       IL_0043
-  IL_00a1:  ldsfld     ""bool Program.b""
-  IL_00a6:  brtrue.s   IL_00be
-  IL_00a8:  ldsfld     ""bool Program.b""
-  IL_00ad:  brtrue.s   IL_00be
-  IL_00af:  br.s       IL_0062
-  IL_00b1:  ldsfld     ""bool Program.b""
-  IL_00b6:  brtrue.s   IL_00be
-  IL_00b8:  ldsfld     ""bool Program.b""
-  IL_00bd:  pop
-  IL_00be:  ret
+  IL_0096:  pop
+  IL_0097:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -9429,8 +9275,8 @@ public class Program
                 expectedOutput: "");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size      272 (0x110)
-  .maxstack  2
+  // Code size      224 (0xe0)
+  .maxstack  1
   .locals init (object V_0,
                 int V_1,
                 int V_2, //i
@@ -9446,122 +9292,98 @@ public class Program
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  brtrue.s   IL_000c
-  IL_000a:  br.s       IL_002b
+  IL_000a:  br.s       IL_0022
   IL_000c:  ldloc.0
   IL_000d:  stloc.s    V_7
   IL_000f:  ldloc.s    V_7
   IL_0011:  isinst     ""int""
-  IL_0016:  ldnull
-  IL_0017:  cgt.un
-  IL_0019:  dup
-  IL_001a:  brtrue.s   IL_001f
-  IL_001c:  ldc.i4.0
-  IL_001d:  br.s       IL_0026
-  IL_001f:  ldloc.s    V_7
-  IL_0021:  unbox.any  ""int""
-  IL_0026:  stloc.1
-  IL_0027:  brfalse.s  IL_002b
-  IL_0029:  br.s       IL_00a4
-  IL_002b:  br         IL_00b4
-  IL_0030:  ldloc.0
-  IL_0031:  brtrue.s   IL_0035
-  IL_0033:  br.s       IL_0054
-  IL_0035:  ldloc.0
-  IL_0036:  stloc.s    V_7
-  IL_0038:  ldloc.s    V_7
-  IL_003a:  isinst     ""int""
-  IL_003f:  ldnull
-  IL_0040:  cgt.un
-  IL_0042:  dup
-  IL_0043:  brtrue.s   IL_0048
-  IL_0045:  ldc.i4.0
-  IL_0046:  br.s       IL_004f
-  IL_0048:  ldloc.s    V_7
-  IL_004a:  unbox.any  ""int""
-  IL_004f:  stloc.1
-  IL_0050:  brfalse.s  IL_0054
-  IL_0052:  br.s       IL_00c2
-  IL_0054:  br.s       IL_00cf
-  IL_0056:  ldloc.0
-  IL_0057:  brtrue.s   IL_005b
-  IL_0059:  br.s       IL_007a
-  IL_005b:  ldloc.0
-  IL_005c:  stloc.s    V_7
-  IL_005e:  ldloc.s    V_7
-  IL_0060:  isinst     ""int""
-  IL_0065:  ldnull
-  IL_0066:  cgt.un
-  IL_0068:  dup
-  IL_0069:  brtrue.s   IL_006e
-  IL_006b:  ldc.i4.0
-  IL_006c:  br.s       IL_0075
-  IL_006e:  ldloc.s    V_7
-  IL_0070:  unbox.any  ""int""
-  IL_0075:  stloc.1
-  IL_0076:  brfalse.s  IL_007a
-  IL_0078:  br.s       IL_00dd
-  IL_007a:  br.s       IL_00eb
-  IL_007c:  ldloc.0
-  IL_007d:  brtrue.s   IL_0081
-  IL_007f:  br.s       IL_00a0
-  IL_0081:  ldloc.0
-  IL_0082:  stloc.s    V_7
-  IL_0084:  ldloc.s    V_7
-  IL_0086:  isinst     ""int""
-  IL_008b:  ldnull
-  IL_008c:  cgt.un
-  IL_008e:  dup
-  IL_008f:  brtrue.s   IL_0094
-  IL_0091:  ldc.i4.0
-  IL_0092:  br.s       IL_009b
-  IL_0094:  ldloc.s    V_7
-  IL_0096:  unbox.any  ""int""
-  IL_009b:  stloc.1
-  IL_009c:  brfalse.s  IL_00a0
-  IL_009e:  br.s       IL_00f6
-  IL_00a0:  br.s       IL_0104
-  IL_00a2:  br.s       IL_010f
-  IL_00a4:  ldloc.1
-  IL_00a5:  stloc.2
-  IL_00a6:  ldsfld     ""bool Program.b""
-  IL_00ab:  brtrue.s   IL_00b2
-  IL_00ad:  br         IL_002b
-  IL_00b2:  br.s       IL_010f
-  IL_00b4:  ldsfld     ""bool Program.b""
-  IL_00b9:  brtrue.s   IL_00c0
-  IL_00bb:  br         IL_0030
-  IL_00c0:  br.s       IL_010f
-  IL_00c2:  ldloc.1
-  IL_00c3:  stloc.3
-  IL_00c4:  ldsfld     ""bool Program.b""
-  IL_00c9:  brtrue.s   IL_00cd
-  IL_00cb:  br.s       IL_0054
-  IL_00cd:  br.s       IL_010f
-  IL_00cf:  ldsfld     ""bool Program.b""
-  IL_00d4:  brtrue.s   IL_00db
-  IL_00d6:  br         IL_0056
-  IL_00db:  br.s       IL_010f
-  IL_00dd:  ldloc.1
-  IL_00de:  stloc.s    V_4
-  IL_00e0:  ldsfld     ""bool Program.b""
-  IL_00e5:  brtrue.s   IL_00e9
-  IL_00e7:  br.s       IL_007a
-  IL_00e9:  br.s       IL_010f
-  IL_00eb:  ldsfld     ""bool Program.b""
-  IL_00f0:  brtrue.s   IL_00f4
-  IL_00f2:  br.s       IL_007c
-  IL_00f4:  br.s       IL_010f
-  IL_00f6:  ldloc.1
-  IL_00f7:  stloc.s    V_5
-  IL_00f9:  ldsfld     ""bool Program.b""
-  IL_00fe:  brtrue.s   IL_0102
-  IL_0100:  br.s       IL_00a0
-  IL_0102:  br.s       IL_010f
-  IL_0104:  ldsfld     ""bool Program.b""
-  IL_0109:  brtrue.s   IL_010d
-  IL_010b:  br.s       IL_00a2
-  IL_010d:  br.s       IL_010f
-  IL_010f:  ret
+  IL_0016:  brfalse.s  IL_0022
+  IL_0018:  ldloc.s    V_7
+  IL_001a:  unbox.any  ""int""
+  IL_001f:  stloc.1
+  IL_0020:  br.s       IL_007d
+  IL_0022:  br.s       IL_008a
+  IL_0024:  ldloc.0
+  IL_0025:  brtrue.s   IL_0029
+  IL_0027:  br.s       IL_003f
+  IL_0029:  ldloc.0
+  IL_002a:  stloc.s    V_7
+  IL_002c:  ldloc.s    V_7
+  IL_002e:  isinst     ""int""
+  IL_0033:  brfalse.s  IL_003f
+  IL_0035:  ldloc.s    V_7
+  IL_0037:  unbox.any  ""int""
+  IL_003c:  stloc.1
+  IL_003d:  br.s       IL_0095
+  IL_003f:  br.s       IL_00a2
+  IL_0041:  ldloc.0
+  IL_0042:  brtrue.s   IL_0046
+  IL_0044:  br.s       IL_005c
+  IL_0046:  ldloc.0
+  IL_0047:  stloc.s    V_7
+  IL_0049:  ldloc.s    V_7
+  IL_004b:  isinst     ""int""
+  IL_0050:  brfalse.s  IL_005c
+  IL_0052:  ldloc.s    V_7
+  IL_0054:  unbox.any  ""int""
+  IL_0059:  stloc.1
+  IL_005a:  br.s       IL_00ad
+  IL_005c:  br.s       IL_00bb
+  IL_005e:  ldloc.0
+  IL_005f:  brtrue.s   IL_0063
+  IL_0061:  br.s       IL_0079
+  IL_0063:  ldloc.0
+  IL_0064:  stloc.s    V_7
+  IL_0066:  ldloc.s    V_7
+  IL_0068:  isinst     ""int""
+  IL_006d:  brfalse.s  IL_0079
+  IL_006f:  ldloc.s    V_7
+  IL_0071:  unbox.any  ""int""
+  IL_0076:  stloc.1
+  IL_0077:  br.s       IL_00c6
+  IL_0079:  br.s       IL_00d4
+  IL_007b:  br.s       IL_00df
+  IL_007d:  ldloc.1
+  IL_007e:  stloc.2
+  IL_007f:  ldsfld     ""bool Program.b""
+  IL_0084:  brtrue.s   IL_0088
+  IL_0086:  br.s       IL_0022
+  IL_0088:  br.s       IL_00df
+  IL_008a:  ldsfld     ""bool Program.b""
+  IL_008f:  brtrue.s   IL_0093
+  IL_0091:  br.s       IL_0024
+  IL_0093:  br.s       IL_00df
+  IL_0095:  ldloc.1
+  IL_0096:  stloc.3
+  IL_0097:  ldsfld     ""bool Program.b""
+  IL_009c:  brtrue.s   IL_00a0
+  IL_009e:  br.s       IL_003f
+  IL_00a0:  br.s       IL_00df
+  IL_00a2:  ldsfld     ""bool Program.b""
+  IL_00a7:  brtrue.s   IL_00ab
+  IL_00a9:  br.s       IL_0041
+  IL_00ab:  br.s       IL_00df
+  IL_00ad:  ldloc.1
+  IL_00ae:  stloc.s    V_4
+  IL_00b0:  ldsfld     ""bool Program.b""
+  IL_00b5:  brtrue.s   IL_00b9
+  IL_00b7:  br.s       IL_005c
+  IL_00b9:  br.s       IL_00df
+  IL_00bb:  ldsfld     ""bool Program.b""
+  IL_00c0:  brtrue.s   IL_00c4
+  IL_00c2:  br.s       IL_005e
+  IL_00c4:  br.s       IL_00df
+  IL_00c6:  ldloc.1
+  IL_00c7:  stloc.s    V_5
+  IL_00c9:  ldsfld     ""bool Program.b""
+  IL_00ce:  brtrue.s   IL_00d2
+  IL_00d0:  br.s       IL_0079
+  IL_00d2:  br.s       IL_00df
+  IL_00d4:  ldsfld     ""bool Program.b""
+  IL_00d9:  brtrue.s   IL_00dd
+  IL_00db:  br.s       IL_007b
+  IL_00dd:  br.s       IL_00df
+  IL_00df:  ret
 }"
             );
             compVerifier.VerifyPdb(
@@ -9603,40 +9425,40 @@ public class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa4"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa6"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xb2"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xb4"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xc0"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xc2"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc4"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xcd"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xcf"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xdb"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xdd"" hidden=""true"" document=""1"" />
-        <entry offset=""0xe0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xe9"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xeb"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xf4"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xf6"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x102"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
-        <entry offset=""0x104"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x10d"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
-        <entry offset=""0x10f"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x7d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7f"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x88"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x8a"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x93"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x95"" hidden=""true"" document=""1"" />
+        <entry offset=""0x97"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xa0"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xa2"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xab"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xad"" hidden=""true"" document=""1"" />
+        <entry offset=""0xb0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xb9"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xbb"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xc4"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xc6"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xd2"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xd4"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xdd"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xdf"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x110"">
-        <scope startOffset=""0xa4"" endOffset=""0xb4"">
-          <local name=""i"" il_index=""2"" il_start=""0xa4"" il_end=""0xb4"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0xe0"">
+        <scope startOffset=""0x7d"" endOffset=""0x8a"">
+          <local name=""i"" il_index=""2"" il_start=""0x7d"" il_end=""0x8a"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0xc2"" endOffset=""0xcf"">
-          <local name=""i"" il_index=""3"" il_start=""0xc2"" il_end=""0xcf"" attributes=""0"" />
+        <scope startOffset=""0x95"" endOffset=""0xa2"">
+          <local name=""i"" il_index=""3"" il_start=""0x95"" il_end=""0xa2"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0xdd"" endOffset=""0xeb"">
-          <local name=""i"" il_index=""4"" il_start=""0xdd"" il_end=""0xeb"" attributes=""0"" />
+        <scope startOffset=""0xad"" endOffset=""0xbb"">
+          <local name=""i"" il_index=""4"" il_start=""0xad"" il_end=""0xbb"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0xf6"" endOffset=""0x104"">
-          <local name=""i"" il_index=""5"" il_start=""0xf6"" il_end=""0x104"" attributes=""0"" />
+        <scope startOffset=""0xc6"" endOffset=""0xd4"">
+          <local name=""i"" il_index=""5"" il_start=""0xc6"" il_end=""0xd4"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -8013,7 +8013,7 @@ public class Program
         }
 
         [Fact, WorkItem(18859, "https://github.com/dotnet/roslyn/issues/18859")]
-        public void UnoxInPatternSwitch_07()
+        public void UnboxInPatternSwitch_07()
         {
             var source = @"using System;
 
@@ -8109,7 +8109,7 @@ public class Program
         }
 
         [Fact, WorkItem(18859, "https://github.com/dotnet/roslyn/issues/18859")]
-        public void UnoxInPatternSwitch_08()
+        public void UnboxInPatternSwitch_08()
         {
             var source = @"using System;
 
@@ -8205,7 +8205,7 @@ public class Program
         }
 
         [Fact, WorkItem(18859, "https://github.com/dotnet/roslyn/issues/18859")]
-        public void UnoxInPatternSwitch_09()
+        public void UnboxInPatternSwitch_09()
         {
             var source = @"using System;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -7949,7 +7949,7 @@ public class Program
             compVerifier.VerifyIL("Program.M",
 @"{
   // Code size       29 (0x1d)
-  .maxstack  1
+  .maxstack  2
   .locals init (object V_0,
                 int V_1,
                 object V_2)
@@ -7958,8 +7958,8 @@ public class Program
   IL_0002:  ldloc.0
   IL_0003:  brfalse.s  IL_001c
   IL_0005:  ldloc.0
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0006:  dup
+  IL_0007:  stloc.2
   IL_0008:  isinst     ""int""
   IL_000d:  brfalse.s  IL_001c
   IL_000f:  ldloc.2
@@ -7975,8 +7975,8 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size       48 (0x30)
-  .maxstack  1
+  // Code size       47 (0x2f)
+  .maxstack  2
   .locals init (object V_0,
                 int V_1,
                 int V_2, //i
@@ -7989,25 +7989,25 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0020
+  IL_0008:  br.s       IL_001f
   IL_000a:  ldloc.0
-  IL_000b:  stloc.s    V_4
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  isinst     ""int""
-  IL_0014:  brfalse.s  IL_0020
-  IL_0016:  ldloc.s    V_4
-  IL_0018:  unbox.any  ""int""
-  IL_001d:  stloc.1
-  IL_001e:  br.s       IL_0022
-  IL_0020:  br.s       IL_002f
-  IL_0022:  ldloc.1
-  IL_0023:  stloc.2
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.2
-  IL_0027:  call       ""void System.Console.Write(int)""
-  IL_002c:  nop
-  IL_002d:  br.s       IL_002f
-  IL_002f:  ret
+  IL_000b:  dup
+  IL_000c:  stloc.s    V_4
+  IL_000e:  isinst     ""int""
+  IL_0013:  brfalse.s  IL_001f
+  IL_0015:  ldloc.s    V_4
+  IL_0017:  unbox.any  ""int""
+  IL_001c:  stloc.1
+  IL_001d:  br.s       IL_0021
+  IL_001f:  br.s       IL_002e
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.2
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.2
+  IL_0026:  call       ""void System.Console.Write(int)""
+  IL_002b:  nop
+  IL_002c:  br.s       IL_002e
+  IL_002e:  ret
 }"
             );
         }
@@ -8043,7 +8043,7 @@ public class Program
             compVerifier.VerifyIL("Program.M<T>",
 @"{
   // Code size       34 (0x22)
-  .maxstack  1
+  .maxstack  2
   .locals init (object V_0,
                 T V_1,
                 object V_2)
@@ -8052,8 +8052,8 @@ public class Program
   IL_0002:  ldloc.0
   IL_0003:  brfalse.s  IL_0021
   IL_0005:  ldloc.0
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0006:  dup
+  IL_0007:  stloc.2
   IL_0008:  isinst     ""T""
   IL_000d:  brfalse.s  IL_0021
   IL_000f:  ldloc.2
@@ -8070,8 +8070,8 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       53 (0x35)
-  .maxstack  1
+  // Code size       52 (0x34)
+  .maxstack  2
   .locals init (object V_0,
                 T V_1,
                 T V_2, //i
@@ -8084,26 +8084,26 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0020
+  IL_0008:  br.s       IL_001f
   IL_000a:  ldloc.0
-  IL_000b:  stloc.s    V_4
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  isinst     ""T""
-  IL_0014:  brfalse.s  IL_0020
-  IL_0016:  ldloc.s    V_4
-  IL_0018:  unbox.any  ""T""
-  IL_001d:  stloc.1
-  IL_001e:  br.s       IL_0022
-  IL_0020:  br.s       IL_0034
-  IL_0022:  ldloc.1
-  IL_0023:  stloc.2
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.2
-  IL_0027:  box        ""T""
-  IL_002c:  call       ""void System.Console.Write(object)""
-  IL_0031:  nop
-  IL_0032:  br.s       IL_0034
-  IL_0034:  ret
+  IL_000b:  dup
+  IL_000c:  stloc.s    V_4
+  IL_000e:  isinst     ""T""
+  IL_0013:  brfalse.s  IL_001f
+  IL_0015:  ldloc.s    V_4
+  IL_0017:  unbox.any  ""T""
+  IL_001c:  stloc.1
+  IL_001d:  br.s       IL_0021
+  IL_001f:  br.s       IL_0033
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.2
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.2
+  IL_0026:  box        ""T""
+  IL_002b:  call       ""void System.Console.Write(object)""
+  IL_0030:  nop
+  IL_0031:  br.s       IL_0033
+  IL_0033:  ret
 }"
             );
         }
@@ -8139,17 +8139,17 @@ public class Program
             compVerifier.VerifyIL("Program.M<T>",
 @"{
   // Code size       34 (0x22)
-  .maxstack  1
+  .maxstack  2
   .locals init (System.IComparable V_0,
                 T V_1,
-                object V_2)
+                System.IComparable V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  brfalse.s  IL_0021
   IL_0005:  ldloc.0
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0006:  dup
+  IL_0007:  stloc.2
   IL_0008:  isinst     ""T""
   IL_000d:  brfalse.s  IL_0021
   IL_000f:  ldloc.2
@@ -8166,13 +8166,13 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T>",
 @"{
-  // Code size       53 (0x35)
-  .maxstack  1
+  // Code size       52 (0x34)
+  .maxstack  2
   .locals init (System.IComparable V_0,
                 T V_1,
                 T V_2, //i
                 System.IComparable V_3,
-                object V_4)
+                System.IComparable V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.3
@@ -8180,26 +8180,26 @@ public class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0020
+  IL_0008:  br.s       IL_001f
   IL_000a:  ldloc.0
-  IL_000b:  stloc.s    V_4
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  isinst     ""T""
-  IL_0014:  brfalse.s  IL_0020
-  IL_0016:  ldloc.s    V_4
-  IL_0018:  unbox.any  ""T""
-  IL_001d:  stloc.1
-  IL_001e:  br.s       IL_0022
-  IL_0020:  br.s       IL_0034
-  IL_0022:  ldloc.1
-  IL_0023:  stloc.2
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.2
-  IL_0027:  box        ""T""
-  IL_002c:  call       ""void System.Console.Write(object)""
-  IL_0031:  nop
-  IL_0032:  br.s       IL_0034
-  IL_0034:  ret
+  IL_000b:  dup
+  IL_000c:  stloc.s    V_4
+  IL_000e:  isinst     ""T""
+  IL_0013:  brfalse.s  IL_001f
+  IL_0015:  ldloc.s    V_4
+  IL_0017:  unbox.any  ""T""
+  IL_001c:  stloc.1
+  IL_001d:  br.s       IL_0021
+  IL_001f:  br.s       IL_0033
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.2
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.2
+  IL_0026:  box        ""T""
+  IL_002b:  call       ""void System.Console.Write(object)""
+  IL_0030:  nop
+  IL_0031:  br.s       IL_0033
+  IL_0033:  ret
 }"
             );
         }
@@ -8234,29 +8234,30 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T, U>",
 @"{
-  // Code size       44 (0x2c)
-  .maxstack  1
+  // Code size       49 (0x31)
+  .maxstack  2
   .locals init (U V_0,
                 T V_1,
-                object V_2)
+                U V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  box        ""U""
-  IL_0008:  brfalse.s  IL_002b
+  IL_0008:  brfalse.s  IL_0030
   IL_000a:  ldloc.0
-  IL_000b:  box        ""U""
-  IL_0010:  stloc.2
-  IL_0011:  ldloc.2
+  IL_000b:  dup
+  IL_000c:  stloc.2
+  IL_000d:  box        ""U""
   IL_0012:  isinst     ""T""
-  IL_0017:  brfalse.s  IL_002b
+  IL_0017:  brfalse.s  IL_0030
   IL_0019:  ldloc.2
-  IL_001a:  unbox.any  ""T""
-  IL_001f:  stloc.1
-  IL_0020:  ldloc.1
-  IL_0021:  box        ""T""
-  IL_0026:  call       ""void System.Console.Write(object)""
-  IL_002b:  ret
+  IL_001a:  box        ""U""
+  IL_001f:  unbox.any  ""T""
+  IL_0024:  stloc.1
+  IL_0025:  ldloc.1
+  IL_0026:  box        ""T""
+  IL_002b:  call       ""void System.Console.Write(object)""
+  IL_0030:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8264,13 +8265,13 @@ public class Program
                 expectedOutput: "1");
             compVerifier.VerifyIL("Program.M<T, U>",
 @"{
-  // Code size       63 (0x3f)
-  .maxstack  1
+  // Code size       67 (0x43)
+  .maxstack  2
   .locals init (U V_0,
                 T V_1,
                 T V_2, //i
                 U V_3,
-                object V_4)
+                U V_4)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.3
@@ -8279,27 +8280,28 @@ public class Program
   IL_0005:  ldloc.0
   IL_0006:  box        ""U""
   IL_000b:  brtrue.s   IL_000f
-  IL_000d:  br.s       IL_002a
+  IL_000d:  br.s       IL_002e
   IL_000f:  ldloc.0
-  IL_0010:  box        ""U""
-  IL_0015:  stloc.s    V_4
-  IL_0017:  ldloc.s    V_4
-  IL_0019:  isinst     ""T""
-  IL_001e:  brfalse.s  IL_002a
-  IL_0020:  ldloc.s    V_4
-  IL_0022:  unbox.any  ""T""
-  IL_0027:  stloc.1
-  IL_0028:  br.s       IL_002c
-  IL_002a:  br.s       IL_003e
-  IL_002c:  ldloc.1
-  IL_002d:  stloc.2
-  IL_002e:  br.s       IL_0030
-  IL_0030:  ldloc.2
-  IL_0031:  box        ""T""
-  IL_0036:  call       ""void System.Console.Write(object)""
-  IL_003b:  nop
-  IL_003c:  br.s       IL_003e
-  IL_003e:  ret
+  IL_0010:  dup
+  IL_0011:  stloc.s    V_4
+  IL_0013:  box        ""U""
+  IL_0018:  isinst     ""T""
+  IL_001d:  brfalse.s  IL_002e
+  IL_001f:  ldloc.s    V_4
+  IL_0021:  box        ""U""
+  IL_0026:  unbox.any  ""T""
+  IL_002b:  stloc.1
+  IL_002c:  br.s       IL_0030
+  IL_002e:  br.s       IL_0042
+  IL_0030:  ldloc.1
+  IL_0031:  stloc.2
+  IL_0032:  br.s       IL_0034
+  IL_0034:  ldloc.2
+  IL_0035:  box        ""T""
+  IL_003a:  call       ""void System.Console.Write(object)""
+  IL_003f:  nop
+  IL_0040:  br.s       IL_0042
+  IL_0042:  ret
 }"
             );
         }
@@ -8407,13 +8409,13 @@ class Program
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
   // Code size       31 (0x1f)
-  .maxstack  1
+  .maxstack  2
   .locals init (T V_0, //t
-                object V_1,
+                System.ValueType V_1,
                 T V_2)
   IL_0000:  ldarg.0
-  IL_0001:  stloc.1
-  IL_0002:  ldloc.1
+  IL_0001:  dup
+  IL_0002:  stloc.1
   IL_0003:  isinst     ""T""
   IL_0008:  brfalse.s  IL_0013
   IL_000a:  ldloc.1
@@ -8431,18 +8433,18 @@ class Program
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
   // Code size       34 (0x22)
-  .maxstack  1
+  .maxstack  2
   .locals init (System.ValueType V_0,
                 T V_1,
-                object V_2,
+                System.ValueType V_2,
                 T V_3)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  brfalse.s  IL_0018
   IL_0005:  ldloc.0
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0006:  dup
+  IL_0007:  stloc.2
   IL_0008:  isinst     ""T""
   IL_000d:  brfalse.s  IL_0018
   IL_000f:  ldloc.2
@@ -8463,15 +8465,15 @@ class Program
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
   // Code size       37 (0x25)
-  .maxstack  1
+  .maxstack  2
   .locals init (T V_0, //t
-                object V_1,
+                System.ValueType V_1,
                 T V_2,
                 T V_3)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.1
-  IL_0003:  ldloc.1
+  IL_0002:  dup
+  IL_0003:  stloc.1
   IL_0004:  isinst     ""T""
   IL_0009:  brfalse.s  IL_0014
   IL_000b:  ldloc.1
@@ -8491,13 +8493,13 @@ class Program
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       60 (0x3c)
-  .maxstack  1
+  // Code size       59 (0x3b)
+  .maxstack  2
   .locals init (System.ValueType V_0,
                 T V_1,
                 T V_2, //t
                 System.ValueType V_3,
-                object V_4,
+                System.ValueType V_4,
                 T V_5,
                 T V_6)
   IL_0000:  nop
@@ -8507,30 +8509,30 @@ class Program
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0020
+  IL_0008:  br.s       IL_001f
   IL_000a:  ldloc.0
-  IL_000b:  stloc.s    V_4
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  isinst     ""T""
-  IL_0014:  brfalse.s  IL_0020
-  IL_0016:  ldloc.s    V_4
-  IL_0018:  unbox.any  ""T""
-  IL_001d:  stloc.1
-  IL_001e:  br.s       IL_0022
-  IL_0020:  br.s       IL_002b
-  IL_0022:  ldloc.1
-  IL_0023:  stloc.2
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.2
-  IL_0027:  stloc.s    V_5
-  IL_0029:  br.s       IL_0039
-  IL_002b:  ldloca.s   V_6
-  IL_002d:  initobj    ""T""
-  IL_0033:  ldloc.s    V_6
-  IL_0035:  stloc.s    V_5
-  IL_0037:  br.s       IL_0039
-  IL_0039:  ldloc.s    V_5
-  IL_003b:  ret
+  IL_000b:  dup
+  IL_000c:  stloc.s    V_4
+  IL_000e:  isinst     ""T""
+  IL_0013:  brfalse.s  IL_001f
+  IL_0015:  ldloc.s    V_4
+  IL_0017:  unbox.any  ""T""
+  IL_001c:  stloc.1
+  IL_001d:  br.s       IL_0021
+  IL_001f:  br.s       IL_002a
+  IL_0021:  ldloc.1
+  IL_0022:  stloc.2
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.2
+  IL_0026:  stloc.s    V_5
+  IL_0028:  br.s       IL_0038
+  IL_002a:  ldloca.s   V_6
+  IL_002c:  initobj    ""T""
+  IL_0032:  ldloc.s    V_6
+  IL_0034:  stloc.s    V_5
+  IL_0036:  br.s       IL_0038
+  IL_0038:  ldloc.s    V_5
+  IL_003a:  ret
 }"
             );
         }
@@ -8578,51 +8580,53 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       28 (0x1c)
-  .maxstack  1
+  // Code size       33 (0x21)
+  .maxstack  2
   .locals init (int V_0, //t
-                object V_1)
+                T V_1)
   IL_0000:  ldarg.0
-  IL_0001:  box        ""T""
-  IL_0006:  stloc.1
-  IL_0007:  ldloc.1
+  IL_0001:  dup
+  IL_0002:  stloc.1
+  IL_0003:  box        ""T""
   IL_0008:  isinst     ""int""
-  IL_000d:  brfalse.s  IL_0018
+  IL_000d:  brfalse.s  IL_001d
   IL_000f:  ldloc.1
-  IL_0010:  unbox.any  ""int""
-  IL_0015:  stloc.0
-  IL_0016:  br.s       IL_001a
-  IL_0018:  ldc.i4.0
-  IL_0019:  ret
-  IL_001a:  ldloc.0
-  IL_001b:  ret
+  IL_0010:  box        ""T""
+  IL_0015:  unbox.any  ""int""
+  IL_001a:  stloc.0
+  IL_001b:  br.s       IL_001f
+  IL_001d:  ldc.i4.0
+  IL_001e:  ret
+  IL_001f:  ldloc.0
+  IL_0020:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       36 (0x24)
-  .maxstack  1
+  // Code size       41 (0x29)
+  .maxstack  2
   .locals init (T V_0,
                 int V_1,
-                object V_2)
+                T V_2)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  box        ""T""
-  IL_0008:  brfalse.s  IL_0022
+  IL_0008:  brfalse.s  IL_0027
   IL_000a:  ldloc.0
-  IL_000b:  box        ""T""
-  IL_0010:  stloc.2
-  IL_0011:  ldloc.2
+  IL_000b:  dup
+  IL_000c:  stloc.2
+  IL_000d:  box        ""T""
   IL_0012:  isinst     ""int""
-  IL_0017:  brfalse.s  IL_0022
+  IL_0017:  brfalse.s  IL_0027
   IL_0019:  ldloc.2
-  IL_001a:  unbox.any  ""int""
-  IL_001f:  stloc.1
-  IL_0020:  ldloc.1
-  IL_0021:  ret
-  IL_0022:  ldc.i4.0
-  IL_0023:  ret
+  IL_001a:  box        ""T""
+  IL_001f:  unbox.any  ""int""
+  IL_0024:  stloc.1
+  IL_0025:  ldloc.1
+  IL_0026:  ret
+  IL_0027:  ldc.i4.0
+  IL_0028:  ret
 }"
             );
             compVerifier = CompileAndVerify(source,
@@ -8631,40 +8635,41 @@ class Program
                 expectedOutput: "2300");
             compVerifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       34 (0x22)
-  .maxstack  1
+  // Code size       39 (0x27)
+  .maxstack  2
   .locals init (int V_0, //t
-                object V_1,
+                T V_1,
                 int V_2)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  box        ""T""
-  IL_0007:  stloc.1
-  IL_0008:  ldloc.1
+  IL_0002:  dup
+  IL_0003:  stloc.1
+  IL_0004:  box        ""T""
   IL_0009:  isinst     ""int""
-  IL_000e:  brfalse.s  IL_0019
+  IL_000e:  brfalse.s  IL_001e
   IL_0010:  ldloc.1
-  IL_0011:  unbox.any  ""int""
-  IL_0016:  stloc.0
-  IL_0017:  br.s       IL_001c
-  IL_0019:  ldc.i4.0
-  IL_001a:  br.s       IL_001d
-  IL_001c:  ldloc.0
-  IL_001d:  stloc.2
-  IL_001e:  br.s       IL_0020
-  IL_0020:  ldloc.2
-  IL_0021:  ret
+  IL_0011:  box        ""T""
+  IL_0016:  unbox.any  ""int""
+  IL_001b:  stloc.0
+  IL_001c:  br.s       IL_0021
+  IL_001e:  ldc.i4.0
+  IL_001f:  br.s       IL_0022
+  IL_0021:  ldloc.0
+  IL_0022:  stloc.2
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.2
+  IL_0026:  ret
 }"
             );
             compVerifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       61 (0x3d)
-  .maxstack  1
+  // Code size       65 (0x41)
+  .maxstack  2
   .locals init (T V_0,
                 int V_1,
                 int V_2, //t
                 T V_3,
-                object V_4,
+                T V_4,
                 int V_5)
   IL_0000:  nop
   IL_0001:  ldarg.0
@@ -8674,29 +8679,30 @@ class Program
   IL_0005:  ldloc.0
   IL_0006:  box        ""T""
   IL_000b:  brtrue.s   IL_000f
-  IL_000d:  br.s       IL_002a
+  IL_000d:  br.s       IL_002e
   IL_000f:  ldloc.0
-  IL_0010:  box        ""T""
-  IL_0015:  stloc.s    V_4
-  IL_0017:  ldloc.s    V_4
-  IL_0019:  isinst     ""int""
-  IL_001e:  brfalse.s  IL_002a
-  IL_0020:  ldloc.s    V_4
-  IL_0022:  unbox.any  ""int""
-  IL_0027:  stloc.1
-  IL_0028:  br.s       IL_002c
-  IL_002a:  br.s       IL_0035
-  IL_002c:  ldloc.1
-  IL_002d:  stloc.2
-  IL_002e:  br.s       IL_0030
-  IL_0030:  ldloc.2
-  IL_0031:  stloc.s    V_5
-  IL_0033:  br.s       IL_003a
-  IL_0035:  ldc.i4.0
-  IL_0036:  stloc.s    V_5
-  IL_0038:  br.s       IL_003a
-  IL_003a:  ldloc.s    V_5
-  IL_003c:  ret
+  IL_0010:  dup
+  IL_0011:  stloc.s    V_4
+  IL_0013:  box        ""T""
+  IL_0018:  isinst     ""int""
+  IL_001d:  brfalse.s  IL_002e
+  IL_001f:  ldloc.s    V_4
+  IL_0021:  box        ""T""
+  IL_0026:  unbox.any  ""int""
+  IL_002b:  stloc.1
+  IL_002c:  br.s       IL_0030
+  IL_002e:  br.s       IL_0039
+  IL_0030:  ldloc.1
+  IL_0031:  stloc.2
+  IL_0032:  br.s       IL_0034
+  IL_0034:  ldloc.2
+  IL_0035:  stloc.s    V_5
+  IL_0037:  br.s       IL_003e
+  IL_0039:  ldc.i4.0
+  IL_003a:  stloc.s    V_5
+  IL_003c:  br.s       IL_003e
+  IL_003e:  ldloc.s    V_5
+  IL_0040:  ret
 }"
             );
         }
@@ -9049,7 +9055,7 @@ None
 Generic<object>.Color.Red");
             compVerifier.VerifyIL("Program.M2",
 @"{
-  // Code size      130 (0x82)
+  // Code size      128 (0x80)
   .maxstack  2
   .locals init (object V_0,
                 Generic<long>.Color V_1,
@@ -9066,56 +9072,56 @@ Generic<object>.Color.Red");
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  brtrue.s   IL_000c
-  IL_000a:  br.s       IL_004a
+  IL_000a:  br.s       IL_0048
   IL_000c:  ldloc.0
-  IL_000d:  stloc.s    V_5
-  IL_000f:  ldloc.s    V_5
-  IL_0011:  isinst     ""Generic<long>.Color""
-  IL_0016:  brfalse.s  IL_0022
-  IL_0018:  ldloc.s    V_5
-  IL_001a:  unbox.any  ""Generic<long>.Color""
-  IL_001f:  stloc.1
-  IL_0020:  br.s       IL_004c
-  IL_0022:  ldloc.0
+  IL_000d:  dup
+  IL_000e:  stloc.s    V_5
+  IL_0010:  isinst     ""Generic<long>.Color""
+  IL_0015:  brfalse.s  IL_0021
+  IL_0017:  ldloc.s    V_5
+  IL_0019:  unbox.any  ""Generic<long>.Color""
+  IL_001e:  stloc.1
+  IL_001f:  br.s       IL_004a
+  IL_0021:  ldloc.0
+  IL_0022:  dup
   IL_0023:  stloc.s    V_5
-  IL_0025:  ldloc.s    V_5
-  IL_0027:  isinst     ""Generic<object>.Color""
-  IL_002c:  brfalse.s  IL_004a
-  IL_002e:  ldloc.s    V_5
-  IL_0030:  unbox.any  ""Generic<object>.Color""
-  IL_0035:  stloc.2
-  IL_0036:  ldloc.2
-  IL_0037:  stloc.s    V_6
-  IL_0039:  ldloc.s    V_6
-  IL_003b:  brfalse.s  IL_0046
-  IL_003d:  br.s       IL_003f
-  IL_003f:  ldloc.s    V_6
-  IL_0041:  ldc.i4.1
-  IL_0042:  beq.s      IL_0048
-  IL_0044:  br.s       IL_004a
-  IL_0046:  br.s       IL_0064
-  IL_0048:  br.s       IL_006d
-  IL_004a:  br.s       IL_0076
-  IL_004c:  ldloc.1
-  IL_004d:  stloc.3
-  IL_004e:  br.s       IL_0050
-  IL_0050:  ldstr      ""Generic<long>.Color.""
-  IL_0055:  ldloc.3
-  IL_0056:  box        ""Generic<long>.Color""
-  IL_005b:  call       ""string string.Concat(object, object)""
-  IL_0060:  stloc.s    V_7
-  IL_0062:  br.s       IL_007f
-  IL_0064:  ldstr      ""Generic<object>.Color.Red""
-  IL_0069:  stloc.s    V_7
-  IL_006b:  br.s       IL_007f
-  IL_006d:  ldstr      ""Generic<dynamic>.Color.Blue""
-  IL_0072:  stloc.s    V_7
-  IL_0074:  br.s       IL_007f
-  IL_0076:  ldstr      ""None""
-  IL_007b:  stloc.s    V_7
-  IL_007d:  br.s       IL_007f
-  IL_007f:  ldloc.s    V_7
-  IL_0081:  ret
+  IL_0025:  isinst     ""Generic<object>.Color""
+  IL_002a:  brfalse.s  IL_0048
+  IL_002c:  ldloc.s    V_5
+  IL_002e:  unbox.any  ""Generic<object>.Color""
+  IL_0033:  stloc.2
+  IL_0034:  ldloc.2
+  IL_0035:  stloc.s    V_6
+  IL_0037:  ldloc.s    V_6
+  IL_0039:  brfalse.s  IL_0044
+  IL_003b:  br.s       IL_003d
+  IL_003d:  ldloc.s    V_6
+  IL_003f:  ldc.i4.1
+  IL_0040:  beq.s      IL_0046
+  IL_0042:  br.s       IL_0048
+  IL_0044:  br.s       IL_0062
+  IL_0046:  br.s       IL_006b
+  IL_0048:  br.s       IL_0074
+  IL_004a:  ldloc.1
+  IL_004b:  stloc.3
+  IL_004c:  br.s       IL_004e
+  IL_004e:  ldstr      ""Generic<long>.Color.""
+  IL_0053:  ldloc.3
+  IL_0054:  box        ""Generic<long>.Color""
+  IL_0059:  call       ""string string.Concat(object, object)""
+  IL_005e:  stloc.s    V_7
+  IL_0060:  br.s       IL_007d
+  IL_0062:  ldstr      ""Generic<object>.Color.Red""
+  IL_0067:  stloc.s    V_7
+  IL_0069:  br.s       IL_007d
+  IL_006b:  ldstr      ""Generic<dynamic>.Color.Blue""
+  IL_0070:  stloc.s    V_7
+  IL_0072:  br.s       IL_007d
+  IL_0074:  ldstr      ""None""
+  IL_0079:  stloc.s    V_7
+  IL_007b:  br.s       IL_007d
+  IL_007d:  ldloc.s    V_7
+  IL_007f:  ret
 }"
             );
         }
@@ -9198,7 +9204,7 @@ public class Program
             compVerifier.VerifyIL("Program.M",
 @"{
   // Code size      152 (0x98)
-  .maxstack  1
+  .maxstack  2
   .locals init (object V_0,
                 int V_1,
                 object V_2)
@@ -9207,8 +9213,8 @@ public class Program
   IL_0002:  ldloc.0
   IL_0003:  brfalse.s  IL_0061
   IL_0005:  ldloc.0
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0006:  dup
+  IL_0007:  stloc.2
   IL_0008:  isinst     ""int""
   IL_000d:  brfalse.s  IL_0061
   IL_000f:  ldloc.2
@@ -9218,8 +9224,8 @@ public class Program
   IL_0018:  ldloc.0
   IL_0019:  brfalse.s  IL_0071
   IL_001b:  ldloc.0
-  IL_001c:  stloc.2
-  IL_001d:  ldloc.2
+  IL_001c:  dup
+  IL_001d:  stloc.2
   IL_001e:  isinst     ""int""
   IL_0023:  brfalse.s  IL_0071
   IL_0025:  ldloc.2
@@ -9229,8 +9235,8 @@ public class Program
   IL_002e:  ldloc.0
   IL_002f:  brfalse.s  IL_0081
   IL_0031:  ldloc.0
-  IL_0032:  stloc.2
-  IL_0033:  ldloc.2
+  IL_0032:  dup
+  IL_0033:  stloc.2
   IL_0034:  isinst     ""int""
   IL_0039:  brfalse.s  IL_0081
   IL_003b:  ldloc.2
@@ -9240,8 +9246,8 @@ public class Program
   IL_0044:  ldloc.0
   IL_0045:  brfalse.s  IL_0091
   IL_0047:  ldloc.0
-  IL_0048:  stloc.2
-  IL_0049:  ldloc.2
+  IL_0048:  dup
+  IL_0049:  stloc.2
   IL_004a:  isinst     ""int""
   IL_004f:  brfalse.s  IL_0091
   IL_0051:  ldloc.2
@@ -9275,8 +9281,8 @@ public class Program
                 expectedOutput: "");
             compVerifier.VerifyIL("Program.M",
 @"{
-  // Code size      224 (0xe0)
-  .maxstack  1
+  // Code size      220 (0xdc)
+  .maxstack  2
   .locals init (object V_0,
                 int V_1,
                 int V_2, //i
@@ -9292,98 +9298,98 @@ public class Program
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  brtrue.s   IL_000c
-  IL_000a:  br.s       IL_0022
+  IL_000a:  br.s       IL_0021
   IL_000c:  ldloc.0
-  IL_000d:  stloc.s    V_7
-  IL_000f:  ldloc.s    V_7
-  IL_0011:  isinst     ""int""
-  IL_0016:  brfalse.s  IL_0022
-  IL_0018:  ldloc.s    V_7
-  IL_001a:  unbox.any  ""int""
-  IL_001f:  stloc.1
-  IL_0020:  br.s       IL_007d
-  IL_0022:  br.s       IL_008a
-  IL_0024:  ldloc.0
-  IL_0025:  brtrue.s   IL_0029
-  IL_0027:  br.s       IL_003f
-  IL_0029:  ldloc.0
+  IL_000d:  dup
+  IL_000e:  stloc.s    V_7
+  IL_0010:  isinst     ""int""
+  IL_0015:  brfalse.s  IL_0021
+  IL_0017:  ldloc.s    V_7
+  IL_0019:  unbox.any  ""int""
+  IL_001e:  stloc.1
+  IL_001f:  br.s       IL_0079
+  IL_0021:  br.s       IL_0086
+  IL_0023:  ldloc.0
+  IL_0024:  brtrue.s   IL_0028
+  IL_0026:  br.s       IL_003d
+  IL_0028:  ldloc.0
+  IL_0029:  dup
   IL_002a:  stloc.s    V_7
-  IL_002c:  ldloc.s    V_7
-  IL_002e:  isinst     ""int""
-  IL_0033:  brfalse.s  IL_003f
-  IL_0035:  ldloc.s    V_7
-  IL_0037:  unbox.any  ""int""
-  IL_003c:  stloc.1
-  IL_003d:  br.s       IL_0095
-  IL_003f:  br.s       IL_00a2
-  IL_0041:  ldloc.0
-  IL_0042:  brtrue.s   IL_0046
-  IL_0044:  br.s       IL_005c
-  IL_0046:  ldloc.0
-  IL_0047:  stloc.s    V_7
-  IL_0049:  ldloc.s    V_7
-  IL_004b:  isinst     ""int""
-  IL_0050:  brfalse.s  IL_005c
-  IL_0052:  ldloc.s    V_7
-  IL_0054:  unbox.any  ""int""
-  IL_0059:  stloc.1
-  IL_005a:  br.s       IL_00ad
-  IL_005c:  br.s       IL_00bb
-  IL_005e:  ldloc.0
-  IL_005f:  brtrue.s   IL_0063
-  IL_0061:  br.s       IL_0079
-  IL_0063:  ldloc.0
-  IL_0064:  stloc.s    V_7
-  IL_0066:  ldloc.s    V_7
-  IL_0068:  isinst     ""int""
-  IL_006d:  brfalse.s  IL_0079
-  IL_006f:  ldloc.s    V_7
-  IL_0071:  unbox.any  ""int""
-  IL_0076:  stloc.1
-  IL_0077:  br.s       IL_00c6
-  IL_0079:  br.s       IL_00d4
-  IL_007b:  br.s       IL_00df
-  IL_007d:  ldloc.1
-  IL_007e:  stloc.2
-  IL_007f:  ldsfld     ""bool Program.b""
-  IL_0084:  brtrue.s   IL_0088
-  IL_0086:  br.s       IL_0022
-  IL_0088:  br.s       IL_00df
-  IL_008a:  ldsfld     ""bool Program.b""
-  IL_008f:  brtrue.s   IL_0093
-  IL_0091:  br.s       IL_0024
-  IL_0093:  br.s       IL_00df
-  IL_0095:  ldloc.1
-  IL_0096:  stloc.3
-  IL_0097:  ldsfld     ""bool Program.b""
-  IL_009c:  brtrue.s   IL_00a0
-  IL_009e:  br.s       IL_003f
-  IL_00a0:  br.s       IL_00df
-  IL_00a2:  ldsfld     ""bool Program.b""
-  IL_00a7:  brtrue.s   IL_00ab
-  IL_00a9:  br.s       IL_0041
-  IL_00ab:  br.s       IL_00df
-  IL_00ad:  ldloc.1
-  IL_00ae:  stloc.s    V_4
-  IL_00b0:  ldsfld     ""bool Program.b""
-  IL_00b5:  brtrue.s   IL_00b9
-  IL_00b7:  br.s       IL_005c
-  IL_00b9:  br.s       IL_00df
-  IL_00bb:  ldsfld     ""bool Program.b""
-  IL_00c0:  brtrue.s   IL_00c4
-  IL_00c2:  br.s       IL_005e
-  IL_00c4:  br.s       IL_00df
-  IL_00c6:  ldloc.1
-  IL_00c7:  stloc.s    V_5
-  IL_00c9:  ldsfld     ""bool Program.b""
-  IL_00ce:  brtrue.s   IL_00d2
-  IL_00d0:  br.s       IL_0079
-  IL_00d2:  br.s       IL_00df
-  IL_00d4:  ldsfld     ""bool Program.b""
-  IL_00d9:  brtrue.s   IL_00dd
-  IL_00db:  br.s       IL_007b
-  IL_00dd:  br.s       IL_00df
-  IL_00df:  ret
+  IL_002c:  isinst     ""int""
+  IL_0031:  brfalse.s  IL_003d
+  IL_0033:  ldloc.s    V_7
+  IL_0035:  unbox.any  ""int""
+  IL_003a:  stloc.1
+  IL_003b:  br.s       IL_0091
+  IL_003d:  br.s       IL_009e
+  IL_003f:  ldloc.0
+  IL_0040:  brtrue.s   IL_0044
+  IL_0042:  br.s       IL_0059
+  IL_0044:  ldloc.0
+  IL_0045:  dup
+  IL_0046:  stloc.s    V_7
+  IL_0048:  isinst     ""int""
+  IL_004d:  brfalse.s  IL_0059
+  IL_004f:  ldloc.s    V_7
+  IL_0051:  unbox.any  ""int""
+  IL_0056:  stloc.1
+  IL_0057:  br.s       IL_00a9
+  IL_0059:  br.s       IL_00b7
+  IL_005b:  ldloc.0
+  IL_005c:  brtrue.s   IL_0060
+  IL_005e:  br.s       IL_0075
+  IL_0060:  ldloc.0
+  IL_0061:  dup
+  IL_0062:  stloc.s    V_7
+  IL_0064:  isinst     ""int""
+  IL_0069:  brfalse.s  IL_0075
+  IL_006b:  ldloc.s    V_7
+  IL_006d:  unbox.any  ""int""
+  IL_0072:  stloc.1
+  IL_0073:  br.s       IL_00c2
+  IL_0075:  br.s       IL_00d0
+  IL_0077:  br.s       IL_00db
+  IL_0079:  ldloc.1
+  IL_007a:  stloc.2
+  IL_007b:  ldsfld     ""bool Program.b""
+  IL_0080:  brtrue.s   IL_0084
+  IL_0082:  br.s       IL_0021
+  IL_0084:  br.s       IL_00db
+  IL_0086:  ldsfld     ""bool Program.b""
+  IL_008b:  brtrue.s   IL_008f
+  IL_008d:  br.s       IL_0023
+  IL_008f:  br.s       IL_00db
+  IL_0091:  ldloc.1
+  IL_0092:  stloc.3
+  IL_0093:  ldsfld     ""bool Program.b""
+  IL_0098:  brtrue.s   IL_009c
+  IL_009a:  br.s       IL_003d
+  IL_009c:  br.s       IL_00db
+  IL_009e:  ldsfld     ""bool Program.b""
+  IL_00a3:  brtrue.s   IL_00a7
+  IL_00a5:  br.s       IL_003f
+  IL_00a7:  br.s       IL_00db
+  IL_00a9:  ldloc.1
+  IL_00aa:  stloc.s    V_4
+  IL_00ac:  ldsfld     ""bool Program.b""
+  IL_00b1:  brtrue.s   IL_00b5
+  IL_00b3:  br.s       IL_0059
+  IL_00b5:  br.s       IL_00db
+  IL_00b7:  ldsfld     ""bool Program.b""
+  IL_00bc:  brtrue.s   IL_00c0
+  IL_00be:  br.s       IL_005b
+  IL_00c0:  br.s       IL_00db
+  IL_00c2:  ldloc.1
+  IL_00c3:  stloc.s    V_5
+  IL_00c5:  ldsfld     ""bool Program.b""
+  IL_00ca:  brtrue.s   IL_00ce
+  IL_00cc:  br.s       IL_0075
+  IL_00ce:  br.s       IL_00db
+  IL_00d0:  ldsfld     ""bool Program.b""
+  IL_00d5:  brtrue.s   IL_00d9
+  IL_00d7:  br.s       IL_0077
+  IL_00d9:  br.s       IL_00db
+  IL_00db:  ret
 }"
             );
             compVerifier.VerifyPdb(
@@ -9425,40 +9431,40 @@ public class Program
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""19"" document=""1"" />
         <entry offset=""0x4"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x7f"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x88"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
-        <entry offset=""0x8a"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
-        <entry offset=""0x93"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
-        <entry offset=""0x95"" hidden=""true"" document=""1"" />
-        <entry offset=""0x97"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xa0"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xa2"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xab"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xad"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb0"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xb9"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xbb"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xc4"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xc6"" hidden=""true"" document=""1"" />
-        <entry offset=""0xc9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xd2"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xd4"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
-        <entry offset=""0xdd"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
-        <entry offset=""0xdf"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x79"" hidden=""true"" document=""1"" />
+        <entry offset=""0x7b"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x84"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x86"" startLine=""13"" startColumn=""24"" endLine=""13"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x8f"" startLine=""13"" startColumn=""32"" endLine=""13"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x91"" hidden=""true"" document=""1"" />
+        <entry offset=""0x93"" startLine=""14"" startColumn=""24"" endLine=""14"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x9c"" startLine=""14"" startColumn=""32"" endLine=""14"" endColumn=""38"" document=""1"" />
+        <entry offset=""0x9e"" startLine=""15"" startColumn=""24"" endLine=""15"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""15"" startColumn=""32"" endLine=""15"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xa9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xac"" startLine=""16"" startColumn=""24"" endLine=""16"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xb5"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xb7"" startLine=""17"" startColumn=""24"" endLine=""17"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xc0"" startLine=""17"" startColumn=""32"" endLine=""17"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xc2"" hidden=""true"" document=""1"" />
+        <entry offset=""0xc5"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xce"" startLine=""18"" startColumn=""32"" endLine=""18"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xd0"" startLine=""19"" startColumn=""24"" endLine=""19"" endColumn=""30"" document=""1"" />
+        <entry offset=""0xd9"" startLine=""19"" startColumn=""32"" endLine=""19"" endColumn=""38"" document=""1"" />
+        <entry offset=""0xdb"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xe0"">
-        <scope startOffset=""0x7d"" endOffset=""0x8a"">
-          <local name=""i"" il_index=""2"" il_start=""0x7d"" il_end=""0x8a"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0xdc"">
+        <scope startOffset=""0x79"" endOffset=""0x86"">
+          <local name=""i"" il_index=""2"" il_start=""0x79"" il_end=""0x86"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0x95"" endOffset=""0xa2"">
-          <local name=""i"" il_index=""3"" il_start=""0x95"" il_end=""0xa2"" attributes=""0"" />
+        <scope startOffset=""0x91"" endOffset=""0x9e"">
+          <local name=""i"" il_index=""3"" il_start=""0x91"" il_end=""0x9e"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0xad"" endOffset=""0xbb"">
-          <local name=""i"" il_index=""4"" il_start=""0xad"" il_end=""0xbb"" attributes=""0"" />
+        <scope startOffset=""0xa9"" endOffset=""0xb7"">
+          <local name=""i"" il_index=""4"" il_start=""0xa9"" il_end=""0xb7"" attributes=""0"" />
         </scope>
-        <scope startOffset=""0xc6"" endOffset=""0xd4"">
-          <local name=""i"" il_index=""5"" il_start=""0xc6"" il_end=""0xd4"" attributes=""0"" />
+        <scope startOffset=""0xc2"" endOffset=""0xd0"">
+          <local name=""i"" il_index=""5"" il_start=""0xc2"" il_end=""0xd0"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7617,15 +7617,15 @@ class C
             v0.VerifyIL("C.F", @"
 {
   // Code size       37 (0x25)
-  .maxstack  1
+  .maxstack  2
   .locals init (int V_0, //i
                 bool V_1,
                 object V_2,
                 int V_3)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.2
-  IL_0003:  ldloc.2
+  IL_0002:  dup
+  IL_0003:  stloc.2
   IL_0004:  isinst     ""int""
   IL_0009:  brfalse.s  IL_0015
   IL_000b:  ldloc.2
@@ -7658,8 +7658,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       53 (0x35)
-  .maxstack  1
+  // Code size       52 (0x34)
+  .maxstack  2
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7670,32 +7670,32 @@ class C
                 int V_7)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.s    V_6
-  IL_0004:  ldloc.s    V_6
-  IL_0006:  isinst     ""bool""
-  IL_000b:  brfalse.s  IL_0019
-  IL_000d:  ldloc.s    V_6
-  IL_000f:  unbox.any  ""bool""
-  IL_0014:  stloc.s    V_4
-  IL_0016:  ldc.i4.1
-  IL_0017:  br.s       IL_001a
-  IL_0019:  ldc.i4.0
-  IL_001a:  stloc.s    V_5
-  IL_001c:  ldloc.s    V_5
-  IL_001e:  brfalse.s  IL_002d
-  IL_0020:  nop
-  IL_0021:  ldloc.s    V_4
-  IL_0023:  brtrue.s   IL_0028
-  IL_0025:  ldc.i4.0
-  IL_0026:  br.s       IL_0029
-  IL_0028:  ldc.i4.1
-  IL_0029:  stloc.s    V_7
-  IL_002b:  br.s       IL_0032
-  IL_002d:  ldc.i4.0
-  IL_002e:  stloc.s    V_7
-  IL_0030:  br.s       IL_0032
-  IL_0032:  ldloc.s    V_7
-  IL_0034:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.s    V_6
+  IL_0005:  isinst     ""bool""
+  IL_000a:  brfalse.s  IL_0018
+  IL_000c:  ldloc.s    V_6
+  IL_000e:  unbox.any  ""bool""
+  IL_0013:  stloc.s    V_4
+  IL_0015:  ldc.i4.1
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  stloc.s    V_5
+  IL_001b:  ldloc.s    V_5
+  IL_001d:  brfalse.s  IL_002c
+  IL_001f:  nop
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  brtrue.s   IL_0027
+  IL_0024:  ldc.i4.0
+  IL_0025:  br.s       IL_0028
+  IL_0027:  ldc.i4.1
+  IL_0028:  stloc.s    V_7
+  IL_002a:  br.s       IL_0031
+  IL_002c:  ldc.i4.0
+  IL_002d:  stloc.s    V_7
+  IL_002f:  br.s       IL_0031
+  IL_0031:  ldloc.s    V_7
+  IL_0033:  ret
 }");
 
             var diff2 = compilation2.EmitDifference(
@@ -7705,8 +7705,8 @@ class C
 
             diff2.VerifyIL("C.F", @"
 {
-  // Code size       47 (0x2f)
-  .maxstack  1
+  // Code size       46 (0x2e)
+  .maxstack  2
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7721,28 +7721,28 @@ class C
                 int V_11)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.s    V_10
-  IL_0004:  ldloc.s    V_10
-  IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_0019
-  IL_000d:  ldloc.s    V_10
-  IL_000f:  unbox.any  ""int""
-  IL_0014:  stloc.s    V_8
-  IL_0016:  ldc.i4.1
-  IL_0017:  br.s       IL_001a
-  IL_0019:  ldc.i4.0
-  IL_001a:  stloc.s    V_9
-  IL_001c:  ldloc.s    V_9
-  IL_001e:  brfalse.s  IL_0027
-  IL_0020:  nop
-  IL_0021:  ldloc.s    V_8
-  IL_0023:  stloc.s    V_11
-  IL_0025:  br.s       IL_002c
-  IL_0027:  ldc.i4.0
-  IL_0028:  stloc.s    V_11
-  IL_002a:  br.s       IL_002c
-  IL_002c:  ldloc.s    V_11
-  IL_002e:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.s    V_10
+  IL_0005:  isinst     ""int""
+  IL_000a:  brfalse.s  IL_0018
+  IL_000c:  ldloc.s    V_10
+  IL_000e:  unbox.any  ""int""
+  IL_0013:  stloc.s    V_8
+  IL_0015:  ldc.i4.1
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  stloc.s    V_9
+  IL_001b:  ldloc.s    V_9
+  IL_001d:  brfalse.s  IL_0026
+  IL_001f:  nop
+  IL_0020:  ldloc.s    V_8
+  IL_0022:  stloc.s    V_11
+  IL_0024:  br.s       IL_002b
+  IL_0026:  ldc.i4.0
+  IL_0027:  stloc.s    V_11
+  IL_0029:  br.s       IL_002b
+  IL_002b:  ldloc.s    V_11
+  IL_002d:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7778,15 +7778,15 @@ class C
             v0.VerifyIL("C.F", @"
 {
   // Code size       37 (0x25)
-  .maxstack  1
+  .maxstack  2
   .locals init (int V_0, //i
                 bool V_1,
                 object V_2,
                 int V_3)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.2
-  IL_0003:  ldloc.2
+  IL_0002:  dup
+  IL_0003:  stloc.2
   IL_0004:  isinst     ""int""
   IL_0009:  brfalse.s  IL_0015
   IL_000b:  ldloc.2
@@ -7854,8 +7854,8 @@ class C
 
             diff2.VerifyIL("C.F", @"
 {
-  // Code size       47 (0x2f)
-  .maxstack  1
+  // Code size       46 (0x2e)
+  .maxstack  2
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7868,28 +7868,28 @@ class C
                 int V_9)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  stloc.s    V_8
-  IL_0004:  ldloc.s    V_8
-  IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_0019
-  IL_000d:  ldloc.s    V_8
-  IL_000f:  unbox.any  ""int""
-  IL_0014:  stloc.s    V_6
-  IL_0016:  ldc.i4.1
-  IL_0017:  br.s       IL_001a
-  IL_0019:  ldc.i4.0
-  IL_001a:  stloc.s    V_7
-  IL_001c:  ldloc.s    V_7
-  IL_001e:  brfalse.s  IL_0027
-  IL_0020:  nop
-  IL_0021:  ldloc.s    V_6
-  IL_0023:  stloc.s    V_9
-  IL_0025:  br.s       IL_002c
-  IL_0027:  ldc.i4.0
-  IL_0028:  stloc.s    V_9
-  IL_002a:  br.s       IL_002c
-  IL_002c:  ldloc.s    V_9
-  IL_002e:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.s    V_8
+  IL_0005:  isinst     ""int""
+  IL_000a:  brfalse.s  IL_0018
+  IL_000c:  ldloc.s    V_8
+  IL_000e:  unbox.any  ""int""
+  IL_0013:  stloc.s    V_6
+  IL_0015:  ldc.i4.1
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  stloc.s    V_7
+  IL_001b:  ldloc.s    V_7
+  IL_001d:  brfalse.s  IL_0026
+  IL_001f:  nop
+  IL_0020:  ldloc.s    V_6
+  IL_0022:  stloc.s    V_9
+  IL_0024:  br.s       IL_002b
+  IL_0026:  ldc.i4.0
+  IL_0027:  stloc.s    V_9
+  IL_0029:  br.s       IL_002b
+  IL_002b:  ldloc.s    V_9
+  IL_002d:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7616,8 +7616,8 @@ class C
             var v0 = CompileAndVerify(compilation0);
             v0.VerifyIL("C.F", @"
 {
-  // Code size       40 (0x28)
-  .maxstack  2
+  // Code size       37 (0x25)
+  .maxstack  1
   .locals init (int V_0, //i
                 bool V_1,
                 object V_2,
@@ -7627,27 +7627,25 @@ class C
   IL_0002:  stloc.2
   IL_0003:  ldloc.2
   IL_0004:  isinst     ""int""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  dup
-  IL_000d:  brtrue.s   IL_0012
-  IL_000f:  ldc.i4.0
-  IL_0010:  br.s       IL_0018
-  IL_0012:  ldloc.2
-  IL_0013:  unbox.any  ""int""
-  IL_0018:  stloc.0
-  IL_0019:  stloc.1
-  IL_001a:  ldloc.1
-  IL_001b:  brfalse.s  IL_0022
-  IL_001d:  nop
-  IL_001e:  ldloc.0
-  IL_001f:  stloc.3
-  IL_0020:  br.s       IL_0026
-  IL_0022:  ldc.i4.0
-  IL_0023:  stloc.3
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.3
-  IL_0027:  ret
+  IL_0009:  brfalse.s  IL_0015
+  IL_000b:  ldloc.2
+  IL_000c:  unbox.any  ""int""
+  IL_0011:  stloc.0
+  IL_0012:  ldc.i4.1
+  IL_0013:  br.s       IL_0016
+  IL_0015:  ldc.i4.0
+  IL_0016:  stloc.1
+  IL_0017:  ldloc.1
+  IL_0018:  brfalse.s  IL_001f
+  IL_001a:  nop
+  IL_001b:  ldloc.0
+  IL_001c:  stloc.3
+  IL_001d:  br.s       IL_0023
+  IL_001f:  ldc.i4.0
+  IL_0020:  stloc.3
+  IL_0021:  br.s       IL_0023
+  IL_0023:  ldloc.3
+  IL_0024:  ret
 }");
 
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
@@ -7660,8 +7658,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       56 (0x38)
-  .maxstack  2
+  // Code size       53 (0x35)
+  .maxstack  1
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7675,31 +7673,29 @@ class C
   IL_0002:  stloc.s    V_6
   IL_0004:  ldloc.s    V_6
   IL_0006:  isinst     ""bool""
-  IL_000b:  ldnull
-  IL_000c:  cgt.un
-  IL_000e:  dup
-  IL_000f:  brtrue.s   IL_0014
-  IL_0011:  ldc.i4.0
-  IL_0012:  br.s       IL_001b
-  IL_0014:  ldloc.s    V_6
-  IL_0016:  unbox.any  ""bool""
-  IL_001b:  stloc.s    V_4
-  IL_001d:  stloc.s    V_5
-  IL_001f:  ldloc.s    V_5
-  IL_0021:  brfalse.s  IL_0030
-  IL_0023:  nop
-  IL_0024:  ldloc.s    V_4
-  IL_0026:  brtrue.s   IL_002b
-  IL_0028:  ldc.i4.0
-  IL_0029:  br.s       IL_002c
-  IL_002b:  ldc.i4.1
-  IL_002c:  stloc.s    V_7
-  IL_002e:  br.s       IL_0035
-  IL_0030:  ldc.i4.0
-  IL_0031:  stloc.s    V_7
-  IL_0033:  br.s       IL_0035
-  IL_0035:  ldloc.s    V_7
-  IL_0037:  ret
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloc.s    V_6
+  IL_000f:  unbox.any  ""bool""
+  IL_0014:  stloc.s    V_4
+  IL_0016:  ldc.i4.1
+  IL_0017:  br.s       IL_001a
+  IL_0019:  ldc.i4.0
+  IL_001a:  stloc.s    V_5
+  IL_001c:  ldloc.s    V_5
+  IL_001e:  brfalse.s  IL_002d
+  IL_0020:  nop
+  IL_0021:  ldloc.s    V_4
+  IL_0023:  brtrue.s   IL_0028
+  IL_0025:  ldc.i4.0
+  IL_0026:  br.s       IL_0029
+  IL_0028:  ldc.i4.1
+  IL_0029:  stloc.s    V_7
+  IL_002b:  br.s       IL_0032
+  IL_002d:  ldc.i4.0
+  IL_002e:  stloc.s    V_7
+  IL_0030:  br.s       IL_0032
+  IL_0032:  ldloc.s    V_7
+  IL_0034:  ret
 }");
 
             var diff2 = compilation2.EmitDifference(
@@ -7709,8 +7705,8 @@ class C
 
             diff2.VerifyIL("C.F", @"
 {
-  // Code size       50 (0x32)
-  .maxstack  2
+  // Code size       47 (0x2f)
+  .maxstack  1
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7728,27 +7724,25 @@ class C
   IL_0002:  stloc.s    V_10
   IL_0004:  ldloc.s    V_10
   IL_0006:  isinst     ""int""
-  IL_000b:  ldnull
-  IL_000c:  cgt.un
-  IL_000e:  dup
-  IL_000f:  brtrue.s   IL_0014
-  IL_0011:  ldc.i4.0
-  IL_0012:  br.s       IL_001b
-  IL_0014:  ldloc.s    V_10
-  IL_0016:  unbox.any  ""int""
-  IL_001b:  stloc.s    V_8
-  IL_001d:  stloc.s    V_9
-  IL_001f:  ldloc.s    V_9
-  IL_0021:  brfalse.s  IL_002a
-  IL_0023:  nop
-  IL_0024:  ldloc.s    V_8
-  IL_0026:  stloc.s    V_11
-  IL_0028:  br.s       IL_002f
-  IL_002a:  ldc.i4.0
-  IL_002b:  stloc.s    V_11
-  IL_002d:  br.s       IL_002f
-  IL_002f:  ldloc.s    V_11
-  IL_0031:  ret
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloc.s    V_10
+  IL_000f:  unbox.any  ""int""
+  IL_0014:  stloc.s    V_8
+  IL_0016:  ldc.i4.1
+  IL_0017:  br.s       IL_001a
+  IL_0019:  ldc.i4.0
+  IL_001a:  stloc.s    V_9
+  IL_001c:  ldloc.s    V_9
+  IL_001e:  brfalse.s  IL_0027
+  IL_0020:  nop
+  IL_0021:  ldloc.s    V_8
+  IL_0023:  stloc.s    V_11
+  IL_0025:  br.s       IL_002c
+  IL_0027:  ldc.i4.0
+  IL_0028:  stloc.s    V_11
+  IL_002a:  br.s       IL_002c
+  IL_002c:  ldloc.s    V_11
+  IL_002e:  ret
 }");
         }
 
@@ -7783,8 +7777,8 @@ class C
             var v0 = CompileAndVerify(compilation0);
             v0.VerifyIL("C.F", @"
 {
-  // Code size       40 (0x28)
-  .maxstack  2
+  // Code size       37 (0x25)
+  .maxstack  1
   .locals init (int V_0, //i
                 bool V_1,
                 object V_2,
@@ -7794,27 +7788,25 @@ class C
   IL_0002:  stloc.2
   IL_0003:  ldloc.2
   IL_0004:  isinst     ""int""
-  IL_0009:  ldnull
-  IL_000a:  cgt.un
-  IL_000c:  dup
-  IL_000d:  brtrue.s   IL_0012
-  IL_000f:  ldc.i4.0
-  IL_0010:  br.s       IL_0018
-  IL_0012:  ldloc.2
-  IL_0013:  unbox.any  ""int""
-  IL_0018:  stloc.0
-  IL_0019:  stloc.1
-  IL_001a:  ldloc.1
-  IL_001b:  brfalse.s  IL_0022
-  IL_001d:  nop
-  IL_001e:  ldloc.0
-  IL_001f:  stloc.3
-  IL_0020:  br.s       IL_0026
-  IL_0022:  ldc.i4.0
-  IL_0023:  stloc.3
-  IL_0024:  br.s       IL_0026
-  IL_0026:  ldloc.3
-  IL_0027:  ret
+  IL_0009:  brfalse.s  IL_0015
+  IL_000b:  ldloc.2
+  IL_000c:  unbox.any  ""int""
+  IL_0011:  stloc.0
+  IL_0012:  ldc.i4.1
+  IL_0013:  br.s       IL_0016
+  IL_0015:  ldc.i4.0
+  IL_0016:  stloc.1
+  IL_0017:  ldloc.1
+  IL_0018:  brfalse.s  IL_001f
+  IL_001a:  nop
+  IL_001b:  ldloc.0
+  IL_001c:  stloc.3
+  IL_001d:  br.s       IL_0023
+  IL_001f:  ldc.i4.0
+  IL_0020:  stloc.3
+  IL_0021:  br.s       IL_0023
+  IL_0023:  ldloc.3
+  IL_0024:  ret
 }");
 
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
@@ -7862,8 +7854,8 @@ class C
 
             diff2.VerifyIL("C.F", @"
 {
-  // Code size       50 (0x32)
-  .maxstack  2
+  // Code size       47 (0x2f)
+  .maxstack  1
   .locals init ([int] V_0,
                 [bool] V_1,
                 [object] V_2,
@@ -7879,27 +7871,25 @@ class C
   IL_0002:  stloc.s    V_8
   IL_0004:  ldloc.s    V_8
   IL_0006:  isinst     ""int""
-  IL_000b:  ldnull
-  IL_000c:  cgt.un
-  IL_000e:  dup
-  IL_000f:  brtrue.s   IL_0014
-  IL_0011:  ldc.i4.0
-  IL_0012:  br.s       IL_001b
-  IL_0014:  ldloc.s    V_8
-  IL_0016:  unbox.any  ""int""
-  IL_001b:  stloc.s    V_6
-  IL_001d:  stloc.s    V_7
-  IL_001f:  ldloc.s    V_7
-  IL_0021:  brfalse.s  IL_002a
-  IL_0023:  nop
-  IL_0024:  ldloc.s    V_6
-  IL_0026:  stloc.s    V_9
-  IL_0028:  br.s       IL_002f
-  IL_002a:  ldc.i4.0
-  IL_002b:  stloc.s    V_9
-  IL_002d:  br.s       IL_002f
-  IL_002f:  ldloc.s    V_9
-  IL_0031:  ret
+  IL_000b:  brfalse.s  IL_0019
+  IL_000d:  ldloc.s    V_8
+  IL_000f:  unbox.any  ""int""
+  IL_0014:  stloc.s    V_6
+  IL_0016:  ldc.i4.1
+  IL_0017:  br.s       IL_001a
+  IL_0019:  ldc.i4.0
+  IL_001a:  stloc.s    V_7
+  IL_001c:  ldloc.s    V_7
+  IL_001e:  brfalse.s  IL_0027
+  IL_0020:  nop
+  IL_0021:  ldloc.s    V_6
+  IL_0023:  stloc.s    V_9
+  IL_0025:  br.s       IL_002c
+  IL_0027:  ldc.i4.0
+  IL_0028:  stloc.s    V_9
+  IL_002a:  br.s       IL_002c
+  IL_002c:  ldloc.s    V_9
+  IL_002e:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2419,7 +2419,7 @@ class C
 
             v0.VerifyIL("C.M", @"
 {
-  // Code size      230 (0xe6)
+  // Code size      203 (0xcb)
   .maxstack  2
   .locals init (object V_0,
                 int V_1,
@@ -2437,107 +2437,89 @@ class C
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
   IL_000c:  brtrue.s   IL_0010
-  IL_000e:  br.s       IL_0081
+  IL_000e:  br.s       IL_0066
   IL_0010:  ldloc.0
   IL_0011:  stloc.s    V_8
   IL_0013:  ldloc.s    V_8
   IL_0015:  isinst     ""int""
-  IL_001a:  ldnull
-  IL_001b:  cgt.un
-  IL_001d:  dup
-  IL_001e:  brtrue.s   IL_0023
-  IL_0020:  ldc.i4.0
-  IL_0021:  br.s       IL_002a
-  IL_0023:  ldloc.s    V_8
-  IL_0025:  unbox.any  ""int""
-  IL_002a:  stloc.1
-  IL_002b:  brfalse.s  IL_0035
-  IL_002d:  ldloc.1
-  IL_002e:  ldc.i4.1
-  IL_002f:  beq.s      IL_0033
-  IL_0031:  br.s       IL_0035
-  IL_0033:  br.s       IL_0083
-  IL_0035:  ldloc.0
-  IL_0036:  stloc.s    V_8
+  IL_001a:  brfalse.s  IL_002c
+  IL_001c:  ldloc.s    V_8
+  IL_001e:  unbox.any  ""int""
+  IL_0023:  stloc.1
+  IL_0024:  ldloc.1
+  IL_0025:  ldc.i4.1
+  IL_0026:  beq.s      IL_002a
+  IL_0028:  br.s       IL_002c
+  IL_002a:  br.s       IL_0068
+  IL_002c:  ldloc.0
+  IL_002d:  stloc.s    V_8
+  IL_002f:  ldloc.s    V_8
+  IL_0031:  isinst     ""byte""
+  IL_0036:  brfalse.s  IL_004a
   IL_0038:  ldloc.s    V_8
-  IL_003a:  isinst     ""byte""
-  IL_003f:  ldnull
-  IL_0040:  cgt.un
-  IL_0042:  dup
-  IL_0043:  brtrue.s   IL_0048
-  IL_0045:  ldc.i4.0
-  IL_0046:  br.s       IL_004f
-  IL_0048:  ldloc.s    V_8
-  IL_004a:  unbox.any  ""byte""
-  IL_004f:  stloc.2
-  IL_0050:  brfalse.s  IL_005c
-  IL_0052:  br.s       IL_0090
-  IL_0054:  ldloc.2
-  IL_0055:  ldc.i4.1
-  IL_0056:  beq.s      IL_005a
-  IL_0058:  br.s       IL_005c
-  IL_005a:  br.s       IL_00ba
-  IL_005c:  ldloc.0
-  IL_005d:  stloc.s    V_8
-  IL_005f:  ldloc.s    V_8
-  IL_0061:  isinst     ""int""
-  IL_0066:  ldnull
-  IL_0067:  cgt.un
-  IL_0069:  dup
-  IL_006a:  brtrue.s   IL_006f
-  IL_006c:  ldc.i4.0
-  IL_006d:  br.s       IL_0076
-  IL_006f:  ldloc.s    V_8
-  IL_0071:  unbox.any  ""int""
-  IL_0076:  stloc.1
-  IL_0077:  brfalse.s  IL_007d
-  IL_0079:  br.s       IL_00a4
-  IL_007b:  br.s       IL_00c7
-  IL_007d:  ldloc.0
-  IL_007e:  stloc.0
-  IL_007f:  br.s       IL_00d6
-  IL_0081:  br.s       IL_00e5
-  IL_0083:  ldstr      ""int 1""
-  IL_0088:  call       ""void System.Console.WriteLine(string)""
-  IL_008d:  nop
-  IL_008e:  br.s       IL_00e5
-  IL_0090:  ldloc.2
-  IL_0091:  stloc.3
-  IL_0092:  call       ""bool C.P()""
-  IL_0097:  brtrue.s   IL_009b
-  IL_0099:  br.s       IL_0054
-  IL_009b:  ldloc.3
-  IL_009c:  call       ""void System.Console.WriteLine(int)""
-  IL_00a1:  nop
-  IL_00a2:  br.s       IL_00e5
-  IL_00a4:  ldloc.1
-  IL_00a5:  stloc.s    V_4
-  IL_00a7:  call       ""bool C.P()""
-  IL_00ac:  brtrue.s   IL_00b0
-  IL_00ae:  br.s       IL_007b
-  IL_00b0:  ldloc.s    V_4
-  IL_00b2:  call       ""void System.Console.WriteLine(int)""
-  IL_00b7:  nop
-  IL_00b8:  br.s       IL_00e5
-  IL_00ba:  ldstr      ""byte 1""
-  IL_00bf:  call       ""void System.Console.WriteLine(string)""
-  IL_00c4:  nop
-  IL_00c5:  br.s       IL_00e5
-  IL_00c7:  ldloc.1
-  IL_00c8:  stloc.s    V_5
-  IL_00ca:  br.s       IL_00cc
-  IL_00cc:  ldloc.s    V_5
-  IL_00ce:  call       ""void System.Console.WriteLine(int)""
-  IL_00d3:  nop
-  IL_00d4:  br.s       IL_00e5
-  IL_00d6:  ldloc.0
-  IL_00d7:  stloc.s    V_6
-  IL_00d9:  br.s       IL_00db
-  IL_00db:  ldloc.s    V_6
-  IL_00dd:  call       ""void System.Console.WriteLine(object)""
-  IL_00e2:  nop
-  IL_00e3:  br.s       IL_00e5
-  IL_00e5:  ret
+  IL_003a:  unbox.any  ""byte""
+  IL_003f:  stloc.2
+  IL_0040:  br.s       IL_0075
+  IL_0042:  ldloc.2
+  IL_0043:  ldc.i4.1
+  IL_0044:  beq.s      IL_0048
+  IL_0046:  br.s       IL_004a
+  IL_0048:  br.s       IL_009f
+  IL_004a:  ldloc.0
+  IL_004b:  stloc.s    V_8
+  IL_004d:  ldloc.s    V_8
+  IL_004f:  isinst     ""int""
+  IL_0054:  brfalse.s  IL_0062
+  IL_0056:  ldloc.s    V_8
+  IL_0058:  unbox.any  ""int""
+  IL_005d:  stloc.1
+  IL_005e:  br.s       IL_0089
+  IL_0060:  br.s       IL_00ac
+  IL_0062:  ldloc.0
+  IL_0063:  stloc.0
+  IL_0064:  br.s       IL_00bb
+  IL_0066:  br.s       IL_00ca
+  IL_0068:  ldstr      ""int 1""
+  IL_006d:  call       ""void System.Console.WriteLine(string)""
+  IL_0072:  nop
+  IL_0073:  br.s       IL_00ca
+  IL_0075:  ldloc.2
+  IL_0076:  stloc.3
+  IL_0077:  call       ""bool C.P()""
+  IL_007c:  brtrue.s   IL_0080
+  IL_007e:  br.s       IL_0042
+  IL_0080:  ldloc.3
+  IL_0081:  call       ""void System.Console.WriteLine(int)""
+  IL_0086:  nop
+  IL_0087:  br.s       IL_00ca
+  IL_0089:  ldloc.1
+  IL_008a:  stloc.s    V_4
+  IL_008c:  call       ""bool C.P()""
+  IL_0091:  brtrue.s   IL_0095
+  IL_0093:  br.s       IL_0060
+  IL_0095:  ldloc.s    V_4
+  IL_0097:  call       ""void System.Console.WriteLine(int)""
+  IL_009c:  nop
+  IL_009d:  br.s       IL_00ca
+  IL_009f:  ldstr      ""byte 1""
+  IL_00a4:  call       ""void System.Console.WriteLine(string)""
+  IL_00a9:  nop
+  IL_00aa:  br.s       IL_00ca
+  IL_00ac:  ldloc.1
+  IL_00ad:  stloc.s    V_5
+  IL_00af:  br.s       IL_00b1
+  IL_00b1:  ldloc.s    V_5
+  IL_00b3:  call       ""void System.Console.WriteLine(int)""
+  IL_00b8:  nop
+  IL_00b9:  br.s       IL_00ca
+  IL_00bb:  ldloc.0
+  IL_00bc:  stloc.s    V_6
+  IL_00be:  br.s       IL_00c0
+  IL_00c0:  ldloc.s    V_6
+  IL_00c2:  call       ""void System.Console.WriteLine(object)""
+  IL_00c7:  nop
+  IL_00c8:  br.s       IL_00ca
+  IL_00ca:  ret
 }");
             var methodData0 = v0.TestData.GetMethodData("C.M");
             var method0 = compilation0.GetMember<MethodSymbol>("C.M");
@@ -2550,7 +2532,7 @@ class C
 
             diff1.VerifyIL("C.M", @"
 {
-  // Code size      230 (0xe6)
+  // Code size      203 (0xcb)
   .maxstack  2
   .locals init (object V_0,
                 int V_1,
@@ -2569,107 +2551,89 @@ class C
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
   IL_000c:  brtrue.s   IL_0010
-  IL_000e:  br.s       IL_0081
+  IL_000e:  br.s       IL_0066
   IL_0010:  ldloc.0
   IL_0011:  stloc.s    V_9
   IL_0013:  ldloc.s    V_9
   IL_0015:  isinst     ""int""
-  IL_001a:  ldnull
-  IL_001b:  cgt.un
-  IL_001d:  dup
-  IL_001e:  brtrue.s   IL_0023
-  IL_0020:  ldc.i4.0
-  IL_0021:  br.s       IL_002a
-  IL_0023:  ldloc.s    V_9
-  IL_0025:  unbox.any  ""int""
-  IL_002a:  stloc.1
-  IL_002b:  brfalse.s  IL_0035
-  IL_002d:  ldloc.1
-  IL_002e:  ldc.i4.1
-  IL_002f:  beq.s      IL_0033
-  IL_0031:  br.s       IL_0035
-  IL_0033:  br.s       IL_0083
-  IL_0035:  ldloc.0
-  IL_0036:  stloc.s    V_9
+  IL_001a:  brfalse.s  IL_002c
+  IL_001c:  ldloc.s    V_9
+  IL_001e:  unbox.any  ""int""
+  IL_0023:  stloc.1
+  IL_0024:  ldloc.1
+  IL_0025:  ldc.i4.1
+  IL_0026:  beq.s      IL_002a
+  IL_0028:  br.s       IL_002c
+  IL_002a:  br.s       IL_0068
+  IL_002c:  ldloc.0
+  IL_002d:  stloc.s    V_9
+  IL_002f:  ldloc.s    V_9
+  IL_0031:  isinst     ""byte""
+  IL_0036:  brfalse.s  IL_004a
   IL_0038:  ldloc.s    V_9
-  IL_003a:  isinst     ""byte""
-  IL_003f:  ldnull
-  IL_0040:  cgt.un
-  IL_0042:  dup
-  IL_0043:  brtrue.s   IL_0048
-  IL_0045:  ldc.i4.0
-  IL_0046:  br.s       IL_004f
-  IL_0048:  ldloc.s    V_9
-  IL_004a:  unbox.any  ""byte""
-  IL_004f:  stloc.2
-  IL_0050:  brfalse.s  IL_005c
-  IL_0052:  br.s       IL_0090
-  IL_0054:  ldloc.2
-  IL_0055:  ldc.i4.1
-  IL_0056:  beq.s      IL_005a
-  IL_0058:  br.s       IL_005c
-  IL_005a:  br.s       IL_00ba
-  IL_005c:  ldloc.0
-  IL_005d:  stloc.s    V_9
-  IL_005f:  ldloc.s    V_9
-  IL_0061:  isinst     ""int""
-  IL_0066:  ldnull
-  IL_0067:  cgt.un
-  IL_0069:  dup
-  IL_006a:  brtrue.s   IL_006f
-  IL_006c:  ldc.i4.0
-  IL_006d:  br.s       IL_0076
-  IL_006f:  ldloc.s    V_9
-  IL_0071:  unbox.any  ""int""
-  IL_0076:  stloc.1
-  IL_0077:  brfalse.s  IL_007d
-  IL_0079:  br.s       IL_00a4
-  IL_007b:  br.s       IL_00c7
-  IL_007d:  ldloc.0
-  IL_007e:  stloc.0
-  IL_007f:  br.s       IL_00d6
-  IL_0081:  br.s       IL_00e5
-  IL_0083:  ldstr      ""int 1""
-  IL_0088:  call       ""void System.Console.WriteLine(string)""
-  IL_008d:  nop
-  IL_008e:  br.s       IL_00e5
-  IL_0090:  ldloc.2
-  IL_0091:  stloc.3
-  IL_0092:  call       ""bool C.P()""
-  IL_0097:  brtrue.s   IL_009b
-  IL_0099:  br.s       IL_0054
-  IL_009b:  ldloc.3
-  IL_009c:  call       ""void System.Console.WriteLine(int)""
-  IL_00a1:  nop
-  IL_00a2:  br.s       IL_00e5
-  IL_00a4:  ldloc.1
-  IL_00a5:  stloc.s    V_4
-  IL_00a7:  call       ""bool C.P()""
-  IL_00ac:  brtrue.s   IL_00b0
-  IL_00ae:  br.s       IL_007b
-  IL_00b0:  ldloc.s    V_4
-  IL_00b2:  call       ""void System.Console.WriteLine(int)""
-  IL_00b7:  nop
-  IL_00b8:  br.s       IL_00e5
-  IL_00ba:  ldstr      ""byte 1""
-  IL_00bf:  call       ""void System.Console.WriteLine(string)""
-  IL_00c4:  nop
-  IL_00c5:  br.s       IL_00e5
-  IL_00c7:  ldloc.1
-  IL_00c8:  stloc.s    V_5
-  IL_00ca:  br.s       IL_00cc
-  IL_00cc:  ldloc.s    V_5
-  IL_00ce:  call       ""void System.Console.WriteLine(int)""
-  IL_00d3:  nop
-  IL_00d4:  br.s       IL_00e5
-  IL_00d6:  ldloc.0
-  IL_00d7:  stloc.s    V_6
-  IL_00d9:  br.s       IL_00db
-  IL_00db:  ldloc.s    V_6
-  IL_00dd:  call       ""void System.Console.WriteLine(object)""
-  IL_00e2:  nop
-  IL_00e3:  br.s       IL_00e5
-  IL_00e5:  ret
+  IL_003a:  unbox.any  ""byte""
+  IL_003f:  stloc.2
+  IL_0040:  br.s       IL_0075
+  IL_0042:  ldloc.2
+  IL_0043:  ldc.i4.1
+  IL_0044:  beq.s      IL_0048
+  IL_0046:  br.s       IL_004a
+  IL_0048:  br.s       IL_009f
+  IL_004a:  ldloc.0
+  IL_004b:  stloc.s    V_9
+  IL_004d:  ldloc.s    V_9
+  IL_004f:  isinst     ""int""
+  IL_0054:  brfalse.s  IL_0062
+  IL_0056:  ldloc.s    V_9
+  IL_0058:  unbox.any  ""int""
+  IL_005d:  stloc.1
+  IL_005e:  br.s       IL_0089
+  IL_0060:  br.s       IL_00ac
+  IL_0062:  ldloc.0
+  IL_0063:  stloc.0
+  IL_0064:  br.s       IL_00bb
+  IL_0066:  br.s       IL_00ca
+  IL_0068:  ldstr      ""int 1""
+  IL_006d:  call       ""void System.Console.WriteLine(string)""
+  IL_0072:  nop
+  IL_0073:  br.s       IL_00ca
+  IL_0075:  ldloc.2
+  IL_0076:  stloc.3
+  IL_0077:  call       ""bool C.P()""
+  IL_007c:  brtrue.s   IL_0080
+  IL_007e:  br.s       IL_0042
+  IL_0080:  ldloc.3
+  IL_0081:  call       ""void System.Console.WriteLine(int)""
+  IL_0086:  nop
+  IL_0087:  br.s       IL_00ca
+  IL_0089:  ldloc.1
+  IL_008a:  stloc.s    V_4
+  IL_008c:  call       ""bool C.P()""
+  IL_0091:  brtrue.s   IL_0095
+  IL_0093:  br.s       IL_0060
+  IL_0095:  ldloc.s    V_4
+  IL_0097:  call       ""void System.Console.WriteLine(int)""
+  IL_009c:  nop
+  IL_009d:  br.s       IL_00ca
+  IL_009f:  ldstr      ""byte 1""
+  IL_00a4:  call       ""void System.Console.WriteLine(string)""
+  IL_00a9:  nop
+  IL_00aa:  br.s       IL_00ca
+  IL_00ac:  ldloc.1
+  IL_00ad:  stloc.s    V_5
+  IL_00af:  br.s       IL_00b1
+  IL_00b1:  ldloc.s    V_5
+  IL_00b3:  call       ""void System.Console.WriteLine(int)""
+  IL_00b8:  nop
+  IL_00b9:  br.s       IL_00ca
+  IL_00bb:  ldloc.0
+  IL_00bc:  stloc.s    V_6
+  IL_00be:  br.s       IL_00c0
+  IL_00c0:  ldloc.s    V_6
+  IL_00c2:  call       ""void System.Console.WriteLine(object)""
+  IL_00c7:  nop
+  IL_00c8:  br.s       IL_00ca
+  IL_00ca:  ret
 }");
         }
 
@@ -3667,8 +3631,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       46 (0x2e)
-  .maxstack  2
+  // Code size       43 (0x2b)
+  .maxstack  1
   .locals init (int V_0, //i
                 bool V_1,
                 [object] V_2,
@@ -3680,27 +3644,25 @@ class C
   IL_0002:  stloc.s    V_4
   IL_0004:  ldloc.s    V_4
   IL_0006:  isinst     ""int""
-  IL_000b:  ldnull
-  IL_000c:  cgt.un
-  IL_000e:  dup
-  IL_000f:  brtrue.s   IL_0014
-  IL_0011:  ldc.i4.0
-  IL_0012:  br.s       IL_001b
-  IL_0014:  ldloc.s    V_4
-  IL_0016:  unbox.any  ""int""
-  IL_001b:  stloc.0
-  IL_001c:  stloc.1
- ~IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_0026
- -IL_0020:  nop
- -IL_0021:  ldloc.0
-  IL_0022:  stloc.s    V_5
-  IL_0024:  br.s       IL_002b
- -IL_0026:  ldc.i4.0
-  IL_0027:  stloc.s    V_5
-  IL_0029:  br.s       IL_002b
- -IL_002b:  ldloc.s    V_5
-  IL_002d:  ret
+  IL_000b:  brfalse.s  IL_0018
+  IL_000d:  ldloc.s    V_4
+  IL_000f:  unbox.any  ""int""
+  IL_0014:  stloc.0
+  IL_0015:  ldc.i4.1
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  stloc.1
+ ~IL_001a:  ldloc.1
+  IL_001b:  brfalse.s  IL_0023
+ -IL_001d:  nop
+ -IL_001e:  ldloc.0
+  IL_001f:  stloc.s    V_5
+  IL_0021:  br.s       IL_0028
+ -IL_0023:  ldc.i4.0
+  IL_0024:  stloc.s    V_5
+  IL_0026:  br.s       IL_0028
+ -IL_0028:  ldloc.s    V_5
+  IL_002a:  ret
 }", methodToken: diff1.UpdatedMethods.Single());
         }
 
@@ -3836,8 +3798,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       46 (0x2e)
-  .maxstack  2
+  // Code size       43 (0x2b)
+  .maxstack  1
   .locals init (int V_0, //i
                 bool V_1,
                 [object] V_2,
@@ -3849,27 +3811,25 @@ class C
   IL_0002:  stloc.s    V_4
   IL_0004:  ldloc.s    V_4
   IL_0006:  isinst     ""int""
-  IL_000b:  ldnull
-  IL_000c:  cgt.un
-  IL_000e:  dup
-  IL_000f:  brtrue.s   IL_0014
-  IL_0011:  ldc.i4.0
-  IL_0012:  br.s       IL_001b
-  IL_0014:  ldloc.s    V_4
-  IL_0016:  unbox.any  ""int""
-  IL_001b:  stloc.0
-  IL_001c:  stloc.1
- ~IL_001d:  ldloc.1
-  IL_001e:  brfalse.s  IL_0026
- -IL_0020:  nop
- -IL_0021:  ldloc.0
-  IL_0022:  stloc.s    V_5
-  IL_0024:  br.s       IL_002b
- -IL_0026:  ldc.i4.0
-  IL_0027:  stloc.s    V_5
-  IL_0029:  br.s       IL_002b
- -IL_002b:  ldloc.s    V_5
-  IL_002d:  ret
+  IL_000b:  brfalse.s  IL_0018
+  IL_000d:  ldloc.s    V_4
+  IL_000f:  unbox.any  ""int""
+  IL_0014:  stloc.0
+  IL_0015:  ldc.i4.1
+  IL_0016:  br.s       IL_0019
+  IL_0018:  ldc.i4.0
+  IL_0019:  stloc.1
+ ~IL_001a:  ldloc.1
+  IL_001b:  brfalse.s  IL_0023
+ -IL_001d:  nop
+ -IL_001e:  ldloc.0
+  IL_001f:  stloc.s    V_5
+  IL_0021:  br.s       IL_0028
+ -IL_0023:  ldc.i4.0
+  IL_0024:  stloc.s    V_5
+  IL_0026:  br.s       IL_0028
+ -IL_0028:  ldloc.s    V_5
+  IL_002a:  ret
 }", methodToken: diff1.UpdatedMethods.Single());
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2419,7 +2419,7 @@ class C
 
             v0.VerifyIL("C.M", @"
 {
-  // Code size      203 (0xcb)
+  // Code size      200 (0xc8)
   .maxstack  2
   .locals init (object V_0,
                 int V_1,
@@ -2437,89 +2437,89 @@ class C
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
   IL_000c:  brtrue.s   IL_0010
-  IL_000e:  br.s       IL_0066
+  IL_000e:  br.s       IL_0063
   IL_0010:  ldloc.0
-  IL_0011:  stloc.s    V_8
-  IL_0013:  ldloc.s    V_8
-  IL_0015:  isinst     ""int""
-  IL_001a:  brfalse.s  IL_002c
-  IL_001c:  ldloc.s    V_8
-  IL_001e:  unbox.any  ""int""
-  IL_0023:  stloc.1
-  IL_0024:  ldloc.1
-  IL_0025:  ldc.i4.1
-  IL_0026:  beq.s      IL_002a
-  IL_0028:  br.s       IL_002c
-  IL_002a:  br.s       IL_0068
-  IL_002c:  ldloc.0
+  IL_0011:  dup
+  IL_0012:  stloc.s    V_8
+  IL_0014:  isinst     ""int""
+  IL_0019:  brfalse.s  IL_002b
+  IL_001b:  ldloc.s    V_8
+  IL_001d:  unbox.any  ""int""
+  IL_0022:  stloc.1
+  IL_0023:  ldloc.1
+  IL_0024:  ldc.i4.1
+  IL_0025:  beq.s      IL_0029
+  IL_0027:  br.s       IL_002b
+  IL_0029:  br.s       IL_0065
+  IL_002b:  ldloc.0
+  IL_002c:  dup
   IL_002d:  stloc.s    V_8
-  IL_002f:  ldloc.s    V_8
-  IL_0031:  isinst     ""byte""
-  IL_0036:  brfalse.s  IL_004a
-  IL_0038:  ldloc.s    V_8
-  IL_003a:  unbox.any  ""byte""
-  IL_003f:  stloc.2
-  IL_0040:  br.s       IL_0075
-  IL_0042:  ldloc.2
-  IL_0043:  ldc.i4.1
-  IL_0044:  beq.s      IL_0048
-  IL_0046:  br.s       IL_004a
-  IL_0048:  br.s       IL_009f
-  IL_004a:  ldloc.0
-  IL_004b:  stloc.s    V_8
-  IL_004d:  ldloc.s    V_8
-  IL_004f:  isinst     ""int""
-  IL_0054:  brfalse.s  IL_0062
-  IL_0056:  ldloc.s    V_8
-  IL_0058:  unbox.any  ""int""
-  IL_005d:  stloc.1
-  IL_005e:  br.s       IL_0089
-  IL_0060:  br.s       IL_00ac
-  IL_0062:  ldloc.0
-  IL_0063:  stloc.0
-  IL_0064:  br.s       IL_00bb
-  IL_0066:  br.s       IL_00ca
-  IL_0068:  ldstr      ""int 1""
-  IL_006d:  call       ""void System.Console.WriteLine(string)""
-  IL_0072:  nop
-  IL_0073:  br.s       IL_00ca
-  IL_0075:  ldloc.2
-  IL_0076:  stloc.3
-  IL_0077:  call       ""bool C.P()""
-  IL_007c:  brtrue.s   IL_0080
-  IL_007e:  br.s       IL_0042
-  IL_0080:  ldloc.3
-  IL_0081:  call       ""void System.Console.WriteLine(int)""
-  IL_0086:  nop
-  IL_0087:  br.s       IL_00ca
-  IL_0089:  ldloc.1
-  IL_008a:  stloc.s    V_4
-  IL_008c:  call       ""bool C.P()""
-  IL_0091:  brtrue.s   IL_0095
-  IL_0093:  br.s       IL_0060
-  IL_0095:  ldloc.s    V_4
-  IL_0097:  call       ""void System.Console.WriteLine(int)""
-  IL_009c:  nop
-  IL_009d:  br.s       IL_00ca
-  IL_009f:  ldstr      ""byte 1""
-  IL_00a4:  call       ""void System.Console.WriteLine(string)""
-  IL_00a9:  nop
-  IL_00aa:  br.s       IL_00ca
-  IL_00ac:  ldloc.1
-  IL_00ad:  stloc.s    V_5
-  IL_00af:  br.s       IL_00b1
-  IL_00b1:  ldloc.s    V_5
-  IL_00b3:  call       ""void System.Console.WriteLine(int)""
-  IL_00b8:  nop
-  IL_00b9:  br.s       IL_00ca
-  IL_00bb:  ldloc.0
-  IL_00bc:  stloc.s    V_6
-  IL_00be:  br.s       IL_00c0
-  IL_00c0:  ldloc.s    V_6
-  IL_00c2:  call       ""void System.Console.WriteLine(object)""
-  IL_00c7:  nop
-  IL_00c8:  br.s       IL_00ca
-  IL_00ca:  ret
+  IL_002f:  isinst     ""byte""
+  IL_0034:  brfalse.s  IL_0048
+  IL_0036:  ldloc.s    V_8
+  IL_0038:  unbox.any  ""byte""
+  IL_003d:  stloc.2
+  IL_003e:  br.s       IL_0072
+  IL_0040:  ldloc.2
+  IL_0041:  ldc.i4.1
+  IL_0042:  beq.s      IL_0046
+  IL_0044:  br.s       IL_0048
+  IL_0046:  br.s       IL_009c
+  IL_0048:  ldloc.0
+  IL_0049:  dup
+  IL_004a:  stloc.s    V_8
+  IL_004c:  isinst     ""int""
+  IL_0051:  brfalse.s  IL_005f
+  IL_0053:  ldloc.s    V_8
+  IL_0055:  unbox.any  ""int""
+  IL_005a:  stloc.1
+  IL_005b:  br.s       IL_0086
+  IL_005d:  br.s       IL_00a9
+  IL_005f:  ldloc.0
+  IL_0060:  stloc.0
+  IL_0061:  br.s       IL_00b8
+  IL_0063:  br.s       IL_00c7
+  IL_0065:  ldstr      ""int 1""
+  IL_006a:  call       ""void System.Console.WriteLine(string)""
+  IL_006f:  nop
+  IL_0070:  br.s       IL_00c7
+  IL_0072:  ldloc.2
+  IL_0073:  stloc.3
+  IL_0074:  call       ""bool C.P()""
+  IL_0079:  brtrue.s   IL_007d
+  IL_007b:  br.s       IL_0040
+  IL_007d:  ldloc.3
+  IL_007e:  call       ""void System.Console.WriteLine(int)""
+  IL_0083:  nop
+  IL_0084:  br.s       IL_00c7
+  IL_0086:  ldloc.1
+  IL_0087:  stloc.s    V_4
+  IL_0089:  call       ""bool C.P()""
+  IL_008e:  brtrue.s   IL_0092
+  IL_0090:  br.s       IL_005d
+  IL_0092:  ldloc.s    V_4
+  IL_0094:  call       ""void System.Console.WriteLine(int)""
+  IL_0099:  nop
+  IL_009a:  br.s       IL_00c7
+  IL_009c:  ldstr      ""byte 1""
+  IL_00a1:  call       ""void System.Console.WriteLine(string)""
+  IL_00a6:  nop
+  IL_00a7:  br.s       IL_00c7
+  IL_00a9:  ldloc.1
+  IL_00aa:  stloc.s    V_5
+  IL_00ac:  br.s       IL_00ae
+  IL_00ae:  ldloc.s    V_5
+  IL_00b0:  call       ""void System.Console.WriteLine(int)""
+  IL_00b5:  nop
+  IL_00b6:  br.s       IL_00c7
+  IL_00b8:  ldloc.0
+  IL_00b9:  stloc.s    V_6
+  IL_00bb:  br.s       IL_00bd
+  IL_00bd:  ldloc.s    V_6
+  IL_00bf:  call       ""void System.Console.WriteLine(object)""
+  IL_00c4:  nop
+  IL_00c5:  br.s       IL_00c7
+  IL_00c7:  ret
 }");
             var methodData0 = v0.TestData.GetMethodData("C.M");
             var method0 = compilation0.GetMember<MethodSymbol>("C.M");
@@ -2532,7 +2532,7 @@ class C
 
             diff1.VerifyIL("C.M", @"
 {
-  // Code size      203 (0xcb)
+  // Code size      200 (0xc8)
   .maxstack  2
   .locals init (object V_0,
                 int V_1,
@@ -2551,89 +2551,89 @@ class C
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
   IL_000c:  brtrue.s   IL_0010
-  IL_000e:  br.s       IL_0066
+  IL_000e:  br.s       IL_0063
   IL_0010:  ldloc.0
-  IL_0011:  stloc.s    V_9
-  IL_0013:  ldloc.s    V_9
-  IL_0015:  isinst     ""int""
-  IL_001a:  brfalse.s  IL_002c
-  IL_001c:  ldloc.s    V_9
-  IL_001e:  unbox.any  ""int""
-  IL_0023:  stloc.1
-  IL_0024:  ldloc.1
-  IL_0025:  ldc.i4.1
-  IL_0026:  beq.s      IL_002a
-  IL_0028:  br.s       IL_002c
-  IL_002a:  br.s       IL_0068
-  IL_002c:  ldloc.0
+  IL_0011:  dup
+  IL_0012:  stloc.s    V_9
+  IL_0014:  isinst     ""int""
+  IL_0019:  brfalse.s  IL_002b
+  IL_001b:  ldloc.s    V_9
+  IL_001d:  unbox.any  ""int""
+  IL_0022:  stloc.1
+  IL_0023:  ldloc.1
+  IL_0024:  ldc.i4.1
+  IL_0025:  beq.s      IL_0029
+  IL_0027:  br.s       IL_002b
+  IL_0029:  br.s       IL_0065
+  IL_002b:  ldloc.0
+  IL_002c:  dup
   IL_002d:  stloc.s    V_9
-  IL_002f:  ldloc.s    V_9
-  IL_0031:  isinst     ""byte""
-  IL_0036:  brfalse.s  IL_004a
-  IL_0038:  ldloc.s    V_9
-  IL_003a:  unbox.any  ""byte""
-  IL_003f:  stloc.2
-  IL_0040:  br.s       IL_0075
-  IL_0042:  ldloc.2
-  IL_0043:  ldc.i4.1
-  IL_0044:  beq.s      IL_0048
-  IL_0046:  br.s       IL_004a
-  IL_0048:  br.s       IL_009f
-  IL_004a:  ldloc.0
-  IL_004b:  stloc.s    V_9
-  IL_004d:  ldloc.s    V_9
-  IL_004f:  isinst     ""int""
-  IL_0054:  brfalse.s  IL_0062
-  IL_0056:  ldloc.s    V_9
-  IL_0058:  unbox.any  ""int""
-  IL_005d:  stloc.1
-  IL_005e:  br.s       IL_0089
-  IL_0060:  br.s       IL_00ac
-  IL_0062:  ldloc.0
-  IL_0063:  stloc.0
-  IL_0064:  br.s       IL_00bb
-  IL_0066:  br.s       IL_00ca
-  IL_0068:  ldstr      ""int 1""
-  IL_006d:  call       ""void System.Console.WriteLine(string)""
-  IL_0072:  nop
-  IL_0073:  br.s       IL_00ca
-  IL_0075:  ldloc.2
-  IL_0076:  stloc.3
-  IL_0077:  call       ""bool C.P()""
-  IL_007c:  brtrue.s   IL_0080
-  IL_007e:  br.s       IL_0042
-  IL_0080:  ldloc.3
-  IL_0081:  call       ""void System.Console.WriteLine(int)""
-  IL_0086:  nop
-  IL_0087:  br.s       IL_00ca
-  IL_0089:  ldloc.1
-  IL_008a:  stloc.s    V_4
-  IL_008c:  call       ""bool C.P()""
-  IL_0091:  brtrue.s   IL_0095
-  IL_0093:  br.s       IL_0060
-  IL_0095:  ldloc.s    V_4
-  IL_0097:  call       ""void System.Console.WriteLine(int)""
-  IL_009c:  nop
-  IL_009d:  br.s       IL_00ca
-  IL_009f:  ldstr      ""byte 1""
-  IL_00a4:  call       ""void System.Console.WriteLine(string)""
-  IL_00a9:  nop
-  IL_00aa:  br.s       IL_00ca
-  IL_00ac:  ldloc.1
-  IL_00ad:  stloc.s    V_5
-  IL_00af:  br.s       IL_00b1
-  IL_00b1:  ldloc.s    V_5
-  IL_00b3:  call       ""void System.Console.WriteLine(int)""
-  IL_00b8:  nop
-  IL_00b9:  br.s       IL_00ca
-  IL_00bb:  ldloc.0
-  IL_00bc:  stloc.s    V_6
-  IL_00be:  br.s       IL_00c0
-  IL_00c0:  ldloc.s    V_6
-  IL_00c2:  call       ""void System.Console.WriteLine(object)""
-  IL_00c7:  nop
-  IL_00c8:  br.s       IL_00ca
-  IL_00ca:  ret
+  IL_002f:  isinst     ""byte""
+  IL_0034:  brfalse.s  IL_0048
+  IL_0036:  ldloc.s    V_9
+  IL_0038:  unbox.any  ""byte""
+  IL_003d:  stloc.2
+  IL_003e:  br.s       IL_0072
+  IL_0040:  ldloc.2
+  IL_0041:  ldc.i4.1
+  IL_0042:  beq.s      IL_0046
+  IL_0044:  br.s       IL_0048
+  IL_0046:  br.s       IL_009c
+  IL_0048:  ldloc.0
+  IL_0049:  dup
+  IL_004a:  stloc.s    V_9
+  IL_004c:  isinst     ""int""
+  IL_0051:  brfalse.s  IL_005f
+  IL_0053:  ldloc.s    V_9
+  IL_0055:  unbox.any  ""int""
+  IL_005a:  stloc.1
+  IL_005b:  br.s       IL_0086
+  IL_005d:  br.s       IL_00a9
+  IL_005f:  ldloc.0
+  IL_0060:  stloc.0
+  IL_0061:  br.s       IL_00b8
+  IL_0063:  br.s       IL_00c7
+  IL_0065:  ldstr      ""int 1""
+  IL_006a:  call       ""void System.Console.WriteLine(string)""
+  IL_006f:  nop
+  IL_0070:  br.s       IL_00c7
+  IL_0072:  ldloc.2
+  IL_0073:  stloc.3
+  IL_0074:  call       ""bool C.P()""
+  IL_0079:  brtrue.s   IL_007d
+  IL_007b:  br.s       IL_0040
+  IL_007d:  ldloc.3
+  IL_007e:  call       ""void System.Console.WriteLine(int)""
+  IL_0083:  nop
+  IL_0084:  br.s       IL_00c7
+  IL_0086:  ldloc.1
+  IL_0087:  stloc.s    V_4
+  IL_0089:  call       ""bool C.P()""
+  IL_008e:  brtrue.s   IL_0092
+  IL_0090:  br.s       IL_005d
+  IL_0092:  ldloc.s    V_4
+  IL_0094:  call       ""void System.Console.WriteLine(int)""
+  IL_0099:  nop
+  IL_009a:  br.s       IL_00c7
+  IL_009c:  ldstr      ""byte 1""
+  IL_00a1:  call       ""void System.Console.WriteLine(string)""
+  IL_00a6:  nop
+  IL_00a7:  br.s       IL_00c7
+  IL_00a9:  ldloc.1
+  IL_00aa:  stloc.s    V_5
+  IL_00ac:  br.s       IL_00ae
+  IL_00ae:  ldloc.s    V_5
+  IL_00b0:  call       ""void System.Console.WriteLine(int)""
+  IL_00b5:  nop
+  IL_00b6:  br.s       IL_00c7
+  IL_00b8:  ldloc.0
+  IL_00b9:  stloc.s    V_6
+  IL_00bb:  br.s       IL_00bd
+  IL_00bd:  ldloc.s    V_6
+  IL_00bf:  call       ""void System.Console.WriteLine(object)""
+  IL_00c4:  nop
+  IL_00c5:  br.s       IL_00c7
+  IL_00c7:  ret
 }");
         }
 
@@ -3631,8 +3631,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       43 (0x2b)
-  .maxstack  1
+  // Code size       42 (0x2a)
+  .maxstack  2
   .locals init (int V_0, //i
                 bool V_1,
                 [object] V_2,
@@ -3641,28 +3641,28 @@ class C
                 int V_5)
  -IL_0000:  nop
  -IL_0001:  ldarg.0
-  IL_0002:  stloc.s    V_4
-  IL_0004:  ldloc.s    V_4
-  IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_0018
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  unbox.any  ""int""
-  IL_0014:  stloc.0
-  IL_0015:  ldc.i4.1
-  IL_0016:  br.s       IL_0019
-  IL_0018:  ldc.i4.0
-  IL_0019:  stloc.1
- ~IL_001a:  ldloc.1
-  IL_001b:  brfalse.s  IL_0023
- -IL_001d:  nop
- -IL_001e:  ldloc.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  br.s       IL_0028
- -IL_0023:  ldc.i4.0
-  IL_0024:  stloc.s    V_5
-  IL_0026:  br.s       IL_0028
- -IL_0028:  ldloc.s    V_5
-  IL_002a:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.s    V_4
+  IL_0005:  isinst     ""int""
+  IL_000a:  brfalse.s  IL_0017
+  IL_000c:  ldloc.s    V_4
+  IL_000e:  unbox.any  ""int""
+  IL_0013:  stloc.0
+  IL_0014:  ldc.i4.1
+  IL_0015:  br.s       IL_0018
+  IL_0017:  ldc.i4.0
+  IL_0018:  stloc.1
+ ~IL_0019:  ldloc.1
+  IL_001a:  brfalse.s  IL_0022
+ -IL_001c:  nop
+ -IL_001d:  ldloc.0
+  IL_001e:  stloc.s    V_5
+  IL_0020:  br.s       IL_0027
+ -IL_0022:  ldc.i4.0
+  IL_0023:  stloc.s    V_5
+  IL_0025:  br.s       IL_0027
+ -IL_0027:  ldloc.s    V_5
+  IL_0029:  ret
 }", methodToken: diff1.UpdatedMethods.Single());
         }
 
@@ -3798,8 +3798,8 @@ class C
 
             diff1.VerifyIL("C.F", @"
 {
-  // Code size       43 (0x2b)
-  .maxstack  1
+  // Code size       42 (0x2a)
+  .maxstack  2
   .locals init (int V_0, //i
                 bool V_1,
                 [object] V_2,
@@ -3808,28 +3808,28 @@ class C
                 int V_5)
  -IL_0000:  nop
  -IL_0001:  ldarg.0
-  IL_0002:  stloc.s    V_4
-  IL_0004:  ldloc.s    V_4
-  IL_0006:  isinst     ""int""
-  IL_000b:  brfalse.s  IL_0018
-  IL_000d:  ldloc.s    V_4
-  IL_000f:  unbox.any  ""int""
-  IL_0014:  stloc.0
-  IL_0015:  ldc.i4.1
-  IL_0016:  br.s       IL_0019
-  IL_0018:  ldc.i4.0
-  IL_0019:  stloc.1
- ~IL_001a:  ldloc.1
-  IL_001b:  brfalse.s  IL_0023
- -IL_001d:  nop
- -IL_001e:  ldloc.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  br.s       IL_0028
- -IL_0023:  ldc.i4.0
-  IL_0024:  stloc.s    V_5
-  IL_0026:  br.s       IL_0028
- -IL_0028:  ldloc.s    V_5
-  IL_002a:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.s    V_4
+  IL_0005:  isinst     ""int""
+  IL_000a:  brfalse.s  IL_0017
+  IL_000c:  ldloc.s    V_4
+  IL_000e:  unbox.any  ""int""
+  IL_0013:  stloc.0
+  IL_0014:  ldc.i4.1
+  IL_0015:  br.s       IL_0018
+  IL_0017:  ldc.i4.0
+  IL_0018:  stloc.1
+ ~IL_0019:  ldloc.1
+  IL_001a:  brfalse.s  IL_0022
+ -IL_001c:  nop
+ -IL_001d:  ldloc.0
+  IL_001e:  stloc.s    V_5
+  IL_0020:  br.s       IL_0027
+ -IL_0022:  ldc.i4.0
+  IL_0023:  stloc.s    V_5
+  IL_0025:  br.s       IL_0027
+ -IL_0027:  ldloc.s    V_5
+  IL_0029:  ret
 }", methodToken: diff1.UpdatedMethods.Single());
         }
 

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3405,15 +3405,14 @@ class Program
 
             verifier.VerifyIL(qualifiedMethodName: "Program.M1<T>", sequencePoints: "Program.M1", source: source,
 expectedIL: @"{
-  // Code size       80 (0x50)
-  .maxstack  2
+  // Code size       62 (0x3e)
+  .maxstack  1
   .locals init (T V_0,
                 int V_1,
                 T V_2, //t
                 int V_3, //i
                 int V_4,
-                object V_5,
-                T V_6)
+                object V_5)
   // sequence point: {
   IL_0000:  nop
   // sequence point: switch (1)
@@ -3424,56 +3423,47 @@ expectedIL: @"{
   IL_000a:  stloc.s    V_5
   IL_000c:  ldloc.s    V_5
   IL_000e:  isinst     ""T""
-  IL_0013:  ldnull
-  IL_0014:  cgt.un
-  IL_0016:  dup
-  IL_0017:  brtrue.s   IL_0025
-  IL_0019:  ldloca.s   V_6
-  IL_001b:  initobj    ""T""
-  IL_0021:  ldloc.s    V_6
-  IL_0023:  br.s       IL_002c
-  IL_0025:  ldloc.s    V_5
-  IL_0027:  unbox.any  ""T""
-  IL_002c:  stloc.0
-  IL_002d:  brfalse.s  IL_0031
-  IL_002f:  br.s       IL_0035
-  IL_0031:  ldc.i4.1
-  IL_0032:  stloc.1
-  IL_0033:  br.s       IL_0042
+  IL_0013:  brfalse.s  IL_001f
+  IL_0015:  ldloc.s    V_5
+  IL_0017:  unbox.any  ""T""
+  IL_001c:  stloc.0
+  IL_001d:  br.s       IL_0023
+  IL_001f:  ldc.i4.1
+  IL_0020:  stloc.1
+  IL_0021:  br.s       IL_0030
   // sequence point: <hidden>
-  IL_0035:  ldloc.0
-  IL_0036:  stloc.2
-  IL_0037:  br.s       IL_0039
+  IL_0023:  ldloc.0
+  IL_0024:  stloc.2
+  IL_0025:  br.s       IL_0027
   // sequence point: Console.Write(1);
-  IL_0039:  ldc.i4.1
-  IL_003a:  call       ""void System.Console.Write(int)""
-  IL_003f:  nop
+  IL_0027:  ldc.i4.1
+  IL_0028:  call       ""void System.Console.Write(int)""
+  IL_002d:  nop
   // sequence point: break;
-  IL_0040:  br.s       IL_004f
+  IL_002e:  br.s       IL_003d
   // sequence point: <hidden>
-  IL_0042:  ldloc.1
-  IL_0043:  stloc.3
-  IL_0044:  br.s       IL_0046
+  IL_0030:  ldloc.1
+  IL_0031:  stloc.3
+  IL_0032:  br.s       IL_0034
   // sequence point: Console.Write(2);
-  IL_0046:  ldc.i4.2
-  IL_0047:  call       ""void System.Console.Write(int)""
-  IL_004c:  nop
+  IL_0034:  ldc.i4.2
+  IL_0035:  call       ""void System.Console.Write(int)""
+  IL_003a:  nop
   // sequence point: break;
-  IL_004d:  br.s       IL_004f
+  IL_003b:  br.s       IL_003d
   // sequence point: }
-  IL_004f:  ret
+  IL_003d:  ret
 }");
             verifier.VerifyIL(qualifiedMethodName: "Program.M2<T>", sequencePoints: "Program.M2", source: source,
 expectedIL: @"{
-  // Code size       87 (0x57)
-  .maxstack  2
+  // Code size       69 (0x45)
+  .maxstack  1
   .locals init (T V_0,
                 string V_1,
                 T V_2, //t
                 string V_3, //s
                 string V_4,
-                object V_5,
-                T V_6)
+                object V_5)
   // sequence point: {
   IL_0000:  nop
   // sequence point: switch (nameof(M2))
@@ -3483,44 +3473,36 @@ expectedIL: @"{
   IL_000d:  stloc.s    V_5
   IL_000f:  ldloc.s    V_5
   IL_0011:  isinst     ""T""
-  IL_0016:  ldnull
-  IL_0017:  cgt.un
-  IL_0019:  dup
-  IL_001a:  brtrue.s   IL_0028
-  IL_001c:  ldloca.s   V_6
-  IL_001e:  initobj    ""T""
-  IL_0024:  ldloc.s    V_6
-  IL_0026:  br.s       IL_002f
-  IL_0028:  ldloc.s    V_5
-  IL_002a:  unbox.any  ""T""
-  IL_002f:  stloc.0
-  IL_0030:  brfalse.s  IL_0034
-  IL_0032:  br.s       IL_003c
-  IL_0034:  ldstr      ""M2""
-  IL_0039:  stloc.1
-  IL_003a:  br.s       IL_0049
+  IL_0016:  brfalse.s  IL_0022
+  IL_0018:  ldloc.s    V_5
+  IL_001a:  unbox.any  ""T""
+  IL_001f:  stloc.0
+  IL_0020:  br.s       IL_002a
+  IL_0022:  ldstr      ""M2""
+  IL_0027:  stloc.1
+  IL_0028:  br.s       IL_0037
   // sequence point: <hidden>
-  IL_003c:  ldloc.0
-  IL_003d:  stloc.2
-  IL_003e:  br.s       IL_0040
+  IL_002a:  ldloc.0
+  IL_002b:  stloc.2
+  IL_002c:  br.s       IL_002e
   // sequence point: Console.Write(3);
-  IL_0040:  ldc.i4.3
-  IL_0041:  call       ""void System.Console.Write(int)""
-  IL_0046:  nop
+  IL_002e:  ldc.i4.3
+  IL_002f:  call       ""void System.Console.Write(int)""
+  IL_0034:  nop
   // sequence point: break;
-  IL_0047:  br.s       IL_0056
+  IL_0035:  br.s       IL_0044
   // sequence point: <hidden>
-  IL_0049:  ldloc.1
-  IL_004a:  stloc.3
-  IL_004b:  br.s       IL_004d
+  IL_0037:  ldloc.1
+  IL_0038:  stloc.3
+  IL_0039:  br.s       IL_003b
   // sequence point: Console.Write(4);
-  IL_004d:  ldc.i4.4
-  IL_004e:  call       ""void System.Console.Write(int)""
-  IL_0053:  nop
+  IL_003b:  ldc.i4.4
+  IL_003c:  call       ""void System.Console.Write(int)""
+  IL_0041:  nop
   // sequence point: break;
-  IL_0054:  br.s       IL_0056
+  IL_0042:  br.s       IL_0044
   // sequence point: }
-  IL_0056:  ret
+  IL_0044:  ret
 }");
 
             // Check the release code generation too.
@@ -3530,72 +3512,56 @@ expectedIL: @"{
 
             verifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       57 (0x39)
-  .maxstack  2
+  // Code size       42 (0x2a)
+  .maxstack  1
   .locals init (T V_0,
                 int V_1,
-                object V_2,
-                T V_3)
+                object V_2)
   IL_0000:  ldc.i4.1
   IL_0001:  box        ""int""
   IL_0006:  stloc.2
   IL_0007:  ldloc.2
   IL_0008:  isinst     ""T""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  dup
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  initobj    ""T""
-  IL_001b:  ldloc.3
-  IL_001c:  br.s       IL_0024
-  IL_001e:  ldloc.2
-  IL_001f:  unbox.any  ""T""
-  IL_0024:  stloc.0
-  IL_0025:  brtrue.s   IL_002b
-  IL_0027:  ldc.i4.1
-  IL_0028:  stloc.1
-  IL_0029:  br.s       IL_0032
-  IL_002b:  ldc.i4.1
-  IL_002c:  call       ""void System.Console.Write(int)""
-  IL_0031:  ret
-  IL_0032:  ldc.i4.2
-  IL_0033:  call       ""void System.Console.Write(int)""
-  IL_0038:  ret
+  IL_000d:  brfalse.s  IL_0018
+  IL_000f:  ldloc.2
+  IL_0010:  unbox.any  ""T""
+  IL_0015:  stloc.0
+  IL_0016:  br.s       IL_001c
+  IL_0018:  ldc.i4.1
+  IL_0019:  stloc.1
+  IL_001a:  br.s       IL_0023
+  IL_001c:  ldc.i4.1
+  IL_001d:  call       ""void System.Console.Write(int)""
+  IL_0022:  ret
+  IL_0023:  ldc.i4.2
+  IL_0024:  call       ""void System.Console.Write(int)""
+  IL_0029:  ret
 }");
             verifier.VerifyIL("Program.M2<T>",
 @"{
-  // Code size       60 (0x3c)
-  .maxstack  2
+  // Code size       45 (0x2d)
+  .maxstack  1
   .locals init (T V_0,
                 string V_1,
-                object V_2,
-                T V_3)
+                object V_2)
   IL_0000:  ldstr      ""M2""
   IL_0005:  stloc.2
   IL_0006:  ldloc.2
   IL_0007:  isinst     ""T""
-  IL_000c:  ldnull
-  IL_000d:  cgt.un
-  IL_000f:  dup
-  IL_0010:  brtrue.s   IL_001d
-  IL_0012:  ldloca.s   V_3
-  IL_0014:  initobj    ""T""
-  IL_001a:  ldloc.3
-  IL_001b:  br.s       IL_0023
-  IL_001d:  ldloc.2
-  IL_001e:  unbox.any  ""T""
-  IL_0023:  stloc.0
-  IL_0024:  brtrue.s   IL_002e
-  IL_0026:  ldstr      ""M2""
-  IL_002b:  stloc.1
-  IL_002c:  br.s       IL_0035
-  IL_002e:  ldc.i4.3
-  IL_002f:  call       ""void System.Console.Write(int)""
-  IL_0034:  ret
-  IL_0035:  ldc.i4.4
-  IL_0036:  call       ""void System.Console.Write(int)""
-  IL_003b:  ret
+  IL_000c:  brfalse.s  IL_0017
+  IL_000e:  ldloc.2
+  IL_000f:  unbox.any  ""T""
+  IL_0014:  stloc.0
+  IL_0015:  br.s       IL_001f
+  IL_0017:  ldstr      ""M2""
+  IL_001c:  stloc.1
+  IL_001d:  br.s       IL_0026
+  IL_001f:  ldc.i4.3
+  IL_0020:  call       ""void System.Console.Write(int)""
+  IL_0025:  ret
+  IL_0026:  ldc.i4.4
+  IL_0027:  call       ""void System.Console.Write(int)""
+  IL_002c:  ret
 }");
         }
 
@@ -7209,8 +7175,8 @@ class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""1"" startColumn=""31"" endLine=""1"" endColumn=""64"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x35"">
-        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x35"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x2c"">
+        <local name=""i"" il_index=""0"" il_start=""0x0"" il_end=""0x2c"" attributes=""0"" />
       </scope>
     </method>
   </methods>
@@ -7658,7 +7624,7 @@ partial class C
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
             CompileAndVerify(c).VerifyIL("Program.M",
 @"{
-  // Code size      188 (0xbc)
+  // Code size      170 (0xaa)
   .maxstack  2
   .locals init (object V_0,
                 int V_1,
@@ -7676,96 +7642,84 @@ partial class C
   IL_0004:  stloc.0
   IL_0005:  ldloc.0
   IL_0006:  brtrue.s   IL_000a
-  IL_0008:  br.s       IL_0054
+  IL_0008:  br.s       IL_004b
   IL_000a:  ldloc.0
   IL_000b:  stloc.3
   IL_000c:  ldloc.3
   IL_000d:  isinst     ""int""
-  IL_0012:  ldnull
-  IL_0013:  cgt.un
-  IL_0015:  dup
-  IL_0016:  brtrue.s   IL_001b
-  IL_0018:  ldc.i4.0
-  IL_0019:  br.s       IL_0021
-  IL_001b:  ldloc.3
-  IL_001c:  unbox.any  ""int""
-  IL_0021:  stloc.1
-  IL_0022:  brfalse.s  IL_0054
-  IL_0024:  ldloc.1
-  IL_0025:  ldc.i4.1
-  IL_0026:  sub
-  IL_0027:  switch    (
-        IL_0042,
-        IL_004a,
-        IL_0050,
-        IL_0048,
-        IL_004e)
-  IL_0040:  br.s       IL_0054
-  IL_0042:  br.s       IL_0056
-  IL_0044:  br.s       IL_0062
-  IL_0046:  br.s       IL_0070
-  IL_0048:  br.s       IL_0060
-  IL_004a:  br.s       IL_005b
-  IL_004c:  br.s       IL_0054
-  IL_004e:  br.s       IL_006c
-  IL_0050:  br.s       IL_0067
-  IL_0052:  br.s       IL_0054
-  IL_0054:  br.s       IL_006e
-  IL_0056:  ldarg.0
-  IL_0057:  brfalse.s  IL_0060
-  IL_0059:  br.s       IL_0044
-  IL_005b:  ldarg.0
-  IL_005c:  brfalse.s  IL_0060
-  IL_005e:  br.s       IL_004c
-  IL_0060:  br.s       IL_0072
-  IL_0062:  ldarg.0
-  IL_0063:  brtrue.s   IL_006c
-  IL_0065:  br.s       IL_0046
-  IL_0067:  ldarg.0
-  IL_0068:  brtrue.s   IL_006c
-  IL_006a:  br.s       IL_0052
-  IL_006c:  br.s       IL_0072
-  IL_006e:  br.s       IL_0072
-  IL_0070:  br.s       IL_0072
-  IL_0072:  ldarg.0
-  IL_0073:  stloc.s    V_6
-  IL_0075:  ldloc.s    V_6
-  IL_0077:  stloc.s    V_4
-  IL_0079:  ldloc.s    V_4
-  IL_007b:  brtrue.s   IL_007f
-  IL_007d:  br.s       IL_00a4
-  IL_007f:  ldloc.s    V_4
-  IL_0081:  stloc.3
-  IL_0082:  ldloc.3
-  IL_0083:  isinst     ""int""
-  IL_0088:  ldnull
-  IL_0089:  cgt.un
-  IL_008b:  dup
-  IL_008c:  brtrue.s   IL_0091
-  IL_008e:  ldc.i4.0
-  IL_008f:  br.s       IL_0097
-  IL_0091:  ldloc.3
-  IL_0092:  unbox.any  ""int""
-  IL_0097:  stloc.s    V_5
-  IL_0099:  brfalse.s  IL_00a4
-  IL_009b:  ldloc.s    V_5
-  IL_009d:  ldc.i4.1
-  IL_009e:  beq.s      IL_00a2
-  IL_00a0:  br.s       IL_00a4
-  IL_00a2:  br.s       IL_00a6
-  IL_00a4:  br.s       IL_00a8
-  IL_00a6:  br.s       IL_00aa
-  IL_00a8:  br.s       IL_00aa
-  IL_00aa:  ldarg.0
-  IL_00ab:  stloc.s    V_8
-  IL_00ad:  ldloc.s    V_8
-  IL_00af:  stloc.s    V_7
-  IL_00b1:  ldloc.s    V_7
-  IL_00b3:  brtrue.s   IL_00b7
-  IL_00b5:  br.s       IL_00b7
-  IL_00b7:  br.s       IL_00b9
-  IL_00b9:  br.s       IL_00bb
-  IL_00bb:  ret
+  IL_0012:  brfalse.s  IL_004b
+  IL_0014:  ldloc.3
+  IL_0015:  unbox.any  ""int""
+  IL_001a:  stloc.1
+  IL_001b:  ldloc.1
+  IL_001c:  ldc.i4.1
+  IL_001d:  sub
+  IL_001e:  switch    (
+        IL_0039,
+        IL_0041,
+        IL_0047,
+        IL_003f,
+        IL_0045)
+  IL_0037:  br.s       IL_004b
+  IL_0039:  br.s       IL_004d
+  IL_003b:  br.s       IL_0059
+  IL_003d:  br.s       IL_0067
+  IL_003f:  br.s       IL_0057
+  IL_0041:  br.s       IL_0052
+  IL_0043:  br.s       IL_004b
+  IL_0045:  br.s       IL_0063
+  IL_0047:  br.s       IL_005e
+  IL_0049:  br.s       IL_004b
+  IL_004b:  br.s       IL_0065
+  IL_004d:  ldarg.0
+  IL_004e:  brfalse.s  IL_0057
+  IL_0050:  br.s       IL_003b
+  IL_0052:  ldarg.0
+  IL_0053:  brfalse.s  IL_0057
+  IL_0055:  br.s       IL_0043
+  IL_0057:  br.s       IL_0069
+  IL_0059:  ldarg.0
+  IL_005a:  brtrue.s   IL_0063
+  IL_005c:  br.s       IL_003d
+  IL_005e:  ldarg.0
+  IL_005f:  brtrue.s   IL_0063
+  IL_0061:  br.s       IL_0049
+  IL_0063:  br.s       IL_0069
+  IL_0065:  br.s       IL_0069
+  IL_0067:  br.s       IL_0069
+  IL_0069:  ldarg.0
+  IL_006a:  stloc.s    V_6
+  IL_006c:  ldloc.s    V_6
+  IL_006e:  stloc.s    V_4
+  IL_0070:  ldloc.s    V_4
+  IL_0072:  brtrue.s   IL_0076
+  IL_0074:  br.s       IL_0092
+  IL_0076:  ldloc.s    V_4
+  IL_0078:  stloc.3
+  IL_0079:  ldloc.3
+  IL_007a:  isinst     ""int""
+  IL_007f:  brfalse.s  IL_0092
+  IL_0081:  ldloc.3
+  IL_0082:  unbox.any  ""int""
+  IL_0087:  stloc.s    V_5
+  IL_0089:  ldloc.s    V_5
+  IL_008b:  ldc.i4.1
+  IL_008c:  beq.s      IL_0090
+  IL_008e:  br.s       IL_0092
+  IL_0090:  br.s       IL_0094
+  IL_0092:  br.s       IL_0096
+  IL_0094:  br.s       IL_0098
+  IL_0096:  br.s       IL_0098
+  IL_0098:  ldarg.0
+  IL_0099:  stloc.s    V_8
+  IL_009b:  ldloc.s    V_8
+  IL_009d:  stloc.s    V_7
+  IL_009f:  ldloc.s    V_7
+  IL_00a1:  brtrue.s   IL_00a5
+  IL_00a3:  br.s       IL_00a5
+  IL_00a5:  br.s       IL_00a7
+  IL_00a7:  br.s       IL_00a9
+  IL_00a9:  ret
 }");
             c.VerifyPdb(
 @"<symbols>
@@ -7794,22 +7748,22 @@ partial class C
         <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
         <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""19"" document=""1"" />
         <entry offset=""0x3"" hidden=""true"" document=""1"" />
-        <entry offset=""0x56"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x5b"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x60"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x62"" startLine=""11"" startColumn=""20"" endLine=""11"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x67"" startLine=""13"" startColumn=""20"" endLine=""13"" endColumn=""34"" document=""1"" />
-        <entry offset=""0x6c"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x6e"" startLine=""16"" startColumn=""17"" endLine=""16"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x70"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""23"" document=""1"" />
-        <entry offset=""0x72"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
-        <entry offset=""0x75"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa6"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xa8"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xaa"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""19"" document=""1"" />
-        <entry offset=""0xad"" hidden=""true"" document=""1"" />
-        <entry offset=""0xb9"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""23"" document=""1"" />
-        <entry offset=""0xbb"" startLine=""32"" startColumn=""5"" endLine=""32"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x4d"" startLine=""7"" startColumn=""20"" endLine=""7"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x52"" startLine=""9"" startColumn=""20"" endLine=""9"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x57"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x59"" startLine=""11"" startColumn=""20"" endLine=""11"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x5e"" startLine=""13"" startColumn=""20"" endLine=""13"" endColumn=""34"" document=""1"" />
+        <entry offset=""0x63"" startLine=""14"" startColumn=""17"" endLine=""14"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x65"" startLine=""16"" startColumn=""17"" endLine=""16"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x67"" startLine=""18"" startColumn=""17"" endLine=""18"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x69"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x94"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x96"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""23"" document=""1"" />
+        <entry offset=""0x98"" startLine=""27"" startColumn=""9"" endLine=""27"" endColumn=""19"" document=""1"" />
+        <entry offset=""0x9b"" hidden=""true"" document=""1"" />
+        <entry offset=""0xa7"" startLine=""30"" startColumn=""17"" endLine=""30"" endColumn=""23"" document=""1"" />
+        <entry offset=""0xa9"" startLine=""32"" startColumn=""5"" endLine=""32"" endColumn=""6"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3405,104 +3405,105 @@ class Program
 
             verifier.VerifyIL(qualifiedMethodName: "Program.M1<T>", sequencePoints: "Program.M1", source: source,
 expectedIL: @"{
-  // Code size       62 (0x3e)
-  .maxstack  1
+  // Code size       66 (0x42)
+  .maxstack  2
   .locals init (T V_0,
                 int V_1,
                 T V_2, //t
                 int V_3, //i
                 int V_4,
-                object V_5)
+                int V_5)
   // sequence point: {
   IL_0000:  nop
   // sequence point: switch (1)
   IL_0001:  ldc.i4.1
   IL_0002:  stloc.s    V_4
   IL_0004:  ldc.i4.1
-  IL_0005:  box        ""int""
-  IL_000a:  stloc.s    V_5
-  IL_000c:  ldloc.s    V_5
-  IL_000e:  isinst     ""T""
-  IL_0013:  brfalse.s  IL_001f
-  IL_0015:  ldloc.s    V_5
-  IL_0017:  unbox.any  ""T""
-  IL_001c:  stloc.0
-  IL_001d:  br.s       IL_0023
-  IL_001f:  ldc.i4.1
-  IL_0020:  stloc.1
-  IL_0021:  br.s       IL_0030
+  IL_0005:  dup
+  IL_0006:  stloc.s    V_5
+  IL_0008:  box        ""int""
+  IL_000d:  isinst     ""T""
+  IL_0012:  brfalse.s  IL_0023
+  IL_0014:  ldloc.s    V_5
+  IL_0016:  box        ""int""
+  IL_001b:  unbox.any  ""T""
+  IL_0020:  stloc.0
+  IL_0021:  br.s       IL_0027
+  IL_0023:  ldc.i4.1
+  IL_0024:  stloc.1
+  IL_0025:  br.s       IL_0034
   // sequence point: <hidden>
-  IL_0023:  ldloc.0
-  IL_0024:  stloc.2
-  IL_0025:  br.s       IL_0027
+  IL_0027:  ldloc.0
+  IL_0028:  stloc.2
+  IL_0029:  br.s       IL_002b
   // sequence point: Console.Write(1);
-  IL_0027:  ldc.i4.1
-  IL_0028:  call       ""void System.Console.Write(int)""
-  IL_002d:  nop
+  IL_002b:  ldc.i4.1
+  IL_002c:  call       ""void System.Console.Write(int)""
+  IL_0031:  nop
   // sequence point: break;
-  IL_002e:  br.s       IL_003d
+  IL_0032:  br.s       IL_0041
   // sequence point: <hidden>
-  IL_0030:  ldloc.1
-  IL_0031:  stloc.3
-  IL_0032:  br.s       IL_0034
+  IL_0034:  ldloc.1
+  IL_0035:  stloc.3
+  IL_0036:  br.s       IL_0038
   // sequence point: Console.Write(2);
-  IL_0034:  ldc.i4.2
-  IL_0035:  call       ""void System.Console.Write(int)""
-  IL_003a:  nop
+  IL_0038:  ldc.i4.2
+  IL_0039:  call       ""void System.Console.Write(int)""
+  IL_003e:  nop
   // sequence point: break;
-  IL_003b:  br.s       IL_003d
+  IL_003f:  br.s       IL_0041
   // sequence point: }
-  IL_003d:  ret
+  IL_0041:  ret
 }");
             verifier.VerifyIL(qualifiedMethodName: "Program.M2<T>", sequencePoints: "Program.M2", source: source,
 expectedIL: @"{
-  // Code size       69 (0x45)
-  .maxstack  1
+  // Code size       68 (0x44)
+  .maxstack  2
   .locals init (T V_0,
                 string V_1,
                 T V_2, //t
                 string V_3, //s
                 string V_4,
-                object V_5)
+                string V_5)
   // sequence point: {
   IL_0000:  nop
   // sequence point: switch (nameof(M2))
   IL_0001:  ldstr      ""M2""
   IL_0006:  stloc.s    V_4
   IL_0008:  ldstr      ""M2""
-  IL_000d:  stloc.s    V_5
-  IL_000f:  ldloc.s    V_5
-  IL_0011:  isinst     ""T""
-  IL_0016:  brfalse.s  IL_0022
-  IL_0018:  ldloc.s    V_5
-  IL_001a:  unbox.any  ""T""
-  IL_001f:  stloc.0
-  IL_0020:  br.s       IL_002a
-  IL_0022:  ldstr      ""M2""
-  IL_0027:  stloc.1
-  IL_0028:  br.s       IL_0037
+  IL_000d:  dup
+  IL_000e:  stloc.s    V_5
+  IL_0010:  isinst     ""T""
+  IL_0015:  brfalse.s  IL_0021
+  IL_0017:  ldloc.s    V_5
+  IL_0019:  unbox.any  ""T""
+  IL_001e:  stloc.0
+  IL_001f:  br.s       IL_0029
+  IL_0021:  ldstr      ""M2""
+  IL_0026:  stloc.1
+  IL_0027:  br.s       IL_0036
   // sequence point: <hidden>
-  IL_002a:  ldloc.0
-  IL_002b:  stloc.2
-  IL_002c:  br.s       IL_002e
+  IL_0029:  ldloc.0
+  IL_002a:  stloc.2
+  IL_002b:  br.s       IL_002d
   // sequence point: Console.Write(3);
-  IL_002e:  ldc.i4.3
-  IL_002f:  call       ""void System.Console.Write(int)""
-  IL_0034:  nop
+  IL_002d:  ldc.i4.3
+  IL_002e:  call       ""void System.Console.Write(int)""
+  IL_0033:  nop
   // sequence point: break;
-  IL_0035:  br.s       IL_0044
+  IL_0034:  br.s       IL_0043
   // sequence point: <hidden>
-  IL_0037:  ldloc.1
-  IL_0038:  stloc.3
-  IL_0039:  br.s       IL_003b
+  IL_0036:  ldloc.1
+  IL_0037:  stloc.3
+  IL_0038:  br.s       IL_003a
   // sequence point: Console.Write(4);
-  IL_003b:  ldc.i4.4
-  IL_003c:  call       ""void System.Console.Write(int)""
-  IL_0041:  nop
+  IL_003a:  ldc.i4.4
+  IL_003b:  call       ""void System.Console.Write(int)""
+  IL_0040:  nop
   // sequence point: break;
-  IL_0042:  br.s       IL_0044
+  IL_0041:  br.s       IL_0043
   // sequence point: }
-  IL_0044:  ret
+  IL_0043:  ret
 }");
 
             // Check the release code generation too.
@@ -3512,41 +3513,43 @@ expectedIL: @"{
 
             verifier.VerifyIL("Program.M1<T>",
 @"{
-  // Code size       42 (0x2a)
-  .maxstack  1
+  // Code size       47 (0x2f)
+  .maxstack  2
   .locals init (T V_0,
                 int V_1,
-                object V_2)
+                int V_2)
   IL_0000:  ldc.i4.1
-  IL_0001:  box        ""int""
-  IL_0006:  stloc.2
-  IL_0007:  ldloc.2
+  IL_0001:  dup
+  IL_0002:  stloc.2
+  IL_0003:  box        ""int""
   IL_0008:  isinst     ""T""
-  IL_000d:  brfalse.s  IL_0018
+  IL_000d:  brfalse.s  IL_001d
   IL_000f:  ldloc.2
-  IL_0010:  unbox.any  ""T""
-  IL_0015:  stloc.0
-  IL_0016:  br.s       IL_001c
-  IL_0018:  ldc.i4.1
-  IL_0019:  stloc.1
-  IL_001a:  br.s       IL_0023
-  IL_001c:  ldc.i4.1
-  IL_001d:  call       ""void System.Console.Write(int)""
-  IL_0022:  ret
-  IL_0023:  ldc.i4.2
-  IL_0024:  call       ""void System.Console.Write(int)""
-  IL_0029:  ret
+  IL_0010:  box        ""int""
+  IL_0015:  unbox.any  ""T""
+  IL_001a:  stloc.0
+  IL_001b:  br.s       IL_0021
+  IL_001d:  ldc.i4.1
+  IL_001e:  stloc.1
+  IL_001f:  br.s       IL_0028
+  IL_0021:  ldc.i4.1
+  IL_0022:  call       ""void System.Console.Write(int)""
+  IL_0027:  ret
+  IL_0028:  ldc.i4.2
+  IL_0029:  call       ""void System.Console.Write(int)""
+  IL_002e:  ret
+
 }");
             verifier.VerifyIL("Program.M2<T>",
 @"{
   // Code size       45 (0x2d)
-  .maxstack  1
+  .maxstack  2
   .locals init (T V_0,
                 string V_1,
-                object V_2)
+                string V_2)
   IL_0000:  ldstr      ""M2""
-  IL_0005:  stloc.2
-  IL_0006:  ldloc.2
+  IL_0005:  dup
+  IL_0006:  stloc.2
   IL_0007:  isinst     ""T""
   IL_000c:  brfalse.s  IL_0017
   IL_000e:  ldloc.2
@@ -7644,8 +7647,8 @@ partial class C
   IL_0006:  brtrue.s   IL_000a
   IL_0008:  br.s       IL_004b
   IL_000a:  ldloc.0
-  IL_000b:  stloc.3
-  IL_000c:  ldloc.3
+  IL_000b:  dup
+  IL_000c:  stloc.3
   IL_000d:  isinst     ""int""
   IL_0012:  brfalse.s  IL_004b
   IL_0014:  ldloc.3
@@ -7695,8 +7698,8 @@ partial class C
   IL_0072:  brtrue.s   IL_0076
   IL_0074:  br.s       IL_0092
   IL_0076:  ldloc.s    V_4
-  IL_0078:  stloc.3
-  IL_0079:  ldloc.3
+  IL_0078:  dup
+  IL_0079:  stloc.3
   IL_007a:  isinst     ""int""
   IL_007f:  brfalse.s  IL_0092
   IL_0081:  ldloc.3

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -9,9 +9,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class ExpressionParsingTexts : ParsingTests
+    public class ExpressionParsingTests : ParsingTests
     {
-        public ExpressionParsingTexts(ITestOutputHelper output) : base(output) { }
+        public ExpressionParsingTests(ITestOutputHelper output) : base(output) { }
 
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -9,9 +9,9 @@ using Xunit.Abstractions;
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     [CompilerTrait(CompilerFeature.Patterns)]
-    public class PatternParsingTexts : ParsingTests
+    public class PatternParsingTests : ParsingTests
     {
-        public PatternParsingTexts(ITestOutputHelper output) : base(output)
+        public PatternParsingTests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -309,7 +309,7 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       70 (0x46)
+  // Code size       69 (0x45)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
@@ -325,20 +325,20 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_4
-  IL_0021:  ldloc.s    V_4
-  IL_0023:  isinst     ""int""
-  IL_0028:  brfalse.s  IL_003f
-  IL_002a:  ldstr      ""z""
-  IL_002f:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0034:  ldloc.s    V_4
-  IL_0036:  unbox.any  ""int""
-  IL_003b:  stind.i4
-  IL_003c:  ldc.i4.1
-  IL_003d:  br.s       IL_0040
-  IL_003f:  ldc.i4.0
-  IL_0040:  call       ""void C.Test(bool)""
-  IL_0045:  ret
+  IL_001f:  dup
+  IL_0020:  stloc.s    V_4
+  IL_0022:  isinst     ""int""
+  IL_0027:  brfalse.s  IL_003e
+  IL_0029:  ldstr      ""z""
+  IL_002e:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0033:  ldloc.s    V_4
+  IL_0035:  unbox.any  ""int""
+  IL_003a:  stind.i4
+  IL_003b:  ldc.i4.1
+  IL_003c:  br.s       IL_003f
+  IL_003e:  ldc.i4.0
+  IL_003f:  call       ""void C.Test(bool)""
+  IL_0044:  ret
 }");
             });
         }
@@ -1772,8 +1772,8 @@ class C
                 testData = new CompilationTestData();
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
-    @"{
-  // Code size       72 (0x48)
+@"{
+  // Code size       71 (0x47)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
@@ -1789,21 +1789,21 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_4
-  IL_0021:  ldloc.s    V_4
-  IL_0023:  isinst     ""int""
-  IL_0028:  brfalse.s  IL_003f
-  IL_002a:  ldstr      ""i""
-  IL_002f:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0034:  ldloc.s    V_4
-  IL_0036:  unbox.any  ""int""
-  IL_003b:  stind.i4
-  IL_003c:  ldc.i4.1
-  IL_003d:  br.s       IL_0040
-  IL_003f:  ldc.i4.0
-  IL_0040:  call       ""object C.Test(bool)""
-  IL_0045:  starg.s    V_0
-  IL_0047:  ret
+  IL_001f:  dup
+  IL_0020:  stloc.s    V_4
+  IL_0022:  isinst     ""int""
+  IL_0027:  brfalse.s  IL_003e
+  IL_0029:  ldstr      ""i""
+  IL_002e:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0033:  ldloc.s    V_4
+  IL_0035:  unbox.any  ""int""
+  IL_003a:  stind.i4
+  IL_003b:  ldc.i4.1
+  IL_003c:  br.s       IL_003f
+  IL_003e:  ldc.i4.0
+  IL_003f:  call       ""object C.Test(bool)""
+  IL_0044:  starg.s    V_0
+  IL_0046:  ret
 }");
             });
         }
@@ -2095,7 +2095,7 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size      111 (0x6f)
+  // Code size      110 (0x6e)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
@@ -2121,21 +2121,21 @@ class C
   IL_003c:  ldstr      ""z""
   IL_0041:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
   IL_0046:  ldarg.0
-  IL_0047:  stloc.s    V_4
-  IL_0049:  ldloc.s    V_4
-  IL_004b:  isinst     ""int""
-  IL_0050:  brfalse.s  IL_0067
-  IL_0052:  ldstr      ""i""
-  IL_0057:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_005c:  ldloc.s    V_4
-  IL_005e:  unbox.any  ""int""
-  IL_0063:  stind.i4
-  IL_0064:  ldc.i4.1
-  IL_0065:  br.s       IL_0068
-  IL_0067:  ldc.i4.0
-  IL_0068:  call       ""int C.Test(bool)""
-  IL_006d:  stind.i4
-  IL_006e:  ret
+  IL_0047:  dup
+  IL_0048:  stloc.s    V_4
+  IL_004a:  isinst     ""int""
+  IL_004f:  brfalse.s  IL_0066
+  IL_0051:  ldstr      ""i""
+  IL_0056:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_005b:  ldloc.s    V_4
+  IL_005d:  unbox.any  ""int""
+  IL_0062:  stind.i4
+  IL_0063:  ldc.i4.1
+  IL_0064:  br.s       IL_0067
+  IL_0066:  ldc.i4.0
+  IL_0067:  call       ""int C.Test(bool)""
+  IL_006c:  stind.i4
+  IL_006d:  ret
 }");
             });
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -309,14 +309,13 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       77 (0x4d)
+  // Code size       70 (0x46)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                object V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z""
@@ -326,24 +325,20 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldstr      ""z""
-  IL_0026:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_002b:  ldloc.s    V_5
-  IL_002d:  isinst     ""int""
-  IL_0032:  ldnull
-  IL_0033:  cgt.un
-  IL_0035:  dup
-  IL_0036:  stloc.s    V_4
-  IL_0038:  brtrue.s   IL_003d
-  IL_003a:  ldc.i4.0
-  IL_003b:  br.s       IL_0044
-  IL_003d:  ldloc.s    V_5
-  IL_003f:  unbox.any  ""int""
-  IL_0044:  stind.i4
-  IL_0045:  ldloc.s    V_4
-  IL_0047:  call       ""void C.Test(bool)""
-  IL_004c:  ret
+  IL_001f:  stloc.s    V_4
+  IL_0021:  ldloc.s    V_4
+  IL_0023:  isinst     ""int""
+  IL_0028:  brfalse.s  IL_003f
+  IL_002a:  ldstr      ""z""
+  IL_002f:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0034:  ldloc.s    V_4
+  IL_0036:  unbox.any  ""int""
+  IL_003b:  stind.i4
+  IL_003c:  ldc.i4.1
+  IL_003d:  br.s       IL_0040
+  IL_003f:  ldc.i4.0
+  IL_0040:  call       ""void C.Test(bool)""
+  IL_0045:  ret
 }");
             });
         }
@@ -1778,14 +1773,13 @@ class C
                 context.CompileAssignment("x", "Test(x is int i)", out error, testData);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size       79 (0x4f)
+  // Code size       72 (0x48)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                object V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""i""
@@ -1795,25 +1789,21 @@ class C
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
   IL_001e:  ldarg.0
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldstr      ""i""
-  IL_0026:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_002b:  ldloc.s    V_5
-  IL_002d:  isinst     ""int""
-  IL_0032:  ldnull
-  IL_0033:  cgt.un
-  IL_0035:  dup
-  IL_0036:  stloc.s    V_4
-  IL_0038:  brtrue.s   IL_003d
-  IL_003a:  ldc.i4.0
-  IL_003b:  br.s       IL_0044
-  IL_003d:  ldloc.s    V_5
-  IL_003f:  unbox.any  ""int""
-  IL_0044:  stind.i4
-  IL_0045:  ldloc.s    V_4
-  IL_0047:  call       ""object C.Test(bool)""
-  IL_004c:  starg.s    V_0
-  IL_004e:  ret
+  IL_001f:  stloc.s    V_4
+  IL_0021:  ldloc.s    V_4
+  IL_0023:  isinst     ""int""
+  IL_0028:  brfalse.s  IL_003f
+  IL_002a:  ldstr      ""i""
+  IL_002f:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0034:  ldloc.s    V_4
+  IL_0036:  unbox.any  ""int""
+  IL_003b:  stind.i4
+  IL_003c:  ldc.i4.1
+  IL_003d:  br.s       IL_0040
+  IL_003f:  ldc.i4.0
+  IL_0040:  call       ""object C.Test(bool)""
+  IL_0045:  starg.s    V_0
+  IL_0047:  ret
 }");
             });
         }
@@ -2105,14 +2095,13 @@ class C
                 Assert.Equal(flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
     @"{
-  // Code size      118 (0x76)
+  // Code size      111 (0x6f)
   .maxstack  4
   .locals init (object V_0, //y
                 bool V_1,
                 object V_2,
                 System.Guid V_3,
-                bool V_4,
-                object V_5)
+                object V_4)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z""
@@ -2132,25 +2121,21 @@ class C
   IL_003c:  ldstr      ""z""
   IL_0041:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
   IL_0046:  ldarg.0
-  IL_0047:  stloc.s    V_5
-  IL_0049:  ldstr      ""i""
-  IL_004e:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0053:  ldloc.s    V_5
-  IL_0055:  isinst     ""int""
-  IL_005a:  ldnull
-  IL_005b:  cgt.un
-  IL_005d:  dup
-  IL_005e:  stloc.s    V_4
-  IL_0060:  brtrue.s   IL_0065
-  IL_0062:  ldc.i4.0
-  IL_0063:  br.s       IL_006c
-  IL_0065:  ldloc.s    V_5
-  IL_0067:  unbox.any  ""int""
-  IL_006c:  stind.i4
-  IL_006d:  ldloc.s    V_4
-  IL_006f:  call       ""int C.Test(bool)""
-  IL_0074:  stind.i4
-  IL_0075:  ret
+  IL_0047:  stloc.s    V_4
+  IL_0049:  ldloc.s    V_4
+  IL_004b:  isinst     ""int""
+  IL_0050:  brfalse.s  IL_0067
+  IL_0052:  ldstr      ""i""
+  IL_0057:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_005c:  ldloc.s    V_4
+  IL_005e:  unbox.any  ""int""
+  IL_0063:  stind.i4
+  IL_0064:  ldc.i4.1
+  IL_0065:  br.s       IL_0068
+  IL_0067:  ldc.i4.0
+  IL_0068:  call       ""int C.Test(bool)""
+  IL_006d:  stind.i4
+  IL_006e:  ret
 }");
             });
         }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -591,12 +591,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<M>d__1.<>4__this""
   IL_0006:  ret
@@ -609,12 +608,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.o""
   IL_0006:  ret
@@ -627,12 +625,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""string C.<M>d__1.<a>5__4""
   IL_0006:  ret
@@ -645,12 +642,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""string C.<M>d__1.<s>5__5""
   IL_0006:  ret
@@ -674,12 +670,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""C C.<M>d__1.<>4__this""
   IL_0006:  ret
@@ -692,12 +687,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.o""
   IL_0006:  ret
@@ -710,12 +704,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""string C.<M>d__1.<a>5__4""
   IL_0006:  ret
@@ -728,12 +721,11 @@ class C
                 object V_1,
                 object V_2,
                 string V_3,
-                bool V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                C.<M>d__1 V_7,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
-                System.Exception V_9)
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                C.<M>d__1 V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__1.<s>5__6""
   IL_0006:  ret


### PR DESCRIPTION
Use a slightly simpler lowering for pattern-matching with type parameters and value types.

### Customer scenario

Use pattern-matching with a value type, e.g. `if (o is int i) ...`. Note that the quality of the code can be improved.

### Bugs this fixes

None. It is an improvement in the quality of the generated code.

### Workarounds, if any

N/A

### Risk

Tiny. This is a replacement of one code pattern by a slightly better but equivalent one.

### Performance impact

Slight performance improvement for compiled applications.

### Is this a regression from a previous update?

No.

### Root cause analysis

N/A

### How was the bug found?

Customer noticed the potential for improving the code.

### Test documentation updated?

N/A
