### PR TITLE
Properties with expression bodies don't add backing fields

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2168,7 +2168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         !ContainsModifier(propertyDecl.Modifiers, SyntaxKind.AbstractKeyword) &&
                         !ContainsModifier(propertyDecl.Modifiers, SyntaxKind.ExternKeyword) &&
                         propertyDecl.AccessorList != null &&
-                        All(propertyDecl.AccessorList.Accessors, a => a.Body == null);
+                        All(propertyDecl.AccessorList.Accessors, a => a.Body == null && a.ExpressionBody == null);
                 case SyntaxKind.EventFieldDeclaration:
                     // field-like event declaration
                     var eventFieldDecl = (EventFieldDeclarationSyntax)m;

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1057,31 +1057,6 @@ partial struct S2
         }
 
         [Fact]
-        [WorkItem(23668, "https://github.com/dotnet/roslyn/issues/23668")]
-        public void PartialWithPropertyButSingleField()
-        {
-            string program =
-@"partial struct X // Warning CS0282
-{
-    // The only field of X is a backing field of A.
-    public int A { get; set; }
-}
-
-partial struct X : I
-{
-    // This partial definition has no field.
-    int I.A { get => A; set => A = value; }
-}
-
-interface I
-{
-    int A { get; set; }
-}";
-            var comp = CreateStandardCompilation(program);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
         public void StaticInitializer()
         {
             string program = @"

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1057,6 +1057,31 @@ partial struct S2
         }
 
         [Fact]
+        [WorkItem(23668, "https://github.com/dotnet/roslyn/issues/23668")]
+        public void Bug()
+        {
+            string program =
+@"partial struct X // Warning CS0282
+{
+    // The only field of X is a backing field of A.
+    public int A { get; set; }
+}
+
+partial struct X : I
+{
+    // This partial definition has no field.
+    int I.A { get => A; set => A = value; }
+}
+
+interface I
+{
+    int A { get; set; }
+}";
+            var comp = CreateStandardCompilation(program);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void StaticInitializer()
         {
             string program = @"

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1058,7 +1058,7 @@ partial struct S2
 
         [Fact]
         [WorkItem(23668, "https://github.com/dotnet/roslyn/issues/23668")]
-        public void Bug()
+        public void PartialWithPropertyButSingleField()
         {
             string program =
 @"partial struct X // Warning CS0282

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -16613,6 +16613,31 @@ partial struct A
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "j").WithArguments("A.j"));
         }
 
+        [Fact]
+        [WorkItem(23668, "https://github.com/dotnet/roslyn/issues/23668")]
+        public void CS0282WRN_PartialWithPropertyButSingleField()
+        {
+            string program =
+@"partial struct X // No warning CS0282
+{
+    // The only field of X is a backing field of A.
+    public int A { get; set; }
+}
+
+partial struct X : I
+{
+    // This partial definition has no field.
+    int I.A { get => A; set => A = value; }
+}
+
+interface I
+{
+    int A { get; set; }
+}";
+            var comp = CreateStandardCompilation(program);
+            comp.VerifyDiagnostics();
+        }
+
         /// <summary>
         /// import - Lib:  class A     { class B {} } 
         ///      vs. curr: Namespace A { class B {} } - use B


### PR DESCRIPTION
### Customer scenario
Define a partial struct with a field and a property that isn't an auto-property. If the property uses expression-bodied accessors, a warning is reported as if it was an auto-property (ie. it has a backing field), when it actually isn't.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23668

### Workarounds, if any
Suppress warning or use blocks in property bodies.

### Risk
### Performance impact
None. Checking both for block and expression bodies where we used to only check for block bodies.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer.

Note: this warning (CS0282) doesn't seem to have a VB counter-part. I'm 
```VB
' No warning
Partial Structure C
	Property x As Integer
End Structure
Partial Structure C
	Property y As Integer
End Structure
```