### PR TITLE
Fix semantic model on type parameters of local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1987,29 +1987,29 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentException("typeParameter not within tree");
             }
 
-            var typeParamList = typeParameter.Parent as TypeParameterListSyntax;
-            if (typeParamList != null)
+            if (typeParameter.Parent is TypeParameterListSyntax typeParamList)
             {
-                var memberDecl = typeParamList.Parent as MemberDeclarationSyntax;
-                if (memberDecl != null)
+                ISymbol parameterizedSymbol = null;
+                switch (typeParamList.Parent)
                 {
-                    var symbol = GetDeclaredSymbol(memberDecl, cancellationToken);
-                    if ((object)symbol != null)
-                    {
-                        var typeSymbol = symbol as NamedTypeSymbol;
-                        if ((object)typeSymbol != null)
-                        {
-                            return this.GetTypeParameterSymbol(typeSymbol.TypeParameters, typeParameter);
-                        }
+                    case MemberDeclarationSyntax memberDecl:
+                        parameterizedSymbol = GetDeclaredSymbol(memberDecl, cancellationToken);
+                        break;
+                    case LocalFunctionStatementSyntax localDecl:
+                        parameterizedSymbol = GetDeclaredSymbol(localDecl, cancellationToken);
+                        break;
+                }
 
-                        var methodSymbol = symbol as MethodSymbol;
-                        if ((object)methodSymbol != null)
-                        {
-                            return
-                                this.GetTypeParameterSymbol(methodSymbol.TypeParameters, typeParameter) ??
-                                ((object)methodSymbol.PartialDefinitionPart == null ? null : this.GetTypeParameterSymbol(methodSymbol.PartialDefinitionPart.TypeParameters, typeParameter));
-                        }
-                    }
+                switch (parameterizedSymbol)
+                {
+                    case NamedTypeSymbol typeSymbol:
+                        return this.GetTypeParameterSymbol(typeSymbol.TypeParameters, typeParameter);
+
+                    case MethodSymbol methodSymbol:
+                        return this.GetTypeParameterSymbol(methodSymbol.TypeParameters, typeParameter) ??
+                            ((object)methodSymbol.PartialDefinitionPart == null
+                                ? null
+                                : this.GetTypeParameterSymbol(methodSymbol.PartialDefinitionPart.TypeParameters, typeParameter));
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1998,6 +1998,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case LocalFunctionStatementSyntax localDecl:
                         parameterizedSymbol = GetDeclaredSymbol(localDecl, cancellationToken);
                         break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(typeParameter.Parent.Kind());
                 }
 
                 switch (parameterizedSymbol)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3366,7 +3366,7 @@ class C<T>
 
                 var parameterSymbol = model.GetDeclaredSymbol(parameter);
                 Assert.Equal(expected, parameterSymbol.Type.ToTestDisplayString());
-                Assert.True(symbol == parameterSymbol.Type);
+                Assert.Same(symbol, parameterSymbol.Type);
             }
         }
     }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.TypeParameterTypeSymbol.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.TypeParameterTypeSymbol.vb
@@ -25,6 +25,94 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Await TestAPIAndFeature(input)
         End Function
 
+        <WorkItem(23699, "https://github.com/dotnet/roslyn/issues/23699")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_LocalFunctionTypeParameter() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    void M()
+    {
+        void local<{|Definition:TPar$$am|}>([|TParam|] parameter)
+        {
+        }
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(23699, "https://github.com/dotnet/roslyn/issues/23699")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_LocalFunctionTypeParameter2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    void M()
+    {
+        void local<{|Definition:TParam|}>([|TPa$$ram|] parameter)
+        {
+        }
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(23699, "https://github.com/dotnet/roslyn/issues/23699")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_LocalFunctionTypeParameter3() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    void M<{|Definition:TParam|}>()
+    {
+        void local([|TPa$$ram|] parameter)
+        {
+        }
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(23699, "https://github.com/dotnet/roslyn/issues/23699")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestCSharp_LocalFunctionTypeParameter4() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    void M<{|Definition:TPa$$ram|}>()
+    {
+        void local([|TParam|] parameter)
+        {
+        }
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestTypeParameter2() As Task
             Dim input =


### PR DESCRIPTION
### Customer scenario
Use a type parameter in a local function, then place your cursor or use FindAllReferences on it. You expect usages to be found and highlighted.
Since the problem stems for semantic model API from the compiler, this also affects API users. If you call `GetDeclaredSymbol` on the syntax of such a type parameter, you should get the declared symbol back (rather than `null`). 

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23699

### Workarounds, if any
None that I can think of.

### Risk
### Performance impact
Low. The change is limited to the semantic model. That code has specialized logic to find which parameterized symbol a type parameter belong to. It handled method declarations, but not local function declarations.

### Is this a regression from a previous update?
No.

### Root cause analysis
This seems to have been a testing gap in the C# 7.0 local functions feature.

### How was the bug found?
Reported by customer.