### PR TITLE
Fixed completion for variable initializer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -9201,5 +9201,44 @@ class C
 ";
             await VerifyItemExistsAsync(markup, "o");
         }
+
+        [WorkItem(13682, "https://github.com/dotnet/roslyn/issues/13682")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompletionDoesNotHaveTargetTypeAfterCast()
+        {
+            var code = @"
+interface IVsSolution {}
+interface IVsSolution5{}
+
+class C
+{
+    void M()
+    {
+        IVsSolution solution = null;
+        var solution5 = (IVsSolution5)solution$$
+    }
+}
+";
+            await VerifyItemExistsAsync(code, "solution");
+            await VerifyItemIsAbsentAsync(code, "solution5");
+        }
+
+        [WorkItem(13682, "https://github.com/dotnet/roslyn/issues/13682")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotLocalVariableInItsDeclarator()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        var bar1 = 10;
+        var bar2 = bar$$
+    }
+}
+";
+            await VerifyItemExistsAsync(code, "bar1");
+            await VerifyItemIsAbsentAsync(code, "bar2");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -35,6 +35,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
             var hideAdvancedMembers = options.GetOption(RecommendationOptions.HideAdvancedMembers, semanticModel.Language);
             symbols = symbols.FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, semanticModel.Compilation);
 
+            var localdeclarationSyntax = context.TargetToken.Parent?.GetAncestor<VariableDeclaratorSyntax>();
+            if (localdeclarationSyntax != null && 
+                (localdeclarationSyntax.GetAncestor<VariableDeclarationSyntax>().Type.IsVar || 
+                localdeclarationSyntax.DescendantNodes().Any(n => n.IsKind(SyntaxKind.CastExpression))))
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(localdeclarationSyntax);
+                symbols = symbols.WhereAsArray(s => !s.Equals(symbol));
+            }
+
             return Task.FromResult(Tuple.Create<ImmutableArray<ISymbol>, SyntaxContext>(symbols, context));
         }
 


### PR DESCRIPTION
Fixes #13682
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
