### PR TITLE
Pass in optional arguments by ref

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Step three: Now fill in the optional arguments.
-            InsertMissingOptionalArguments(syntax, optionalParametersMethod.Parameters, actualArguments, enableCallerInfo);
+            InsertMissingOptionalArguments(syntax, optionalParametersMethod.Parameters, actualArguments, refKinds, enableCallerInfo);
 
             if (isComReceiver)
             {
@@ -1070,16 +1070,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void InsertMissingOptionalArguments(SyntaxNode syntax,
             ImmutableArray<ParameterSymbol> parameters,
             BoundExpression[] arguments,
+            ArrayBuilder<RefKind> refKinds,
             ThreeState enableCallerInfo = ThreeState.Unknown)
         {
+            Debug.Assert(refKinds.Count == arguments.Length);
+
             for (int p = 0; p < arguments.Length; ++p)
             {
                 if (arguments[p] == null)
                 {
                     ParameterSymbol parameter = parameters[p];
                     Debug.Assert(parameter.IsOptional);
+
                     arguments[p] = GetDefaultParameterValue(syntax, parameter, enableCallerInfo);
                     Debug.Assert(arguments[p].Type == parameter.Type);
+
+                    if (parameters[p].RefKind == RefKind.In)
+                    {
+                        Debug.Assert(refKinds[p] == RefKind.None);
+                        refKinds[p] = RefKind.In;
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Step three: Now fill in the optional arguments. (Dev11 uses the getter for optional arguments in
             // compound assignments, but for deconstructions we use the setter if the getter is missing.)
             var accessor = indexer.GetOwnOrInheritedGetMethod() ?? indexer.GetOwnOrInheritedSetMethod();
-            InsertMissingOptionalArguments(syntax, accessor.Parameters, actualArguments);
+            InsertMissingOptionalArguments(syntax, accessor.Parameters, actualArguments, refKinds);
 
             // For a call, step four would be to optimize away some of the temps.  However, we need them all to prevent
             // duplicate side-effects, so we'll skip that step.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -2069,6 +2069,7 @@ class Program
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Optional_NoArgs()
         {
@@ -2112,6 +2113,7 @@ IInvocationOperation (void Program.Test([in System.Int32 value = 5])) (Operation
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Optional_OneArg()
         {
@@ -2155,6 +2157,7 @@ IInvocationOperation (void Program.Test([in System.Int32 value = 5])) (Operation
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Optional_Optional_NoArgs()
         {
@@ -2205,6 +2208,7 @@ IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Optional_Optional_OneArg()
         {
@@ -2255,6 +2259,7 @@ IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Optional_Optional_TwoArgs()
         {
@@ -2305,6 +2310,7 @@ IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Required_Optional_OneArg()
         {
@@ -2355,6 +2361,7 @@ IInvocationOperation (void Program.Test(in System.Int32 value1, [in System.Int32
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_Method_Required_Optional_TwoArgs()
         {
@@ -2405,6 +2412,7 @@ IInvocationOperation (void Program.Test(in System.Int32 value1, [in System.Int32
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_CompoundAssignment_Optional_Optional_OneArg()
         {
@@ -2484,6 +2492,7 @@ IPropertyReferenceOperation: System.Int32 Program.this[[in System.Int32 p1 = 1],
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_CompoundAssignment_Optional_Optional_TwoArgs()
         {
@@ -2563,6 +2572,7 @@ IPropertyReferenceOperation: System.Int32 Program.this[[in System.Int32 p1 = 1],
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_CompoundAssignment_Required_Optional_OneArg()
         {
@@ -2642,6 +2652,7 @@ IPropertyReferenceOperation: System.Int32 Program.this[in System.Int32 p1, [in S
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void OptionalInParameters_CompoundAssignment_Required_Optional_TwoArgs()
         {
@@ -2721,6 +2732,7 @@ IPropertyReferenceOperation: System.Int32 Program.this[in System.Int32 p1, [in S
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void Issue23691_PassingInOptionalArgumentsByRef_OneArg()
         {
@@ -2773,6 +2785,7 @@ IInvocationOperation (void Program.A([in System.Double x = 1], [in System.String
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.ReadOnlyReferences)]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
         public void Issue23691_PassingInOptionalArgumentsByRef_TwoArgs()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -2069,7 +2070,7 @@ class Program
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void OptionalInParameters_Method_Optional()
+        public void OptionalInParameters_Method_Optional_NoArgs()
         {
             var code = @"
 class Program
@@ -2081,34 +2082,81 @@ class Program
 
     static void Main(string[] args)
     {
-        Test();
-        Test(10);
+        /*<bind>*/Test()/*<bind>*/;
     }
 }";
 
-            CompileAndVerify(code, expectedOutput: @"
-5
-10
-").VerifyIL("Program.Main", @"
+            CompileAndVerify(code, expectedOutput: "5").VerifyIL("Program.Main", @"
 {
-  // Code size       20 (0x14)
+  // Code size       10 (0xa)
   .maxstack  1
   .locals init (int V_0)
   IL_0000:  ldc.i4.5
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
   IL_0004:  call       ""void Program.Test(in int)""
-  IL_0009:  ldc.i4.s   10
-  IL_000b:  stloc.0
-  IL_000c:  ldloca.s   V_0
-  IL_000e:  call       ""void Program.Test(in int)""
-  IL_0013:  ret
+  IL_0009:  ret
 }");
+
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test([in System.Int32 value = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test()')
+  Instance Receiver: 
+    null
+  Arguments(1):
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: value) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Test()')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5, IsImplicit) (Syntax: 'Test()')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void OptionalInParameters_Method_Optional_Optional()
+        public void OptionalInParameters_Method_Optional_OneArg()
+        {
+            var code = @"
+class Program
+{
+    static void Test(in int value = 5)
+    {
+        System.Console.WriteLine(value);
+    }
+
+    static void Main(string[] args)
+    {
+        /*<bind>*/Test(10)/*<bind>*/;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: "10").VerifyIL("Program.Main", @"
+{
+  // Code size       11 (0xb)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.s   10
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""void Program.Test(in int)""
+  IL_000a:  ret
+}");
+
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test([in System.Int32 value = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test(10)')
+  Instance Receiver: 
+    null
+  Arguments(1):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value) (OperationKind.Argument, Type: null) (Syntax: '10')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 10) (Syntax: '10')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void OptionalInParameters_Method_Optional_Optional_NoArgs()
         {
             var code = @"
 class Program
@@ -2120,19 +2168,13 @@ class Program
 
     static void Main(string[] args)
     {
-        Test();
-        Test(2);
-        Test(3, 10);
+        /*<bind>*/Test()/*<bind>*/;
     }
 }";
 
-            CompileAndVerify(code, expectedOutput: @"
-(1, 5)
-(2, 5)
-(3, 10)
-").VerifyIL("Program.Main", @"
+            CompileAndVerify(code, expectedOutput: "(1, 5)").VerifyIL("Program.Main", @"
 {
-  // Code size       41 (0x29)
+  // Code size       14 (0xe)
   .maxstack  2
   .locals init (int V_0,
                 int V_1)
@@ -2143,27 +2185,128 @@ class Program
   IL_0005:  stloc.1
   IL_0006:  ldloca.s   V_1
   IL_0008:  call       ""void Program.Test(in int, in int)""
-  IL_000d:  ldc.i4.2
-  IL_000e:  stloc.0
-  IL_000f:  ldloca.s   V_0
-  IL_0011:  ldc.i4.5
-  IL_0012:  stloc.1
-  IL_0013:  ldloca.s   V_1
-  IL_0015:  call       ""void Program.Test(in int, in int)""
-  IL_001a:  ldc.i4.3
-  IL_001b:  stloc.0
-  IL_001c:  ldloca.s   V_0
-  IL_001e:  ldc.i4.s   10
-  IL_0020:  stloc.1
-  IL_0021:  ldloca.s   V_1
-  IL_0023:  call       ""void Program.Test(in int, in int)""
-  IL_0028:  ret
+  IL_000d:  ret
 }");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System.Int32 value2 = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test()')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: value1) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Test()')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsImplicit) (Syntax: 'Test()')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: value2) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Test()')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5, IsImplicit) (Syntax: 'Test()')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void OptionalInParameters_Method_Required_Optional()
+        public void OptionalInParameters_Method_Optional_Optional_OneArg()
+        {
+            var code = @"
+class Program
+{
+    static void Test(in int value1 = 1, in int value2 = 5)
+    {
+        System.Console.WriteLine($""({value1}, {value2})"");
+    }
+
+    static void Main(string[] args)
+    {
+        /*<bind>*/Test(2)/*<bind>*/;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: "(2, 5)").VerifyIL("Program.Main", @"
+{
+  // Code size       14 (0xe)
+  .maxstack  2
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  ldc.i4.2
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldc.i4.5
+  IL_0005:  stloc.1
+  IL_0006:  ldloca.s   V_1
+  IL_0008:  call       ""void Program.Test(in int, in int)""
+  IL_000d:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System.Int32 value2 = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test(2)')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value1) (OperationKind.Argument, Type: null) (Syntax: '2')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: value2) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Test(2)')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5, IsImplicit) (Syntax: 'Test(2)')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void OptionalInParameters_Method_Optional_Optional_TwoArgs()
+        {
+            var code = @"
+class Program
+{
+    static void Test(in int value1 = 1, in int value2 = 5)
+    {
+        System.Console.WriteLine($""({value1}, {value2})"");
+    }
+
+    static void Main(string[] args)
+    {
+        /*<bind>*/Test(3, 10)/*<bind>*/;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: "(3, 10)").VerifyIL("Program.Main", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  2
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  ldc.i4.3
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldc.i4.s   10
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  call       ""void Program.Test(in int, in int)""
+  IL_000e:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test([in System.Int32 value1 = 1], [in System.Int32 value2 = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test(3, 10)')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value1) (OperationKind.Argument, Type: null) (Syntax: '3')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value2) (OperationKind.Argument, Type: null) (Syntax: '10')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 10) (Syntax: '10')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void OptionalInParameters_Method_Required_Optional_OneArg()
         {
             var code = @"
 class Program
@@ -2175,17 +2318,13 @@ class Program
 
     static void Main(string[] args)
     {
-        Test(1);
-        Test(2, 10);
+        /*<bind>*/Test(1)/*<bind>*/;
     }
 }";
 
-            CompileAndVerify(code, expectedOutput: @"
-(1, 5)
-(2, 10)
-").VerifyIL("Program.Main", @"
+            CompileAndVerify(code, expectedOutput: "(1, 5)").VerifyIL("Program.Main", @"
 {
-  // Code size       28 (0x1c)
+  // Code size       14 (0xe)
   .maxstack  2
   .locals init (int V_0,
                 int V_1)
@@ -2196,20 +2335,78 @@ class Program
   IL_0005:  stloc.1
   IL_0006:  ldloca.s   V_1
   IL_0008:  call       ""void Program.Test(in int, in int)""
-  IL_000d:  ldc.i4.2
-  IL_000e:  stloc.0
-  IL_000f:  ldloca.s   V_0
-  IL_0011:  ldc.i4.s   10
-  IL_0013:  stloc.1
-  IL_0014:  ldloca.s   V_1
-  IL_0016:  call       ""void Program.Test(in int, in int)""
-  IL_001b:  ret
+  IL_000d:  ret
 }");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test(in System.Int32 value1, [in System.Int32 value2 = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test(1)')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value1) (OperationKind.Argument, Type: null) (Syntax: '1')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: value2) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'Test(1)')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5, IsImplicit) (Syntax: 'Test(1)')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void OptionalInParameters_CompoundAssignment_Optional_Optional()
+        public void OptionalInParameters_Method_Required_Optional_TwoArgs()
+        {
+            var code = @"
+class Program
+{
+    static void Test(in int value1, in int value2 = 5)
+    {
+        System.Console.WriteLine($""({value1}, {value2})"");
+    }
+
+    static void Main(string[] args)
+    {
+        /*<bind>*/Test(2, 10)/*<bind>*/;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: "(2, 10)").VerifyIL("Program.Main", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  2
+  .locals init (int V_0,
+                int V_1)
+  IL_0000:  ldc.i4.2
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  ldc.i4.s   10
+  IL_0006:  stloc.1
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  call       ""void Program.Test(in int, in int)""
+  IL_000e:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.Test(in System.Int32 value1, [in System.Int32 value2 = 5])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'Test(2, 10)')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value1) (OperationKind.Argument, Type: null) (Syntax: '2')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: value2) (OperationKind.Argument, Type: null) (Syntax: '10')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 10) (Syntax: '10')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void OptionalInParameters_CompoundAssignment_Optional_Optional_OneArg()
         {
             var code = @"
 class Program
@@ -2231,72 +2428,143 @@ class Program
     {
         var obj = new Program();
 
-        obj[3] += 10;
-        obj[4, 5] += 11;
+        /*<bind>*/obj[3]/*<bind>*/ += 10;
     }
 }";
 
             CompileAndVerify(code, expectedOutput: @"
 get p1=3 p2=2
 set p1=3 p2=2 to 10
-get p1=4 p2=5
-set p1=4 p2=5 to 11
 ").VerifyIL("Program.Main", @"
 {
-  // Code size       73 (0x49)
-  .maxstack  7
+  // Code size       39 (0x27)
+  .maxstack  6
   .locals init (Program V_0,
                 int V_1,
                 int V_2,
                 int V_3,
                 int V_4)
   IL_0000:  newobj     ""Program..ctor()""
-  IL_0005:  dup
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldc.i4.3
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldc.i4.2
-  IL_000d:  stloc.2
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  ldloc.0
-  IL_0011:  ldc.i4.3
-  IL_0012:  stloc.3
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  ldc.i4.2
-  IL_0016:  stloc.s    V_4
-  IL_0018:  ldloca.s   V_4
-  IL_001a:  callvirt   ""int Program.this[in int, in int].get""
-  IL_001f:  ldc.i4.s   10
-  IL_0021:  add
-  IL_0022:  callvirt   ""void Program.this[in int, in int].set""
-  IL_0027:  stloc.0
-  IL_0028:  ldloc.0
-  IL_0029:  ldc.i4.4
-  IL_002a:  stloc.1
-  IL_002b:  ldloca.s   V_1
-  IL_002d:  ldc.i4.5
-  IL_002e:  stloc.2
-  IL_002f:  ldloca.s   V_2
-  IL_0031:  ldloc.0
-  IL_0032:  ldc.i4.4
-  IL_0033:  stloc.3
-  IL_0034:  ldloca.s   V_3
-  IL_0036:  ldc.i4.5
-  IL_0037:  stloc.s    V_4
-  IL_0039:  ldloca.s   V_4
-  IL_003b:  callvirt   ""int Program.this[in int, in int].get""
-  IL_0040:  ldc.i4.s   11
-  IL_0042:  add
-  IL_0043:  callvirt   ""void Program.this[in int, in int].set""
-  IL_0048:  ret
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.3
+  IL_0008:  stloc.1
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldc.i4.2
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.3
+  IL_0011:  stloc.3
+  IL_0012:  ldloca.s   V_3
+  IL_0014:  ldc.i4.2
+  IL_0015:  stloc.s    V_4
+  IL_0017:  ldloca.s   V_4
+  IL_0019:  callvirt   ""int Program.this[in int, in int].get""
+  IL_001e:  ldc.i4.s   10
+  IL_0020:  add
+  IL_0021:  callvirt   ""void Program.this[in int, in int].set""
+  IL_0026:  ret
 }");
+
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(code, @"
+IPropertyReferenceOperation: System.Int32 Program.this[[in System.Int32 p1 = 1], [in System.Int32 p2 = 2]] { get; set; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'obj[3]')
+  Instance Receiver: 
+    ILocalReferenceOperation: obj (OperationKind.LocalReference, Type: Program) (Syntax: 'obj')
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p1) (OperationKind.Argument, Type: null) (Syntax: '3')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: p2) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'obj[3]')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2, IsImplicit) (Syntax: 'obj[3]')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void OptionalInParameters_CompoundAssignment_Required_Optional()
+        public void OptionalInParameters_CompoundAssignment_Optional_Optional_TwoArgs()
+        {
+            var code = @"
+class Program
+{
+    public int this[in int p1 = 1, in int p2 = 2]
+    {
+        get
+        {
+            System.Console.WriteLine($""get p1={p1} p2={p2}"");
+            return 0;
+        }
+        set
+        {
+            System.Console.WriteLine($""set p1={p1} p2={p2} to {value}"");
+        }
+    }
+
+    static void Main(string[] args)
+    {
+        var obj = new Program();
+
+        /*<bind>*/obj[4, 5]/*<bind>*/ += 11;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: @"
+get p1=4 p2=5
+set p1=4 p2=5 to 11
+").VerifyIL("Program.Main", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  6
+  .locals init (Program V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4)
+  IL_0000:  newobj     ""Program..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.4
+  IL_0008:  stloc.1
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldc.i4.5
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.4
+  IL_0011:  stloc.3
+  IL_0012:  ldloca.s   V_3
+  IL_0014:  ldc.i4.5
+  IL_0015:  stloc.s    V_4
+  IL_0017:  ldloca.s   V_4
+  IL_0019:  callvirt   ""int Program.this[in int, in int].get""
+  IL_001e:  ldc.i4.s   11
+  IL_0020:  add
+  IL_0021:  callvirt   ""void Program.this[in int, in int].set""
+  IL_0026:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(code, @"
+IPropertyReferenceOperation: System.Int32 Program.this[[in System.Int32 p1 = 1], [in System.Int32 p2 = 2]] { get; set; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'obj[4, 5]')
+  Instance Receiver: 
+    ILocalReferenceOperation: obj (OperationKind.LocalReference, Type: Program) (Syntax: 'obj')
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p1) (OperationKind.Argument, Type: null) (Syntax: '4')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 4) (Syntax: '4')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p2) (OperationKind.Argument, Type: null) (Syntax: '5')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void OptionalInParameters_CompoundAssignment_Required_Optional_OneArg()
         {
             var code = @"
 class Program
@@ -2318,80 +2586,150 @@ class Program
     {
         var obj = new Program();
 
-        obj[3] += 10;
-        obj[4, 5] += 11;
+        /*<bind>*/obj[3]/*<bind>*/ += 10;
     }
 }";
 
             CompileAndVerify(code, expectedOutput: @"
 get p1=3 p2=2
 set p1=3 p2=2 to 10
-get p1=4 p2=5
-set p1=4 p2=5 to 11
 ").VerifyIL("Program.Main", @"
 {
-  // Code size       73 (0x49)
-  .maxstack  7
+  // Code size       39 (0x27)
+  .maxstack  6
   .locals init (Program V_0,
                 int V_1,
                 int V_2,
                 int V_3,
                 int V_4)
   IL_0000:  newobj     ""Program..ctor()""
-  IL_0005:  dup
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldc.i4.3
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_1
-  IL_000c:  ldc.i4.2
-  IL_000d:  stloc.2
-  IL_000e:  ldloca.s   V_2
-  IL_0010:  ldloc.0
-  IL_0011:  ldc.i4.3
-  IL_0012:  stloc.3
-  IL_0013:  ldloca.s   V_3
-  IL_0015:  ldc.i4.2
-  IL_0016:  stloc.s    V_4
-  IL_0018:  ldloca.s   V_4
-  IL_001a:  callvirt   ""int Program.this[in int, in int].get""
-  IL_001f:  ldc.i4.s   10
-  IL_0021:  add
-  IL_0022:  callvirt   ""void Program.this[in int, in int].set""
-  IL_0027:  stloc.0
-  IL_0028:  ldloc.0
-  IL_0029:  ldc.i4.4
-  IL_002a:  stloc.1
-  IL_002b:  ldloca.s   V_1
-  IL_002d:  ldc.i4.5
-  IL_002e:  stloc.2
-  IL_002f:  ldloca.s   V_2
-  IL_0031:  ldloc.0
-  IL_0032:  ldc.i4.4
-  IL_0033:  stloc.3
-  IL_0034:  ldloca.s   V_3
-  IL_0036:  ldc.i4.5
-  IL_0037:  stloc.s    V_4
-  IL_0039:  ldloca.s   V_4
-  IL_003b:  callvirt   ""int Program.this[in int, in int].get""
-  IL_0040:  ldc.i4.s   11
-  IL_0042:  add
-  IL_0043:  callvirt   ""void Program.this[in int, in int].set""
-  IL_0048:  ret
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.3
+  IL_0008:  stloc.1
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldc.i4.2
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.3
+  IL_0011:  stloc.3
+  IL_0012:  ldloca.s   V_3
+  IL_0014:  ldc.i4.2
+  IL_0015:  stloc.s    V_4
+  IL_0017:  ldloca.s   V_4
+  IL_0019:  callvirt   ""int Program.this[in int, in int].get""
+  IL_001e:  ldc.i4.s   10
+  IL_0020:  add
+  IL_0021:  callvirt   ""void Program.this[in int, in int].set""
+  IL_0026:  ret
 }");
+
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(code, @"
+IPropertyReferenceOperation: System.Int32 Program.this[in System.Int32 p1, [in System.Int32 p2 = 2]] { get; set; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'obj[3]')
+  Instance Receiver: 
+    ILocalReferenceOperation: obj (OperationKind.LocalReference, Type: Program) (Syntax: 'obj')
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p1) (OperationKind.Argument, Type: null) (Syntax: '3')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: p2) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'obj[3]')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2, IsImplicit) (Syntax: 'obj[3]')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
 
         [Fact]
         [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
-        public void Issue23691_PassingInOptionalArgumentsByRef()
+        public void OptionalInParameters_CompoundAssignment_Required_Optional_TwoArgs()
+        {
+            var code = @"
+class Program
+{
+    public int this[in int p1, in int p2 = 2]
+    {
+        get
+        {
+            System.Console.WriteLine($""get p1={p1} p2={p2}"");
+            return 0;
+        }
+        set
+        {
+            System.Console.WriteLine($""set p1={p1} p2={p2} to {value}"");
+        }
+    }
+
+    static void Main(string[] args)
+    {
+        var obj = new Program();
+
+        /*<bind>*/obj[4, 5]/*<bind>*/ += 11;
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: @"
+get p1=4 p2=5
+set p1=4 p2=5 to 11
+").VerifyIL("Program.Main", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  6
+  .locals init (Program V_0,
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4)
+  IL_0000:  newobj     ""Program..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.4
+  IL_0008:  stloc.1
+  IL_0009:  ldloca.s   V_1
+  IL_000b:  ldc.i4.5
+  IL_000c:  stloc.2
+  IL_000d:  ldloca.s   V_2
+  IL_000f:  ldloc.0
+  IL_0010:  ldc.i4.4
+  IL_0011:  stloc.3
+  IL_0012:  ldloca.s   V_3
+  IL_0014:  ldc.i4.5
+  IL_0015:  stloc.s    V_4
+  IL_0017:  ldloca.s   V_4
+  IL_0019:  callvirt   ""int Program.this[in int, in int].get""
+  IL_001e:  ldc.i4.s   11
+  IL_0020:  add
+  IL_0021:  callvirt   ""void Program.this[in int, in int].set""
+  IL_0026:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<ElementAccessExpressionSyntax>(code, @"
+IPropertyReferenceOperation: System.Int32 Program.this[in System.Int32 p1, [in System.Int32 p2 = 2]] { get; set; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'obj[4, 5]')
+  Instance Receiver: 
+    ILocalReferenceOperation: obj (OperationKind.LocalReference, Type: Program) (Syntax: 'obj')
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p1) (OperationKind.Argument, Type: null) (Syntax: '4')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 4) (Syntax: '4')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: p2) (OperationKind.Argument, Type: null) (Syntax: '5')
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void Issue23691_PassingInOptionalArgumentsByRef_OneArg()
         {
             var code = @"
 class Program
 {
     static void Main()
     {
-        A(1);
-        B(1, 2);
+        /*<bind>*/A(1)/*<bind>*/;
     }
 
     static void A(in double x = 1, in string y = ""test"") => System.Console.WriteLine(y);
@@ -2399,18 +2737,12 @@ class Program
 
 }";
 
-            CompileAndVerify(code, expectedOutput: @"
-test
-6
-").VerifyIL("Program.Main", @"
+            CompileAndVerify(code, expectedOutput: "test").VerifyIL("Program.Main", @"
 {
-  // Code size       56 (0x38)
-  .maxstack  3
+  // Code size       26 (0x1a)
+  .maxstack  2
   .locals init (double V_0,
-                string V_1,
-                float V_2,
-                float V_3,
-                float V_4)
+                string V_1)
   IL_0000:  ldc.r8     1
   IL_0009:  stloc.0
   IL_000a:  ldloca.s   V_0
@@ -2418,18 +2750,89 @@ test
   IL_0011:  stloc.1
   IL_0012:  ldloca.s   V_1
   IL_0014:  call       ""void Program.A(in double, in string)""
-  IL_0019:  ldc.r4     1
-  IL_001e:  stloc.2
-  IL_001f:  ldloca.s   V_2
-  IL_0021:  ldc.r4     2
-  IL_0026:  stloc.3
-  IL_0027:  ldloca.s   V_3
-  IL_0029:  ldc.r4     3
-  IL_002e:  stloc.s    V_4
-  IL_0030:  ldloca.s   V_4
-  IL_0032:  call       ""void Program.B(in float, in float, in float)""
-  IL_0037:  ret
+  IL_0019:  ret
 }");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.A([in System.Double x = 1], [in System.String y = ""test""])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'A(1)')
+  Instance Receiver: 
+    null
+  Arguments(2):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument, Type: null) (Syntax: '1')
+        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Double, Constant: 1, IsImplicit) (Syntax: '1')
+          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          Operand: 
+            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: y) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'A(1)')
+        ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""test"", IsImplicit) (Syntax: 'A(1)')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
+        }
+
+        [Fact]
+        [WorkItem(23691, "https://github.com/dotnet/roslyn/issues/23691")]
+        public void Issue23691_PassingInOptionalArgumentsByRef_TwoArgs()
+        {
+            var code = @"
+class Program
+{
+    static void Main()
+    {
+        /*<bind>*/B(1, 2)/*<bind>*/;
+    }
+
+    static void A(in double x = 1, in string y = ""test"") => System.Console.WriteLine(y);
+    static void B(in float x, in float y, in float z = 3.0f) => System.Console.WriteLine(x * y * z);
+
+}";
+
+            CompileAndVerify(code, expectedOutput: "6").VerifyIL("Program.Main", @"
+{
+  // Code size       30 (0x1e)
+  .maxstack  3
+  .locals init (float V_0,
+                float V_1,
+                float V_2)
+  IL_0000:  ldc.r4     1
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  ldc.r4     2
+  IL_000d:  stloc.1
+  IL_000e:  ldloca.s   V_1
+  IL_0010:  ldc.r4     3
+  IL_0015:  stloc.2
+  IL_0016:  ldloca.s   V_2
+  IL_0018:  call       ""void Program.B(in float, in float, in float)""
+  IL_001d:  ret
+}");
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, @"
+IInvocationOperation (void Program.B(in System.Single x, in System.Single y, [in System.Single z = 3])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'B(1, 2)')
+  Instance Receiver: 
+    null
+  Arguments(3):
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument, Type: null) (Syntax: '1')
+        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Single, Constant: 1, IsImplicit) (Syntax: '1')
+          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          Operand: 
+            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument, Type: null) (Syntax: '2')
+        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Single, Constant: 2, IsImplicit) (Syntax: '2')
+          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+          Operand: 
+            ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      IArgumentOperation (ArgumentKind.DefaultValue, Matching Parameter: z) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: 'B(1, 2)')
+        ILiteralOperation (OperationKind.Literal, Type: System.Single, Constant: 3, IsImplicit) (Syntax: 'B(1, 2)')
+        InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)",
+        DiagnosticDescription.None);
         }
     }
 }


### PR DESCRIPTION
### Customer scenario

Not passing values to optional parameters of `RefKind.In` will emit invalid IL, causing runtime exceptions.

Code this fixes:

```C#
using System;

class Program
{
    static void Main()
    {
        // buffer overrun
        A(1);

        // throw NullReference or AccessViolation Exception
        B(1, 2);
    }

    static void A(in double x = 1, in string y = "") => Console.WriteLine(y);
    static double B(in float x, in float y, in float z = 1.0f) => x * y * z;

}
```

### Bugs this fixes

Fixes #23691

### Workarounds, if any

None.

### Risk

Low. This is fixing an already failing scenario.

### Performance impact

None.

### Is this a regression from a previous update?

This fixes a bug introduced by an earlier PR in the same release, and adds appropriate tests.

### Root cause analysis

An earlier change was made to distinguish between arguments passed with no modifier to an `in` parameter, and arguments passed explicitly by `in` at the call site. This change refactored the local rewriter, which introduced the bug. The compiler (now in master) ignores the refkind of optional parameters when trying to generate the values for non-existing arguments, and passes them by value.

### How was the bug found?

Customer reported on github.

### Test documentation updated?

--