### PR TITLE
Fix and re-enable portable signing

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     WithMetadataReferenceResolver(referenceDirectiveResolver).
                     WithAssemblyIdentityComparer(assemblyIdentityComparer).
                     WithXmlReferenceResolver(xmlFileResolver).
-                    WithStrongNameProvider(Arguments.GetStrongNameProvider(loggingFileSystem)).
+                    WithStrongNameProvider(Arguments.GetStrongNameProvider(loggingFileSystem, _tempDirectory)).
                     WithSourceReferenceResolver(sourceFileResolver));
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9721,6 +9721,24 @@ class C
             }
         }
 
+        [Fact]
+        public void StrongNameProviderWithCustomTempPath()
+        {
+            var tempDir = Temp.CreateDirectory();
+            var workingDir = Temp.CreateDirectory();
+            workingDir.CreateFile("a.cs");
+
+            var csc = new Csc(null, new BuildPaths("", workingDir.Path, null, tempDir.Path),
+                new[] { "/features:UseLegacyStrongNameProvider", "/nostdlib", "a.cs" },
+                analyzerLoader: null);
+            var comp = csc.CreateCompilation(new StringWriter(), new TouchedFileLogger(), errorLogger: null);
+            var desktopProvider = Assert.IsType<DesktopStrongNameProvider>(comp.Options.StrongNameProvider);
+            using (var inputStream = Assert.IsType<DesktopStrongNameProvider.TempFileStream>(desktopProvider.CreateInputStream()))
+            {
+                Assert.Equal(tempDir.Path, Path.GetDirectoryName(inputStream.Path));
+            }
+        }
+
         public class QuotedArgumentTests
         {
             private void VerifyQuotedValid<T>(string name, string value, T expected, Func<CSharpCommandLineArguments, T> getValue)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2470,17 +2470,6 @@ class B
                 Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
         }
 
-        [Fact]
-        public void VerifyMscorlib()
-        {
-            // This test is meant to verify that our verification code correctly calculates
-            // the signature for a well-known signed framework assembly
-            using (var fileStream = new FileStream(typeof(object).Assembly.Location, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                Assert.True(ILValidation.IsStreamFullSigned(fileStream));
-            }
-        }
-
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1208,57 +1208,57 @@ public class C
             }
         }
 
