### PR TITLE
When all inferred tuple names are duplicates, TupleElementNames should be default

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -560,18 +560,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<string> tupleNames = namesBuilder is null ? default : namesBuilder.ToImmutableAndFree();
 
             bool disallowInferredNames = this.Compilation.LanguageVersion.DisallowInferredTupleElementNames();
-            var errorPositions = (tupleNames.IsDefault || disallowInferredNames) ? default : tupleNames.SelectAsArray(n => n != null);
+            var inferredPositions = tupleNames.IsDefault ? default : tupleNames.SelectAsArray(n => n != null);
 
             var type = TupleTypeSymbol.Create(syntax.Location,
                 typesBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
                 tupleNames, this.Compilation,
                 shouldCheckConstraints: !ignoreDiagnosticsFromTuple,
-                errorPositions,
+                errorPositions: disallowInferredNames ? inferredPositions : default,
                 syntax: syntax, diagnostics: ignoreDiagnosticsFromTuple ? null : diagnostics);
 
             // Always track the inferred positions in the bound node, so that conversions don't produce a warning
             // for "dropped names" on tuple literal when the name was inferred.
-            return new BoundTupleLiteral(syntax, tupleNames, errorPositions, arguments: valuesBuilder.ToImmutableAndFree(), type: type);
+            return new BoundTupleLiteral(syntax, tupleNames, inferredPositions, arguments: valuesBuilder.ToImmutableAndFree(), type: type);
         }
 
         /// <summary>Extract inferred name from a single deconstruction variable.</summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -549,6 +549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 locationsBuilder.Add(variable.Syntax.Location);
             }
+            var arguments = valuesBuilder.ToImmutableAndFree();
 
             var uniqueFieldNames = PooledHashSet<string>.GetInstance();
             if (RemoveDuplicateInferredTupleNamesAndReportEmptied(namesBuilder, uniqueFieldNames))
@@ -557,12 +558,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 namesBuilder = null;
             }
             uniqueFieldNames.Free();
-            ImmutableArray<string> tupleNames = namesBuilder is null ? default : namesBuilder.ToImmutableAndFree();
 
-            bool disallowInferredNames = this.Compilation.LanguageVersion.DisallowInferredTupleElementNames();
+            var tupleNames = namesBuilder is null ? default : namesBuilder.ToImmutableAndFree();
             var inferredPositions = tupleNames.IsDefault ? default : tupleNames.SelectAsArray(n => n != null);
+            bool disallowInferredNames = this.Compilation.LanguageVersion.DisallowInferredTupleElementNames();
 
-            var type = TupleTypeSymbol.Create(syntax.Location,
+            var type = TupleTypeSymbol.Create(
+                syntax.Location,
                 typesBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
                 tupleNames, this.Compilation,
                 shouldCheckConstraints: !ignoreDiagnosticsFromTuple,
@@ -571,7 +573,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Always track the inferred positions in the bound node, so that conversions don't produce a warning
             // for "dropped names" on tuple literal when the name was inferred.
-            return new BoundTupleLiteral(syntax, tupleNames, inferredPositions, arguments: valuesBuilder.ToImmutableAndFree(), type: type);
+            return new BoundTupleLiteral(syntax, tupleNames, inferredPositions, arguments, type);
         }
 
         /// <summary>Extract inferred name from a single deconstruction variable.</summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -549,18 +549,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 locationsBuilder.Add(variable.Syntax.Location);
             }
-            var arguments = valuesBuilder.ToImmutableAndFree();
+            ImmutableArray<BoundExpression> arguments = valuesBuilder.ToImmutableAndFree();
 
             var uniqueFieldNames = PooledHashSet<string>.GetInstance();
-            if (RemoveDuplicateInferredTupleNamesAndReportEmptied(namesBuilder, uniqueFieldNames))
-            {
-                namesBuilder.Free();
-                namesBuilder = null;
-            }
+            RemoveDuplicateInferredTupleNamesAndFreeIfEmptied(ref namesBuilder, uniqueFieldNames);
             uniqueFieldNames.Free();
 
-            var tupleNames = namesBuilder is null ? default : namesBuilder.ToImmutableAndFree();
-            var inferredPositions = tupleNames.IsDefault ? default : tupleNames.SelectAsArray(n => n != null);
+            ImmutableArray<string> tupleNames = namesBuilder is null ? default : namesBuilder.ToImmutableAndFree();
+            ImmutableArray<bool> inferredPositions = tupleNames.IsDefault ? default : tupleNames.SelectAsArray(n => n != null);
             bool disallowInferredNames = this.Compilation.LanguageVersion.DisallowInferredTupleElementNames();
 
             var type = TupleTypeSymbol.Create(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1394,7 +1394,9 @@ class C
 
                 Assert.Equal("(System.Int32, System.Int32 x) c", model.GetDeclaredSymbol(declarations.ElementAt(6)).ToTestDisplayString());
 
-                Assert.Equal("(System.Int32, System.Int32) d", model.GetDeclaredSymbol(declarations.ElementAt(7)).ToTestDisplayString());
+                var x = model.GetDeclaredSymbol(declarations.ElementAt(7)) as LocalSymbol;
+                Assert.Equal("(System.Int32, System.Int32) d", x.ToTestDisplayString());
+                Assert.True(x.Type.TupleElementNames.IsDefault);
 
                 Assert.Equal("(System.Int32 x, System.Int32, System.Int32 y, (System.Int32, System.Int32, System.Int32), (System.Int32 x, System.Int32 y)) nested",
                     model.GetDeclaredSymbol(declarations.ElementAt(8)).ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1394,7 +1394,7 @@ class C
 
                 Assert.Equal("(System.Int32, System.Int32 x) c", model.GetDeclaredSymbol(declarations.ElementAt(6)).ToTestDisplayString());
 
-                var x = model.GetDeclaredSymbol(declarations.ElementAt(7)) as LocalSymbol;
+                var x = (LocalSymbol)model.GetDeclaredSymbol(declarations.ElementAt(7));
                 Assert.Equal("(System.Int32, System.Int32) d", x.ToTestDisplayString());
                 Assert.True(x.Type.TupleElementNames.IsDefault);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16128,6 +16128,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(23651, "https://github.com/dotnet/roslyn/issues/23651")]
         public void GetSymbolInfo_WithDuplicateInferredName()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16151,7 +16151,7 @@ class C
 
             var x1 = nodes.OfType<VariableDeclaratorSyntax>().Single();
             Assert.Equal("x1 = (Bob, Bob)", x1.ToString());
-            var x1Symbol = model.GetDeclaredSymbol(x1) as LocalSymbol;
+            var x1Symbol = (LocalSymbol)model.GetDeclaredSymbol(x1);
             Assert.Equal("(System.String, System.String) x1", x1Symbol.ToTestDisplayString());
             Assert.True(x1Symbol.Type.TupleElementNames.IsDefault);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16128,6 +16128,34 @@ class C
         }
 
         [Fact]
