### PR TITLE
made bucketing to be better even in telemetry site.

### DIFF
--- a/src/VisualStudio/CSharp/Test/Watson/WatsonTests.cs
+++ b/src/VisualStudio/CSharp/Test/Watson/WatsonTests.cs
@@ -167,7 +167,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
             var exception = new Exception("not thrown");
             mockFault.SetExtraParameters(exception, emptyCallstack: true);
 
-            Assert.NotNull(mockFault.Map[9]);
+            Assert.NotNull(mockFault.Map[4]);
         }
 
         public class MockFault : IFaultUtility

--- a/src/VisualStudio/CSharp/Test/Watson/WatsonTests.cs
+++ b/src/VisualStudio/CSharp/Test/Watson/WatsonTests.cs
@@ -26,7 +26,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
 
                 // there should be no extra bucket info
                 // for regular exception
-                Assert.False(mockFault.Map.ContainsKey(8));
+                Assert.False(mockFault.Map.ContainsKey(7));
             }
         }
 
@@ -50,7 +50,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
                 var mockFault = new MockFault();
                 mockFault.SetExtraParameters(exception, emptyCallstack: false);
 
-                Assert.Equal(exception.InnerException.GetParameterString(), mockFault.Map[8]);
+                Assert.Equal(exception.InnerException.GetParameterString(), mockFault.Map[7]);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
             var exception = new RemoteInvocationException("test", "remoteCallstack", "remoteErrorCode");
             mockFault.SetExtraParameters(exception, emptyCallstack: false);
 
-            Assert.Equal(exception.GetParameterString(), mockFault.Map[8]);
+            Assert.Equal(exception.GetParameterString(), mockFault.Map[7]);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
             var exception = new RemoteInvocationException(message: null, remoteStack: null, remoteCode: null);
             mockFault.SetExtraParameters(exception, emptyCallstack: false);
 
-            Assert.Equal(exception.GetParameterString(), mockFault.Map[8]);
+            Assert.Equal(exception.GetParameterString(), mockFault.Map[7]);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
 
                 // there should be no extra bucket info
                 // for regular exception
-                Assert.False(mockFault.Map.ContainsKey(8));
+                Assert.False(mockFault.Map.ContainsKey(7));
             }
         }
 
@@ -115,7 +115,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
                 var mockFault = new MockFault();
                 mockFault.SetExtraParameters(exception, emptyCallstack: false);
 
-                Assert.Equal(exception.GetParameterString(), mockFault.Map[8]);
+                Assert.Equal(exception.GetParameterString(), mockFault.Map[7]);
             }
         }
 
@@ -154,8 +154,8 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
                 mockFault.SetExtraParameters(exception, emptyCallstack: false);
 
                 var flatten = exception.Flatten();
-                Assert.Equal(flatten.CalculateHash(), mockFault.Map[7]);
-                Assert.Equal(flatten.InnerException.GetParameterString(), mockFault.Map[8]);
+                Assert.Equal(flatten.CalculateHash(), mockFault.Map[6]);
+                Assert.Equal(flatten.InnerException.GetParameterString(), mockFault.Map[7]);
             }
         }
 
@@ -167,7 +167,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Watson
             var exception = new Exception("not thrown");
             mockFault.SetExtraParameters(exception, emptyCallstack: true);
 