-        private static MethodInfo _peheaderSizeMethod;
+        private static MethodInfo s_peheaderSizeMethod;
         private static int PEHeaderSize(bool is32Bit)
         {
-            if (_peheaderSizeMethod == null)
+            if (s_peheaderSizeMethod == null)
             {
-                _peheaderSizeMethod = typeof(PEHeader).GetMethod("Size",
+                s_peheaderSizeMethod = typeof(PEHeader).GetMethod("Size",
                     BindingFlags.Static | BindingFlags.NonPublic);
             }
 
-            return (int)_peheaderSizeMethod.Invoke(null, new object[] { is32Bit });
+            return (int)s_peheaderSizeMethod.Invoke(null, new object[] { is32Bit });
         }
 
-        private static ConstructorInfo _blobCtor;
+        private static ConstructorInfo s_blobCtor;
         private static Blob MakeBlob(byte[] buffer, int offset, int size)
         {
-            if (_blobCtor == null)
+            if (s_blobCtor == null)
             {
-                _blobCtor = typeof(Blob).GetConstructor(
+                s_blobCtor = typeof(Blob).GetConstructor(
                     BindingFlags.NonPublic | BindingFlags.Instance,
                     Type.DefaultBinder,
                     new[] { typeof(byte[]), typeof(int), typeof(int) },
                     null);
             }
 
-            return (Blob)_blobCtor.Invoke(new object[] { buffer, offset, size });
+            return (Blob)s_blobCtor.Invoke(new object[] { buffer, offset, size });
         }
 
-        private static FieldInfo _bufferField;
+        private static FieldInfo s_bufferField;
         private static byte[] GetBlobBuffer(Blob blob)
         {
-            if (_bufferField == null)
+            if (s_bufferField == null)
             {
-                _bufferField = typeof(Blob).GetField("Buffer", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_bufferField = typeof(Blob).GetField("Buffer", BindingFlags.NonPublic | BindingFlags.Instance);
             }
 
-            return (byte[])_bufferField.GetValue(blob);
+            return (byte[])s_bufferField.GetValue(blob);
         }
 
-        private static MethodInfo _getContentToSignMethod;
+        private static MethodInfo s_getContentToSignMethod;
         private static IEnumerable<Blob> GetContentToSign(
             BlobBuilder peImage,
             int peHeadersSize,
             int peHeaderAlignment,
             Blob strongNameSignatureFixup)
         {
-            if (_getContentToSignMethod == null)
+            if (s_getContentToSignMethod == null)
             {
-                _getContentToSignMethod = typeof(PEBuilder).GetMethod("GetContentToSign", BindingFlags.Static | BindingFlags.NonPublic);
+                s_getContentToSignMethod = typeof(PEBuilder).GetMethod("GetContentToSign", BindingFlags.Static | BindingFlags.NonPublic);
             }
 
-            return (IEnumerable<Blob>)_getContentToSignMethod.Invoke(null, new object[]
+            return (IEnumerable<Blob>)s_getContentToSignMethod.Invoke(null, new object[]
             {
                 peImage,
                 peHeadersSize,

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -1137,10 +1142,131 @@ public class C
         {
             using (var metadata = ModuleMetadata.CreateFromStream(moduleContents))
             {
-                var flags = metadata.Module.PEReaderOpt.PEHeaders.CorHeader.Flags;
-                return CorFlags.StrongNameSigned == (flags & CorFlags.StrongNameSigned);
+                var metadataReader = metadata.MetadataReader;
+                var peReader = metadata.Module.PEReaderOpt;
+                var peHeaders = peReader.PEHeaders;
+                var flags = peHeaders.CorHeader.Flags;
+
+                bool is32bit = peHeaders.PEHeader.Magic == PEMagic.PE32;
+                const int SectionHeaderSize = 40;
+                int peHeadersSize = peHeaders.PEHeaderStartOffset
+                    + PEHeaderSize(is32bit)
+                    + SectionHeaderSize * peHeaders.SectionHeaders.Length;
+
+                if (CorFlags.StrongNameSigned != (flags & CorFlags.StrongNameSigned))
+                {
+                    return false;
+                }
+
+                var snDirectory = peReader.PEHeaders.CorHeader.StrongNameSignatureDirectory;
+                int rva = snDirectory.RelativeVirtualAddress;
+                int size = snDirectory.Size;
+                var signature = peReader.GetSectionData(rva).GetContent(0, size);
+                Assert.True(peHeaders.TryGetDirectoryOffset(snDirectory, out var snOffset));
+
+                moduleContents.Position = 0;
+                int peSize = (int)moduleContents.Length;
+                var peImage = new BlobBuilder(peSize);
+                Assert.Equal(peSize, peImage.TryWriteBytes(moduleContents, peSize));
+                byte[] buffer = GetBlobBuffer(peImage.GetBlobs().Single());
+
+                const int ChecksumOffset = 0x40;
+                uint expectedChecksum = peHeaders.PEHeader.CheckSum;
+                var checksumBlob = MakeBlob(buffer, peHeaders.PEHeaderStartOffset + ChecksumOffset, sizeof(uint));
+                var signatureBlob = MakeBlob(buffer, snOffset, size);
+
+                if (expectedChecksum != PeWriter.CalculateChecksum(peImage, checksumBlob))
+                {
+                    return false;
+                }
+
+                var snKey = CryptoBlobParser.ToRSAParameters(
+                    metadataReader.GetBlobBytes(metadataReader.GetAssemblyDefinition().PublicKey),
+                    includePrivateParameters: false);
+
+                // Signature is calculated with checksum zeroed
+                new BlobWriter(checksumBlob).WriteUInt32(0);
+
+                var content = GetContentToSign(peImage, peHeadersSize, peHeaders.PEHeader.FileAlignment, signatureBlob);
+                var hash = SigningUtilities.CalculateSha1(content);
+
+                var publicKey = CryptoBlobParser.ToRSAParameters(TestResources.General.snKey,
+                    includePrivateParameters: false);
+
+                using (var rsa = RSA.Create())
+                {
+                    rsa.ImportParameters(publicKey);
+                    var reversedSignature = signature.ToArray();
+                    Array.Reverse(reversedSignature);
+                    if (!rsa.VerifyHash(hash, reversedSignature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
+
+        private static MethodInfo _peheaderSizeMethod;
+        private static int PEHeaderSize(bool is32Bit)
+        {
+            if (_peheaderSizeMethod == null)
+            {
+                _peheaderSizeMethod = typeof(PEHeader).GetMethod("Size",
+                    BindingFlags.Static | BindingFlags.NonPublic);
+            }
+
+            return (int)_peheaderSizeMethod.Invoke(null, new object[] { is32Bit });
+        }
+
+        private static ConstructorInfo _blobCtor;
+        private static Blob MakeBlob(byte[] buffer, int offset, int size)
+        {
+            if (_blobCtor == null)
+            {
+                _blobCtor = typeof(Blob).GetConstructor(
+                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    Type.DefaultBinder,
+                    new[] { typeof(byte[]), typeof(int), typeof(int) },
+                    null);
+            }
+
+            return (Blob)_blobCtor.Invoke(new object[] { buffer, offset, size });
+        }
+
+        private static FieldInfo _bufferField;
+        private static byte[] GetBlobBuffer(Blob blob)
+        {
+            if (_bufferField == null)
+            {
+                _bufferField = typeof(Blob).GetField("Buffer", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+
+            return (byte[])_bufferField.GetValue(blob);
+        }
+
+        private static MethodInfo _getContentToSignMethod;
+        private static IEnumerable<Blob> GetContentToSign(
+            BlobBuilder peImage,
+            int peHeadersSize,
+            int peHeaderAlignment,
+            Blob strongNameSignatureFixup)
+        {
+            if (_getContentToSignMethod == null)
+            {
+                _getContentToSignMethod = typeof(PEBuilder).GetMethod("GetContentToSign", BindingFlags.Static | BindingFlags.NonPublic);
+            }
+
+            return (IEnumerable<Blob>)_getContentToSignMethod.Invoke(null, new object[]
+            {
+                peImage,
+                peHeadersSize,
+                peHeaderAlignment,
+                strongNameSignatureFixup
+            });
+        }
+
         private void ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(MemoryStream moduleContents, AttributeDescription expectedModuleAttr, bool legacyStrongName)
         {
             //a module doesn't get signed for real. It should have either a keyfile or keycontainer attribute

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -1121,15 +1121,14 @@ public class C
                 Assert.True(success.Success);
             }
 
-            Assert.True(IsFileSigned(tempFile));
+            Assert.True(IsFileFullSigned(tempFile));
         }
 
-        private static bool IsFileSigned(TempFile file)
+        private static bool IsFileFullSigned(TempFile file)
         {
-            //TODO should check to see that the output was actually signed
             using (var metadata = new FileStream(file.Path, FileMode.Open))
             {
-                return ILValidation.IsStreamSigned(metadata);
+                return ILValidation.IsStreamFullSigned(metadata);
             }
         }
 
@@ -1184,7 +1183,7 @@ public class Z
             success.Diagnostics.Verify();
 
             Assert.True(success.Success);
-            Assert.True(IsFileSigned(tempFile));
+            Assert.True(IsFileFullSigned(tempFile));
         }
 
         [Fact]
@@ -1415,8 +1414,8 @@ public class C {}";
             outStrm.Position = 0;
             refStrm.Position = 0;
 
-            Assert.True(ILValidation.IsStreamSigned(outStrm));
-            Assert.True(ILValidation.IsStreamSigned(refStrm));
+            Assert.True(ILValidation.IsStreamFullSigned(outStrm));
+            Assert.True(ILValidation.IsStreamFullSigned(refStrm));
         }
 
         [WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")]
@@ -2163,7 +2162,7 @@ public class C
                 Assert.True(success.Success);
             }
 
-            Assert.True(IsFileSigned(tempFile));
+            Assert.True(IsFileFullSigned(tempFile));
         }
 
         [Fact]
@@ -2469,6 +2468,17 @@ class B
             CreateStandardCompilation(string.Empty, options: options).VerifyDiagnostics(
                 // error CS8102: Public signing was specified and requires a public key, but no public key was specified.
                 Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
+        }
+
+        [Fact]
+        public void VerifyMscorlib()
+        {
+            // This test is meant to verify that our verification code correctly calculates
+            // the signature for a well-known signed framework assembly
+            using (var fileStream = new FileStream(typeof(object).Assembly.Location, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Assert.True(ILValidation.IsStreamFullSigned(fileStream));
+            }
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -282,12 +282,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public CultureInfo PreferredUILang { get; internal set; }
 
-        internal StrongNameProvider GetStrongNameProvider(StrongNameFileSystem fileSystem)
+        internal StrongNameProvider GetStrongNameProvider(
+            StrongNameFileSystem fileSystem,
+            string tempDirectory)
         {
             bool fallback = ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
                 CompilationOptionsCore.CryptoKeyContainer != null;
             return fallback ?
-                new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem) :
+                new DesktopStrongNameProvider(KeyFileSearchPaths, tempDirectory, fileSystem) :
                 (StrongNameProvider)new PortableStrongNameProvider(KeyFileSearchPaths, fileSystem);
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -284,10 +284,11 @@ namespace Microsoft.CodeAnalysis
 
         internal StrongNameProvider GetStrongNameProvider(StrongNameFileSystem fileSystem)
         {
-            // https://github.com/dotnet/roslyn/issues/23521
-            // Disable the portable strong name provider until we can find and fix the
-            // root cause of the bug
-            return new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem);
+            bool fallback = ParseOptionsCore.Features.ContainsKey("UseLegacyStrongNameProvider") ||
+                CompilationOptionsCore.CryptoKeyContainer != null;
+            return fallback ?
+                new DesktopStrongNameProvider(KeyFileSearchPaths, null, fileSystem) :
+                (StrongNameProvider)new PortableStrongNameProvider(KeyFileSearchPaths, fileSystem);
         }
 
         internal CommandLineArguments()

--- a/src/Compilers/Core/Portable/Interop/IClrStrongName.cs
+++ b/src/Compilers/Core/Portable/Interop/IClrStrongName.cs
@@ -132,10 +132,11 @@ namespace Microsoft.CodeAnalysis.Interop
             [In, MarshalAs(UnmanagedType.LPWStr)] string pwzFilePath,
             [In, MarshalAs(UnmanagedType.U4)] int dwInFlags);
 
-        [return: MarshalAs(UnmanagedType.I1)]
-        byte StrongNameSignatureVerificationEx(
+        [return: MarshalAs(UnmanagedType.Bool)]
+        bool StrongNameSignatureVerificationEx(
             [In, MarshalAs(UnmanagedType.LPWStr)] string pwzFilePath,
-            [In, MarshalAs(UnmanagedType.I1)] byte fForceVerification);
+            [In, MarshalAs(UnmanagedType.Bool)] bool fForceVerification,
+            out IntPtr ptr);
 
         [return: MarshalAs(UnmanagedType.U4)]
         int StrongNameSignatureVerificationFromImage(

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -249,6 +249,7 @@ namespace Microsoft.Cci
         private static void FixupChecksum(ExtendedPEBuilder peBuilder, BlobBuilder peBlob)
         {
             // Checksum fixup, workaround for https://github.com/dotnet/corefx/issues/25829
+            // Tracked by https://github.com/dotnet/roslyn/issues/23762
             // Since the checksum is calculated before signing in the PEBuilder,
             // we need to redo the calculation and write in the correct checksum
             Blob checksumBlob = getChecksumBlob(peBuilder);

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -258,18 +258,18 @@ namespace Microsoft.Cci
                     .GetValue(builder);
         }
 
-        private static MethodInfo _calculateChecksumMethod;
+        private static MethodInfo s_calculateChecksumMethod;
         // internal for testing
         internal static uint CalculateChecksum(BlobBuilder peBlob, Blob checksumBlob)
         {
-            if (_calculateChecksumMethod == null)
+            if (s_calculateChecksumMethod == null)
             {
-                _calculateChecksumMethod = typeof(PEBuilder).GetRuntimeMethods()
+                s_calculateChecksumMethod = typeof(PEBuilder).GetRuntimeMethods()
                     .Where(m => m.Name == "CalculateChecksum" && m.GetParameters().Length == 2)
                     .Single();
             }
 
-            return (uint)_calculateChecksumMethod.Invoke(null, new object[]
+            return (uint)s_calculateChecksumMethod.Invoke(null, new object[]
             {
                 peBlob,
                 checksumBlob,

--- a/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
+++ b/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
@@ -31,11 +31,7 @@ namespace Microsoft.CodeAnalysis
         {
             using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1))
             {
-                foreach (var blob in content)
-                {
-                    hash.AppendData(blob.GetBytes());
-                }
-
+                hash.AppendData(content);
                 return hash.GetHashAndReset();
             }
         }

--- a/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
+++ b/src/Compilers/Core/Portable/PEWriter/SigningUtilities.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Roslyn.Utilities;
 
-namespace Microsoft.Cci
+namespace Microsoft.CodeAnalysis
 {
     internal static class SigningUtilities
     {
@@ -27,11 +27,15 @@ namespace Microsoft.Cci
             }
         }
 
-        private static byte[] CalculateSha1(IEnumerable<Blob> content)
+        internal static byte[] CalculateSha1(IEnumerable<Blob> content)
         {
             using (var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA1))
             {
-                hash.AppendData(content);
+                foreach (var blob in content)
+                {
+                    hash.AppendData(blob.GetBytes());
+                }
+
                 return hash.GetHashAndReset();
             }
         }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      WithMetadataReferenceResolver(referenceDirectiveResolver).
                      WithAssemblyIdentityComparer(assemblyIdentityComparer).
                      WithXmlReferenceResolver(xmlFileResolver).
-                     WithStrongNameProvider(Arguments.GetStrongNameProvider(loggingFileSystem)).
+                     WithStrongNameProvider(Arguments.GetStrongNameProvider(loggingFileSystem, _tempDirectory)).
                      WithSourceReferenceResolver(sourceFileResolver))
         End Function
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8822,6 +8822,21 @@ End Module
             End Using
         End Sub
 
+        <Fact>
+        Public Sub StrongNameProviderWithCustomTempPath()
+            Dim tempDir = Temp.CreateDirectory()
+            Dim workingDir = Temp.CreateDirectory()
+            workingDir.CreateFile("a.vb")
+
+            Dim vbc = New Vbc(Nothing, New BuildPaths("", workingDir.Path, Nothing, tempDir.Path),
+                              {"/features:UseLegacyStrongNameProvider", "/nostdlib", "a.vb"},
+                              analyzerLoader:=Nothing)
+            Dim comp = vbc.CreateCompilation(New StringWriter(), New TouchedFileLogger(), errorLogger:=Nothing)
+            Dim desktopProvider = Assert.IsType(Of DesktopStrongNameProvider)(comp.Options.StrongNameProvider)
+            Using inputStream = Assert.IsType(Of DesktopStrongNameProvider.TempFileStream)(desktopProvider.CreateInputStream())
+                Assert.Equal(tempDir.Path, Path.GetDirectoryName(inputStream.Path))
+            End Using
+        End Sub
 
         Private Function MakeTrivialExe(Optional directory As String = Nothing) As String
             Return Temp.CreateFile(directory:=directory, prefix:="", extension:=".vb").WriteAllText("

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1142,7 +1142,7 @@ End Class
         Dim outStrm = New MemoryStream()
         Dim emitResult = other.Emit(outStrm)
         Assert.True(emitResult.Success)
-        Assert.True(ILValidation.IsStreamSigned(outStrm))
+        Assert.True(ILValidation.IsStreamFullSigned(outStrm))
     End Sub
 
     <WorkItem(545720, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545720")>
@@ -1304,7 +1304,7 @@ End Class
 
     Private Shared Sub AssertFileIsSigned(file As TempFile)
         Using peStream = New FileStream(file.Path, FileMode.Open)
-            Assert.True(ILValidation.IsStreamSigned(peStream))
+            Assert.True(ILValidation.IsStreamFullSigned(peStream))
         End Using
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1142,6 +1142,7 @@ End Class
         Dim outStrm = New MemoryStream()
         Dim emitResult = other.Emit(outStrm)
         Assert.True(emitResult.Success)
+        Assert.True(ILValidation.IsStreamSigned(outStrm))
     End Sub
 
     <WorkItem(545720, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545720")>
@@ -1243,13 +1244,12 @@ End Class
         Dim outStrm = New MemoryStream()
         Dim emitResult = comp.Emit(outStrm)
         Assert.True(emitResult.Success)
-
     End Sub
 
     Private Sub ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
         moduleContents As Stream,
-        expectedModuleAttr As AttributeDescription
-    )
+        expectedModuleAttr As AttributeDescription,
+        legacyStrongName As Boolean)
         ' a module doesn't get signed for real. It should have either a keyfile or keycontainer attribute
         ' parked on a typeRef named 'AssemblyAttributesGoHere.' When the module is added to an assembly, the
         ' resulting assembly is signed with the key referred to by the aforementioned attribute.
@@ -1260,8 +1260,14 @@ End Class
 
         Using metadata = ModuleMetadata.CreateFromStream(moduleContents)
             Dim flags = metadata.Module.PEReaderOpt.PEHeaders.CorHeader.Flags
-            ' confirm file does not claim to be signed
-            Assert.Equal(0, CInt(flags And CorFlags.StrongNameSigned))
+            If legacyStrongName Then
+                ' confirm file does not claim to be signed
+                Assert.Equal(0, CInt(flags And CorFlags.StrongNameSigned))
+            Else
+                ' portable signing should sign the module
+                Assert.Equal(CorFlags.StrongNameSigned, CInt(flags And CorFlags.StrongNameSigned))
+            End If
+
             Dim token As EntityHandle = metadata.Module.GetTypeRef(metadata.Module.GetAssemblyRef("mscorlib"), "System.Runtime.CompilerServices", "AssemblyAttributesGoHere")
             Assert.False(token.IsNil)   ' could the magic type ref be located? If not then the attribute's not there.
             Dim attrInfos = metadata.Module.FindTargetAttributes(token, expectedModuleAttr)
@@ -1276,9 +1282,14 @@ End Class
     </file>
 </compilation>
 
+            Dim snProvider As StrongNameProvider = If(legacyStrongName, s_defaultDesktopProvider, s_defaultPortableProvider)
+
             ' now that the module checks out, ensure that adding it to a compilation outputting a dll
             ' results in a signed assembly.
-            Dim assemblyComp = CreateCompilationWithMscorlibAndReferences(source, {metadata.GetReference()}, TestOptions.ReleaseDll.WithStrongNameProvider(s_defaultDesktopProvider))
+            Dim assemblyComp = CreateCompilationWithMscorlibAndReferences(
+                source,
+                {metadata.GetReference()},
+                TestOptions.ReleaseDll.WithStrongNameProvider(snProvider))
 
             Using finalStrm = tempFile.Open()
                 success = assemblyComp.Emit(finalStrm)
@@ -1292,15 +1303,13 @@ End Class
     End Sub
 
     Private Shared Sub AssertFileIsSigned(file As TempFile)
-        ' TODO should check to see that the output was actually signed
         Using peStream = New FileStream(file.Path, FileMode.Open)
-            Dim flags = New PEHeaders(peStream).CorHeader.Flags
-            Assert.Equal(CorFlags.StrongNameSigned, flags And CorFlags.StrongNameSigned)
+            Assert.True(ILValidation.IsStreamSigned(peStream))
         End Using
     End Sub
 
     <Fact>
-    Public Sub SignModuleKeyFileAttr()
+    Public Sub SignModuleKeyFileAttr_Legacy()
         Dim x = s_keyPairFile
 
         Dim source =
@@ -1317,7 +1326,10 @@ End Class
             source,
             options:=TestOptions.ReleaseModule.WithStrongNameProvider(s_defaultDesktopProvider))
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(other.EmitToStream(), AttributeDescription.AssemblyKeyFileAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            other.EmitToStream(),
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=True)
     End Sub
 
     <Fact>
@@ -1338,7 +1350,10 @@ End Class
         Dim success = other.Emit(outStrm)
         Assert.True(success.Success)
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyNameAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyNameAttribute,
+            legacyStrongName:=True)
     End Sub
 
     <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
@@ -1358,7 +1373,10 @@ End Class
         Dim success = other.Emit(outStrm)
         Assert.True(success.Success)
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyNameAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyNameAttribute,
+            legacyStrongName:=True)
     End Sub
 
     <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
@@ -1374,13 +1392,42 @@ End Class
     ]]></file>
 </compilation>
 
-        Dim other = CreateCompilationWithMscorlib(source, TestOptions.ReleaseModule.WithCryptoKeyContainer("roslynTestContainer").WithStrongNameProvider(s_defaultDesktopProvider))
+        Dim other = CreateCompilationWithMscorlib(
+            source,
+            TestOptions.ReleaseModule.WithCryptoKeyContainer("roslynTestContainer").WithStrongNameProvider(s_defaultDesktopProvider))
 
         Dim outStrm = New MemoryStream()
         Dim success = other.Emit(outStrm)
         Assert.True(success.Success)
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyNameAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyNameAttribute,
+            legacyStrongName:=True)
+    End Sub
+
+    <Fact>
+    Public Sub SignModuleKeyFileAttr()
+        Dim x = s_keyPairFile
+
+        Dim source =
+<compilation>
+    <file name="a.vb">
+        <![CDATA[<]]>Assembly: System.Reflection.AssemblyKeyFile("<%= x %>")>
+
+Public Class C
+End Class
+    </file>
+</compilation>
+
+        Dim other = CreateCompilationWithMscorlib(
+            source,
+            options:=TestOptions.ReleaseModule.WithStrongNameProvider(s_defaultPortableProvider))
+
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            other.EmitToStream(),
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=False)
     End Sub
 
     <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
@@ -1406,7 +1453,7 @@ BC37207: Attribute 'System.Reflection.AssemblyKeyNameAttribute' given in a sourc
 
     <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
     <Fact>
-    Public Sub SignModuleKeyFileCmdLine()
+    Public Sub SignModuleKeyFileCmdLine_Legacy()
         Dim source =
 <compilation>
     <file name="a.vb">
@@ -1423,12 +1470,15 @@ End Class
         Dim success = other.Emit(outStrm)
         Assert.True(success.Success)
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=True)
     End Sub
 
     <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
     <Fact>
-    Public Sub SignModuleKeyFileCmdLine_1()
+    Public Sub SignModuleKeyFileCmdLine_1_Legacy()
         Dim x = s_keyPairFile
         Dim source =
 <compilation>
@@ -1448,7 +1498,63 @@ End Class
         Dim success = other.Emit(outStrm)
         Assert.True(success.Success)
 
-        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(outStrm, AttributeDescription.AssemblyKeyFileAttribute)
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=True)
+    End Sub
+
+    <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
+    <Fact>
+    Public Sub SignModuleKeyFileCmdLine()
+        Dim source =
+<compilation>
+    <file name="a.vb">
+Public Class C
+End Class
+    </file>
+</compilation>
+
+        Dim other = CreateCompilationWithMscorlib(
+            source,
+            options:=TestOptions.ReleaseModule.WithCryptoKeyFile(s_keyPairFile).WithStrongNameProvider(s_defaultPortableProvider))
+
+        Dim outStrm = New MemoryStream()
+        Dim success = other.Emit(outStrm)
+        Assert.True(success.Success)
+
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=False)
+    End Sub
+
+    <WorkItem(531195, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531195")>
+    <Fact>
+    Public Sub SignModuleKeyFileCmdLine_1()
+        Dim x = s_keyPairFile
+        Dim source =
+<compilation>
+    <file name="a.vb">
+        <![CDATA[<]]>assembly: System.Reflection.AssemblyKeyFile("<%= x %>")>        
+
+Public Class C
+End Class
+    </file>
+</compilation>
+
+        Dim other = CreateCompilationWithMscorlib(
+            source,
+            options:=TestOptions.ReleaseModule.WithCryptoKeyFile(s_keyPairFile).WithStrongNameProvider(s_defaultPortableProvider))
+
+        Dim outStrm = New MemoryStream()
+        Dim success = other.Emit(outStrm)
+        Assert.True(success.Success)
+
+        ConfirmModuleAttributePresentAndAddingToAssemblyResultsInSignedOutput(
+            outStrm,
+            AttributeDescription.AssemblyKeyFileAttribute,
+            legacyStrongName:=False)
     End Sub
 
     <Fact>

--- a/src/Test/Utilities/Portable/Metadata/ILValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILValidation.cs
@@ -85,12 +85,9 @@ namespace Roslyn.Test.Utilities
                 IEnumerable<Blob> content = GetContentToSign(peImage, peHeadersSize, peHeaders.PEHeader.FileAlignment, signatureBlob);
                 byte[] hash = SigningUtilities.CalculateSha1(content);
 
-                var publicKey = CryptoBlobParser.ToRSAParameters(TestResources.General.snKey,
-                    includePrivateParameters: false);
-
                 using (var rsa = RSA.Create())
                 {
-                    rsa.ImportParameters(publicKey);
+                    rsa.ImportParameters(snKey);
                     var reversedSignature = signature.ToArray();
 
                     // Unknown why the signature is reversed, but this matches the behavior of the CLR

--- a/src/Test/Utilities/Portable/Metadata/ILValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILValidation.cs
@@ -3,16 +3,175 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Xml;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis;
 using Microsoft.Metadata.Tools;
 
 namespace Roslyn.Test.Utilities
 {
     public static class ILValidation
     {
+        public static bool IsStreamSigned(Stream moduleContents)
+        {
+            moduleContents.Position = 0;
+
+            using (var metadata = ModuleMetadata.CreateFromStream(moduleContents))
+            {
+                var metadataReader = metadata.MetadataReader;
+                var peReader = metadata.Module.PEReaderOpt;
+                var peHeaders = peReader.PEHeaders;
+                var flags = peHeaders.CorHeader.Flags;
+
+                bool is32bit = peHeaders.PEHeader.Magic == PEMagic.PE32;
+                const int SectionHeaderSize = 40;
+                int peHeadersSize = peHeaders.PEHeaderStartOffset
+                    + PEHeaderSize(is32bit)
+                    + SectionHeaderSize * peHeaders.SectionHeaders.Length;
+
+                if (CorFlags.StrongNameSigned != (flags & CorFlags.StrongNameSigned))
+                {
+                    return false;
+                }
+
+                var snDirectory = peReader.PEHeaders.CorHeader.StrongNameSignatureDirectory;
+                int rva = snDirectory.RelativeVirtualAddress;
+                int size = snDirectory.Size;
+                var signature = peReader.GetSectionData(rva).GetContent(0, size);
+                if (!peHeaders.TryGetDirectoryOffset(snDirectory, out var snOffset))
+                {
+                    return false;
+                }
+
+                moduleContents.Position = 0;
+                int peSize = (int)moduleContents.Length;
+                var peImage = new BlobBuilder(peSize);
+                if (peSize != peImage.TryWriteBytes(moduleContents, peSize))
+                {
+                    return false;
+                }
+
+                byte[] buffer = GetBlobBuffer(peImage.GetBlobs().Single());
+
+                const int ChecksumOffset = 0x40;
+                uint expectedChecksum = peHeaders.PEHeader.CheckSum;
+                var checksumBlob = MakeBlob(buffer, peHeaders.PEHeaderStartOffset + ChecksumOffset, sizeof(uint));
+                var signatureBlob = MakeBlob(buffer, snOffset, size);
+
+                if (expectedChecksum != PeWriter.CalculateChecksum(peImage, checksumBlob))
+                {
+                    return false;
+                }
+
+                var snKey = CryptoBlobParser.ToRSAParameters(
+                    metadataReader.GetBlobBytes(metadataReader.GetAssemblyDefinition().PublicKey),
+                    includePrivateParameters: false);
+
+                // Signature is calculated with checksum zeroed
+                new BlobWriter(checksumBlob).WriteUInt32(0);
+
+                var content = GetContentToSign(peImage, peHeadersSize, peHeaders.PEHeader.FileAlignment, signatureBlob);
+                var hash = SigningUtilities.CalculateSha1(content);
+
+                var publicKey = CryptoBlobParser.ToRSAParameters(TestResources.General.snKey,
+                    includePrivateParameters: false);
+
+                using (var rsa = RSA.Create())
+                {
+                    rsa.ImportParameters(publicKey);
+                    var reversedSignature = signature.ToArray();
+                    Array.Reverse(reversedSignature);
+                    if (!rsa.VerifyHash(hash, reversedSignature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        private static MethodInfo s_peheaderSizeMethod;
+        private static int PEHeaderSize(bool is32Bit)
+        {
+            if (s_peheaderSizeMethod == null)
+            {
+                Interlocked.CompareExchange(
+                    ref s_peheaderSizeMethod,
+                    typeof(PEHeader).GetMethod(
+                        "Size",
+                        BindingFlags.Static | BindingFlags.NonPublic),
+                    null);
+            }
+
+            return (int)s_peheaderSizeMethod.Invoke(null, new object[] { is32Bit });
+        }
+
+        private static ConstructorInfo s_blobCtor;
+        private static Blob MakeBlob(byte[] buffer, int offset, int size)
+        {
+            if (s_blobCtor == null)
+            {
+                Interlocked.CompareExchange(
+                    ref s_blobCtor,
+                    typeof(Blob).GetConstructors(
+                        BindingFlags.NonPublic | BindingFlags.Instance).Single(),
+                    null);
+            }
+
+            return (Blob)s_blobCtor.Invoke(new object[] { buffer, offset, size });
+        }
+
+        private static FieldInfo s_bufferField;
+        private static byte[] GetBlobBuffer(Blob blob)
+        {
+            if (s_bufferField == null)
+            {
+                Interlocked.CompareExchange(
+                    ref s_bufferField,
+                    typeof(Blob).GetField(
+                        "Buffer",
+                        BindingFlags.NonPublic | BindingFlags.Instance),
+                    null);
+            }
+
+            return (byte[])s_bufferField.GetValue(blob);
+        }
+
+        private static MethodInfo s_getContentToSignMethod;
+        private static IEnumerable<Blob> GetContentToSign(
+            BlobBuilder peImage,
+            int peHeadersSize,
+            int peHeaderAlignment,
+            Blob strongNameSignatureFixup)
+        {
+            if (s_getContentToSignMethod == null)
+            {
+                Interlocked.CompareExchange(
+                    ref s_getContentToSignMethod,
+                    typeof(PEBuilder).GetMethod(
+                        "GetContentToSign",
+                        BindingFlags.Static | BindingFlags.NonPublic),
+                    null);
+            }
+
+            return (IEnumerable<Blob>)s_getContentToSignMethod.Invoke(null, new object[]
+            {
+                peImage,
+                peHeadersSize,
+                peHeaderAlignment,
+                strongNameSignatureFixup
+            });
+        }
+
         public static unsafe string GetMethodIL(this ImmutableArray<byte> ilArray)
         {
             var result = new StringBuilder();

--- a/src/Test/Utilities/Portable/Metadata/ILValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILValidation.cs
@@ -92,7 +92,11 @@ namespace Roslyn.Test.Utilities
                 {
                     rsa.ImportParameters(publicKey);
                     var reversedSignature = signature.ToArray();
+
+                    // Unknown why the signature is reversed, but this matches the behavior of the CLR
+                    // signing implementation.
                     Array.Reverse(reversedSignature);
+
                     if (!rsa.VerifyHash(hash, reversedSignature, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1))
                     {
                         return false;

--- a/src/Test/Utilities/Portable/Metadata/ILValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILValidation.cs
@@ -32,7 +32,7 @@ namespace Roslyn.Test.Utilities
             {
                 moduleContents.Position = 0;
 
-                using (var metadata = ModuleMetadata.CreateFromStream(moduleContents))
+                using (var metadata = ModuleMetadata.CreateFromStream(moduleContents, leaveOpen: true))
                 {
                     var metadataReader = metadata.MetadataReader;
                     var peReader = metadata.Module.PEReaderOpt;


### PR DESCRIPTION
### Customer scenario

Re-enable portable signing, allowing binaries to be signed on Mac & Linux.

There were two separate bugs here:
    
1. Fixing up the MVID of the binary was being done *after* signing,
    when it should be done before.

2. System.Reflection.Metadata has a bug where calculating the
    checksum occurs before signing, when it should happen after.

Both of these isues have been fixed and the helper utility that checks
to see whether a binary was signed has been changed to verify that the
signature and checksums of the binaries are valid, not just that the
signed bit is set on the assembly.

### Bugs this fixes

Fixes #23521

### Workarounds, if any

None. Binaries cannot be strongname signed on Mac or Linux without this change.

### Risk

This change is isolated to signing.

### Performance impact

None. Portable signing is likely faster since it allows PE streams to be signed without
copying to a temporary file.

### Is this a regression from a previous update?

No.

### Root cause analysis

The primary helper used by the signing tests, IsStreamSigned, only checked to see
if the sign bit was set, not that the signature was valid. This helper has been modified
to use the verification used by System.Reflection.Metadata for its tests as well. That
helper includes a test that verifies a large number of core framework types (mscorlib, et al)
and thus is very likely to produce the same verification as the CLR itself.

### How was the bug found?

Toolset insertion into Visual Studio, which verified the strong name signatures after signing.
