### PR TITLE
Change local function definite assignment

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -124,16 +124,28 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var oldPending = SavePending(); // we do not support branches into a lambda
 
-            // Local functions don't affect outer state and are analyzed
-            // with everything unassigned and reachable
+            // SPEC: The entry point to a local function is always reachable.
+            // Captured variables are assigned if they are assigned on all
+            // branches into the local function.
+
             var savedState = this.State;
             this.State = this.ReachableState();
 
-            var usages = GetOrCreateLocalFuncUsages(localFuncSymbol);
-            var oldReads = usages.ReadVars;
-            usages.ReadVars = BitVector.Empty;
-
             if (!localFunc.WasCompilerGenerated) EnterParameters(localFuncSymbol.Parameters);
+
+            // Captured variables are definitely assigned if they are assigned on
+            // all branches into the local function, so we store all reads from
+            // possibly unassigned captured variables and later report definite
+            // assignment errors if any of the captured variables is not assigned
+            // on a particular branch.
+            // Assignments to captured variables are also recorded, as a local function
+            // definitely assigns captured variables on a call to a local function
+            // if that variable is definitely assigned at all branches out of the
+            // local function
+
+            var usages = GetOrCreateLocalFuncUsages(localFuncSymbol);
+            var oldReads = usages.ReadVars.Clone();
+            usages.ReadVars.Clear();
 
             var oldPending2 = SavePending();
 
@@ -158,6 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LeaveParameters(localFuncSymbol.Parameters, localFunc.Syntax, location);
 
+            // Intersect the state of all branches out of the local function
             LocalState stateAtReturn = this.State;
             foreach (PendingBranch pending in pendingReturns)
             {
@@ -173,13 +186,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 IntersectWith(ref stateAtReturn, ref this.State);
             }
 
-            // Check for changes to the read and write sets
+            // Check for changes to the possibly unassigned and assigned sets
+            // of captured variables
             if (RecordChangedVars(ref usages.WrittenVars,
                                   ref stateAtReturn,
                                   ref oldReads,
                                   ref usages.ReadVars) &&
                 usages.LocalFuncVisited)
             {
+                // If the sets have changed and we already used the results
+                // of this local function in another computation, the previous
+                // calculations may be invalid. We need to analyze until we
+                // reach a fixed-point. The previous writes are always valid,
+                // so they are stored in usages.WrittenVars, while the reads
+                // may be invalidated by new writes, so we throw the results out.
                 stateChangedAfterUse = true;
                 usages.LocalFuncVisited = false;
             }
@@ -261,8 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return mask;
         }
 
-        private bool IsCapturedInLocalFunction(int slot,
-            ParameterSymbol rangeVariableUnderlyingParameter = null)
+        private bool IsCapturedInLocalFunction(int slot)
         {
             if (slot <= 0) return false;
 
@@ -276,8 +295,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // container is higher in the tree than the nearest
             // local function
             var nearestLocalFunc = GetNearestLocalFunctionOpt(currentMethodOrLambda);
-            return (object)nearestLocalFunc != null &&
-                   IsCaptured(rootSymbol, nearestLocalFunc, rangeVariableUnderlyingParameter);
+
+            return !(nearestLocalFunc is null) && IsCaptured(rootSymbol, nearestLocalFunc);
         }
 
         private LocalFuncUsages GetOrCreateLocalFuncUsages(LocalFunctionSymbol localFunc)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -394,38 +394,52 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="rangeVariableUnderlyingParameter">If variable.Kind is RangeVariable, its underlying lambda parameter. Else null.</param>
         private void CheckCaptured(Symbol variable, ParameterSymbol rangeVariableUnderlyingParameter = null)
         {
-            if (IsCaptured(variable,
-                           currentMethodOrLambda,
-                           rangeVariableUnderlyingParameter))
+            if (IsCaptured(rangeVariableUnderlyingParameter ?? variable, currentMethodOrLambda))
             {
                 NoteCaptured(variable);
             }
         }
 
