### PR TITLE
Hide EmbeddedFiles items

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -13,6 +13,16 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    EmbeddedFiles are source files to be embedded to the PDB. 
+    We need to set Visible to false in order to not display duplicate entries in project UI.
+  -->
+  <ItemDefinitionGroup>
+    <EmbeddedFiles>
+      <Visible>false</Visible>
+    </EmbeddedFiles>
+  </ItemDefinitionGroup>
+
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -13,6 +13,16 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    EmbeddedFiles are source files to be embedded to the PDB. 
+    We need to set Visible to false in order to not display duplicate entries in project UI.
+  -->
+  <ItemDefinitionGroup>
+    <EmbeddedFiles>
+      <Visible>false</Visible>
+    </EmbeddedFiles>
+  </ItemDefinitionGroup>
+
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);


### PR DESCRIPTION
### Customer scenario

Legacy project system displays duplicate items in solution explorer for files that are included in EmbeddedFiles item group in order to be embedded to the PDB.

### Bugs this fixes

VSO [490111](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/490111)

### Workarounds, if any

Set the Visible attribute manually in .csproj file

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

Customer reported.

### Test documentation updated?

N/A