+        public void GetSymbolInfo_WithDuplicateInferredName()
+        {
+            var source = @"
+class C
+{
+    static object M(string Bob)
+    {
+        var x1 = (Bob, Bob);
+        return x1;
+    }
+}
+";
+
+            var tree = Parse(source, options: TestOptions.Regular7_1);
+            var comp = CreateStandardCompilation(tree, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics();
+
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var x1 = nodes.OfType<VariableDeclaratorSyntax>().Single();
+            Assert.Equal("x1 = (Bob, Bob)", x1.ToString());
+            var x1Symbol = model.GetDeclaredSymbol(x1) as LocalSymbol;
+            Assert.Equal("(System.String, System.String) x1", x1Symbol.ToTestDisplayString());
+            Assert.True(x1Symbol.Type.TupleElementNames.IsDefault);
+        }
+
+        [Fact]
         public void CompileTupleLib()
         {
             string additionalSource = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -4707,6 +4707,34 @@ class C
             Assert.Equal("var=System.Int32", model.GetAliasInfo(declarations[1].Type).ToTestDisplayString());
         }
 
+        [Fact]
+        [WorkItem(23651, "https://github.com/dotnet/roslyn/issues/23651")]
+        public void StandAlone_05_WithDuplicateNames()
+        {
+            string source1 = @"
+using var = System.Int32;
+
+class C
+{
+    static void Main()
+    {
+        (var (a, a), var c);
+    }
+}
+";
+
+            var comp1 = CreateStandardCompilation(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+
+            var tree = comp1.SyntaxTrees.Single();
+            var model = comp1.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var aa = nodes.OfType<DeclarationExpressionSyntax>().ElementAt(0);
+            Assert.Equal("var (a, a)", aa.ToString());
+            var aaType = model.GetTypeInfo(aa).Type as TypeSymbol;
+            Assert.True(aaType.TupleElementNames.IsDefault);
+        }
+
         [Fact, WorkItem(17572, "https://github.com/dotnet/roslyn/issues/17572")]
         public void StandAlone_06()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -4731,7 +4731,7 @@ class C
 
             var aa = nodes.OfType<DeclarationExpressionSyntax>().ElementAt(0);
             Assert.Equal("var (a, a)", aa.ToString());
-            var aaType = model.GetTypeInfo(aa).Type as TypeSymbol;
+            var aaType = (TypeSymbol)model.GetTypeInfo(aa).Type;
             Assert.True(aaType.TupleElementNames.IsDefault);
         }
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -8845,6 +8845,28 @@ End Class
         End Sub
 
         <Fact>
+        <WorkItem(23651, "https://github.com/dotnet/roslyn/issues/23651")>
+        Public Sub GetSymbolInfo_WithDuplicateInferredNames()
+            Dim source = "
+ Class C
+    Shared Sub M(Bob As String)
+         Dim x1 = (Bob, Bob)
+    End Sub
+End Class
+ "
+
+            Dim tree = Parse(source, options:=TestOptions.Regular)
+            Dim comp = CreateCompilationWithMscorlib(tree)
+
+            Dim model = comp.GetSemanticModel(tree, ignoreAccessibility:=False)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+            Dim tuple = nodes.OfType(Of TupleExpressionSyntax)().Single()
+            Dim type = DirectCast(model.GetTypeInfo(tuple).Type, TypeSymbol)
+            Assert.True(type.TupleElementNames.IsDefault)
+        End Sub
+
+        <Fact>
         Public Sub RetargetTupleErrorType()
             Dim libComp = CreateCompilationWithMscorlibAndVBRuntime(
  <compilation>


### PR DESCRIPTION
### Customer scenario
Use the semantic model API (`GetTypeInfo`) on a tuple with inferred elements names, but the names are all duplicates. The type returned should have a default `TupleElementNames` array, but previously was an array filled with `null`s.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23651

### Workarounds, if any
Handle a returned array of nulls.

### Risk
### Performance impact
Low. The change in logic is limited to binding tuples and deconstructions.

### Is this a regression from a previous update?
No.

### Root cause analysis
Missed that case in testing.

### How was the bug found?
Reported by team member.