### PR TITLE
Ruleset should also apply to "unused using" diagnostic

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -173,24 +173,6 @@ public class C : NotFound
                 );
         }
 
-        [Fact]
-        [WorkItem(22579, "https://github.com/dotnet/roslyn/issues/22579")]
-        public void UncessaryUsingNotReportedAsErrorWithRuleset()
-        {
-            string source = @"using System;";
-
-            var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
-                new[] { KeyValuePair.Create("CS8019", ReportDiagnostic.Error) });
-
-            var comp = CreateStandardCompilation(source, options: options);
-
-            comp.VerifyDiagnostics(
-                // (2,1): error CS8019: Unnecessary using directive.
-                // using System;
-                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1)
-                );
-        }
-
         [WorkItem(892467, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/892467")]
         [Fact]
         public void DiagnosticAnalyzerWarnAsErrorGlobal()

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -173,6 +173,24 @@ public class C : NotFound
                 );
         }
 
+        [Fact]
+        [WorkItem(22579, "https://github.com/dotnet/roslyn/issues/22579")]
+        public void UncessaryUsingNotReportedAsErrorWithRuleset()
+        {
+            string source = @"using System;";
+
+            var options = TestOptions.ReleaseDll.WithSpecificDiagnosticOptions(
+                new[] { KeyValuePair.Create("CS8019", ReportDiagnostic.Error) });
+
+            var comp = CreateStandardCompilation(source, options: options);
+
+            comp.VerifyDiagnostics(
+                // (2,1): error CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1)
+                );
+        }
+
         [WorkItem(892467, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/892467")]
         [Fact]
         public void DiagnosticAnalyzerWarnAsErrorGlobal()

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -799,7 +799,7 @@ namespace Microsoft.CodeAnalysis
                             // only report unused usings if we have success.
                             if (success)
                             {
-                                compilation.ReportUnusedImports(null, diagnostics, cancellationToken);
+                                compilation.ReportAndFilterUnusedImports(diagnostics, cancellationToken);
                             }
                         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1853,6 +1853,15 @@ namespace Microsoft.CodeAnalysis
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken);
 
+        internal void ReportAndFilterUnusedImports(
+            DiagnosticBag diagnostics,
+            CancellationToken cancellationToken)
+        {
+            var bag = new DiagnosticBag();
+            ReportUnusedImports(filterTree: null, bag, cancellationToken);
+            FilterAndAppendDiagnostics(diagnostics, bag.AsEnumerable(), exclude: null);
+        }
+
         /// <summary>
         /// Signals the event queue, if any, that we are done compiling.
         /// There should not be more compiling actions after this step.
@@ -2215,7 +2224,11 @@ namespace Microsoft.CodeAnalysis
 
                         if (success)
                         {
-                            ReportUnusedImports(null, diagnostics, cancellationToken);
+                            ReportAndFilterUnusedImports(diagnostics, cancellationToken);
+                            if (diagnostics.HasAnyErrors())
+                            {
+                                success = false;
+                            }
                         }
                    }
                 }


### PR DESCRIPTION
### Customer scenario
Set rule or compilation option to treat the "unused using" warning as an error. The compilation should fail when there is an unused using.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/22579

### Workarounds, if any
None that I know of.

### Risk
### Performance impact
Low. The diagnostics for unused usings are computed after other diagnostics, and so the existing filtering didn't apply. The fix adds similar filtering on those late-added diagnostics.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer.