### PR TITLE
Add name property to Legend button for accessibility

### DIFF
--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.xaml
@@ -22,7 +22,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <Label Grid.Column="0" VerticalAlignment="Center" Content="Syntax Tree" FontWeight="Bold"/>
-                <Button Grid.Column="2" Name="legendButton" Click="LegendButton_Click" Visibility="Hidden" Margin="3" Padding="2" >
+                <Button Grid.Column="2" Name="legendButton" Click="LegendButton_Click" AutomationProperties.Name="Legend" Visibility="Hidden" Margin="3" Padding="2" >
                     <StackPanel>
                         <TextBlock>Legend</TextBlock>
                         <Popup StaysOpen="False" Name="legendPopup">


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=483430

The Syntax Visualizer has a Legend button that did not have it's name property set.  As a result, when viewing the Legend button in Inspect the name property is empty, and when using Narrator the button is announced as "Button".