### PR TITLE
Suggest stackalloc keyword in Span legal places

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
@@ -55,40 +55,6 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotInEmptySpace()
-        {
-            await VerifyAbsenceAsync(AddInsideMethod(
-@"var v = $$"));
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestInUnsafeEmptySpace()
-        {
-            await VerifyKeywordAsync(
-@"unsafe class C {
-    void Goo() {
-      var v = $$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestInUnsafeEmptySpace_NotAfterNonPointer()
-        {
-            await VerifyAbsenceAsync(
-@"unsafe class C {
-    void Goo() {
-      int v = $$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestInUnsafeEmptySpace_AfterPointer()
-        {
-            await VerifyKeywordAsync(
-@"unsafe class C {
-    void Goo() {
-      int* v = $$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotInField()
         {
             await VerifyAbsenceAsync(
@@ -124,12 +90,99 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInsideForStatementVarDecl3()
         {
-            await VerifyAbsenceAsync(
+            await VerifyKeywordAsync(
 @"class C
 {
     unsafe static void Main(string[] args)
     {
         for (string i = $$");
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSOfAssignment_Span()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+Span<int> s = $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSOfAssignment_Var()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var v = $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSOfAssignment_Pointer()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"int* v = $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSOfAssignment_ReAssignment()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"v = $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithCast()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = (Span<char>)$$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = (Span<char>)$$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_True()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value ? $$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value ? $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_True_WithCast()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value ? (Span<int>)$$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value ? (Span<int>)$$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_False()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value ? stackalloc int[10] : $$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value ? stackalloc int[10] : $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_False_WithCast()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value ? stackalloc int[10] : (Span<int>)$$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value ? stackalloc int[10] : (Span<int>)$$"));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
@@ -55,6 +55,41 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInEmptySpaceAfterAssignment()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var v = $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInUnsafeEmptySpace()
+        {
+            await VerifyKeywordAsync(
+@"unsafe class C {
+    void Goo() {
+      var v = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInUnsafeEmptySpace_AfterNonPointer()
+        {
+            // There can be an implicit conversion to int
+            await VerifyKeywordAsync(
+@"unsafe class C {
+    void Goo() {
+      int v = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInUnsafeEmptySpace_AfterPointer()
+        {
+            await VerifyKeywordAsync(
+@"unsafe class C {
+    void Goo() {
+      int* v = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotInField()
         {
             await VerifyAbsenceAsync(
@@ -104,14 +139,6 @@ $$");
         {
             await VerifyKeywordAsync(AddInsideMethod(@"
 Span<int> s = $$"));
-        }
-
-        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestOnRHSOfAssignment_Var()
-        {
-            await VerifyKeywordAsync(AddInsideMethod(
-@"var v = $$"));
         }
 
         [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
@@ -227,6 +254,17 @@ var s = value1 ? value2 ? stackalloc int [10] : (Span<int>)$$"));
 
             await VerifyKeywordAsync(AddInsideMethod(@"
 s = value1 ? value2 ? stackalloc int [10] : (Span<int>)$$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInLHSOfAssignment()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(@"
+var x $$ ="));
+
+            await VerifyAbsenceAsync(AddInsideMethod(@"
+x $$ ="));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StackAllocKeywordRecommenderTests.cs
@@ -184,5 +184,49 @@ var s = value ? stackalloc int[10] : (Span<int>)$$"));
             await VerifyKeywordAsync(AddInsideMethod(@"
 s = value ? stackalloc int[10] : (Span<int>)$$"));
         }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_NestedConditional_True()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value1 ? value2 ? $$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value1 ? value2 ? $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_NestedConditional_WithCast_True()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value1 ? value2 ? (Span<int>)$$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value1 ? value2 ? (Span<int>)$$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_NestedConditional_False()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value1 ? value2 ? stackalloc int [10] : $$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value1 ? value2 ? stackalloc int [10] : $$"));
+        }
+
+        [WorkItem(23584, "https://github.com/dotnet/roslyn/issues/23584")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestOnRHSWithConditionalExpression_NestedConditional_WithCast_False()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(@"
+var s = value1 ? value2 ? stackalloc int [10] : (Span<int>)$$"));
+
+            await VerifyKeywordAsync(AddInsideMethod(@"
+s = value1 ? value2 ? stackalloc int [10] : (Span<int>)$$"));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
@@ -18,13 +18,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             var node = context.TargetToken.Parent;
 
-            // In case of an empty string
+            // When in an empty string
             if (node == null)
             {
                 return false;
             }
 
-            // After a cast
+            // After a cast or parenthesized expression: (Span<int>)stackalloc
             if (context.TargetToken.IsKind(SyntaxKind.CloseParenToken) &&
                 (node.IsKind(SyntaxKind.ParenthesizedExpression) || node.IsKind(SyntaxKind.CastExpression)))
             {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
@@ -18,26 +18,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             var node = context.TargetToken.Parent;
 
+            // In case of an empty string
             if (node == null)
             {
                 return false;
             }
 
-            if (node.IsKind(SyntaxKind.ParenthesizedExpression) || node.IsKind(SyntaxKind.CastExpression))
+            // After a cast
+            if (context.TargetToken.IsKind(SyntaxKind.CloseParenToken) &&
+                (node.IsKind(SyntaxKind.ParenthesizedExpression) || node.IsKind(SyntaxKind.CastExpression)))
             {
                 node = node.Parent;
             }
 
-            while (node.IsKind(SyntaxKind.ConditionalExpression))
+            // Inside a conditional expression: value ? stackalloc : stackalloc
+            while (node.IsKind(SyntaxKind.ConditionalExpression) &&
+                (context.TargetToken.IsKind(SyntaxKind.CloseParenToken) || context.TargetToken.IsKind(SyntaxKind.QuestionToken) || context.TargetToken.IsKind(SyntaxKind.ColonToken)))
             {
                 node = node.Parent;
             }
 
+            // assignment: x = stackalloc
             if (node.IsKind(SyntaxKind.SimpleAssignmentExpression))
             {
                 return node.Parent.IsKind(SyntaxKind.ExpressionStatement);
             }
 
+            // declaration: var x = stackalloc
             if (node.IsKind(SyntaxKind.EqualsValueClause))
             {
                 node = node.Parent;

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StackAllocKeywordRecommender.cs
@@ -18,22 +18,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             var node = context.TargetToken.Parent;
 
-            // When in an empty string
+            // At start of a file
             if (node == null)
             {
                 return false;
             }
 
             // After a cast or parenthesized expression: (Span<int>)stackalloc
-            if (context.TargetToken.IsKind(SyntaxKind.CloseParenToken) &&
-                (node.IsKind(SyntaxKind.ParenthesizedExpression) || node.IsKind(SyntaxKind.CastExpression)))
+            if (context.TargetToken.IsAfterPossibleCast())
             {
                 node = node.Parent;
             }
 
             // Inside a conditional expression: value ? stackalloc : stackalloc
             while (node.IsKind(SyntaxKind.ConditionalExpression) &&
-                (context.TargetToken.IsKind(SyntaxKind.CloseParenToken) || context.TargetToken.IsKind(SyntaxKind.QuestionToken) || context.TargetToken.IsKind(SyntaxKind.ColonToken)))
+                (context.TargetToken.IsKind(SyntaxKind.QuestionToken, SyntaxKind.ColonToken) || context.TargetToken.IsAfterPossibleCast()))
             {
                 node = node.Parent;
             }
@@ -57,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     {
                         node = node.Parent;
 
-                        return node.IsKind(SyntaxKind.LocalDeclarationStatement) || node.IsKind(SyntaxKind.ForStatement);
+                        return node.IsKind(SyntaxKind.LocalDeclarationStatement, SyntaxKind.ForStatement);
                     }
                 }
             }


### PR DESCRIPTION
### Customer scenario

C# 7.2 introduce safe stackalloc with the Span<T> struct. So stackalloc keyword should be listed in the IntelliSense window. The completion provider suggests other types/keywords (ex: `StackOverflowException`).

### Code this fixes:

![image](https://user-images.githubusercontent.com/15987992/34232826-0ecc4498-e597-11e7-84e3-6a4b149342de.png)

### Bugs this fixes

Fixes #23584

### Workarounds, if any

None.

### Risk

Low. This is suggesting an additional keyword. Tests were added.

### Performance impact

Minimal.

### Is this a regression from a previous update?

No.

### Root cause analysis

Was not implemented yet in 7.2.

### How was the bug found?

Customer reported on github.

### Test documentation updated?

--