### PR TITLE
Infrastructure: Source packages improvements

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -361,6 +361,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILAsm", "src\Tools\ILAsm\IL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildUtil", "src\Tools\BuildUtil\BuildUtil.csproj", "{137922A2-5B1E-44C4-B0EC-0F49D2BD323A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Debugging.Package", "src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.Package.csproj", "{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PooledObjects.Package", "src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.Package.csproj", "{49E7C367-181B-499C-AC2E-8E17C81418D6}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
@@ -959,6 +963,14 @@ Global
 		{137922A2-5B1E-44C4-B0EC-0F49D2BD323A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{137922A2-5B1E-44C4-B0EC-0F49D2BD323A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{137922A2-5B1E-44C4-B0EC-0F49D2BD323A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49E7C367-181B-499C-AC2E-8E17C81418D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49E7C367-181B-499C-AC2E-8E17C81418D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49E7C367-181B-499C-AC2E-8E17C81418D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49E7C367-181B-499C-AC2E-8E17C81418D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1130,6 +1142,8 @@ Global
 		{2D36C343-BB6A-4CB5-902B-E2145ACCB58F} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{DA8522ED-02BC-499C-AC71-1DF884F63987} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{137922A2-5B1E-44C4-B0EC-0F49D2BD323A} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
+		{FC2AE90B-2E4B-4045-9FDD-73D4F5ED6C89} = {C2D1346B-9665-4150-B644-075CF1636BAA}
+		{49E7C367-181B-499C-AC2E-8E17C81418D6} = {C2D1346B-9665-4150-B644-075CF1636BAA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/build/Targets/BeforeCommonTargets.targets
+++ b/build/Targets/BeforeCommonTargets.targets
@@ -22,6 +22,11 @@
     <When Condition="'$(RoslynProjectType)' == 'Custom'">
       <!-- Do nothing -->
     </When>
+    <When Condition="'$(RoslynProjectType)' == 'SourcePackage'">
+      <PropertyGroup>
+        <OutputPath>$(OutputPath)SourcePackages\$(MSBuildProjectName)\</OutputPath>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(RoslynProjectType)' == '' AND '$(OutputType)' == 'Library'">
       <PropertyGroup>
         <_CopyReferences>false</_CopyReferences>
@@ -63,7 +68,7 @@
 
   <PropertyGroup Condition="'$(TargetFrameworks)' != ''">
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
-    <OutputPath>$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
+    <OutputPath Condition="'$(RoslynProjectType)' != 'SourcePackage'">$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
     <DocumentationFile Condition="'$(GenerateDocumentationFile)' == 'true' AND '$(ProjectLanguage)' == 'CSharp'">$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -13,7 +13,6 @@
     <FileAlignment>512</FileAlignment>
     <HighEntropyVA>true</HighEntropyVA>
     <Deterministic>True</Deterministic>
-    <UseCommonOutputDirectory>false</UseCommonOutputDirectory>
 
     <GetVsixSourceItemsDependsOn>$(GetVsixSourceItemsDependsOn);IncludeVsixLocalOnlyItems</GetVsixSourceItemsDependsOn>
     <GetVsixSourceItemsDependsOn>$(GetVsixSourceItemsDependsOn);IncludeNuGetResolvedAssets</GetVsixSourceItemsDependsOn>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -149,7 +149,7 @@
     <RoslynToolsMicrosoftSignToolVersion>0.3.7-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <RoslynToolsMSBuildVersion>0.4.0-alpha</RoslynToolsMSBuildVersion>
-    <RoslynToolsReferenceAssembliesVersion>0.1.1</RoslynToolsReferenceAssembliesVersion>
+    <RoslynToolsReferenceAssembliesVersion>0.1.3</RoslynToolsReferenceAssembliesVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <StreamJsonRpcVersion>1.1.92</StreamJsonRpcVersion>
     <SystemAppContextVersion>4.3.0</SystemAppContextVersion>

--- a/build/Targets/RepoToolset/SourceLink.targets
+++ b/build/Targets/RepoToolset/SourceLink.targets
@@ -17,7 +17,7 @@ Update this file only if the change to RepoToolset gets approved and merged.
   </PropertyGroup>
   
   <PropertyGroup>
-    <SourceLink>$(IntermediateOutputPath)$(MSBuildProjectName).sourcelink.json</SourceLink>
+    <SourceLink Condition="'$(DebugType)' != 'none'">$(IntermediateOutputPath)$(MSBuildProjectName).sourcelink.json</SourceLink>
     
     <!-- Override SourceLinkRoot if DeterministicSourceRoot is set, otherwise use RepoRoot as a default value -->
     <SourceLinkRoot Condition="'$(DeterministicSourceRoot)' != ''">$(DeterministicSourceRoot)</SourceLinkRoot>
@@ -27,7 +27,8 @@ Update this file only if the change to RepoToolset gets approved and merged.
   <Target Name="GenerateSourceLinkFile"
           Outputs="$(SourceLink)"
           DependsOnTargets="PrepareForBuild"
-          BeforeTargets="CoreCompile">
+          BeforeTargets="CoreCompile"
+          Condition="'$(SourceLink)' != ''">
 
     <Error Text="GitHeadSha has invalid value: '$(GitHeadSha)'" Condition="'$(GitHeadSha.Length)' != '40'" />
     <Error Text="SourceLinkRoot must end with a slash or backslash: '$(SourceLinkRoot)'" Condition="!HasTrailingSlash('$(SourceLinkRoot)')"/>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\'))</RepoRoot>
     <RepositoryUrl>https://github.com/dotnet/roslyn</RepositoryUrl>
+    <RepositoryRawUrl>https://raw.githubusercontent.com/dotnet/roslyn</RepositoryRawUrl>
   </PropertyGroup>
 
   <Import Project="Packages.props" />

--- a/build/Targets/SourcePackage.targets
+++ b/build/Targets/SourcePackage.targets
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  
+  <!--
+    Imported to project that produce source packages.
+  -->
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <RoslynProjectType>SourcePackage</RoslynProjectType>
+
+    <!-- We only build to validate the code, we are not interested in any outputs. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <DebugType>none</DebugType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- Disables copying any build files to output dir -->
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+
+    <!-- Disables copying any dependent files to output dir -->
+    <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_SourcePackagePropsDirPath>$(OutputPath)SourcePackages\$(MSBuildProjectName)\</_SourcePackagePropsDirPath>
+    <_SourcePackagePropsFilePath>$(_SourcePackagePropsDirPath)$(PackageId).props</_SourcePackagePropsFilePath>
+  </PropertyGroup>
+  
+  <!-- The condition ensures the target is only run once even if the project is cross-targeting. -->
+  <Target Name="GenerateSourcePackagePropsFile"
+          BeforeTargets="Build"
+          Condition="'$(TargetFrameworks)' == '' or '$(IsCrossTargetingBuild)' == 'true'"
+          Outputs="$(_SourcePackagePropsFilePath)">
+    
+    <PropertyGroup>
+      <_RelativePath>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</_RelativePath>
+      
+      <!-- TODO: Proper URL escaping -->
+      <_RawUrl>$(RepositoryRawUrl)/$(GitHeadSha)/$(_RelativePath.Replace('\', '/'))</_RawUrl>
+      
+      <_Content>
+        <![CDATA[<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <SourceRoot Include="%24([System.IO.Path]::GetFullPath('%24(MSBuildThisFileDirectory)..\contentFiles\cs\%24(TargetFramework)\'))"
+                RawUrl="$(_RawUrl)"
+                UniqueName="%24(MSBuildThisFileName)"/>
+  </ItemGroup>
+</Project>]]>
+      </_Content>
+    </PropertyGroup>
+    <MakeDir Directories="$(_SourcePackagePropsDirPath)" />
+    <WriteLinesToFile File="$(_SourcePackagePropsFilePath)" Lines="$(_Content)" Overwrite="true" Encoding="UTF-8"/>
+    <ItemGroup>
+      <FileWrites Include="$(_SourcePackagePropsFilePath)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/build/Targets/SourcePackage.targets
+++ b/build/Targets/SourcePackage.targets
@@ -11,8 +11,6 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <RoslynProjectType>SourcePackage</RoslynProjectType>
-
     <!-- We only build to validate the code, we are not interested in any outputs. -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageId>Microsoft.CodeAnalysis.Debugging</PackageId>
+    <RoslynProjectType>SourcePackage</RoslynProjectType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections" Version="$(SystemCollectionsVersion)" />

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageId>Microsoft.CodeAnalysis.Debugging</PackageId>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <PackageId>Microsoft.CodeAnalysis.Debugging</PackageId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Collections" Version="$(SystemCollectionsVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
+  </ItemGroup>
+  <Import Project="..\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems" Label="Shared" />
+  <Import Project="$(RepoRoot)build\Targets\SourcePackage.targets"/>
+</Project>

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -2,7 +2,7 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageId>Microsoft.CodeAnalysis.PooledObjects</PackageId>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageId>Microsoft.CodeAnalysis.PooledObjects</PackageId>
+    <RoslynProjectType>SourcePackage</RoslynProjectType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+    <PackageId>Microsoft.CodeAnalysis.PooledObjects</PackageId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Collections" Version="$(SystemCollectionsVersion)" />
+  </ItemGroup>
+  <Import Project="$(RepoRoot)build\Targets\SourcePackage.targets"/>
+</Project>

--- a/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
@@ -29,6 +29,7 @@
     </contentFiles>
   </metadata>
   <files>
+    <file src="SourcePackages\Microsoft.CodeAnalysis.Debugging.Package\Microsoft.CodeAnalysis.Debugging.props" target="build" />
     <file src="$srcDirPath$\Dependencies\CodeAnalysis.Debugging\**\*.cs" target="contentFiles/cs/netstandard1.3" />
     <file src="$srcDirPath$\Dependencies\CodeAnalysis.Debugging\**\*.cs" target="contentFiles/cs/net45" />
   </files>

--- a/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
@@ -26,6 +26,7 @@
     </contentFiles>
   </metadata>
   <files>
+    <file src="SourcePackages\Microsoft.CodeAnalysis.PooledObjects.Package\Microsoft.CodeAnalysis.PooledObjects.props" target="build" />
     <file src="$srcDirPath$\Dependencies\PooledObjects\**\*.cs" target="contentFiles/cs/netstandard1.3" />
     <file src="$srcDirPath$\Dependencies\PooledObjects\**\*.cs" target="contentFiles/cs/net45" />
   </files>

--- a/src/Tools/BuildBoss/ProjectUtil.cs
+++ b/src/Tools/BuildBoss/ProjectUtil.cs
@@ -60,7 +60,7 @@ namespace BuildBoss
 
         internal bool TryGetRoslynProjectData(out RoslynProjectData data, out string error)
         {
-            data = default(RoslynProjectData);
+            data = default;
             error = null;
 
             var typeElement = FindSingleProperty("RoslynProjectType");

--- a/src/Tools/BuildBoss/RoslynProjectData.cs
+++ b/src/Tools/BuildBoss/RoslynProjectData.cs
@@ -16,7 +16,8 @@ namespace BuildBoss
         UnitTestPortable,
         Vsix,
         Depedency,
-        Custom
+        SourcePackage,
+        Custom,
     }
 
     internal static class RoslynProjectKindUtil
@@ -38,6 +39,8 @@ namespace BuildBoss
                     return RoslynProjectKind.Depedency;
                 case "Custom":
                     return RoslynProjectKind.Custom;
+                case "SourcePackage":
+                    return RoslynProjectKind.SourcePackage;
                 default:
                     return null;
             }


### PR DESCRIPTION
### Customer scenario

Source link is currently broken in repositories that have a package reference to source packages Roslyn produces (Microsoft.CodeAnalysis.Debugging, Microsoft.CodeAnalysis.PooledObjects). 

This change enables such repository to generate source link mappings that point back to the Roslyn repository for files imported from the source packages. This is implemented by generating .props file in the source package with metadata needed to create the source link mapping. 

In addition this change adds projects that validate that the source packages build correctly on their own, which prevents us from accidentally breaking them by adding dependency on types that are not available outside of Roslyn.

Complementary to PR: https://github.com/dotnet/symreader-converter/pull/65

### Bugs this fixes

### Workarounds, if any

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

Switching symreader-converter repository to source packages and validating source link.

### Test documentation updated?

n/a
