### PR TITLE
Move to dotnet restore

### DIFF
--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -6,36 +6,36 @@
     <NonShipping>true</NonShipping>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Sdk" Version="$(MicrosoftNetSdkVersion)" />
-    <PackageReference Include="Microsoft.Build.Logging.StructuredLogger" Version="$(MicrosoftBuildLoggingStructuredLoggerVersion)" />
-    <PackageReference Include="MicroBuild.Core.Sentinel" Version="$(MicroBuildCoreSentinelVersion)" />
-    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
-    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" />
-    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersion)" />
-    <PackageReference Include="FakeSign" Version="$(FakeSignVersion)" />
-    <PackageReference Include="xunit" Version="$(xunitVersion)" />
-    <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
-    <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" />
-    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" />
-    <PackageReference Include="RoslynTools.ReferenceAssemblies" Version="$(RoslynToolsReferenceAssembliesVersion)" />
-    <PackageReference Include="pdb2pdb" Version="$(Pdb2PdbVersion)" />
+    <PackageReference Include="Microsoft.Net.Sdk" Version="$(MicrosoftNetSdkVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Build.Logging.StructuredLogger" Version="$(MicrosoftBuildLoggingStructuredLoggerVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Core.Sentinel" Version="$(MicroBuildCoreSentinelVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersion)" ExcludeAssets="all" />
+    <PackageReference Include="FakeSign" Version="$(FakeSignVersion)" ExcludeAssets="all" />
+    <PackageReference Include="xunit" Version="$(xunitVersion)" ExcludeAssets="all" />
+    <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" ExcludeAssets="all" />
+    <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.ReferenceAssemblies" Version="$(RoslynToolsReferenceAssembliesVersion)" ExcludeAssets="all" />
+    <PackageReference Include="pdb2pdb" Version="$(Pdb2PdbVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
-    <PackageReference Include="Roslyn.Build.Util" Version="$(RoslynBuildUtilVersion)" />
-    <PackageReference Include="RoslynTools.Microsoft.LocateVS" Version="$(RoslynToolsMicrosoftLocateVSVersion)" />
-    <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="$(RoslynToolsMicrosoftSignToolVersion)" />
-    <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" />
-    <PackageReference Include="RoslynTools.MSBuild" Version="$(RoslynToolsMSBuildVersion)" />
-    <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" />
-    <PackageReference Include="vswhere" Version="$(vswhereVersion)" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Roslyn.Build.Util" Version="$(RoslynBuildUtilVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.Microsoft.LocateVS" Version="$(RoslynToolsMicrosoftLocateVSVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="$(RoslynToolsMicrosoftSignToolVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynTools.MSBuild" Version="$(RoslynToolsMSBuildVersion)" ExcludeAssets="all" />
+    <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" ExcludeAssets="all" />
+    <PackageReference Include="vswhere" Version="$(vswhereVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" />
+    <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" ExcludeAssets="all" />
   </ItemGroup>
 </Project>

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -4,30 +4,31 @@
   <PropertyGroup>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <NonShipping>true</NonShipping>
+    <OutputType>Library</OutputType>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Sdk" Version="$(MicrosoftNetSdkVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.Build.Logging.StructuredLogger" Version="$(MicrosoftBuildLoggingStructuredLoggerVersion)" ExcludeAssets="all" />
-    <PackageReference Include="MicroBuild.Core.Sentinel" Version="$(MicroBuildCoreSentinelVersion)" ExcludeAssets="all" />
-    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" ExcludeAssets="all" />
-    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersion)" ExcludeAssets="all" />
-    <PackageReference Include="FakeSign" Version="$(FakeSignVersion)" ExcludeAssets="all" />
     <PackageReference Include="xunit" Version="$(xunitVersion)" ExcludeAssets="all" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" ExcludeAssets="all" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" ExcludeAssets="all" />
-    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.ReferenceAssemblies" Version="$(RoslynToolsReferenceAssembliesVersion)" ExcludeAssets="all" />
     <PackageReference Include="pdb2pdb" Version="$(Pdb2PdbVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="FakeSign" Version="$(FakeSignVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Core.Sentinel" Version="$(MicroBuildCoreSentinelVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" ExcludeAssets="all" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild" Version="$(MicroBuildPluginsSwixBuildVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" ExcludeAssets="all" />
     <PackageReference Include="Roslyn.Build.Util" Version="$(RoslynBuildUtilVersion)" ExcludeAssets="all" />
+    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.Microsoft.LocateVS" Version="$(RoslynToolsMicrosoftLocateVSVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="$(RoslynToolsMicrosoftSignToolVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" ExcludeAssets="all" />
@@ -37,5 +38,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" ExcludeAssets="all" />
   </ItemGroup>
 </Project>

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -31,7 +31,9 @@
     <PackageReference Include="RoslynTools.Microsoft.LocateVS" Version="$(RoslynToolsMicrosoftLocateVSVersion)" />
     <PackageReference Include="RoslynTools.Microsoft.SignTool" Version="$(RoslynToolsMicrosoftSignToolVersion)" />
     <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" />
+    <PackageReference Include="RoslynTools.MSBuild" Version="$(RoslynToolsMSBuildVersion)" />
     <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" />
+    <PackageReference Include="vswhere" Version="$(vswhereVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="dotnet-xunit" Version="$(dotnetxunitVersion)" />

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -165,11 +165,11 @@ function Ensure-BasicTool([string]$name, [string]$version = "") {
         $version = Get-PackageVersion $name
     }
 
-    $p = Join-Path (Get-PackagesDir) "$($name).$($version)"
+    $p = Join-Path (Get-PackagesDir) "$($name)\$($version)"
     if (-not (Test-Path $p)) {
         $toolsetProject = Join-Path $repoDir "build\ToolsetPackages\RoslynToolset.csproj"
         $dotnet = Ensure-DotnetSdk
-        Write-Host "Restoring $toolsetProject"
+        Write-Host "Downloading $name"
         Restore-Project $dotnet $toolsetProject
     }
     

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -366,7 +366,7 @@ function Get-VisualStudioDir() {
 # Clear out the NuGet package cache
 function Clear-PackageCache() {
     $dotnet = Ensure-DotnetSdk
-    Exec-Console $dotnet "nuget locals all -clear"
+    Exec-Console $dotnet "nuget locals all --clear"
 }
 
 # Restore a single project

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -365,8 +365,8 @@ function Get-VisualStudioDir() {
 
 # Clear out the NuGet package cache
 function Clear-PackageCache() {
-    $nuget = Ensure-NuGet
-    Exec-Block { & $nuget locals all -clear } | Out-Host
+    $dotnet = Ensure-DotnetSdk
+    Exec-Console $dotnet "nuget locals all -clear"
 }
 
 # Restore a single project

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -27,7 +27,6 @@ param (
     [switch]$sign = $false,
     [switch]$pack = $false,
     [switch]$binaryLog = $false,
-    [string]$msbuildDir = "",
     [string]$signType = "",
 
     # Test options 
@@ -61,7 +60,6 @@ function Print-Usage() {
     Write-Host "  -sign                     Sign our binaries"
     Write-Host "  -signType                 Type of sign: real, test, verify"
     Write-Host "  -pack                     Create our NuGet packages"
-    Write-Host "  -msbuildDir               MSBuild to use for operations"
     Write-Host "  -binaryLog                Create binary log for every MSBuild invocation"
     Write-Host "" 
     Write-Host "Test options" 
@@ -597,7 +595,7 @@ try {
 
     Process-Arguments
 
-    $msbuild, $msbuildDir = Ensure-MSBuildAndDir -msbuildDir $msbuildDir
+    $msbuild = Ensure-MSBuild
     $dotnet = Ensure-DotnetSdk
     $buildConfiguration = if ($release) { "Release" } else { "Debug" }
     $configDir = Join-Path $binariesDir $buildConfiguration

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -179,7 +179,9 @@ function Make-BootstrapBuild() {
 }
 
 function Build-Artifacts() { 
-    Run-MSBuild "Roslyn.sln" "/p:DeployExtension=false"
+    if ($build) { 
+        Run-MSBuild "Roslyn.sln" "/p:DeployExtension=false"
+    }
 
     if ($buildAll) {
         Build-ExtraSignArtifacts
@@ -281,6 +283,7 @@ function Build-NuGetPackages() {
         $buildArgs = '/p:SkipReleaseVersion=true /p:SkipPreReleaseVersion=true'
     }
 
+    Ensure-NuGet | Out-Null
     Run-MSBuild "src\NuGet\NuGet.proj" $buildArgs
 }
 
@@ -625,7 +628,7 @@ try {
         $bootstrapDir = Make-BootstrapBuild
     }
 
-    if ($build) {
+    if ($build -or $pack) {
         Build-Artifacts
     }
 

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -615,7 +615,7 @@ try {
 
     if ($restore) {
         Write-Host "Running restore"
-        Restore-All -msbuildDir $msbuildDir
+        Restore-All $dotnet
     }
 
     if ($isAnyTestSpecial) {

--- a/build/scripts/generate-compiler-code.ps1
+++ b/build/scripts/generate-compiler-code.ps1
@@ -86,10 +86,7 @@ function Run-GetText() {
 # Build all of the tools that we need to generate the syntax trees and ensure
 # they are in a published / runnable state.
 function Build-Tools() {
-    $msbuild = Ensure-MSBuild
-    $msbuildDir = Split-Path -parent $msbuild
-    $nuget = Ensure-NuGet
-
+    $dotnet = Ensure-DotnetSdk
     $list = @(
         'boundTreeGenerator;BoundTreeGenerator;BoundTreeGenerator\CompilersBoundTreeGenerator.csproj',
         'csharpErrorFactsGenerator;CSharpErrorFactsGenerator;CSharpErrorFactsGenerator\CSharpErrorFactsGenerator.csproj',
@@ -106,8 +103,8 @@ function Build-Tools() {
             $proj = $all[2]
             $fileName = [IO.Path]::GetFileNameWithoutExtension($proj)
             Write-Host "Building $fileName"
-            Restore-Project $proj -nuget $nuget -msbuildDir $msbuildDir
-            Exec-Command $msbuild "/t:Publish /p:Configuration=Debug /p:RuntimeIdentifier=win-x64 /v:m $proj" | Out-Null
+            Restore-Project $dotnet $proj
+            Exec-Command $dotnet "publish /p:Configuration=Debug /p:RuntimeIdentifier=win-x64 /v:m $proj" | Out-Null
 
             $exePath = Join-Path $binariesDir "Debug\Exes\$fileName\win-x64\publish\$($exeName).exe"
             if (-not (Test-Path $exePath)) { 

--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -26,7 +26,7 @@ function Run-Build([string]$rootDir, [switch]$restore = $false, [string]$logFile
 
         if ($restore) {
             Write-Host "Restoring the packages"
-            Restore-Project -fileName "Roslyn.sln" -nuget (Ensure-NuGet) -msbuildDir (Split-Path -parent $msbuild)
+            Restore-Project $dotnet "Roslyn.sln"
         }
 
         $args = "/nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:bootstrapDir /p:Features=`"debug-determinism`" /p:UseRoslynAnalyzers=false Roslyn.sln"
@@ -197,6 +197,7 @@ function Run-Test() {
 try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
 
+    $dotnet = Ensure-DotnetSdk
     $msbuild = Ensure-MSBuild
     if (($bootstrapDir -eq "") -or (-not ([IO.Path]::IsPathRooted($script:bootstrapDir)))) {
         Write-Host "The bootstrap build path must be absolute"

--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -97,7 +97,7 @@ try {
     $configDir = Join-Path $binariesDir $config
     $setupDir = Join-Path $repoDir "src\Setup"
 
-    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -cibuild:$cibuild -official:$official release:$release -sign -signType $signType -pack -testDesktop:$testDesktop -binaryLog }
+    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -cibuild:$cibuild -official:$official -release:$release -sign -signType $signType -pack -testDesktop:$testDesktop -binaryLog }
     Copy-InsertionItems
 
     # Insertion scripts currently look for a sentinel file on the drop share to determine that the build was green

--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -115,8 +115,7 @@ try {
     # one job runs with a clean cache and assures all packages we depend on are restored during 
     # the restore phase. As opposed to getting lucky based on a NuGet being available in the cache.
     if ($cibuild) {
-        $nuget = Ensure-NuGet
-        Exec-Block { & $nuget locals all -clear } | Out-Host
+        Clear-PackageCache
     }
 
     $msbuild, $msbuildDir = Ensure-MSBuildAndDir -msbuildDir $msbuildDir

--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -48,7 +48,7 @@ function Publish-NuGet([string]$packageDir, [string]$uploadUrl) {
             }
 
             if (-not $test) {
-                Exec-Console $nuget "push $nupkg -Source $uploadUrl -ApiKey $apiKey -NonInteractive -Verbosity quiet"
+                Exec-Console $dotnet "nuget push $nupkg --source $uploadUrl --apiKey $apiKey -v q"
             }
         }
     } 
@@ -147,7 +147,7 @@ function Normalize-BranchName([string]$branchName) {
 
 try {
     . (Join-Path $PSScriptRoot "..\..\..\build\scripts\build-utils.ps1")
-    $nuget = Ensure-NuGet
+    $dotnet = Ensure-DotnetExe
     $nugetDir = Join-Path $configDir "NuGet"
 
     if ($configDir -eq "") {


### PR DESCRIPTION
Presently we are using a mix of msbuild.exe, dotnet.exe and nuget.exe in our build. This is a lot of tools to maintain and keep in sync. This change removes nuget.exe from our build in favor of using `dotnet restore` instead. This also means that as we move forward with the SDK updates we will get updated restore behavior / warnings as well. 