### PR TITLE
Revert "Merge pull request #23364 from tmat/DisableBackgroundCompiler"

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -39,6 +39,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public IList<TestHostDocument> AdditionalDocuments { get; }
         public IList<TestHostDocument> ProjectionDocuments { get; }
 
+        private readonly BackgroundCompiler _backgroundCompiler;
+        private readonly BackgroundParser _backgroundParser;
+
         public TestWorkspace()
             : this(TestExportProvider.ExportProviderWithCSharpAndVisualBasic, WorkspaceKind.Test)
         {
@@ -57,6 +60,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             this.ProjectionDocuments = new List<TestHostDocument>();
 
             this.CanApplyChangeDocument = true;
+
+            _backgroundCompiler = new BackgroundCompiler(this);
+            _backgroundParser = new BackgroundParser(this);
+            _backgroundParser.Start();
         }
 
         /// <summary>
@@ -83,8 +90,29 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
+        protected internal override bool PartialSemanticsEnabled
+        {
+            get { return _backgroundCompiler != null; }
+        }
+
         public TestHostDocument DocumentWithCursor 
             => Documents.Single(d => d.CursorPosition.HasValue && !d.IsLinkFile);
+
+        protected override void OnDocumentTextChanged(Document document)
+        {
+            if (_backgroundParser != null)
+            {
+                _backgroundParser.Parse(document);
+            }
+        }
+
+        protected override void OnDocumentClosing(DocumentId documentId)
+        {
+            if (_backgroundParser != null)
+            {
+                _backgroundParser.CancelParse(documentId);
+            }
+        }
 
         public new void RegisterText(SourceTextContainer text)
         {
@@ -151,6 +179,11 @@ of the problem.");
             if (SynchronizationContext.Current != null)
             {
                 Dispatcher.CurrentDispatcher.DoEvents();
+            }
+
+            if (_backgroundParser != null)
+            {
+                _backgroundParser.CancelAllParses();
             }
 
             base.Dispose(finalize);


### PR DESCRIPTION
This reverts commit 80d79c4041b4ac2d0d9f9aacf127e734291bd112, reversing changes made to 37ef0cdea72622fa9195b770808624c8dca007b3.

git bisect revealed #23364 as the source of problems. The test sequence to reproduce locally involved modifying the following test:

https://github.com/dotnet/roslyn/blob/2c1d64826d5ec7cd43ecc3f3a3b2960136c9b3d2/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests_XmlDoc.vb#L612-L615

To instead be written like this:

```vb
<WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
Public Async Function InvokeWithOverridableKeywordCommitSeeLangword() As Task
    For index = 1 To 200
        Await InvokeWithKeywordCommitSeeLangword("Overridable", unique:=False)
    Next
End Function
```