### PR TITLE
Fix mac builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,6 +122,13 @@ then
     build_args+=" /p:BootstrapBuildPath=${bootstrap_path}"
 fi
 
+# https://github.com/dotnet/roslyn/issues/23736
+UNAME="$(uname)"
+if [[ "$UNAME" == "Darwin" ]]
+then
+    build_args+=" /p:UseRoslynAnalyzers=false"
+fi
+
 if [[ "${build}" == true ]]
 then
     echo "Building Compilers.sln"

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -45,8 +45,8 @@ do
     runtimeconfig_json="${file_name%.*}".runtimeconfig.json
 
     # If the user specifies a test on the command line, only run that one
-    # "${2:-}" => take second arg, empty string if unset (regex always matches if empty)
-    if [[ ! "${file_name}" =~ "${2:-}" ]]
+    # "${2:-}" => take second arg, empty string if unset
+    if [[ ("${2:-}" != "") && (! "${file_name}" =~ "${2:-}") ]]
     then
         echo "Skipping ${file_name}"
         continue


### PR DESCRIPTION
The Mac builds were primarily failing due to a regex check which behaves differently on Mac and Linux. In Linux an empty string matched all inputs while it does not on Mac builds. Added an explicit check for the empty case. 

Closes #23681