-        private static bool IsCaptured(Symbol variable,
-                                         MethodSymbol containingMethodOrLambda,
-                                         ParameterSymbol rangeVariableUnderlyingParameter)
+        private static bool IsCaptured(Symbol variable, MethodSymbol containingMethodOrLambda)
         {
             switch (variable.Kind)
             {
-                case SymbolKind.Local:
-                    if (((LocalSymbol)variable).IsConst) break;
-                    goto case SymbolKind.Parameter;
-                case SymbolKind.Parameter:
-                    if (containingMethodOrLambda != variable.ContainingSymbol)
-                    {
-                        return true;
-                    }
-                    break;
+                case SymbolKind.Field:
+                case SymbolKind.Property:
+                case SymbolKind.Event:
+                // Range variables are not captured, but their underlying parameters
+                // may be. If this is a range underlying parameter it will be a
+                // ParameterSymbol, not a RangeVariableSymbol.
                 case SymbolKind.RangeVariable:
-                    if (rangeVariableUnderlyingParameter != null &&
-                        containingMethodOrLambda != rangeVariableUnderlyingParameter.ContainingSymbol)
+                    return false;
+
+                case SymbolKind.Local:
+                    if (((LocalSymbol)variable).IsConst)
                     {
-                        return true;
+                        return false;
                     }
                     break;
+
+                case SymbolKind.Parameter:
+                    break;
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(variable.Kind);
             }
-            return false;
+
+            // Walk up the containing symbols until we find the target function, in which
+            // case the variable is not captured by the target function, or null, in which 
+            // case it is.
+            var currentFunction = variable.ContainingSymbol;
+            while (currentFunction != null)
+            {
+                if (currentFunction == containingMethodOrLambda)
+                {
+                    return false;
+                }
+                currentFunction = currentFunction.ContainingSymbol;
+            }
+            return true;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Collections/BitVector.cs
+++ b/src/Compilers/Core/Portable/Collections/BitVector.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis
         /// For the purposes of the intersection, any bits beyond the current length will be treated as zeroes.
         /// Return true if any changes were made to the bits of this bit vector.
         /// </summary>
-        public bool IntersectWith(BitVector other)
+        public bool IntersectWith(in BitVector other)
         {
             bool anyChanged = false;
             int otherLength = other._bits.Length;
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis
         /// <returns>
         /// True if any bits were set as a result of the union.
         /// </returns>
-        public bool UnionWith(BitVector other)
+        public bool UnionWith(in BitVector other)
         {
             bool anyChanged = false;
 


### PR DESCRIPTION
### Customer scenario

The LDM has decided that the following rules should be in effect when
calculating definite assignment for local functions:

  1. The entry point to a local function is always reachable.
  2. Variables captured in local functions are definitely assigned if
  they are definitely assigned in all branches into the local function.

It turns out these rules were almost exactly what the compiler already
implemented, but there was a bug in captured variable detection that
meant that variables captured in lambdas within local functions were
sometimes not counted as captured. This change fixes the bug around
capturing, which should cause the compiler to conform to this
specification.

### Bugs this fixes

Fixes #17829

### Workarounds, if any

Language change. If new errors are reported due to the language change, the containing local function can simply be deleted since it must be unreachable for this code to run. In addition, a warning about an unused local function should already be produced, so diagnostics are already produced for this code.

### Risk

This is a simple change to capturing, closer to a bug fix than a design change.

### Performance impact

Low. This is a change from a constant-time check to a linear check of containing symbols, but
the level of nesting of local functions should be small enough that performance should not
matter.

### Is this a regression from a previous update?

No, this is a design change/bug fix to something that has been present since VS2017 shipped.

### Root cause analysis

This is a very subtle case that can only happen with a nested lambda inside a local function
where that local function is unreachable.

### How was the bug found?

Customer reported.
