### PR TITLE
Use ConcurrentDictionary to avoid locks in IsGeneratedCode and HasHiddenRegions

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PerformanceSensitiveAttribute.cs
@@ -65,6 +65,15 @@ namespace Roslyn.Utilities
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether locks are allowed.
+        /// </summary>
+        public bool AllowLocks
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the asynchronous state machine typically completes synchronously.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
### Customer scenario

Compiling a large managed solution with analyzers enabled takes longer than expected. In some cases, the compilation process is *much* slower than other times, even though no changes were made to the code.

Profiling during slow builds identified two locks that were showing up as highly contended while compiling dotnet/roslyn@949c9b4f4dbd4880884c64456db7955748645e1f from within the IDE. For reasons that are still unknown, the thread time for these locks was spent in `clr!JIT_MonEnterWorker_InlineGetThread_GetThread_PatchLabel`, a method I have not observe in traces for any other profiling situation to date.

### Bugs this fixes

N/A (to date, reports on this were limited to sporadic emails)

### Workarounds, if any

None, though it doesn't occur in every build.

### Risk

Low. The lock-free algorithm is equivalent to the concurrent algorithm.

### Performance impact

Performance is generally improved, and stabilized across runs.

### Is this a regression from a previous update?

No.

### Root cause analysis

The problem did not always occur, and manifested with greater magnitude on machines with large numbers of cores.

### How was the bug found?

PerfView profiling during a slow build.

### Test documentation updated?

No.
