### PR TITLE
Add EmbedAllSources build task parameter

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -63,6 +63,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (ITaskItem[])_store[nameof(EmbeddedFiles)]; }
         }
 
+        public bool EmbedAllSources
+        {
+            set { _store[nameof(EmbedAllSources)] = value; }
+            get { return _store.GetOrDefault(nameof(EmbedAllSources), false); }
+        }
+
         public ITaskItem[] Analyzers
         {
             set { _store[nameof(Analyzers)] = value; }
@@ -845,6 +851,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         private void AddEmbeddedFilesToCommandLine(CommandLineBuilderExtension commandLine)
         {
+            if (EmbedAllSources)
+            {
+                commandLine.AppendSwitch("/embed");
+            }
+
             if (EmbeddedFiles != null)
             {
                 foreach (ITaskItem embeddedFile in EmbeddedFiles)

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -98,6 +98,7 @@
          DelaySign="$(DelaySign)"
          DisabledWarnings="$(NoWarn)"
          DocumentationFile="@(DocFileItem)"
+         EmbedAllSources="$(EmbedAllSources)"
          EmbeddedFiles="@(EmbeddedFiles)"
          EmitDebugInformation="$(DebugSymbols)"
          EnvironmentVariables="$(CscEnvironment)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -84,6 +84,7 @@
          DelaySign="$(DelaySign)"
          DisabledWarnings="$(NoWarn)"
          DocumentationFile="@(DocFileItem)"
+         EmbedAllSources="$(EmbedAllSources)"
          EmbeddedFiles="@(EmbeddedFiles)"
          EmitDebugInformation="$(DebugSymbols)"
          EnvironmentVariables="$(VbcEnvironment)"

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -292,9 +292,26 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             csc = new Csc();
             csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.DebugType = "portable";
+            csc.DebugType = "full";
             csc.EmbeddedFiles = MSBuildUtil.CreateTaskItems();
-            Assert.Equal(@"/debug:portable /out:test.exe test.cs", csc.GenerateResponseFileContents());
+            Assert.Equal(@"/debug:full /out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void EmbedAllSources()
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.EmbeddedFiles = MSBuildUtil.CreateTaskItems(@"test.cs", @"test.txt");
+            csc.EmbedAllSources = true;
+
+            Assert.Equal(@"/out:test.exe /embed /embed:test.cs /embed:test.txt test.cs", csc.GenerateResponseFileContents());
+
+            csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.EmbedAllSources = true;
+
+            Assert.Equal(@"/out:test.exe /embed test.cs", csc.GenerateResponseFileContents());
         }
 
         [Fact]

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -289,9 +289,26 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             vbc = new Vbc();
             vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
-            vbc.DebugType = "portable";
+            vbc.DebugType = "full";
             vbc.EmbeddedFiles = MSBuildUtil.CreateTaskItems();
-            Assert.Equal(@"/optionstrict:custom /debug:portable /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+            Assert.Equal(@"/optionstrict:custom /debug:full /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
+        public void EmbedAllSources()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.EmbeddedFiles = MSBuildUtil.CreateTaskItems(@"test.vb", @"test.txt");
+            vbc.EmbedAllSources = true;
+
+            Assert.Equal(@"/optionstrict:custom /out:test.exe /embed /embed:test.vb /embed:test.txt test.vb", vbc.GenerateResponseFileContents());
+
+            vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.EmbedAllSources = true;
+
+            Assert.Equal(@"/optionstrict:custom /out:test.exe /embed test.vb", vbc.GenerateResponseFileContents());
         }
 
         [Fact]


### PR DESCRIPTION
### Customer scenario

Expose ```/embed``` command line option thru csc and vbc build tasks. 
Introduce ```EmbedAllSources``` property to enables customers to embed all source files without writing custom targets.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/19127

### Workarounds, if any

The customer can add 

```
  <Target Name="PopulateEmbeddedFiles"
          AfterTargets="BeforeCompile"
          BeforeTargets="CoreCompile">
    <ItemGroup>
      <EmbeddedFiles Include="@(Compile)" />
    </ItemGroup>
  </Target>
```

to their targets file.

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

No.

### Root cause analysis

### How was the bug found?

Customer.

### Test documentation updated?

