### PR TITLE
NormalizeWhitespace: no space between keyword and open paren, …

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -205,6 +205,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     return LineBreaksAfterCloseBrace(currentToken, nextToken);
 
                 case SyntaxKind.CloseParenToken:
+                    // Note: the `where` case handles constraints on method declarations
+                    //  and also `where` clauses (consistently with other LINQ cases below)
                     return (((currentToken.Parent is StatementSyntax) && nextToken.Parent != currentToken.Parent)
                         || nextToken.Kind() == SyntaxKind.OpenBraceToken
                         || nextToken.Kind() == SyntaxKind.WhereKeyword) ? 1 : 0;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -206,7 +206,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
                 case SyntaxKind.CloseParenToken:
                     return (((currentToken.Parent is StatementSyntax) && nextToken.Parent != currentToken.Parent)
-                        || nextToken.Kind() == SyntaxKind.OpenBraceToken) ? 1 : 0;
+                        || nextToken.Kind() == SyntaxKind.OpenBraceToken
+                        || nextToken.Kind() == SyntaxKind.WhereKeyword) ? 1 : 0;
 
                 case SyntaxKind.CloseBracketToken:
                     if (currentToken.Parent is AttributeListSyntax && !(currentToken.Parent.Parent is ParameterSyntax))
@@ -428,6 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     !next.IsKind(SyntaxKind.QuestionToken) &&
                     !next.IsKind(SyntaxKind.SemicolonToken) &&
                     !next.IsKind(SyntaxKind.OpenBracketToken) &&
+                    (!next.IsKind(SyntaxKind.OpenParenToken) || KeywordNeedsSeparatorBeforeOpenParen(token.Kind())) &&
                     !next.IsKind(SyntaxKind.CloseParenToken) &&
                     !next.IsKind(SyntaxKind.CloseBraceToken) &&
                     !next.IsKind(SyntaxKind.ColonColonToken) &&
@@ -453,6 +455,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
 
             return false;
+        }
+
+        private static bool KeywordNeedsSeparatorBeforeOpenParen(SyntaxKind kind)
+        {
+            switch (kind)
+            {
+                case SyntaxKind.TypeOfKeyword:
+                case SyntaxKind.DefaultKeyword:
+                case SyntaxKind.NewKeyword:
+                case SyntaxKind.BaseKeyword:
+                case SyntaxKind.ThisKeyword:
+                case SyntaxKind.CheckedKeyword:
+                case SyntaxKind.UncheckedKeyword:
+                case SyntaxKind.SizeOfKeyword:
+                case SyntaxKind.ArgListKeyword:
+                    return false;
+                default:
+                    return true;
+            }
         }
 
         private static bool IsXmlTextToken(SyntaxKind kind)

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -235,6 +235,55 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeDeclaration("class c{void M([a]int x,[b] [c,d]int y){}}", "class c\r\n{\r\n  void M([a] int x, [b][c, d] int y)\r\n  {\r\n  }\r\n}");
         }
 
+        [Fact]
+        [WorkItem(23618, "https://github.com/dotnet/roslyn/issues/23618")]
+        public void TestSpacingOnInvocationLikeKeywords()
+        {
+            // no space between typeof and (
+            TestNormalizeExpression("typeof (T)", "typeof(T)");
+
+            // no space between sizeof and (
+            TestNormalizeExpression("sizeof (T)", "sizeof(T)");
+
+            // no space between default and (
+            TestNormalizeExpression("default (T)", "default(T)");
+
+            // no space between new and (
+            // newline between > and where
+            TestNormalizeDeclaration(
+                "class C<T> where T : new() { }",
+                "class C<T>\r\n  where T : new()\r\n{\r\n}");
+
+            // no space between this and (
+            TestNormalizeDeclaration(
+                "class C { C() : this () { } }",
+                "class C\r\n{\r\n  C(): this()\r\n  {\r\n  }\r\n}");
+
+            // no space between base and (
+            TestNormalizeDeclaration(
+                "class C { C() : base () { } }",
+                "class C\r\n{\r\n  C(): base()\r\n  {\r\n  }\r\n}");
+
+            // no space between checked and (
+            TestNormalizeExpression("checked (a)", "checked(a)");
+
+            // no space between unchecked and (
+            TestNormalizeExpression("unchecked (a)", "unchecked(a)");
+
+            // no space between __arglist and (
+            TestNormalizeExpression("__arglist (a)", "__arglist(a)");
+        }
+
+        [Fact]
+        [WorkItem(23618, "https://github.com/dotnet/roslyn/issues/23618")]
+        public void TestSpacingOnMethodConstraint()
+        {
+            // newline between ) and where
+            TestNormalizeDeclaration(
+                "class C { void M<T>() where T : struct { } }",
+                "class C\r\n{\r\n  void M<T>()\r\n    where T : struct\r\n  {\r\n  }\r\n}");
+        }
+
         [WorkItem(541684, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541684")]
         [Fact]
         public void TestNormalizeRegion1()

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -159,8 +159,8 @@ public class MyAttribute : Attribute { public MyAttribute(E value) { } }",
             VerifySyntax<AttributeListSyntax>(_g.Attribute(GetAttributeData(
 @"using System; 
 public class MyAttribute : Attribute { public MyAttribute(Type value) { } }",
-@"[MyAttribute(typeof(MyAttribute))]")),
-@"[global::MyAttribute(typeof (global::MyAttribute))]");
+@"[MyAttribute(typeof (MyAttribute))]")),
+@"[global::MyAttribute(typeof(global::MyAttribute))]");
 
             VerifySyntax<AttributeListSyntax>(_g.Attribute(GetAttributeData(
 @"using System; 
@@ -393,7 +393,7 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
         {
             VerifySyntax<BinaryExpressionSyntax>(_g.IsTypeExpression(_g.IdentifierName("x"), _g.IdentifierName("y")), "(x) is y");
             VerifySyntax<BinaryExpressionSyntax>(_g.TryCastExpression(_g.IdentifierName("x"), _g.IdentifierName("y")), "(x) as y");
-            VerifySyntax<TypeOfExpressionSyntax>(_g.TypeOfExpression(_g.IdentifierName("x")), "typeof (x)");
+            VerifySyntax<TypeOfExpressionSyntax>(_g.TypeOfExpression(_g.IdentifierName("x")), "typeof(x)");
         }
 
         [Fact]
@@ -913,7 +913,7 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                 _g.ConstructorDeclaration("c",
                     parameters: new[] { _g.ParameterDeclaration("p", _g.IdentifierName("t")) },
                     baseConstructorArguments: new[] { _g.IdentifierName("p") }),
-                "c(t p): base (p)\r\n{\r\n}");
+                "c(t p): base(p)\r\n{\r\n}");
         }
 
         [Fact]
