### PR TITLE
GetDocumentationCommentId should handle generic type in cref

### DIFF
--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (containingSymbol is null)
                 {
                     // For instance a type parameter in cref (CrefTypeParameterSymbol)
-                    builder.Append("`");
+                    builder.Append('`');
                 }
                 else if (containingSymbol.Kind == SymbolKind.Method)
                 {

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -147,7 +147,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Is this a type parameter on a type?
                 Symbol containingSymbol = symbol.ContainingSymbol;
-                if (containingSymbol.Kind == SymbolKind.Method)
+                if (containingSymbol is null)
+                {
+                    // For instance a type parameter in cref (CrefTypeParameterSymbol)
+                    builder.Append("`");
+                }
+                else if (containingSymbol.Kind == SymbolKind.Method)
                 {
                     builder.Append("``");
                 }

--- a/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
@@ -105,7 +105,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim ordinalOffset As Integer = 0
                 Dim containingSymbol As Symbol = symbol.ContainingSymbol
 
-                If containingSymbol.Kind = SymbolKind.NamedType Then
+                If containingSymbol Is Nothing Then
+                    ' For instance a type parameter in cref (CrefTypeParameterSymbol)
+                    builder.Append("`"c)
+                ElseIf containingSymbol.Kind = SymbolKind.NamedType Then
                     ' If the containing type is nested within other types, then we need to add their arities.
                     ' e.g. A(Of T).B(Of U).M(Of V)(t As T, u As U, v As V) should be M(`0, `1, ``0).
                     Dim curr As NamedTypeSymbol = containingSymbol.ContainingType


### PR DESCRIPTION
### Customer scenario
Use a generic type in a cref (`/// <see cref="C{U}.M()"/>`) and use the `GetDocumentationCommentId()` API on the generic symbol for `C<U>`. This would throw a null reference exception.
The API now correctly returns "T:C{\`0}".

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/19756

### Workarounds, if any
I don't know any.

### Risk
### Performance impact
Low. This used to crash and the change is limited to documentation visitor.

### Is this a regression from a previous update?
No

### How was the bug found?
Reported by customer