-            Assert.NotNull(mockFault.Map[4]);
+            Assert.NotNull(mockFault.Map[3]);
         }
 
         public class MockFault : IFaultUtility

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
@@ -11,12 +11,12 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
     {
         // NFW API let caller to customize watson report to make them better bucketed by
         // putting custom string in reserved slots. normally those 3 slots will be empty.
-        private const int Reserved1 = 8;
-        private const int Reserved2 = 7;
+        private const int Reserved1 = 7;
+        private const int Reserved2 = 6;
 
         // replace exception slot for callstack since the exception (with empty callstack) 
         // given is synthesized one that doesn't provide any meaningful data
-        private const int Reserved3 = 4;
+        private const int Reserved3 = 3;
 
         /// <summary>
         /// This sets extra watson bucket parameters to make bucketting better

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
@@ -26,9 +26,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         {
             if (emptyCallstack)
             {
-                // if exception we got started with empty callstack, put runtime
-                // callstack in one of reserved slot for better bucketting
-                fault.SetBucketParameter(Reserved3, Environment.StackTrace);
+                // if exception we got started with empty callstack, put hash of runtime
+                // callstack in one of reserved slot for better bucketting.
+                // we put hash since NFW just takes certain length of callstack which
+                // makes the callstack useless
+                fault.SetBucketParameter(Reserved3, $"{Environment.StackTrace?.GetHashCode() ?? 0}");
             }
 
             switch (exception)

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonExtensions.cs
@@ -13,7 +13,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         // putting custom string in reserved slots. normally those 3 slots will be empty.
         private const int Reserved1 = 8;
         private const int Reserved2 = 7;
-        private const int Reserved3 = 9;
+
+        // replace exception slot for callstack since the exception (with empty callstack) 
+        // given is synthesized one that doesn't provide any meaningful data
+        private const int Reserved3 = 4;
 
         /// <summary>
         /// This sets extra watson bucket parameters to make bucketting better

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 return;
             }
 
-            TelemetryService.DefaultSession.PostFault(
+            var faultEvent = new FaultEvent(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
                 exceptionObject: exception,
@@ -78,6 +78,13 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
                     return callback(arg);
                 });
+
+            // add extra bucket parameters to bucket better in NFW
+            // we do it here as well so that it gets bucketted better in both
+            // watson and telemetry. 
+            faultEvent.SetExtraParameters(exception, emptyCallstack);
+
+            TelemetryService.DefaultSession.PostEvent(faultEvent);
 
             if (exception is OutOfMemoryException)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -73,14 +73,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                     // always add current processes dump
                     arg.AddProcessDump(System.Diagnostics.Process.GetCurrentProcess().Id);
 
-                    // add extra bucket parameters to bucket better in NFW
-                    arg.SetExtraParameters(exception, emptyCallstack);
-
                     return callback(arg);
                 });
 
             // add extra bucket parameters to bucket better in NFW
-            // we do it here as well so that it gets bucketted better in both
+            // we do it here so that it gets bucketted better in both
             // watson and telemetry. 
             faultEvent.SetExtraParameters(exception, emptyCallstack);
 

--- a/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
@@ -87,14 +87,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                     // always add current processes dump
                     arg.AddProcessDump(System.Diagnostics.Process.GetCurrentProcess().Id);
 
-                    // add extra bucket parameters to bucket better in NFW
-                    arg.SetExtraParameters(exception, emptyCallstack);
-
                     return callback(arg);
                 });
 
             // add extra bucket parameters to bucket better in NFW
-            // we do it here as well so that it gets bucketted better in both
+            // we do it here so that it gets bucketted better in both
             // watson and telemetry. 
             faultEvent.SetExtraParameters(exception, emptyCallstack);
 

--- a/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
@@ -73,7 +73,12 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 return;
             }
 
-            SessionOpt?.PostFault(
+            if (SessionOpt == null)
+            {
+                return;
+            }
+
+            var faultEvent = new FaultEvent(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
                 exceptionObject: exception,
@@ -87,6 +92,13 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
                     return callback(arg);
                 });
+
+            // add extra bucket parameters to bucket better in NFW
+            // we do it here as well so that it gets bucketted better in both
+            // watson and telemetry. 
+            faultEvent.SetExtraParameters(exception, emptyCallstack);
+
+            SessionOpt.PostEvent(faultEvent);
         }
 
         private static bool IsNonRecoverableException(Exception exception)


### PR DESCRIPTION
previous way made bucketting to be better in watson site but not telemetry site. this should make it to better on both site.

### Customer scenario

This doesn't affect user experience. this is to make NFW better bucketed in telemetry site.

### Bugs this fixes

N/A

### Workarounds, if any

No

### Risk

I don't see any risk

### Performance impact

No impact

### Is this a regression from a previous update?

No

### Root cause analysis

Previously we made NFW bucketing better but we put that code that is specific to Watson. but we want telemetry of NFW to be separate reports better as well. so this change make those code path to use the better bucketing as well.

### How was the bug found?

Feature dashboard