@@ -1614,13 +1614,13 @@ public class C { } // end").Members[0];
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", _g.IdentifierName("b")),
-                "abstract void m<a>()where a : b;");
+                "abstract void m<a>()\r\n    where a : b;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", _g.IdentifierName("b"), _g.IdentifierName("c")),
-                "abstract void m<a>()where a : b, c;");
+                "abstract void m<a>()\r\n    where a : b, c;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
@@ -1640,43 +1640,43 @@ public class C { } // end").Members[0];
                         _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a", "x"),
                         "a", _g.IdentifierName("b"), _g.IdentifierName("c")),
                     "x", _g.IdentifierName("y")),
-                "abstract void m<a, x>()where a : b, c where x : y;");
+                "abstract void m<a, x>()\r\n    where a : b, c where x : y;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.Constructor),
-                "abstract void m<a>()where a : new ();");
+                "abstract void m<a>()\r\n    where a : new();");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.ReferenceType),
-                "abstract void m<a>()where a : class;");
+                "abstract void m<a>()\r\n    where a : class;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.ValueType),
-                "abstract void m<a>()where a : struct;");
+                "abstract void m<a>()\r\n    where a : struct;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.ReferenceType | SpecialTypeConstraintKind.Constructor),
-                "abstract void m<a>()where a : class, new ();");
+                "abstract void m<a>()\r\n    where a : class, new();");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.ReferenceType | SpecialTypeConstraintKind.ValueType),
-                "abstract void m<a>()where a : class;");
+                "abstract void m<a>()\r\n    where a : class;");
 
             VerifySyntax<MethodDeclarationSyntax>(
                 _g.WithTypeConstraint(
                     _g.WithTypeParameters(_g.MethodDeclaration("m", modifiers: DeclarationModifiers.Abstract), "a"),
                     "a", SpecialTypeConstraintKind.ReferenceType, _g.IdentifierName("b"), _g.IdentifierName("c")),
-                "abstract void m<a>()where a : class, b, c;");
+                "abstract void m<a>()\r\n    where a : class, b, c;");
 
             // type declarations
             VerifySyntax<ClassDeclarationSyntax>(
@@ -1709,7 +1709,7 @@ public class C { } // end").Members[0];
                         _g.DelegateDeclaration("d"),
                         "a", "b"),
                     "a", _g.IdentifierName("x")),
-            "delegate void d<a, b>()where a : x;");
+            "delegate void d<a, b>()\r\n    where a : x;");
         }
 
         [Fact]


### PR DESCRIPTION
…add newline before constraints

### Customer scenario
Parse some syntax and use `NormalizeWhitespace`. 
On an "invocation-like" keyword followed by an open paren, such as `new()`, `typeof(T)` or `default(T)`, there should be no space added.
On a method with a constraint, there should be a newline added before the `where`, just like on a type with a constraint.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23618

### Workarounds, if any
Adjust the syntax manually.

### Risk
### Performance impact
Low. Merely adding a few checks to existing list of checks that determine where to add a space or newline.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer.