### PR TITLE
Migrate command handlers to the new editor commanding

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -72,24 +72,24 @@
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26730-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26730-alpha</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.5.23</MicrosoftVisualStudioCompositionVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>15.6.241-preview</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVisualStudioCoreUtilityVersion>15.6.253-preview</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerEngineVersion>
     <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerMetadataVersion>
     <MicrosoftVisualStudioDebuggerInterop100Version>10.0.30319</MicrosoftVisualStudioDebuggerInterop100Version>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.0.26730-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
-    <MicrosoftVisualStudioEditorVersion>15.6.241-preview</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioEditorVersion>15.6.253-preview</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioGraphModelVersion>15.0.26730-alpha</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>15.0.26730-alpha</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>15.0.26730-alpha</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>15.0.25726-Preview5</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.3.1710.203</MicrosoftVisualStudioLanguageCallHierarchyVersion>
-    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.6.241-preview</MicrosoftVisualStudioLanguageIntellisenseVersion>
-    <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.6.241-preview</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
-    <MicrosoftVisualStudioLanguageStandardClassificationVersion>15.6.241-preview</MicrosoftVisualStudioLanguageStandardClassificationVersion>
+    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.6.253-preview</MicrosoftVisualStudioLanguageIntellisenseVersion>
+    <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.6.253-preview</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
+    <MicrosoftVisualStudioLanguageStandardClassificationVersion>15.6.253-preview</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6070</MicrosoftVisualStudioOLEInteropVersion>
-    <MicrosoftVisualStudioPlatformVSEditorVersion>15.6.241-preview</MicrosoftVisualStudioPlatformVSEditorVersion>
+    <MicrosoftVisualStudioPlatformVSEditorVersion>15.6.253-preview</MicrosoftVisualStudioPlatformVSEditorVersion>
     <MicrosoftVisualStudioProgressionCodeSchemaVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionCodeSchemaVersion>
     <MicrosoftVisualStudioProgressionCommonVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionCommonVersion>
     <MicrosoftVisualStudioProgressionInterfacesVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionInterfacesVersion>
@@ -115,11 +115,11 @@
     <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
     <MicrosoftVisualStudioTelemetryVersion>15.0.26730-alpha</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
-    <MicrosoftVisualStudioTextDataVersion>15.6.241-preview</MicrosoftVisualStudioTextDataVersion>
-    <MicrosoftVisualStudioTextInternalVersion>15.6.241-preview</MicrosoftVisualStudioTextInternalVersion>
-    <MicrosoftVisualStudioTextLogicVersion>15.6.241-preview</MicrosoftVisualStudioTextLogicVersion>
-    <MicrosoftVisualStudioTextUIVersion>15.6.241-preview</MicrosoftVisualStudioTextUIVersion>
-    <MicrosoftVisualStudioTextUIWpfVersion>15.6.241-preview</MicrosoftVisualStudioTextUIWpfVersion>
+    <MicrosoftVisualStudioTextDataVersion>15.6.253-preview</MicrosoftVisualStudioTextDataVersion>
+    <MicrosoftVisualStudioTextInternalVersion>15.6.253-preview</MicrosoftVisualStudioTextInternalVersion>
+    <MicrosoftVisualStudioTextLogicVersion>15.6.253-preview</MicrosoftVisualStudioTextLogicVersion>
+    <MicrosoftVisualStudioTextUIVersion>15.6.253-preview</MicrosoftVisualStudioTextUIVersion>
+    <MicrosoftVisualStudioTextUIWpfVersion>15.6.253-preview</MicrosoftVisualStudioTextUIWpfVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>7.10.6070</MicrosoftVisualStudioTextManagerInteropVersion>
     <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop100Version>
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -17,22 +16,24 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
 {
     /// <summary>
     /// csharp automatic line ender command handler
     /// </summary>
-    [ExportCommandHandler(PredefinedCommandHandlerNames.AutomaticLineEnder, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.AutomaticLineEnder)]
     [Order(After = PredefinedCommandHandlerNames.Completion)]
     internal class AutomaticLineEnderCommandHandler : AbstractAutomaticLineEnderCommandHandler
     {
         [ImportingConstructor]
         public AutomaticLineEnderCommandHandler(
-            IWaitIndicator waitIndicator,
             ITextUndoHistoryRegistry undoRegistry,
             IEditorOperationsFactoryService editorOperations)
-            : base(waitIndicator, undoRegistry, editorOperations)
+            : base(undoRegistry, editorOperations)
         {
         }
 

--- a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs
@@ -11,10 +11,13 @@ using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing
 {
-    [ExportCommandHandler(nameof(BlockCommentEditingCommandHandler), ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(nameof(BlockCommentEditingCommandHandler))]
     [Order(After = PredefinedCommandHandlerNames.Completion)]
     internal class BlockCommentEditingCommandHandler : AbstractBlockCommentEditingCommandHandler
     {

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
@@ -86,5 +86,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
                 return ResourceManager.GetString("Split_string", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Split String Literal Command Handler.
+        /// </summary>
+        internal static string Split_String_Literal_Command_Handler {
+            get {
+                return ResourceManager.GetString("Split_String_Literal_Command_Handler", resourceCulture);
+            }
+        }
     }
 }

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.resx
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.resx
@@ -126,4 +126,7 @@
   <data name="Split_string" xml:space="preserve">
     <value>Split string</value>
   </data>
+  <data name="Split_String_Literal_Command_Handler" xml:space="preserve">
+    <value>Split String Literal Command Handler</value>
+  </data>
 </root>

--- a/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
@@ -1,18 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.ChangeSignature
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.ChangeSignature, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.ChangeSignature)]
     internal class CSharpChangeSignatureCommandHandler : AbstractChangeSignatureCommandHandler
     {
-        [ImportingConstructor]
-        public CSharpChangeSignatureCommandHandler(IWaitIndicator waitIndicator)
-            : base(waitIndicator)
-        {
-        }
     }
 }

--- a/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
@@ -13,10 +13,13 @@ using Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.DocumentationComments, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.DocumentationComments)]
     [Order(After = PredefinedCommandHandlerNames.Rename)]
     [Order(After = PredefinedCommandHandlerNames.Completion)]
     internal class DocumentationCommentCommandHandler

--- a/src/EditorFeatures/CSharp/DocumentationComments/XmlTagCompletionCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/XmlTagCompletionCommandHandler.cs
@@ -5,23 +5,25 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
 {
-    [ExportCommandHandler("XmlTagCompletionCommandHandler", ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(nameof(XmlTagCompletionCommandHandler))]
     [Order(Before = PredefinedCommandHandlerNames.Completion)]
     internal class XmlTagCompletionCommandHandler : AbstractXmlTagCompletionCommandHandler
     {
         [ImportingConstructor]
-        public XmlTagCompletionCommandHandler(ITextUndoHistoryRegistry undoHistory, IWaitIndicator waitIndicator)
-            : base(undoHistory, waitIndicator)
+        public XmlTagCompletionCommandHandler(ITextUndoHistoryRegistry undoHistory)
+            : base(undoHistory)
         {
         }
 

--- a/src/EditorFeatures/CSharp/EncapsulateField/EncapsulateFieldCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/EncapsulateField/EncapsulateFieldCommandHandler.cs
@@ -3,24 +3,25 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.EncapsulateField;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EncapsulateField
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.EncapsulateField, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.EncapsulateField)]
     [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
     internal class EncapsulateFieldCommandHandler : AbstractEncapsulateFieldCommandHandler
     {
         [ImportingConstructor]
         public EncapsulateFieldCommandHandler(
-            IWaitIndicator waitIndicator,
             ITextBufferUndoManagerProvider undoManager,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
-            : base(waitIndicator, undoManager, asyncListeners)
+            : base(undoManager, asyncListeners)
         {
         }
     }

--- a/src/EditorFeatures/CSharp/ExtractInterface/ExtractInterfaceCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ExtractInterface/ExtractInterfaceCommandHandler.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.ExtractInterface
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.ExtractInterface, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.ExtractInterface)]
     internal class ExtractInterfaceCommandHandler : AbstractExtractInterfaceCommandHandler
     {
     }

--- a/src/EditorFeatures/CSharp/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.ExtractMethod;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.ExtractMethod
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.ExtractMethod,
-        ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.ExtractMethod)]
     [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
     internal class ExtractMethodCommandHandler :
         AbstractExtractMethodCommandHandler
@@ -18,9 +19,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.ExtractMethod
         public ExtractMethodCommandHandler(
             ITextBufferUndoManagerProvider undoManager,
             IEditorOperationsFactoryService editorOperationsFactoryService,
-            IInlineRenameService renameService,
-            IWaitIndicator waitIndicator) :
-            base(undoManager, editorOperationsFactoryService, renameService, waitIndicator)
+            IInlineRenameService renameService) :
+            base(undoManager, editorOperationsFactoryService, renameService)
         {
         }
     }

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
@@ -14,10 +14,13 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.Indent, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.Indent)]
     [Order(After = PredefinedCommandHandlerNames.Rename)]
     [Order(Before = PredefinedCommandHandlerNames.Completion)]
     internal class SmartTokenFormatterCommandHandler :

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
@@ -1,21 +1,25 @@
-﻿using System;
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 {
-    [ExportCommandHandler(nameof(SplitStringLiteralCommandHandler), ContentTypeNames.CSharpContentType)]
-    internal partial class SplitStringLiteralCommandHandler : ICommandHandler<ReturnKeyCommandArgs>
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(nameof(SplitStringLiteralCommandHandler))]
+    internal partial class SplitStringLiteralCommandHandler : VSCommanding.ICommandHandler<ReturnKeyCommandArgs>
     {
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
@@ -29,17 +33,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             _editorOperationsFactoryService = editorOperationsFactoryService;
         }
 
-        public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        public string DisplayName => CSharpEditorResources.Split_String_Literal_Command_Handler;
+
+        public VSCommanding.CommandState GetCommandState(ReturnKeyCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
         {
-            if (!ExecuteCommandWorker(args))
-            {
-                nextHandler();
-            }
+            return ExecuteCommandWorker(args);
         }
 
         public bool ExecuteCommandWorker(ReturnKeyCommandArgs args)

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Rozdělit řetězec</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Zeichenfolge teilen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Dividir cadena</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Fractionner la chaîne</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Dividi stringa</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">文字列を分割します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">문자열 분할</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Rozdziel ciąg</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Dividir cadeia de caracteres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Разделить строку</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Dizeyi böl</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">拆分字符串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">分割字串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Split_String_Literal_Command_Handler">
+        <source>Split String Literal Command Handler</source>
+        <target state="new">Split String Literal Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion;
 using Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -845,12 +845,11 @@ $$
             return () => { };
         }
 
-        internal override ICommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
-            Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator waitIndicator,
+        internal override IChainedCommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
             IEditorOperationsFactoryService editorOperations)
         {
-            return new AutomaticLineEnderCommandHandler(waitIndicator, undoRegistry, editorOperations);
+            return new AutomaticLineEnderCommandHandler(undoRegistry, editorOperations);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/BlockCommentEditing/BlockCommentEditingTests.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.BlockCommentEditing;
 using Microsoft.CodeAnalysis.Editor.UnitTests.BlockCommentEditing;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BlockCommentEditing
 {
@@ -680,7 +680,7 @@ $$*";
         protected override TestWorkspace CreateTestWorkspace(string initialMarkup)
             => TestWorkspace.CreateCSharp(initialMarkup);
 
-        internal override ICommandHandler<ReturnKeyCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistoryRegistry, IEditorOperationsFactoryService editorOperationsFactoryService)
+        internal override VSCommanding.ICommandHandler<ReturnKeyCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistoryRegistry, IEditorOperationsFactoryService editorOperationsFactoryService)
             => new BlockCommentEditingCommandHandler(undoHistoryRegistry, editorOperationsFactoryService);
     }
 }

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -291,22 +292,13 @@ class C{i}
 
                 var textView = workspace.Documents.Single().GetTextView();
 
-                var handler = new CSharpChangeSignatureCommandHandler(TestWaitIndicator.Default);
-                var delegatedToNext = false;
-                CommandState nextHandler()
-                {
-                    delegatedToNext = true;
-                    return CommandState.Unavailable;
-                }
+                var handler = new CSharpChangeSignatureCommandHandler();
 
-                var state = handler.GetCommandState(new Commands.RemoveParametersCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                var state = handler.GetCommandState(new RemoveParametersCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
 
-                delegatedToNext = false;
-                state = handler.GetCommandState(new Commands.ReorderParametersCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                state = handler.GetCommandState(new ReorderParametersCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CommentSelection/CSharpCommentSelectionTests.cs
@@ -113,12 +113,11 @@ class C
                 SetupSelection(doc.GetTextView(), doc.SelectedSpans.Select(s => Span.FromBounds(s.Start, s.End)));
 
                 var commandHandler = new CommentUncommentSelectionCommandHandler(
-                    TestWaitIndicator.Default,
                     workspace.ExportProvider.GetExportedValue<ITextUndoHistoryRegistry>(),
                     workspace.ExportProvider.GetExportedValue<IEditorOperationsFactoryService>());
                 var textView = doc.GetTextView();
                 var textBuffer = doc.GetTextBuffer();
-                commandHandler.ExecuteCommand(textView, textBuffer, CommentUncommentSelectionCommandHandler.Operation.Uncomment);
+                commandHandler.ExecuteCommand(textView, textBuffer, CommentUncommentSelectionCommandHandler.Operation.Uncomment, TestCommandExecutionContext.Create());
 
                 Assert.Equal(expected, doc.TextBuffer.CurrentSnapshot.GetText());
             }

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DocumentationComments
 {
@@ -1919,7 +1918,7 @@ class C { }";
             get { return '/'; }
         }
 
-        internal override ICommandHandler CreateCommandHandler(
+        internal override VSCommanding.ICommandHandler CreateCommandHandler(
             IWaitIndicator waitIndicator,
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IEditorOperationsFactoryService editorOperationsFactoryService)

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/XmlTagCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/XmlTagCompletionTests.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -251,9 +252,9 @@ class c { }";
             Verify(text, expected, '/');
         }
 
-        internal override ICommandHandler<TypeCharCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistory)
+        internal override IChainedCommandHandler<TypeCharCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistory)
         {
-            return new XmlTagCompletionCommandHandler(undoHistory, TestWaitIndicator.Default);
+            return new XmlTagCompletionCommandHandler(undoHistory);
         }
 
         protected override TestWorkspace CreateTestWorkspace(string initialMarkup)

--- a/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -211,18 +212,11 @@ class Program
 
                 var textView = workspace.Documents.Single().GetTextView();
 
-                var handler = new EncapsulateFieldCommandHandler(workspace.GetService<Host.IWaitIndicator>(), workspace.GetService<ITextBufferUndoManagerProvider>(),
+                var handler = new EncapsulateFieldCommandHandler(workspace.GetService<ITextBufferUndoManagerProvider>(),
                     workspace.ExportProvider.GetExportedValues<Lazy<IAsynchronousOperationListener, FeatureMetadata>>());
-                var delegatedToNext = false;
-                CommandState nextHandler()
-                {
-                    delegatedToNext = true;
-                    return CommandState.Unavailable;
-                }
 
-                var state = handler.GetCommandState(new Commands.EncapsulateFieldCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                var state = handler.GetCommandState(new EncapsulateFieldCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
+++ b/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
@@ -2,11 +2,8 @@
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.EncapsulateField;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.EncapsulateField;
 using Microsoft.CodeAnalysis.Editor.Implementation.Notification;
 using Microsoft.CodeAnalysis.Editor.Shared;
@@ -16,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Xunit;
 
@@ -57,9 +55,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EncapsulateField
         public void Encapsulate()
         {
             var args = new EncapsulateFieldCommandArgs(_testDocument.GetTextView(), _testDocument.GetTextBuffer());
-            var commandHandler = new EncapsulateFieldCommandHandler(TestWaitIndicator.Default, Workspace.GetService<ITextBufferUndoManagerProvider>(),
+            var commandHandler = new EncapsulateFieldCommandHandler(Workspace.GetService<ITextBufferUndoManagerProvider>(),
                 Workspace.ExportProvider.GetExportedValues<Lazy<IAsynchronousOperationListener, FeatureMetadata>>());
-            commandHandler.ExecuteCommand(args, () => { });
+            commandHandler.ExecuteCommand(args, TestCommandExecutionContext.Create());
         }
 
         public void Dispose()

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractInterface;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1080,16 +1081,9 @@ class $$Test<T, U>
                 var textView = workspace.Documents.Single().GetTextView();
 
                 var handler = new ExtractInterfaceCommandHandler();
-                var delegatedToNext = false;
-                CommandState nextHandler()
-                {
-                    delegatedToNext = true;
-                    return CommandState.Unavailable;
-                }
 
-                var state = handler.GetCommandState(new Commands.ExtractInterfaceCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                var state = handler.GetCommandState(new ExtractInterfaceCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -10278,18 +10279,10 @@ namespace ClassLibrary9
                 var handler = new ExtractMethodCommandHandler(
                     workspace.GetService<ITextBufferUndoManagerProvider>(),
                     workspace.GetService<IEditorOperationsFactoryService>(),
-                    workspace.GetService<IInlineRenameService>(),
-                    workspace.GetService<Host.IWaitIndicator>());
-                var delegatedToNext = false;
-                CommandState nextHandler()
-                {
-                    delegatedToNext = true;
-                    return CommandState.Unavailable;
-                }
+                    workspace.GetService<IInlineRenameService>());
 
-                var state = handler.GetCommandState(new Commands.ExtractMethodCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                var state = handler.GetCommandState(new ExtractMethodCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.Editor.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Host;
@@ -13,6 +14,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -142,10 +144,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 var handler = new ExtractMethodCommandHandler(
                     workspace.ExportProvider.GetExportedValue<ITextBufferUndoManagerProvider>(),
                     workspace.ExportProvider.GetExportedValue<IEditorOperationsFactoryService>(),
-                    workspace.ExportProvider.GetExportedValue<IInlineRenameService>(),
-                    workspace.ExportProvider.GetExportedValue<IWaitIndicator>());
+                    workspace.ExportProvider.GetExportedValue<IInlineRenameService>());
 
-                handler.ExecuteCommand(new Commands.ExtractMethodCommandArgs(view, view.TextBuffer), () => { });
+                handler.ExecuteCommand(new ExtractMethodCommandArgs(view, view.TextBuffer), TestCommandExecutionContext.Create());
 
                 Assert.True(called);
             }

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -23,6 +22,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Roslyn.Utilities;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 {
@@ -191,10 +191,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                 // get original buffer
                 var buffer = workspace.Documents.First().GetTextBuffer();
 
-                var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, workspace.GetService<ITextUndoHistoryRegistry>(), editorOperationsFactoryService.Object);
+                var commandHandler = new FormatCommandHandler(workspace.GetService<ITextUndoHistoryRegistry>(), editorOperationsFactoryService.Object);
 
                 var commandArgs = new FormatDocumentCommandArgs(view, view.TextBuffer);
-                commandHandler.ExecuteCommand(commandArgs, () => { });
+                commandHandler.ExecuteCommand(commandArgs, TestCommandExecutionContext.Create());
                 MarkupTestFile.GetPosition(expectedWithMarker, out var expected, out int expectedPosition);
 
                 Assert.Equal(expected, view.TextSnapshot.GetText());
@@ -221,9 +221,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
                 if (isPaste)
                 {
-                    var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, null, null);
+                    var commandHandler = new FormatCommandHandler(null, null);
                     var commandArgs = new PasteCommandArgs(view, view.TextBuffer);
-                    commandHandler.ExecuteCommand(commandArgs, () => { });
+                    commandHandler.ExecuteCommand(commandArgs, () => { }, TestCommandExecutionContext.Create());
                 }
                 else
                 {
@@ -232,9 +232,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                     var editorOperationsFactory = new Mock<IEditorOperationsFactoryService>();
                     var editorOperations = new Mock<IEditorOperations>();
                     editorOperationsFactory.Setup(x => x.GetEditorOperations(testDocument.GetTextView())).Returns(editorOperations.Object);
-                    var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, textUndoHistory.Object, editorOperationsFactory.Object);
+                    var commandHandler = new FormatCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
                     var commandArgs = new ReturnKeyCommandArgs(view, view.TextBuffer);
-                    commandHandler.ExecuteCommand(commandArgs, () => { });
+                    commandHandler.ExecuteCommand(commandArgs, () => { }, TestCommandExecutionContext.Create());
                 }
 
                 MarkupTestFile.GetPosition(expectedWithMarker, out var expected, out int expectedPosition);

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
@@ -12,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Moq;
 using Roslyn.Test.Utilities;
@@ -1672,9 +1672,9 @@ class C
                 var editorOperations = new Mock<IEditorOperations>();
                 editorOperationsFactory.Setup(x => x.GetEditorOperations(subjectDocument.GetTextView())).Returns(editorOperations.Object);
 
-                var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, textUndoHistory.Object, editorOperationsFactory.Object);
+                var commandHandler = new FormatCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
                 var typedChar = subjectDocument.GetTextBuffer().CurrentSnapshot.GetText(subjectDocument.CursorPosition.Value - 1, 1);
-                commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { });
+                commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { }, TestCommandExecutionContext.Create());
 
                 var newSnapshot = subjectDocument.TextBuffer.CurrentSnapshot;
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
@@ -18,6 +17,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Projection;
 using Moq;
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             var indentationLineFromBuffer = snapshot.GetLineFromPosition(point);
 
             var commandHandler = new SmartTokenFormatterCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
-            commandHandler.ExecuteCommand(new ReturnKeyCommandArgs(textView, subjectDocument.TextBuffer), () => { });
+            commandHandler.ExecuteCommand(new ReturnKeyCommandArgs(textView, subjectDocument.TextBuffer), () => { }, TestCommandExecutionContext.Create());
             var newSnapshot = subjectDocument.TextBuffer.CurrentSnapshot;
 
             int? actualIndentation;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
@@ -19,6 +18,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Moq;
 using Roslyn.Test.Utilities;
@@ -3287,9 +3287,9 @@ class Program{
                 var editorOperations = new Mock<IEditorOperations>();
                 editorOperationsFactory.Setup(x => x.GetEditorOperations(subjectDocument.GetTextView())).Returns(editorOperations.Object);
 
-                var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, textUndoHistory.Object, editorOperationsFactory.Object);
+                var commandHandler = new FormatCommandHandler(textUndoHistory.Object, editorOperationsFactory.Object);
                 var typedChar = subjectDocument.GetTextBuffer().CurrentSnapshot.GetText(subjectDocument.CursorPosition.Value - 1, 1);
-                commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { });
+                commandHandler.ExecuteCommand(new TypeCharCommandArgs(subjectDocument.GetTextView(), subjectDocument.TextBuffer, typedChar[0]), () => { }, TestCommandExecutionContext.Create());
 
                 var newSnapshot = subjectDocument.TextBuffer.CurrentSnapshot;
 

--- a/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Organizing/OrganizeTypeDeclarationTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.Editor.Implementation.Organizing;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
@@ -1095,22 +1096,13 @@ interface I
 
                 var textView = workspace.Documents.Single().GetTextView();
 
-                var handler = new OrganizeDocumentCommandHandler(workspace.GetService<Host.IWaitIndicator>());
-                var delegatedToNext = false;
-                CommandState nextHandler()
-                {
-                    delegatedToNext = true;
-                    return CommandState.Unavailable;
-                }
+                var handler = new OrganizeDocumentCommandHandler();
+                
+                var state = handler.GetCommandState(new SortAndRemoveUnnecessaryImportsCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
 
-                var state = handler.GetCommandState(new Commands.SortAndRemoveUnnecessaryImportsCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
-                delegatedToNext = false;
-
-                state = handler.GetCommandState(new Commands.OrganizeDocumentCommandArgs(textView, textView.TextBuffer), nextHandler);
-                Assert.True(delegatedToNext);
-                Assert.False(state.IsAvailable);
+                state = handler.GetCommandState(new OrganizeDocumentCommandArgs(textView, textView.TextBuffer));
+                Assert.True(state.IsUnspecified);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -31,7 +32,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
                 var commandHandler = new SplitStringLiteralCommandHandler(
                     undoHistoryRegistry,
                     workspace.GetService<IEditorOperationsFactoryService>());
-                commandHandler.ExecuteCommand(new ReturnKeyCommandArgs(view, view.TextBuffer), callback);
+                
+                if (!commandHandler.ExecuteCommand(new ReturnKeyCommandArgs(view, view.TextBuffer), TestCommandExecutionContext.Create()))
+                {
+                    callback();
+                }
 
                 if (expectedOutputMarkup != null)
                 {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -3,14 +3,19 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [ContentType(ContentTypeNames.XamlContentType)]
+    [Name(PredefinedCommandHandlerNames.Rename)]
     // Line commit and rename are both executed on Save. Ensure any rename session is committed
     // before line commit runs to ensure changes from both are correctly applied.
     [Order(Before = PredefinedCommandHandlerNames.Commit)]
@@ -18,35 +23,38 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     [Order(Before = PredefinedCommandHandlerNames.ChangeSignature)]
     [Order(Before = PredefinedCommandHandlerNames.ExtractInterface)]
     [Order(Before = PredefinedCommandHandlerNames.EncapsulateField)]
-    [ExportCommandHandler(PredefinedCommandHandlerNames.Rename, ContentTypeNames.RoslynContentType, ContentTypeNames.XamlContentType)]
     internal partial class RenameCommandHandler
     {
         private readonly InlineRenameService _renameService;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
-        private readonly IWaitIndicator _waitIndicator;
 
         [ImportingConstructor]
         public RenameCommandHandler(
             InlineRenameService renameService,
-            IEditorOperationsFactoryService editorOperationsFactoryService,
-            IWaitIndicator waitIndicator)
+            IEditorOperationsFactoryService editorOperationsFactoryService)
         {
             _renameService = renameService;
             _editorOperationsFactoryService = editorOperationsFactoryService;
-            _waitIndicator = waitIndicator;
         }
 
-        private CommandState GetCommandState(Func<CommandState> nextHandler)
+        public string DisplayName => EditorFeaturesResources.Rename_Command_Handler;
+
+        private VSCommanding.CommandState GetCommandState(Func<VSCommanding.CommandState> nextHandler)
         {
             if (_renameService.ActiveSession != null)
             {
-                return CommandState.Available;
+                return VSCommanding.CommandState.Available;
             }
 
             return nextHandler();
         }
 
-        private void HandlePossibleTypingCommand(CommandArgs args, Action nextHandler, Action<SnapshotSpan> actionIfInsideActiveSpan)
+        private VSCommanding.CommandState GetCommandState()
+        {
+            return _renameService.ActiveSession != null ? VSCommanding.CommandState.Available : VSCommanding.CommandState.Unspecified;
+        }
+
+        private void HandlePossibleTypingCommand(EditorCommandArgs args, Action nextHandler, Action<SnapshotSpan> actionIfInsideActiveSpan)
         {
             if (_renameService.ActiveSession == null)
             {
@@ -79,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        private void CommitIfActiveAndCallNextHandler(CommandArgs args, Action nextHandler)
+        private void CommitIfActive(EditorCommandArgs args)
         {
             if (_renameService.ActiveSession != null)
             {
@@ -91,7 +99,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 args.TextView.Selection.Select(translatedSelection.Start, translatedSelection.End);
                 args.TextView.Caret.MoveTo(translatedSelection.End);
             }
+        }
 
+        private void CommitIfActiveAndCallNextHandler(EditorCommandArgs args, Action nextHandler)
+        {
+            CommitIfActive(args);
             nextHandler();
         }
     }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_BackspaceDeleteHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_BackspaceDeleteHandler.cs
@@ -1,24 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<BackspaceKeyCommandArgs>, ICommandHandler<DeleteKeyCommandArgs>
+    internal partial class RenameCommandHandler : IChainedCommandHandler<BackspaceKeyCommandArgs>, IChainedCommandHandler<DeleteKeyCommandArgs>
     {
-        public CommandState GetCommandState(BackspaceKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(BackspaceKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public CommandState GetCommandState(DeleteKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(DeleteKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
                 {
@@ -30,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 });
         }
 
-        public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
                 {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_CutPasteHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_CutPasteHandler.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<CutCommandArgs>, ICommandHandler<PasteCommandArgs>
+        IChainedCommandHandler<CutCommandArgs>, IChainedCommandHandler<PasteCommandArgs>
     {
-        public CommandState GetCommandState(CutCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(CutCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(CutCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(CutCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
             {
@@ -21,12 +23,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             });
         }
 
-        public CommandState GetCommandState(PasteCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(PasteCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(PasteCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_EscapeHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_EscapeHandler.cs
@@ -1,29 +1,30 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<EscapeKeyCommandArgs>
+    internal partial class RenameCommandHandler : VSCommanding.ICommandHandler<EscapeKeyCommandArgs>
     {
-        public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(EscapeKeyCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
         {
             if (_renameService.ActiveSession != null)
             {
                 _renameService.ActiveSession.Cancel();
                 (args.TextView as IWpfTextView).VisualElement.Focus();
+                return true;
             }
-            else
-            {
-                nextHandler();
-            }
+
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_LineStartEndHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_LineStartEndHandler.cs
@@ -1,75 +1,57 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<LineStartCommandArgs>, ICommandHandler<LineEndCommandArgs>,
-        ICommandHandler<LineStartExtendCommandArgs>, ICommandHandler<LineEndExtendCommandArgs>
+        VSCommanding.ICommandHandler<LineStartCommandArgs>, VSCommanding.ICommandHandler<LineEndCommandArgs>,
+        VSCommanding.ICommandHandler<LineStartExtendCommandArgs>, VSCommanding.ICommandHandler<LineEndExtendCommandArgs>
     {
-        public CommandState GetCommandState(LineStartCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(LineStartCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public CommandState GetCommandState(LineEndCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(LineEndCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public CommandState GetCommandState(LineStartExtendCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(LineStartExtendCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public CommandState GetCommandState(LineEndExtendCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(LineEndExtendCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(LineStartCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(LineStartCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: true, extendSelection: false))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: true, extendSelection: false);
         }
 
-        public void ExecuteCommand(LineEndCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(LineEndCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: false, extendSelection: false))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: false, extendSelection: false);
         }
 
-        public void ExecuteCommand(LineStartExtendCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(LineStartExtendCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: true, extendSelection: true))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: true, extendSelection: true);
         }
 
-        public void ExecuteCommand(LineEndExtendCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(LineEndExtendCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: false, extendSelection: true))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleLineStartOrLineEndCommand(args.SubjectBuffer, args.TextView, lineStart: false, extendSelection: true);
         }
 
         private bool HandleLineStartOrLineEndCommand(ITextBuffer subjectBuffer, ITextView view, bool lineStart, bool extendSelection)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_MoveSelectedLinesHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_MoveSelectedLinesHandler.cs
@@ -1,31 +1,35 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<MoveSelectedLinesUpCommandArgs>, ICommandHandler<MoveSelectedLinesDownCommandArgs>
+        VSCommanding.ICommandHandler<MoveSelectedLinesUpCommandArgs>, VSCommanding.ICommandHandler<MoveSelectedLinesDownCommandArgs>
     {
-        public CommandState GetCommandState(MoveSelectedLinesUpCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(MoveSelectedLinesUpCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(MoveSelectedLinesUpCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(MoveSelectedLinesUpCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
 
-        public CommandState GetCommandState(MoveSelectedLinesDownCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(MoveSelectedLinesDownCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(MoveSelectedLinesDownCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(MoveSelectedLinesDownCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_OpenLineAboveHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_OpenLineAboveHandler.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<OpenLineAboveCommandArgs>
+    internal partial class RenameCommandHandler : IChainedCommandHandler<OpenLineAboveCommandArgs>
     {
-        public CommandState GetCommandState(OpenLineAboveCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(OpenLineAboveCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(OpenLineAboveCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(OpenLineAboveCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_OpenLineBelowHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_OpenLineBelowHandler.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<OpenLineBelowCommandArgs>
+    internal partial class RenameCommandHandler : IChainedCommandHandler<OpenLineBelowCommandArgs>
     {
-        public CommandState GetCommandState(OpenLineBelowCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(OpenLineBelowCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(OpenLineBelowCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(OpenLineBelowCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_RefactoringWithCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_RefactoringWithCommandHandler.cs
@@ -1,54 +1,60 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<ReorderParametersCommandArgs>,
-        ICommandHandler<RemoveParametersCommandArgs>,
-        ICommandHandler<ExtractInterfaceCommandArgs>,
-        ICommandHandler<EncapsulateFieldCommandArgs>
+        VSCommanding.ICommandHandler<ReorderParametersCommandArgs>,
+        VSCommanding.ICommandHandler<RemoveParametersCommandArgs>,
+        VSCommanding.ICommandHandler<ExtractInterfaceCommandArgs>,
+        VSCommanding.ICommandHandler<EncapsulateFieldCommandArgs>
     {
-        public CommandState GetCommandState(ReorderParametersCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ReorderParametersCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(ReorderParametersCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ReorderParametersCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
 
-        public CommandState GetCommandState(RemoveParametersCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(RemoveParametersCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(RemoveParametersCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(RemoveParametersCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
 
-        public CommandState GetCommandState(ExtractInterfaceCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ExtractInterfaceCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(ExtractInterfaceCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ExtractInterfaceCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
 
-        public CommandState GetCommandState(EncapsulateFieldCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(EncapsulateFieldCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(EncapsulateFieldCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(EncapsulateFieldCommandArgs args, CommandExecutionContext context)
         {
-            CommitIfActiveAndCallNextHandler(args, nextHandler);
+            CommitIfActive(args);
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_ReturnHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_ReturnHandler.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<ReturnKeyCommandArgs>
+    internal partial class RenameCommandHandler : IChainedCommandHandler<ReturnKeyCommandArgs>
     {
-        public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ReturnKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             if (_renameService.ActiveSession != null)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_SaveHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_SaveHandler.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal partial class RenameCommandHandler : ICommandHandler<SaveCommandArgs>
+    internal partial class RenameCommandHandler : VSCommanding.ICommandHandler<SaveCommandArgs>
     {
-        public CommandState GetCommandState(SaveCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(SaveCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(SaveCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(SaveCommandArgs args, CommandExecutionContext context)
         {
             if (_renameService.ActiveSession != null)
             {
@@ -21,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 ((IWpfTextView)args.TextView).VisualElement.Focus();
             }
 
-            nextHandler();
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_SelectAllHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_SelectAllHandler.cs
@@ -1,29 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<SelectAllCommandArgs>
+        VSCommanding.ICommandHandler<SelectAllCommandArgs>
     {
-        public CommandState GetCommandState(SelectAllCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(SelectAllCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(SelectAllCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(SelectAllCommandArgs args, CommandExecutionContext context)
         {
-            if (ExecuteSelectAll(args.SubjectBuffer, args.TextView))
-            {
-                return;
-            }
-
-            nextHandler();
+            return ExecuteSelectAll(args.SubjectBuffer, args.TextView);
         }
 
         private bool ExecuteSelectAll(ITextBuffer subjectBuffer, ITextView view)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_TabHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_TabHandler.cs
@@ -2,23 +2,25 @@
 
 using System;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<TabKeyCommandArgs>,
-        ICommandHandler<BackTabKeyCommandArgs>
+        IChainedCommandHandler<TabKeyCommandArgs>,
+        IChainedCommandHandler<BackTabKeyCommandArgs>
     {
-        public CommandState GetCommandState(TabKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(TabKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             // If the Dashboard is focused, just navigate through its UI.
             Dashboard dashboard = GetDashboard(args.TextView);
@@ -48,12 +50,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             });
         }
 
-        public CommandState GetCommandState(BackTabKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(BackTabKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(BackTabKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(BackTabKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             // If the Dashboard is focused, just navigate through its UI.
             var dashboard = GetDashboard(args.TextView);

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_TypeCharHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_TypeCharHandler.cs
@@ -1,21 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Text;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<TypeCharCommandArgs>
+        IChainedCommandHandler<TypeCharCommandArgs>
     {
-        public CommandState GetCommandState(TypeCharCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return GetCommandState(nextHandler);
         }
 
-        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             HandlePossibleTypingCommand(args, nextHandler, span =>
             {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_UndoRedoHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_UndoRedoHandler.cs
@@ -1,24 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<UndoCommandArgs>, ICommandHandler<RedoCommandArgs>
+        VSCommanding.ICommandHandler<UndoCommandArgs>, VSCommanding.ICommandHandler<RedoCommandArgs>
     {
-        public CommandState GetCommandState(UndoCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(UndoCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public CommandState GetCommandState(RedoCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(RedoCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(UndoCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(UndoCommandArgs args, CommandExecutionContext context)
         {
             if (_renameService.ActiveSession != null)
             {
@@ -26,14 +28,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 {
                     _renameService.ActiveSession.UndoManager.Undo(args.SubjectBuffer);
                 }
+
+                return true;
             }
-            else
-            {
-                nextHandler();
-            }
+
+            return false;
         }
 
-        public void ExecuteCommand(RedoCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(RedoCommandArgs args, CommandExecutionContext context)
         {
             if (_renameService.ActiveSession != null)
             {
@@ -41,11 +43,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 {
                     _renameService.ActiveSession.UndoManager.Redo(args.SubjectBuffer);
                 }
+
+                return true;
             }
-            else
-            {
-                nextHandler();
-            }
+
+            return false;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_WordDeleteHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler_WordDeleteHandler.cs
@@ -2,45 +2,37 @@
 
 using System;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
     internal partial class RenameCommandHandler :
-        ICommandHandler<WordDeleteToStartCommandArgs>,
-        ICommandHandler<WordDeleteToEndCommandArgs>
+        VSCommanding.ICommandHandler<WordDeleteToStartCommandArgs>,
+        VSCommanding.ICommandHandler<WordDeleteToEndCommandArgs>
     {
-        public CommandState GetCommandState(WordDeleteToStartCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(WordDeleteToStartCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public CommandState GetCommandState(WordDeleteToEndCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(WordDeleteToEndCommandArgs args)
         {
-            return GetCommandState(nextHandler);
+            return GetCommandState();
         }
 
-        public void ExecuteCommand(WordDeleteToStartCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(WordDeleteToStartCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: true))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: true);
         }
 
-        public void ExecuteCommand(WordDeleteToEndCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(WordDeleteToEndCommandArgs args, CommandExecutionContext context)
         {
-            if (HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: false))
-            {
-                return;
-            }
-
-            nextHandler();
+            return HandleWordDeleteCommand(args.SubjectBuffer, args.TextView, deleteToStart: false);
         }
 
         private bool HandleWordDeleteCommand(ITextBuffer subjectBuffer, ITextView view, bool deleteToStart)

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     internal partial class QuickInfoPresenter
@@ -110,4 +110,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoSource.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     internal partial class QuickInfoPresenter
@@ -31,4 +31,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     [Export(typeof(IQuickInfoSourceProvider))]
@@ -43,4 +43,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core.Wpf/Structure/OutliningCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/Structure/OutliningCommandHandler.cs
@@ -1,14 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Outlining;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
 {
-    [ExportCommandHandler("Outlining Command Handler", ContentTypeNames.RoslynContentType)]
-    internal sealed class OutliningCommandHandler : ICommandHandler<StartAutomaticOutliningCommandArgs>
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name("Outlining Command Handler")]
+    internal sealed class OutliningCommandHandler : VSCommanding.ICommandHandler<StartAutomaticOutliningCommandArgs>
     {
         private readonly IOutliningManagerService _outliningManagerService;
 
@@ -18,13 +22,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             _outliningManagerService = outliningManagerService;
         }
 
-        public void ExecuteCommand(StartAutomaticOutliningCommandArgs args, Action nextHandler)
+        public string DisplayName => EditorFeaturesResources.Outlining_Command_Handler;
+
+        public bool ExecuteCommand(StartAutomaticOutliningCommandArgs args, CommandExecutionContext context)
         {
             // The editor actually handles this command, we just have to make sure it is enabled.
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(StartAutomaticOutliningCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(StartAutomaticOutliningCommandArgs args)
         {
             var outliningManager = _outliningManagerService.GetOutliningManager(args.TextView);
             var enabled = false;
@@ -33,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
                 enabled = outliningManager.Enabled;
             }
 
-            return new CommandState(isAvailable: !enabled);
+            return new VSCommanding.CommandState(isAvailable: !enabled);
         }
     }
 }

--- a/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractCompletionCommandHandler.cs
@@ -1,46 +1,51 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     internal abstract class AbstractCompletionCommandHandler :
         ForegroundThreadAffinitizedObject,
-        ICommandHandler<TabKeyCommandArgs>,
-        ICommandHandler<ToggleCompletionModeCommandArgs>,
-        ICommandHandler<TypeCharCommandArgs>,
-        ICommandHandler<ReturnKeyCommandArgs>,
-        ICommandHandler<InvokeCompletionListCommandArgs>,
-        ICommandHandler<CommitUniqueCompletionListItemCommandArgs>,
-        ICommandHandler<PageUpKeyCommandArgs>,
-        ICommandHandler<PageDownKeyCommandArgs>,
-        ICommandHandler<CutCommandArgs>,
-        ICommandHandler<PasteCommandArgs>,
-        ICommandHandler<BackspaceKeyCommandArgs>,
-        ICommandHandler<InsertSnippetCommandArgs>,
-        ICommandHandler<SurroundWithCommandArgs>,
-        ICommandHandler<AutomaticLineEnderCommandArgs>,
-        ICommandHandler<SaveCommandArgs>,
-        ICommandHandler<DeleteKeyCommandArgs>,
-        ICommandHandler<SelectAllCommandArgs>
+        IChainedCommandHandler<TabKeyCommandArgs>,
+        IChainedCommandHandler<ToggleCompletionModeCommandArgs>,
+        IChainedCommandHandler<TypeCharCommandArgs>,
+        IChainedCommandHandler<ReturnKeyCommandArgs>,
+        IChainedCommandHandler<InvokeCompletionListCommandArgs>,
+        IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>,
+        IChainedCommandHandler<PageUpKeyCommandArgs>,
+        IChainedCommandHandler<PageDownKeyCommandArgs>,
+        IChainedCommandHandler<CutCommandArgs>,
+        IChainedCommandHandler<PasteCommandArgs>,
+        IChainedCommandHandler<BackspaceKeyCommandArgs>,
+        IChainedCommandHandler<InsertSnippetCommandArgs>,
+        IChainedCommandHandler<SurroundWithCommandArgs>,
+        IChainedCommandHandler<AutomaticLineEnderCommandArgs>,
+        IChainedCommandHandler<SaveCommandArgs>,
+        IChainedCommandHandler<DeleteKeyCommandArgs>,
+        IChainedCommandHandler<SelectAllCommandArgs>
     {
         private readonly IAsyncCompletionService _completionService;
+
+        public string DisplayName => EditorFeaturesResources.Completion_Command_Handler;
 
         protected AbstractCompletionCommandHandler(IAsyncCompletionService completionService)
         {
             _completionService = completionService;
         }
 
-        private bool TryGetController(CommandArgs args, out Controller controller)
+        private bool TryGetController(EditorCommandArgs args, out Controller controller)
         {
             return _completionService.TryGetController(args.TextView, args.SubjectBuffer, out controller);
         }
 
-        private bool TryGetControllerCommandHandler<TCommandArgs>(TCommandArgs args, out ICommandHandler<TCommandArgs> commandHandler)
-            where TCommandArgs : CommandArgs
+        private bool TryGetControllerCommandHandler<TCommandArgs>(TCommandArgs args, out VSCommanding.ICommandHandler commandHandler)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             if (!TryGetController(args, out var controller))
@@ -49,14 +54,14 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 return false;
             }
 
-            commandHandler = (ICommandHandler<TCommandArgs>)controller;
+            commandHandler = controller;
             return true;
         }
 
-        private CommandState GetCommandStateWorker<TCommandArgs>(
+        private VSCommanding.CommandState GetCommandStateWorker<TCommandArgs>(
             TCommandArgs args,
-            Func<CommandState> nextHandler)
-            where TCommandArgs : CommandArgs
+            Func<VSCommanding.CommandState> nextHandler)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             return TryGetControllerCommandHandler(args, out var commandHandler)
@@ -66,13 +71,14 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 
         private void ExecuteCommandWorker<TCommandArgs>(
             TCommandArgs args,
-            Action nextHandler)
-            where TCommandArgs : CommandArgs
+            Action nextHandler,
+            CommandExecutionContext context)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             if (TryGetControllerCommandHandler(args, out var commandHandler))
             {
-                commandHandler.ExecuteCommand(args, nextHandler);
+                commandHandler.ExecuteCommand(args, nextHandler, context);
             }
             else
             {
@@ -80,172 +86,172 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             }
         }
 
-        CommandState ICommandHandler<TabKeyCommandArgs>.GetCommandState(TabKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TabKeyCommandArgs>.GetCommandState(TabKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<TabKeyCommandArgs>.ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<TabKeyCommandArgs>.ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<ToggleCompletionModeCommandArgs>.GetCommandState(ToggleCompletionModeCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<ToggleCompletionModeCommandArgs>.GetCommandState(ToggleCompletionModeCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<ToggleCompletionModeCommandArgs>.ExecuteCommand(ToggleCompletionModeCommandArgs args, System.Action nextHandler)
+        void IChainedCommandHandler<ToggleCompletionModeCommandArgs>.ExecuteCommand(ToggleCompletionModeCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, System.Action nextHandler)
+        void IChainedCommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<ReturnKeyCommandArgs>.GetCommandState(ReturnKeyCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<ReturnKeyCommandArgs>.GetCommandState(ReturnKeyCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<ReturnKeyCommandArgs>.ExecuteCommand(ReturnKeyCommandArgs args, System.Action nextHandler)
+        void IChainedCommandHandler<ReturnKeyCommandArgs>.ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<InvokeCompletionListCommandArgs>.GetCommandState(InvokeCompletionListCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InvokeCompletionListCommandArgs>.GetCommandState(InvokeCompletionListCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<InvokeCompletionListCommandArgs>.ExecuteCommand(InvokeCompletionListCommandArgs args, System.Action nextHandler)
+        void IChainedCommandHandler<InvokeCompletionListCommandArgs>.ExecuteCommand(InvokeCompletionListCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<PageUpKeyCommandArgs>.GetCommandState(PageUpKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PageUpKeyCommandArgs>.GetCommandState(PageUpKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<PageUpKeyCommandArgs>.ExecuteCommand(PageUpKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PageUpKeyCommandArgs>.ExecuteCommand(PageUpKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<PageDownKeyCommandArgs>.GetCommandState(PageDownKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PageDownKeyCommandArgs>.GetCommandState(PageDownKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<PageDownKeyCommandArgs>.ExecuteCommand(PageDownKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PageDownKeyCommandArgs>.ExecuteCommand(PageDownKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<CutCommandArgs>.GetCommandState(CutCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<CutCommandArgs>.GetCommandState(CutCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<CutCommandArgs>.ExecuteCommand(CutCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<CutCommandArgs>.ExecuteCommand(CutCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<PasteCommandArgs>.GetCommandState(PasteCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PasteCommandArgs>.GetCommandState(PasteCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<PasteCommandArgs>.ExecuteCommand(PasteCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PasteCommandArgs>.ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<CommitUniqueCompletionListItemCommandArgs>.GetCommandState(CommitUniqueCompletionListItemCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>.GetCommandState(CommitUniqueCompletionListItemCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<CommitUniqueCompletionListItemCommandArgs>.ExecuteCommand(CommitUniqueCompletionListItemCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>.ExecuteCommand(CommitUniqueCompletionListItemCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<BackspaceKeyCommandArgs>.GetCommandState(BackspaceKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<BackspaceKeyCommandArgs>.GetCommandState(BackspaceKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<BackspaceKeyCommandArgs>.ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<BackspaceKeyCommandArgs>.ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<InsertSnippetCommandArgs>.GetCommandState(InsertSnippetCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InsertSnippetCommandArgs>.GetCommandState(InsertSnippetCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<InsertSnippetCommandArgs>.ExecuteCommand(InsertSnippetCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<InsertSnippetCommandArgs>.ExecuteCommand(InsertSnippetCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<SurroundWithCommandArgs>.GetCommandState(SurroundWithCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<SurroundWithCommandArgs>.GetCommandState(SurroundWithCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        public CommandState GetCommandState(AutomaticLineEnderCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(AutomaticLineEnderCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        public void ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        void ICommandHandler<SurroundWithCommandArgs>.ExecuteCommand(SurroundWithCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<SurroundWithCommandArgs>.ExecuteCommand(SurroundWithCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
         internal bool TryHandleEscapeKey(EscapeKeyCommandArgs commandArgs)
@@ -278,40 +284,40 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             return controller.TryHandleDownKey();
         }
 
-        public CommandState GetCommandState(SaveCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(SaveCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        public void ExecuteCommand(SaveCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(SaveCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        public CommandState GetCommandState(DeleteKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(DeleteKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        public CommandState GetCommandState(SelectAllCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(SelectAllCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        public void ExecuteCommand(SelectAllCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(SelectAllCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
     }
 }

--- a/src/EditorFeatures/Core/CommandHandlers/AbstractIntelliSenseCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractIntelliSenseCommandHandler.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
@@ -22,13 +24,15 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
     /// doesn't process the command.
     /// </summary>
     internal abstract class AbstractIntelliSenseCommandHandler :
-        ICommandHandler<EscapeKeyCommandArgs>,
-        ICommandHandler<UpKeyCommandArgs>,
-        ICommandHandler<DownKeyCommandArgs>
+        IChainedCommandHandler<EscapeKeyCommandArgs>,
+        IChainedCommandHandler<UpKeyCommandArgs>,
+        IChainedCommandHandler<DownKeyCommandArgs>
     {
         private readonly CompletionCommandHandler _completionCommandHandler;
         private readonly SignatureHelpCommandHandler _signatureHelpCommandHandler;
         private readonly QuickInfoCommandHandlerAndSourceProvider _quickInfoCommandHandler;
+
+        public string DisplayName => EditorFeaturesResources.IntelliSense_Command_Handler;
 
         protected AbstractIntelliSenseCommandHandler(
             CompletionCommandHandler completionCommandHandler,
@@ -40,22 +44,22 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             _quickInfoCommandHandler = quickInfoCommandHandler;
         }
 
-        public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(EscapeKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public CommandState GetCommandState(UpKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(UpKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public CommandState GetCommandState(DownKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(DownKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             if ((_completionCommandHandler != null && _completionCommandHandler.TryHandleEscapeKey(args)) ||
                 (_signatureHelpCommandHandler != null && _signatureHelpCommandHandler.TryHandleEscapeKey(args)) ||
@@ -67,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             nextHandler();
         }
 
-        public void ExecuteCommand(UpKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(UpKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             if ((_completionCommandHandler != null && _completionCommandHandler.TryHandleUpKey(args)) ||
                 (_signatureHelpCommandHandler != null && _signatureHelpCommandHandler.TryHandleUpKey(args)))
@@ -78,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             nextHandler();
         }
 
-        public void ExecuteCommand(DownKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(DownKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             if ((_completionCommandHandler != null && _completionCommandHandler.TryHandleDownKey(args)) ||
                 (_signatureHelpCommandHandler != null && _signatureHelpCommandHandler.TryHandleDownKey(args)))

--- a/src/EditorFeatures/Core/CommandHandlers/CompletionCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/CompletionCommandHandler.cs
@@ -2,11 +2,14 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     [Export]
-    [ExportCommandHandler(PredefinedCommandHandlerNames.Completion, ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.Completion)]
     [Order(After = PredefinedCommandHandlerNames.SignatureHelp,
            Before = PredefinedCommandHandlerNames.DocumentationComments)]
     internal sealed class CompletionCommandHandler : AbstractCompletionCommandHandler

--- a/src/EditorFeatures/Core/CommandHandlers/ExecuteInInteractiveCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/ExecuteInInteractiveCommandHandler.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.VisualStudio.Text;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
@@ -15,11 +18,15 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
     /// in order to ensure that the interactive command can be exposed without the necessity
     /// to load any of the interactive dll files just to get the command's status.
     /// </summary>
-    [ExportCommandHandler("Interactive Command Handler", ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name("Interactive Command Handler")]
     internal class ExecuteInInteractiveCommandHandler
-        : ICommandHandler<ExecuteInInteractiveCommandArgs>
+        : VSCommanding.ICommandHandler<ExecuteInInteractiveCommandArgs>
     {
         private readonly IEnumerable<Lazy<IExecuteInInteractiveCommandHandler, ContentTypeMetadata>> _executeInInteractiveHandlers;
+
+        public string DisplayName => EditorFeaturesResources.Execute_In_Interactive_Command_Handler;
 
         [ImportingConstructor]
         public ExecuteInInteractiveCommandHandler(
@@ -35,16 +42,16 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 .SingleOrDefault();
         }
 
-        void ICommandHandler<ExecuteInInteractiveCommandArgs>.ExecuteCommand(ExecuteInInteractiveCommandArgs args, Action nextHandler)
+        bool VSCommanding.ICommandHandler<ExecuteInInteractiveCommandArgs>.ExecuteCommand(ExecuteInInteractiveCommandArgs args, CommandExecutionContext context)
         {
-            GetCommandHandler(args.SubjectBuffer)?.Value.ExecuteCommand(args, nextHandler);
+            return GetCommandHandler(args.SubjectBuffer)?.Value.ExecuteCommand(args, context) ?? false;
         }
 
-        CommandState ICommandHandler<ExecuteInInteractiveCommandArgs>.GetCommandState(ExecuteInInteractiveCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState VSCommanding.ICommandHandler<ExecuteInInteractiveCommandArgs>.GetCommandState(ExecuteInInteractiveCommandArgs args)
         {
             return GetCommandHandler(args.SubjectBuffer) == null
-                ? CommandState.Unavailable
-                : CommandState.Available;
+                ? VSCommanding.CommandState.Unavailable
+                : VSCommanding.CommandState.Available;
         }
     }
 }

--- a/src/EditorFeatures/Core/CommandHandlers/GoToAdjacentMemberCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/GoToAdjacentMemberCommandHandler.cs
@@ -5,37 +5,64 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Outlining;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.GoToAdjacentMember, ContentTypeNames.RoslynContentType)]
-    internal class GoToAdjacentMemberCommandHandler : ICommandHandler<GoToAdjacentMemberCommandArgs>
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.GoToAdjacentMember)]
+    internal class GoToAdjacentMemberCommandHandler : 
+        VSCommanding.ICommandHandler<GoToNextMemberCommandArgs>, 
+        VSCommanding.ICommandHandler<GoToPreviousMemberCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
         private readonly IOutliningManagerService _outliningManagerService;
 
+        public string DisplayName => EditorFeaturesResources.Go_To_Adjacent_Member_Command_Handler;
+
         [ImportingConstructor]
-        public GoToAdjacentMemberCommandHandler(IWaitIndicator waitIndicator, IOutliningManagerService outliningManagerService)
+        public GoToAdjacentMemberCommandHandler(IOutliningManagerService outliningManagerService)
         {
-            _waitIndicator = waitIndicator;
             _outliningManagerService = outliningManagerService;
         }
 
-        public CommandState GetCommandState(GoToAdjacentMemberCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(GoToNextMemberCommandArgs args)
         {
+            return GetCommandStateImpl(args);
+        }
+
+        public bool ExecuteCommand(GoToNextMemberCommandArgs args, CommandExecutionContext context)
+        {
+            return ExecuteCommandImpl(args, gotoNextMember: true, context);
+        }
+
+        public VSCommanding.CommandState GetCommandState(GoToPreviousMemberCommandArgs args)
+        {
+            return GetCommandStateImpl(args);
+        }
+
+        public bool ExecuteCommand(GoToPreviousMemberCommandArgs args, CommandExecutionContext context)
+        {
+            return ExecuteCommandImpl(args, gotoNextMember: false, context);
+        }
+
+        private VSCommanding.CommandState GetCommandStateImpl(EditorCommandArgs args)
+        { 
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
-            return IsAvailable(document, caretPoint) ? CommandState.Available : nextHandler();
+            return IsAvailable(document, caretPoint) ? VSCommanding.CommandState.Available : VSCommanding.CommandState.Unspecified;
         }
 
         private static bool IsAvailable(Document document, SnapshotPoint? caretPoint)
@@ -54,29 +81,29 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             return documentSupportsFeatureService?.SupportsNavigationToAnyPosition(document) == true;
         }
 
-        public void ExecuteCommand(GoToAdjacentMemberCommandArgs args, Action nextHandler)
+        private bool ExecuteCommandImpl(EditorCommandArgs args, bool gotoNextMember, CommandExecutionContext context)
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
             if (!IsAvailable(document, caretPoint))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             int? targetPosition = null;
-            var waitResult = _waitIndicator.Wait(EditorFeaturesResources.Navigating, allowCancel: true, action: waitContext =>
-            {
-                var task = GetTargetPositionAsync(document, caretPoint.Value.Position, args.Direction == NavigateDirection.Down, waitContext.CancellationToken);
-                targetPosition = task.WaitAndGetResult(waitContext.CancellationToken);
-            });
 
-            if (waitResult == WaitIndicatorResult.Canceled || targetPosition == null)
+            using (context.WaitContext.AddScope(allowCancellation: true, description: EditorFeaturesResources.Navigating))
             {
-                return;
+                var task = GetTargetPositionAsync(document, caretPoint.Value.Position, gotoNextMember, context.WaitContext.UserCancellationToken);
+                targetPosition = task.WaitAndGetResult(context.WaitContext.UserCancellationToken);
             }
 
-            args.TextView.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(args.SubjectBuffer.CurrentSnapshot, targetPosition.Value), _outliningManagerService);
+            if (targetPosition != null)
+            {
+                args.TextView.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(args.SubjectBuffer.CurrentSnapshot, targetPosition.Value), _outliningManagerService);
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/EditorFeatures/Core/CommandHandlers/IExecuteInInteractiveCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/IExecuteInInteractiveCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
@@ -10,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
     /// without actually being instantiated as all other command handlers.
     /// </summary>
     internal interface IExecuteInInteractiveCommandHandler
-        : ICommandHandler<ExecuteInInteractiveCommandArgs>
+        : VSCommanding.ICommandHandler<ExecuteInInteractiveCommandArgs>
     {
     }
 }

--- a/src/EditorFeatures/Core/CommandHandlers/IntelliSenseCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/IntelliSenseCommandHandler.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.IntelliSense, ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.IntelliSense)]
     internal sealed class IntelliSenseCommandHandler : AbstractIntelliSenseCommandHandler
     {
         [ImportingConstructor]

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     internal partial class QuickInfoCommandHandlerAndSourceProvider
@@ -51,4 +50,4 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
@@ -14,9 +13,11 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     [Export]
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             _presenter = presenter;
         }
 
-        private bool TryGetController(CommandArgs args, out Controller controller)
+        private bool TryGetController(EditorCommandArgs args, out Controller controller)
         {
             AssertIsForeground();
 
@@ -97,4 +98,4 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/SignatureHelpCommandHandler.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -13,22 +12,30 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     [Export]
-    [ExportCommandHandler(PredefinedCommandHandlerNames.SignatureHelp, ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.SignatureHelp)]
     [Order(Before = PredefinedCommandHandlerNames.Completion)]
     internal class SignatureHelpCommandHandler :
         ForegroundThreadAffinitizedObject,
-        ICommandHandler<TypeCharCommandArgs>,
-        ICommandHandler<InvokeSignatureHelpCommandArgs>
+        IChainedCommandHandler<TypeCharCommandArgs>,
+        IChainedCommandHandler<InvokeSignatureHelpCommandArgs>
     {
         private readonly IIntelliSensePresenter<ISignatureHelpPresenterSession, ISignatureHelpSession> _signatureHelpPresenter;
         private readonly IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> _asyncListeners;
         private readonly IList<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> _signatureHelpProviders;
+
+        public string DisplayName => EditorFeaturesResources.Signature_Help_Command_Handler;
 
         [ImportingConstructor]
         public SignatureHelpCommandHandler(
@@ -51,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             _signatureHelpPresenter = signatureHelpPresenter;
         }
 
-        private bool TryGetController(CommandArgs args, out Controller controller)
+        private bool TryGetController(EditorCommandArgs args, out Controller controller)
         {
             AssertIsForeground();
 
@@ -79,8 +86,8 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             return true;
         }
 
-        private bool TryGetControllerCommandHandler<TCommandArgs>(TCommandArgs args, out ICommandHandler<TCommandArgs> commandHandler)
-            where TCommandArgs : CommandArgs
+        private bool TryGetControllerCommandHandler<TCommandArgs>(TCommandArgs args, out VSCommanding.ICommandHandler commandHandler)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             if (!TryGetController(args, out var controller))
@@ -89,14 +96,14 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 return false;
             }
 
-            commandHandler = (ICommandHandler<TCommandArgs>)controller;
+            commandHandler = controller;
             return true;
         }
 
-        private CommandState GetCommandStateWorker<TCommandArgs>(
+        private VSCommanding.CommandState GetCommandStateWorker<TCommandArgs>(
             TCommandArgs args,
-            Func<CommandState> nextHandler)
-            where TCommandArgs : CommandArgs
+            Func<VSCommanding.CommandState> nextHandler)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             return TryGetControllerCommandHandler(args, out var commandHandler)
@@ -106,8 +113,9 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 
         private void ExecuteCommandWorker<TCommandArgs>(
             TCommandArgs args,
-            Action nextHandler)
-            where TCommandArgs : CommandArgs
+            Action nextHandler,
+            CommandExecutionContext context)
+            where TCommandArgs : EditorCommandArgs
         {
             AssertIsForeground();
             if (!TryGetControllerCommandHandler(args, out var commandHandler))
@@ -116,32 +124,32 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
             }
             else
             {
-                commandHandler.ExecuteCommand(args, nextHandler);
+                commandHandler.ExecuteCommand(args, nextHandler, context);
             }
         }
 
-        CommandState ICommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, System.Action nextHandler)
+        void IChainedCommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
-        CommandState ICommandHandler<InvokeSignatureHelpCommandArgs>.GetCommandState(InvokeSignatureHelpCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InvokeSignatureHelpCommandArgs>.GetCommandState(InvokeSignatureHelpCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return GetCommandStateWorker(args, nextHandler);
         }
 
-        void ICommandHandler<InvokeSignatureHelpCommandArgs>.ExecuteCommand(InvokeSignatureHelpCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<InvokeSignatureHelpCommandArgs>.ExecuteCommand(InvokeSignatureHelpCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
+            ExecuteCommandWorker(args, nextHandler, context);
         }
 
         internal bool TryHandleEscapeKey(EscapeKeyCommandArgs commandArgs)

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -270,6 +270,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatic Line Ender Command Handler.
+        /// </summary>
+        internal static string Automatic_Line_Ender_Command_Handler {
+            get {
+                return ResourceManager.GetString("Automatic_Line_Ender_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Automatic Pair Completion.
         /// </summary>
         internal static string Automatic_Pair_Completion {
@@ -293,6 +302,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Automatically_completing {
             get {
                 return ResourceManager.GetString("Automatically_completing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Block Comment Editing Command Handler.
+        /// </summary>
+        internal static string Block_Comment_Editing_Command_Handler {
+            get {
+                return ResourceManager.GetString("Block_Comment_Editing_Command_Handler", resourceCulture);
             }
         }
         
@@ -432,6 +450,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change Signature Command Handler.
+        /// </summary>
+        internal static string Change_Signature_Command_Handler {
+            get {
+                return ResourceManager.GetString("Change_Signature_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changes.
         /// </summary>
         internal static string Changes {
@@ -477,6 +504,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comment/Uncomment Selection Command Handler.
+        /// </summary>
+        internal static string Comment_Uncomment_Selection_Command_Handler {
+            get {
+                return ResourceManager.GetString("Comment_Uncomment_Selection_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Commenting currently selected text....
         /// </summary>
         internal static string Commenting_currently_selected_text {
@@ -491,6 +527,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Completing_Tag {
             get {
                 return ResourceManager.GetString("Completing_Tag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code Completion Command Handler.
+        /// </summary>
+        internal static string Completion_Command_Handler {
+            get {
+                return ResourceManager.GetString("Completion_Command_Handler", resourceCulture);
             }
         }
         
@@ -585,6 +630,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Documentation Comment Command Handler.
+        /// </summary>
+        internal static string Documentation_Comment_Command_Handler {
+            get {
+                return ResourceManager.GetString("Documentation_Comment_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Encapsulate Field.
         /// </summary>
         internal static string Encapsulate_Field {
@@ -603,6 +657,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Encapsulate Field Command Handler.
+        /// </summary>
+        internal static string Encapsulate_Field_Command_Handler {
+            get {
+                return ResourceManager.GetString("Encapsulate_Field_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Engine must be attached to an Interactive Window..
         /// </summary>
         internal static string Engine_must_be_attached_to_an_Interactive_Window {
@@ -612,11 +675,38 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Execute In Interactive Command Handler.
+        /// </summary>
+        internal static string Execute_In_Interactive_Command_Handler {
+            get {
+                return ResourceManager.GetString("Execute_In_Interactive_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extract Interface Command Handler.
+        /// </summary>
+        internal static string Extract_Interface_Command_Handler {
+            get {
+                return ResourceManager.GetString("Extract_Interface_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extract Method.
         /// </summary>
         internal static string Extract_Method {
             get {
                 return ResourceManager.GetString("Extract_Method", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extract Method Command Handler.
+        /// </summary>
+        internal static string Extract_Method_Command_Handler {
+            get {
+                return ResourceManager.GetString("Extract_Method_Command_Handler", resourceCulture);
             }
         }
         
@@ -635,6 +725,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Find_References {
             get {
                 return ResourceManager.GetString("Find_References", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Find References Command Handler.
+        /// </summary>
+        internal static string Find_References_Command_Handler {
+            get {
+                return ResourceManager.GetString("Find_References_Command_Handler", resourceCulture);
             }
         }
         
@@ -707,6 +806,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Fix_all_occurrences_in {
             get {
                 return ResourceManager.GetString("Fix_all_occurrences_in", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Format Command Handler.
+        /// </summary>
+        internal static string Format_Command_Handler {
+            get {
+                return ResourceManager.GetString("Format_Command_Handler", resourceCulture);
             }
         }
         
@@ -801,6 +909,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go To Adjacent Member Command Handler.
+        /// </summary>
+        internal static string Go_To_Adjacent_Member_Command_Handler {
+            get {
+                return ResourceManager.GetString("Go_To_Adjacent_Member_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Go to Definition.
         /// </summary>
         internal static string Go_to_Definition {
@@ -810,11 +927,29 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go To Definition Command Handler.
+        /// </summary>
+        internal static string Go_To_Definition_Command_Handler {
+            get {
+                return ResourceManager.GetString("Go_To_Definition_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Go To Implementation.
         /// </summary>
         internal static string Go_To_Implementation {
             get {
                 return ResourceManager.GetString("Go_To_Implementation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go To Implementation Command Handler.
+        /// </summary>
+        internal static string Go_To_Implementation_Command_Handler {
+            get {
+                return ResourceManager.GetString("Go_To_Implementation_Command_Handler", resourceCulture);
             }
         }
         
@@ -1008,11 +1143,38 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to IntelliSense Command Handler.
+        /// </summary>
+        internal static string IntelliSense_Command_Handler {
+            get {
+                return ResourceManager.GetString("IntelliSense_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to IntelliSense Commit Formatting.
         /// </summary>
         internal static string IntelliSense_Commit_Formatting {
             get {
                 return ResourceManager.GetString("IntelliSense_Commit_Formatting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interactive Command Handler.
+        /// </summary>
+        internal static string Interactive_Command_Handler {
+            get {
+                return ResourceManager.GetString("Interactive_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interactive Paste Command Handler.
+        /// </summary>
+        internal static string Interactive_Paste_Command_Handler {
+            get {
+                return ResourceManager.GetString("Interactive_Paste_Command_Handler", resourceCulture);
             }
         }
         
@@ -1058,6 +1220,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Modify_any_highlighted_location_to_begin_renaming {
             get {
                 return ResourceManager.GetString("Modify_any_highlighted_location_to_begin_renaming", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Navigate To Highlighted Reference Command Handler.
+        /// </summary>
+        internal static string Navigate_To_Highlight_Reference_Command_Handler {
+            get {
+                return ResourceManager.GetString("Navigate_To_Highlight_Reference_Command_Handler", resourceCulture);
             }
         }
         
@@ -1161,11 +1332,29 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Organize Document Command Handler.
+        /// </summary>
+        internal static string Organize_Document_Command_Handler {
+            get {
+                return ResourceManager.GetString("Organize_Document_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Organizing document....
         /// </summary>
         internal static string Organizing_document {
             get {
                 return ResourceManager.GetString("Organizing_document", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Outlining Command Handler.
+        /// </summary>
+        internal static string Outlining_Command_Handler {
+            get {
+                return ResourceManager.GetString("Outlining_Command_Handler", resourceCulture);
             }
         }
         
@@ -1395,6 +1584,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rename Command Handler.
+        /// </summary>
+        internal static string Rename_Command_Handler {
+            get {
+                return ResourceManager.GetString("Rename_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rename operation was cancelled or is not valid.
         /// </summary>
         internal static string Rename_operation_was_cancelled_or_is_not_valid {
@@ -1428,6 +1626,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string Rename_Tracking {
             get {
                 return ResourceManager.GetString("Rename_Tracking", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename Tracking Cancellation Command Handler.
+        /// </summary>
+        internal static string Rename_Tracking_Cancellation_Command_Handler {
+            get {
+                return ResourceManager.GetString("Rename_Tracking_Cancellation_Command_Handler", resourceCulture);
             }
         }
         
@@ -1486,11 +1693,29 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Signature Help Command Handler.
+        /// </summary>
+        internal static string Signature_Help_Command_Handler {
+            get {
+                return ResourceManager.GetString("Signature_Help_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Smart Indenting.
         /// </summary>
         internal static string Smart_Indenting {
             get {
                 return ResourceManager.GetString("Smart_Indenting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smart Token Formatter Command Handler.
+        /// </summary>
+        internal static string Smart_Token_Formatter_Command_Handler {
+            get {
+                return ResourceManager.GetString("Smart_Token_Formatter_Command_Handler", resourceCulture);
             }
         }
         
@@ -1855,6 +2080,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to View Call Hierarchy Command Handler.
+        /// </summary>
+        internal static string View_Call_Hierarchy_Command_Handler {
+            get {
+                return ResourceManager.GetString("View_Call_Hierarchy_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to We can fix the error by not making struct &quot;out/ref&quot; parameter(s). 
         ///Do you want to proceed?.
         /// </summary>
@@ -1961,6 +2195,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         internal static string XML_End_Tag_Completion {
             get {
                 return ResourceManager.GetString("XML_End_Tag_Completion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to XML Tag Completion Command Handler.
+        /// </summary>
+        internal static string Xml_Tag_Completion_Command_Handler {
+            get {
+                return ResourceManager.GetString("Xml_Tag_Completion_Command_Handler", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -767,4 +767,85 @@ Do you want to proceed?</value>
   <data name="Inline_Rename_Field_Text" xml:space="preserve">
     <value>Inline Rename Field Text</value>
   </data>
+  <data name="View_Call_Hierarchy_Command_Handler" xml:space="preserve">
+    <value>View Call Hierarchy Command Handler</value>
+  </data>
+  <data name="Automatic_Line_Ender_Command_Handler" xml:space="preserve">
+    <value>Automatic Line Ender Command Handler</value>
+  </data>
+  <data name="Block_Comment_Editing_Command_Handler" xml:space="preserve">
+    <value>Block Comment Editing Command Handler</value>
+  </data>
+  <data name="Change_Signature_Command_Handler" xml:space="preserve">
+    <value>Change Signature Command Handler</value>
+  </data>
+  <data name="Comment_Uncomment_Selection_Command_Handler" xml:space="preserve">
+    <value>Comment/Uncomment Selection Command Handler</value>
+  </data>
+  <data name="Completion_Command_Handler" xml:space="preserve">
+    <value>Code Completion Command Handler</value>
+  </data>
+  <data name="Documentation_Comment_Command_Handler" xml:space="preserve">
+    <value>Documentation Comment Command Handler</value>
+  </data>
+  <data name="Encapsulate_Field_Command_Handler" xml:space="preserve">
+    <value>Encapsulate Field Command Handler</value>
+  </data>
+  <data name="Execute_In_Interactive_Command_Handler" xml:space="preserve">
+    <value>Execute In Interactive Command Handler</value>
+  </data>
+  <data name="Extract_Interface_Command_Handler" xml:space="preserve">
+    <value>Extract Interface Command Handler</value>
+  </data>
+  <data name="Extract_Method_Command_Handler" xml:space="preserve">
+    <value>Extract Method Command Handler</value>
+  </data>
+  <data name="Find_References_Command_Handler" xml:space="preserve">
+    <value>Find References Command Handler</value>
+  </data>
+  <data name="Format_Command_Handler" xml:space="preserve">
+    <value>Format Command Handler</value>
+  </data>
+  <data name="Go_To_Adjacent_Member_Command_Handler" xml:space="preserve">
+    <value>Go To Adjacent Member Command Handler</value>
+  </data>
+  <data name="Go_To_Definition_Command_Handler" xml:space="preserve">
+    <value>Go To Definition Command Handler</value>
+  </data>
+  <data name="Go_To_Implementation_Command_Handler" xml:space="preserve">
+    <value>Go To Implementation Command Handler</value>
+  </data>
+  <data name="IntelliSense_Command_Handler" xml:space="preserve">
+    <value>IntelliSense Command Handler</value>
+  </data>
+  <data name="Interactive_Command_Handler" xml:space="preserve">
+    <value>Interactive Command Handler</value>
+  </data>
+  <data name="Interactive_Paste_Command_Handler" xml:space="preserve">
+    <value>Interactive Paste Command Handler</value>
+  </data>
+  <data name="Navigate_To_Highlight_Reference_Command_Handler" xml:space="preserve">
+    <value>Navigate To Highlighted Reference Command Handler</value>
+  </data>
+  <data name="Organize_Document_Command_Handler" xml:space="preserve">
+    <value>Organize Document Command Handler</value>
+  </data>
+  <data name="Outlining_Command_Handler" xml:space="preserve">
+    <value>Outlining Command Handler</value>
+  </data>
+  <data name="Rename_Command_Handler" xml:space="preserve">
+    <value>Rename Command Handler</value>
+  </data>
+  <data name="Rename_Tracking_Cancellation_Command_Handler" xml:space="preserve">
+    <value>Rename Tracking Cancellation Command Handler</value>
+  </data>
+  <data name="Signature_Help_Command_Handler" xml:space="preserve">
+    <value>Signature Help Command Handler</value>
+  </data>
+  <data name="Smart_Token_Formatter_Command_Handler" xml:space="preserve">
+    <value>Smart Token Formatter Command Handler</value>
+  </data>
+  <data name="Xml_Tag_Completion_Command_Handler" xml:space="preserve">
+    <value>XML Tag Completion Command Handler</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -4,33 +4,40 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using System.Threading;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.FindReferences
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.FindReferences, ContentTypeNames.RoslynContentType)]
-    internal class FindReferencesCommandHandler : ICommandHandler<FindReferencesCommandArgs>
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.FindReferences)]
+    internal class FindReferencesCommandHandler : VSCommanding.ICommandHandler<FindReferencesCommandArgs>
     {
         private readonly IEnumerable<IDefinitionsAndReferencesPresenter> _synchronousPresenters;
         private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
 
-        private readonly IWaitIndicator _waitIndicator;
         private readonly IAsynchronousOperationListener _asyncListener;
+
+        public string DisplayName => EditorFeaturesResources.Find_References_Command_Handler;
 
         [ImportingConstructor]
         internal FindReferencesCommandHandler(
-            IWaitIndicator waitIndicator,
             [ImportMany] IEnumerable<IDefinitionsAndReferencesPresenter> synchronousPresenters,
             [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
@@ -39,19 +46,18 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
             Contract.ThrowIfNull(streamingPresenters);
             Contract.ThrowIfNull(asyncListeners);
 
-            _waitIndicator = waitIndicator;
             _synchronousPresenters = synchronousPresenters;
             _streamingPresenters = streamingPresenters;
             _asyncListener = new AggregateAsynchronousOperationListener(
                 asyncListeners, FeatureAttribute.FindReferences);
         }
 
-        public CommandState GetCommandState(FindReferencesCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(FindReferencesCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
 
-        public void ExecuteCommand(FindReferencesCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(FindReferencesCommandArgs args, CommandExecutionContext context)
         {
             // Get the selection that user has in our buffer (this also works if there
             // is no selection and the caret is just at a single position).  If we 
@@ -69,17 +75,17 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
                     // user has selected a symbol that has another symbol touching it
                     // on the right (i.e.  Goo++  ), then we'll do the find-refs on the
                     // symbol selected, not the symbol following.
-                    if (TryExecuteCommand(selectedSpan.Start, document))
+                    if (TryExecuteCommand(selectedSpan.Start, document, context))
                     {
-                        return;
+                        return true;
                     }
                 }
             }
 
-            nextHandler();
+            return false;
         }
 
-        private bool TryExecuteCommand(int caretPosition, Document document)
+        private bool TryExecuteCommand(int caretPosition, Document document, CommandExecutionContext context)
         {
             var streamingService = document.GetLanguageService<IFindUsagesService>();
             var streamingPresenter = GetStreamingPresenter();
@@ -100,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
             var synchronousService = document.GetLanguageService<IFindReferencesService>();
             if (synchronousService != null)
             {
-                FindReferences(document, synchronousService, caretPosition);
+                FindReferences(document, synchronousService, caretPosition, context);
                 return true;
             }
 
@@ -158,29 +164,24 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
         }
 
         internal void FindReferences(
-            Document document, IFindReferencesService service, int caretPosition)
+            Document document, IFindReferencesService service, int caretPosition, CommandExecutionContext context)
         {
-            _waitIndicator.Wait(
-                title: EditorFeaturesResources.Find_References,
-                message: EditorFeaturesResources.Finding_references,
-                action: context =>
+            using (var waitScope = context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Finding_references))
+            using (Logger.LogBlock(
+                FunctionId.CommandHandler_FindAllReference,
+                KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "legacy"),
+                context.WaitContext.UserCancellationToken))
+            {
+                if (!service.TryFindReferences(document, caretPosition, new WaitContextAdapter(waitScope)))
                 {
-                    using (Logger.LogBlock(
-                        FunctionId.CommandHandler_FindAllReference,
-                        KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "legacy"),
-                        context.CancellationToken))
+                    // The service failed, so just present an empty list of references
+                    foreach (var presenter in _synchronousPresenters)
                     {
-                        if (!service.TryFindReferences(document, caretPosition, context))
-                        {
-                            // The service failed, so just present an empty list of references
-                            foreach (var presenter in _synchronousPresenters)
-                            {
-                                presenter.DisplayResult(DefinitionsAndReferences.Empty);
-                                return;
-                            }
-                        }
+                        presenter.DisplayResult(DefinitionsAndReferences.Empty);
+                        return;
                     }
-                }, allowCancel: true);
+                }
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
@@ -2,29 +2,25 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.GoToDefinition,
-       ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.GoToDefinition)]
     internal class GoToDefinitionCommandHandler :
-        ICommandHandler<GoToDefinitionCommandArgs>
+        VSCommanding.ICommandHandler<GoToDefinitionCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
-
-        [ImportingConstructor]
-        public GoToDefinitionCommandHandler(
-            IWaitIndicator waitIndicator)
-        {
-            _waitIndicator = waitIndicator;
-        }
+        public string DisplayName => EditorFeaturesResources.Go_To_Definition_Command_Handler;
 
         private (Document, IGoToDefinitionService) GetDocumentAndService(ITextSnapshot snapshot)
         {
@@ -32,58 +28,58 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             return (document, document?.GetLanguageService<IGoToDefinitionService>());
         }
 
-        public CommandState GetCommandState(GoToDefinitionCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(GoToDefinitionCommandArgs args)
         {
             var (document, service) = GetDocumentAndService(args.SubjectBuffer.CurrentSnapshot);
             return service != null
-                ? CommandState.Available
-                : CommandState.Unavailable;
+                ? VSCommanding.CommandState.Available
+                : VSCommanding.CommandState.Unavailable;
         }
 
-        public void ExecuteCommand(GoToDefinitionCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(GoToDefinitionCommandArgs args, CommandExecutionContext context)
         {
             var subjectBuffer = args.SubjectBuffer;
             var (document, service) = GetDocumentAndService(subjectBuffer.CurrentSnapshot);
             if (service != null)
             {
                 var caretPos = args.TextView.GetCaretPoint(subjectBuffer);
-                if (caretPos.HasValue && TryExecuteCommand(document, caretPos.Value, service))
+                if (caretPos.HasValue && TryExecuteCommand(document, caretPos.Value, service, context))
                 {
-                    return;
+                    return true;
                 }
             }
 
-            nextHandler();
+            return false;
         }
 
         // Internal for testing purposes only.
-        internal bool TryExecuteCommand(ITextSnapshot snapshot, int caretPosition)
-            => TryExecuteCommand(snapshot.GetOpenDocumentInCurrentContextWithChanges(), caretPosition);
+        internal bool TryExecuteCommand(ITextSnapshot snapshot, int caretPosition, CommandExecutionContext context)
+            => TryExecuteCommand(snapshot.GetOpenDocumentInCurrentContextWithChanges(), caretPosition, context);
 
-        internal bool TryExecuteCommand(Document document, int caretPosition)
-            => TryExecuteCommand(document, caretPosition, document.GetLanguageService<IGoToDefinitionService>());
+        internal bool TryExecuteCommand(Document document, int caretPosition, CommandExecutionContext context)
+            => TryExecuteCommand(document, caretPosition, document.GetLanguageService<IGoToDefinitionService>(), context);
 
-        internal bool TryExecuteCommand(Document document, int caretPosition, IGoToDefinitionService goToDefinitionService)
+        internal bool TryExecuteCommand(Document document, int caretPosition, IGoToDefinitionService goToDefinitionService, CommandExecutionContext context)
         {
             string errorMessage = null;
 
-            var result = _waitIndicator.Wait(
-                title: EditorFeaturesResources.Go_to_Definition,
-                message: EditorFeaturesResources.Navigating_to_definition,
-                allowCancel: true,
-                action: waitContext =>
-                {
-                    if (goToDefinitionService != null &&
-                        goToDefinitionService.TryGoToDefinition(document, caretPosition, waitContext.CancellationToken))
-                    {
-                        return;
-                    }
-
-                    errorMessage = EditorFeaturesResources.Cannot_navigate_to_the_symbol_under_the_caret;
-                });
-
-            if (result == WaitIndicatorResult.Completed && errorMessage != null)
+            using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Navigating_to_definition))
             {
+                if (goToDefinitionService != null &&
+                    goToDefinitionService.TryGoToDefinition(document, caretPosition, context.WaitContext.UserCancellationToken))
+                {
+                    return true;
+                }
+
+                errorMessage = EditorFeaturesResources.Cannot_navigate_to_the_symbol_under_the_caret;
+            }
+
+            if (errorMessage != null)
+            {
+                // We are about to show a modal UI dialog so we should take over the command execution
+                // wait context. That means the command system won't attempt to show its own wait dialog 
+                // and also will take it into consideration when measuring command handling duration.
+                context.WaitContext.TakeOwnership();
                 var workspace = document.Project.Solution.Workspace;
                 var notificationService = workspace.Services.GetService<INotificationService>();
                 notificationService.SendNotification(errorMessage, title: EditorFeaturesResources.Go_to_Definition, severity: NotificationSeverity.Information);

--- a/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -13,25 +13,28 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.GoToImplementation,
-        ContentTypeNames.RoslynContentType)]
-    internal partial class GoToImplementationCommandHandler : ICommandHandler<GoToImplementationCommandArgs>
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.GoToImplementation)]
+    internal partial class GoToImplementationCommandHandler : VSCommanding.ICommandHandler<GoToImplementationCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
         private readonly IEnumerable<Lazy<IStreamingFindUsagesPresenter>> _streamingPresenters;
 
         [ImportingConstructor]
         public GoToImplementationCommandHandler(
-            IWaitIndicator waitIndicator,
             [ImportMany] IEnumerable<Lazy<IStreamingFindUsagesPresenter>> streamingPresenters)
         {
-            _waitIndicator = waitIndicator;
             _streamingPresenters = streamingPresenters;
         }
+
+        public string DisplayName => EditorFeaturesResources.Go_To_Implementation_Command_Handler;
 
         private (Document, IGoToImplementationService, IFindUsagesService) GetDocumentAndServices(ITextSnapshot snapshot)
         {
@@ -41,16 +44,16 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
                     document?.GetLanguageService<IFindUsagesService>());
         }
 
-        public CommandState GetCommandState(GoToImplementationCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(GoToImplementationCommandArgs args)
         {
             // Because this is expensive to compute, we just always say yes as long as the language allows it.
             var (document, implService, findUsagesService) = GetDocumentAndServices(args.SubjectBuffer.CurrentSnapshot);
             return implService != null || findUsagesService != null
-                ? CommandState.Available
-                : CommandState.Unavailable;
+                ? VSCommanding.CommandState.Available
+                : VSCommanding.CommandState.Unavailable;
         }
 
-        public void ExecuteCommand(GoToImplementationCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(GoToImplementationCommandArgs args, CommandExecutionContext context)
         {
             var (document, implService, findUsagesService) = GetDocumentAndServices(args.SubjectBuffer.CurrentSnapshot);
             if (implService != null || findUsagesService != null)
@@ -58,18 +61,19 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
                 var caret = args.TextView.GetCaretPoint(args.SubjectBuffer);
                 if (caret.HasValue)
                 {
-                    ExecuteCommand(document, caret.Value, implService, findUsagesService);
-                    return;
+                    ExecuteCommand(document, caret.Value, implService, findUsagesService, context);
+                    return true;
                 }
             }
 
-            nextHandler();
+            return false;
         }
 
         private void ExecuteCommand(
             Document document, int caretPosition,
             IGoToImplementationService synchronousService,
-            IFindUsagesService streamingService)
+            IFindUsagesService streamingService,
+            CommandExecutionContext context)
         {
             var streamingPresenter = GetStreamingPresenter();
 
@@ -81,28 +85,30 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
             {
                 // We have all the cheap stuff, so let's do expensive stuff now
                 string messageToShow = null;
-                _waitIndicator.Wait(
-                    EditorFeaturesResources.Go_To_Implementation,
-                    EditorFeaturesResources.Locating_implementations,
-                    allowCancel: true,
-                    action: context =>
+
+                using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Locating_implementations))
+                {
+                    var userCancellationToken = context.WaitContext.UserCancellationToken;
+                    if (canUseStreamingWindow)
                     {
-                        if (canUseStreamingWindow)
-                        {
-                            StreamingGoToImplementation(
-                                document, caretPosition,
-                                streamingService, streamingPresenter,
-                                context.CancellationToken, out messageToShow);
-                        }
-                        else
-                        {
-                            synchronousService.TryGoToImplementation(
-                                document, caretPosition, context.CancellationToken, out messageToShow);
-                        }
-                    });
+                        StreamingGoToImplementation(
+                            document, caretPosition,
+                            streamingService, streamingPresenter,
+                            userCancellationToken, out messageToShow);
+                    }
+                    else
+                    {
+                        synchronousService.TryGoToImplementation(
+                            document, caretPosition, userCancellationToken, out messageToShow);
+                    }
+                }
 
                 if (messageToShow != null)
                 {
+                    // We are about to show a modal UI dialog so we should take over the command execution
+                    // wait context. That means the command system won't attempt to show its own wait dialog 
+                    // and also will take it into consideration when measuring command handling duration.
+                    context.WaitContext.TakeOwnership();
                     var notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
                     notificationService.SendNotification(messageToShow,
                         title: EditorFeaturesResources.Go_To_Implementation,

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
@@ -2,35 +2,31 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
-using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
 {
-    /// <summary>
-    /// abstract line ender command handler
-    /// </summary>
-    internal abstract class AbstractAutomaticLineEnderCommandHandler :
-        ICommandHandler<AutomaticLineEnderCommandArgs>
+    internal abstract class AbstractAutomaticLineEnderCommandHandler : 
+        IChainedCommandHandler<AutomaticLineEnderCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
         private readonly ITextUndoHistoryRegistry _undoRegistry;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
 
+        public string DisplayName => EditorFeaturesResources.Automatic_Line_Ender_Command_Handler;
+
         public AbstractAutomaticLineEnderCommandHandler(
-            IWaitIndicator waitIndicator,
             ITextUndoHistoryRegistry undoRegistry,
             IEditorOperationsFactoryService editorOperationsFactoryService)
         {
-            _waitIndicator = waitIndicator;
             _undoRegistry = undoRegistry;
             _editorOperationsFactoryService = editorOperationsFactoryService;
         }
@@ -55,12 +51,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
         /// </summary>
         protected abstract bool TreatAsReturn(Document document, int position, CancellationToken cancellationToken);
 
-        public CommandState GetCommandState(AutomaticLineEnderCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(AutomaticLineEnderCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
-            return CommandState.Available;
+            return VSCommanding.CommandState.Available;
         }
 
-        public void ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             // get editor operation
             var operations = _editorOperationsFactoryService.GetEditorOperations(args.TextView);
@@ -84,54 +80,54 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                 return;
             }
 
-            _waitIndicator.Wait(
-                title: EditorFeaturesResources.Automatic_Line_Ender,
-                message: EditorFeaturesResources.Automatically_completing,
-                allowCancel: false, action: w =>
+            using (context.WaitContext.AddScope(allowCancellation: false, EditorFeaturesResources.Automatically_completing))
+            {
+                // This is a non cancellable command
+                var userCancellationToken = CancellationToken.None;
+
+                // caret is not on the subject buffer. nothing we can do
+                var position = args.TextView.GetCaretPoint(args.SubjectBuffer);
+                if (!position.HasValue)
                 {
-                    // caret is not on the subject buffer. nothing we can do
-                    var position = args.TextView.GetCaretPoint(args.SubjectBuffer);
-                    if (!position.HasValue)
-                    {
-                        NextAction(operations, nextHandler);
-                        return;
-                    }
+                    NextAction(operations, nextHandler);
+                    return;
+                }
 
-                    var subjectLineWhereCaretIsOn = position.Value.GetContainingLine();
-                    var insertionPoint = GetInsertionPoint(document, subjectLineWhereCaretIsOn, w.CancellationToken);
-                    if (!insertionPoint.HasValue)
-                    {
-                        NextAction(operations, nextHandler);
-                        return;
-                    }
+                var subjectLineWhereCaretIsOn = position.Value.GetContainingLine();
+                var insertionPoint = GetInsertionPoint(document, subjectLineWhereCaretIsOn, userCancellationToken);
+                if (!insertionPoint.HasValue)
+                {
+                    NextAction(operations, nextHandler);
+                    return;
+                }
 
-                    // special cases where we treat this command simply as Return.
-                    if (TreatAsReturn(document, position.Value.Position, w.CancellationToken))
-                    {
-                        // leave it to the VS editor to handle this command.
-                        // VS editor's default implementation of SmartBreakLine is simply BreakLine, which inserts
-                        // a new line and positions the caret with smart indent.
-                        nextHandler();
-                        return;
-                    }
+                // special cases where we treat this command simply as Return.
+                if (TreatAsReturn(document, position.Value.Position, userCancellationToken))
+                {
+                    // leave it to the VS editor to handle this command.
+                    // VS editor's default implementation of SmartBreakLine is simply BreakLine, which inserts
+                    // a new line and positions the caret with smart indent.
+                    nextHandler();
+                    return;
+                }
 
-                    using (var transaction = args.TextView.CreateEditTransaction(EditorFeaturesResources.Automatic_Line_Ender, _undoRegistry, _editorOperationsFactoryService))
-                    {
-                        // try to move the caret to the end of the line on which the caret is
-                        args.TextView.TryMoveCaretToAndEnsureVisible(subjectLineWhereCaretIsOn.End);
+                using (var transaction = args.TextView.CreateEditTransaction(EditorFeaturesResources.Automatic_Line_Ender, _undoRegistry, _editorOperationsFactoryService))
+                {
+                    // try to move the caret to the end of the line on which the caret is
+                    args.TextView.TryMoveCaretToAndEnsureVisible(subjectLineWhereCaretIsOn.End);
 
-                        // okay, now insert ending if we need to
-                        var newDocument = InsertEndingIfRequired(document, insertionPoint.Value, position.Value, w.CancellationToken);
+                    // okay, now insert ending if we need to
+                    var newDocument = InsertEndingIfRequired(document, insertionPoint.Value, position.Value, userCancellationToken);
 
-                        // format the document and apply the changes to the workspace
-                        FormatAndApply(newDocument, insertionPoint.Value, w.CancellationToken);
+                    // format the document and apply the changes to the workspace
+                    FormatAndApply(newDocument, insertionPoint.Value, userCancellationToken);
 
-                        // now, insert new line
-                        NextAction(operations, nextHandler);
+                    // now, insert new line
+                    NextAction(operations, nextHandler);
 
-                        transaction.Complete();
-                    }
-                });
+                    transaction.Complete();
+                }
+            }
         }
 
         /// <summary>

--- a/src/EditorFeatures/Core/Implementation/BlockCommentEditing/AbstractBlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/BlockCommentEditing/AbstractBlockCommentEditingCommandHandler.cs
@@ -1,36 +1,39 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+
 using System;
 using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
-using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
+using VSEditorCommands = Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.BlockCommentEditing
 {
-    internal abstract class AbstractBlockCommentEditingCommandHandler : ICommandHandler<ReturnKeyCommandArgs>
+    /// <summary>
+    /// This class implements both legacy and modern editor command handler becuase TypeScript
+    /// uses it to implement legacy Microsoft.CodeAnalysis.Editor.ICommandHandler based command.
+    /// Once TypeScript migrates to the modern editor commanding (tracked by
+    /// https://devdiv.visualstudio.com/DevDiv/_workitems/edit/548409), the part implementing
+    /// Microsoft.CodeAnalysis.Editor.ICommandHandler can be deleted.
+    /// </summary>
+    internal abstract class AbstractBlockCommentEditingCommandHandler : BaseAbstractBlockCommentEditingCommandHandler, 
+        ICommandHandler<ReturnKeyCommandArgs>,
+        VSCommanding.ICommandHandler<VSEditorCommands.ReturnKeyCommandArgs>
     {
-        private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
-        private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
-
         protected AbstractBlockCommentEditingCommandHandler(
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IEditorOperationsFactoryService editorOperationsFactoryService)
+            : base(undoHistoryRegistry, editorOperationsFactoryService)
         {
-            Contract.ThrowIfNull(undoHistoryRegistry);
-            Contract.ThrowIfNull(editorOperationsFactoryService);
-
-            _undoHistoryRegistry = undoHistoryRegistry;
-            _editorOperationsFactoryService = editorOperationsFactoryService;
         }
+
+        #region Legacy ICommandHandler
 
         public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler) => nextHandler();
 
         public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
         {
-            if (TryHandleReturnKey(args))
+            if (TryHandleReturnKey(args.SubjectBuffer, args.TextView))
             {
                 return;
             }
@@ -38,40 +41,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.BlockCommentEditing
             nextHandler();
         }
 
-        private bool TryHandleReturnKey(ReturnKeyCommandArgs args)
+        #endregion
+
+        #region Modern editor ICommandHandler
+
+        public string DisplayName => EditorFeaturesResources.Block_Comment_Editing_Command_Handler;
+
+        public VSCommanding.CommandState GetCommandState(VSEditorCommands.ReturnKeyCommandArgs args) => VSCommanding.CommandState.Unspecified;
+
+        public bool ExecuteCommand(VSEditorCommands.ReturnKeyCommandArgs args, VSCommanding.CommandExecutionContext context)
         {
-            var subjectBuffer = args.SubjectBuffer;
-            var textView = args.TextView;
-
-            if (!subjectBuffer.GetFeatureOnOffOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString))
-            {
-                return false;
-            }
-
-            var caretPosition = textView.GetCaretPoint(subjectBuffer);
-            if (caretPosition == null)
-            {
-                return false;
-            }
-
-            var exteriorText = GetExteriorTextForNextLine(caretPosition.Value);
-            if (exteriorText == null)
-            {
-                return false;
-            }
-
-            using (var transaction = _undoHistoryRegistry.GetHistory(args.TextView.TextBuffer).CreateTransaction(EditorFeaturesResources.Insert_new_line))
-            {
-                var editorOperations = _editorOperationsFactoryService.GetEditorOperations(args.TextView);
-
-                editorOperations.InsertNewLine();
-                editorOperations.InsertText(exteriorText);
-
-                transaction.Complete();
-                return true;
-            }
+            return TryHandleReturnKey(args.SubjectBuffer, args.TextView);
         }
 
-        protected abstract string GetExteriorTextForNextLine(SnapshotPoint caretPosition);
+        #endregion
     }
 }

--- a/src/EditorFeatures/Core/Implementation/BlockCommentEditing/BaseAbstractBlockCommentEditingCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/BlockCommentEditing/BaseAbstractBlockCommentEditingCommandHandler.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.BlockCommentEditing
+{
+    /// <summary>
+    /// Command system independent abstract Block Comment Editing Command Handler.
+    /// </summary>
+    internal abstract class BaseAbstractBlockCommentEditingCommandHandler
+    {
+        private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
+        private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
+
+        protected BaseAbstractBlockCommentEditingCommandHandler(
+            ITextUndoHistoryRegistry undoHistoryRegistry,
+            IEditorOperationsFactoryService editorOperationsFactoryService)
+        {
+            Contract.ThrowIfNull(undoHistoryRegistry);
+            Contract.ThrowIfNull(editorOperationsFactoryService);
+
+            _undoHistoryRegistry = undoHistoryRegistry;
+            _editorOperationsFactoryService = editorOperationsFactoryService;
+        }
+
+        protected bool TryHandleReturnKey(ITextBuffer subjectBuffer, ITextView textView)
+        {
+            if (!subjectBuffer.GetFeatureOnOffOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString))
+            {
+                return false;
+            }
+
+            var caretPosition = textView.GetCaretPoint(subjectBuffer);
+            if (caretPosition == null)
+            {
+                return false;
+            }
+
+            var exteriorText = GetExteriorTextForNextLine(caretPosition.Value);
+            if (exteriorText == null)
+            {
+                return false;
+            }
+
+            using (var transaction = _undoHistoryRegistry.GetHistory(textView.TextBuffer).CreateTransaction(EditorFeaturesResources.Insert_new_line))
+            {
+                var editorOperations = _editorOperationsFactoryService.GetEditorOperations(textView);
+
+                editorOperations.InsertNewLine();
+                editorOperations.InsertText(exteriorText);
+
+                transaction.Complete();
+                return true;
+            }
+        }
+
+        protected abstract string GetExteriorTextForNextLine(SnapshotPoint caretPosition);
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using Microsoft.CodeAnalysis.ChangeSignature;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -11,104 +8,98 @@ using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
 {
-    internal abstract class AbstractChangeSignatureCommandHandler : ICommandHandler<ReorderParametersCommandArgs>, ICommandHandler<RemoveParametersCommandArgs>
+    internal abstract class AbstractChangeSignatureCommandHandler : VSCommanding.ICommandHandler<ReorderParametersCommandArgs>,
+        VSCommanding.ICommandHandler<RemoveParametersCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
+        public string DisplayName => EditorFeaturesResources.Change_Signature_Command_Handler;
 
-        protected AbstractChangeSignatureCommandHandler(
-            IWaitIndicator waitIndicator)
-        {
-            _waitIndicator = waitIndicator;
-        }
+        public VSCommanding.CommandState GetCommandState(ReorderParametersCommandArgs args)
+            => GetCommandState(args.SubjectBuffer);
 
-        public CommandState GetCommandState(ReorderParametersCommandArgs args, Func<CommandState> nextHandler)
-            => GetCommandState(args.SubjectBuffer, nextHandler);
+        public VSCommanding.CommandState GetCommandState(RemoveParametersCommandArgs args)
+            => GetCommandState(args.SubjectBuffer);
 
-        public CommandState GetCommandState(RemoveParametersCommandArgs args, Func<CommandState> nextHandler)
-            => GetCommandState(args.SubjectBuffer, nextHandler);
-
-        private static CommandState GetCommandState(ITextBuffer subjectBuffer, Func<CommandState> nextHandler)
+        private static VSCommanding.CommandState GetCommandState(ITextBuffer subjectBuffer)
         {
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null ||
                 !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                return nextHandler();
+                return VSCommanding.CommandState.Unspecified;
             }
 
             var supportsFeatureService = document.Project.Solution.Workspace.Services.GetService<IDocumentSupportsFeatureService>();
             if (!supportsFeatureService.SupportsRefactorings(document))
             {
-                return nextHandler();
+                return VSCommanding.CommandState.Unspecified;
             }
 
-            return CommandState.Available;
+            return VSCommanding.CommandState.Available;
         }
 
-        public void ExecuteCommand(RemoveParametersCommandArgs args, Action nextHandler)
-            => ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
+        public bool ExecuteCommand(RemoveParametersCommandArgs args, CommandExecutionContext context)
+            => ExecuteCommand(args.TextView, args.SubjectBuffer, context);
 
-        public void ExecuteCommand(ReorderParametersCommandArgs args, Action nextHandler)
-            => ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
+        public bool ExecuteCommand(ReorderParametersCommandArgs args, CommandExecutionContext context)
+            => ExecuteCommand(args.TextView, args.SubjectBuffer, context);
 
-        private void ExecuteCommand(ITextView textView, ITextBuffer subjectBuffer, Action nextHandler)
+        private bool ExecuteCommand(ITextView textView, ITextBuffer subjectBuffer, CommandExecutionContext context)
         {
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             // TODO: reuse GetCommandState instead
             var workspace = document.Project.Solution.Workspace;
             if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var supportsFeatureService = document.Project.Solution.Workspace.Services.GetService<IDocumentSupportsFeatureService>();
             if (!supportsFeatureService.SupportsRefactorings(document))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var caretPoint = textView.GetCaretPoint(subjectBuffer);
             if (!caretPoint.HasValue)
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             ChangeSignatureResult result = null;
-            var waitResult = _waitIndicator.Wait(
-                FeaturesResources.Change_signature,
-                allowCancel: true,
-                action: w =>
-                {
-                    var reorderParametersService = document.GetLanguageService<AbstractChangeSignatureService>();
-                    result = reorderParametersService.ChangeSignature(
-                        document,
-                        caretPoint.Value.Position,
-                        (errorMessage, severity) => workspace.Services.GetService<INotificationService>().SendNotification(errorMessage, severity: severity),
-                        w.CancellationToken);
-                });
 
-            if (waitResult == WaitIndicatorResult.Canceled)
+            using (context.WaitContext.AddScope(allowCancellation: true, FeaturesResources.Change_signature))
             {
-                return;
+                var reorderParametersService = document.GetLanguageService<AbstractChangeSignatureService>();
+                result = reorderParametersService.ChangeSignature(
+                    document,
+                    caretPoint.Value.Position,
+                    (errorMessage, severity) =>
+                    {
+                        // We are about to show a modal UI dialog so we should take over the command execution
+                        // wait context. That means the command system won't attempt to show its own wait dialog 
+                        // and also will take it into consideration when measuring command handling duration.
+                        context.WaitContext.TakeOwnership();
+                        workspace.Services.GetService<INotificationService>().SendNotification(errorMessage, severity: severity);
+                    },
+                    context.WaitContext.UserCancellationToken);
             }
 
             if (result == null || !result.Succeeded)
             {
-                return;
+                return true;
             }
 
             var finalSolution = result.UpdatedSolution;
@@ -116,6 +107,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
             var previewService = workspace.Services.GetService<IPreviewDialogService>();
             if (previewService != null && result.PreviewChanges)
             {
+                // We are about to show a modal UI dialog so we should take over the command execution
+                // wait context. That means the command system won't attempt to show its own wait dialog 
+                // and also will take it into consideration when measuring command handling duration.
+                context.WaitContext.TakeOwnership();
                 finalSolution = previewService.PreviewChanges(
                     string.Format(EditorFeaturesResources.Preview_Changes_0, EditorFeaturesResources.Change_Signature),
                     "vs.csharp.refactoring.preview",
@@ -129,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
             if (finalSolution == null)
             {
                 // User clicked cancel.
-                return;
+                return true;
             }
 
             using (var workspaceUndoTransaction = workspace.OpenGlobalUndoTransaction(FeaturesResources.Change_signature))
@@ -137,11 +132,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
                 if (!workspace.TryApplyChanges(finalSolution))
                 {
                     // TODO: handle failure
-                    return;
+                    return true;
                 }
 
                 workspaceUndoTransaction.Commit();
             }
+
+            return true;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ExtractInterface/AbstractExtractInterfaceCommandHandler.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.ExtractInterface;
@@ -10,37 +8,41 @@ using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
 {
-    internal abstract class AbstractExtractInterfaceCommandHandler : ICommandHandler<ExtractInterfaceCommandArgs>
+    internal abstract class AbstractExtractInterfaceCommandHandler : VSCommanding.ICommandHandler<ExtractInterfaceCommandArgs>
     {
-        public CommandState GetCommandState(ExtractInterfaceCommandArgs args, Func<CommandState> nextHandler)
+        public string DisplayName => EditorFeaturesResources.Extract_Interface_Command_Handler;
+
+        public VSCommanding.CommandState GetCommandState(ExtractInterfaceCommandArgs args)
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null ||
                 !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.AddDocument) ||
                 !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                return nextHandler();
+                return VSCommanding.CommandState.Unspecified;
             }
 
             var supportsFeatureService = document.Project.Solution.Workspace.Services.GetService<IDocumentSupportsFeatureService>();
             if (!supportsFeatureService.SupportsRefactorings(document))
             {
-                return nextHandler();
+                return VSCommanding.CommandState.Unspecified;
             }
 
-            return CommandState.Available;
+            return VSCommanding.CommandState.Available;
         }
 
-        public void ExecuteCommand(ExtractInterfaceCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ExtractInterfaceCommandArgs args, CommandExecutionContext context)
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var workspace = document.Project.Solution.Workspace;
@@ -48,24 +50,25 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
             if (!workspace.CanApplyChange(ApplyChangesKind.AddDocument) ||
                 !workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var supportsFeatureService = document.Project.Solution.Workspace.Services.GetService<IDocumentSupportsFeatureService>();
             if (!supportsFeatureService.SupportsRefactorings(document))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
             if (!caretPoint.HasValue)
             {
-                nextHandler();
-                return;
+                return false;
             }
 
+            // We are about to show a modal UI dialog so we should take over the command execution
+            // wait context. That means the command system won't attempt to show its own wait dialog 
+            // and also will take it into consideration when measuring command handling duration.
+            context.WaitContext.TakeOwnership();
             var extractInterfaceService = document.GetLanguageService<AbstractExtractInterfaceService>();
             var result = extractInterfaceService.ExtractInterface(
                 document,
@@ -75,17 +78,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
 
             if (result == null || !result.Succeeded)
             {
-                return;
+                return true;
             }
 
             if (!document.Project.Solution.Workspace.TryApplyChanges(result.UpdatedSolution))
             {
                 // TODO: handle failure
-                return;
+                return true;
             }
 
             var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
             navigationService.TryNavigateToPosition(workspace, result.NavigationDocumentId, 0);
+
+            return true;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatSelection.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.FormatSelection.cs
@@ -1,32 +1,30 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
     internal partial class FormatCommandHandler
     {
-        public CommandState GetCommandState(FormatSelectionCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(FormatSelectionCommandArgs args)
         {
-            return GetCommandState(args.SubjectBuffer, nextHandler);
+            return GetCommandState(args.SubjectBuffer);
         }
 
-        public void ExecuteCommand(FormatSelectionCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(FormatSelectionCommandArgs args, CommandExecutionContext context)
         {
-            if (!TryExecuteCommand(args))
-            {
-                nextHandler();
-            }
+            return TryExecuteCommand(args, context);
         }
 
-        private bool TryExecuteCommand(FormatSelectionCommandArgs args)
+        private bool TryExecuteCommand(FormatSelectionCommandArgs args, CommandExecutionContext context)
         {
             if (!args.SubjectBuffer.CanApplyChangeDocumentToWorkspace())
             {
@@ -45,12 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 return false;
             }
 
-            var result = false;
-            _waitIndicator.Wait(
-                title: EditorFeaturesResources.Format_Selection,
-                message: EditorFeaturesResources.Formatting_currently_selected_text,
-                allowCancel: true,
-                action: waitContext =>
+            using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_currently_selected_text))
             {
                 var buffer = args.SubjectBuffer;
 
@@ -58,12 +51,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 var selection = args.TextView.Selection.GetSnapshotSpansOnBuffer(buffer);
                 if (selection.Count != 1)
                 {
-                    return;
+                    return false;
                 }
 
                 var formattingSpan = selection[0].Span.ToTextSpan();
 
-                Format(args.TextView, document, formattingSpan, waitContext.CancellationToken);
+                Format(args.TextView, document, formattingSpan, context.WaitContext.UserCancellationToken);
 
                 // make behavior same as dev12. 
                 // make sure we set selection back and set caret position at the end of selection
@@ -72,11 +65,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
                 args.TextView.SetSelection(currentSelection);
                 args.TextView.TryMoveCaretToAndEnsureVisible(currentSelection.End, ensureSpanVisibleOptions: EnsureSpanVisibleOptions.MinimumScroll);
 
-                // We don't call nextHandler, since we have handled this command.
-                result = true;
-            });
-
-            return result;
+                // We have handled this command
+                return true;
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.Paste.cs
@@ -2,32 +2,33 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
     internal partial class FormatCommandHandler
     {
-        public CommandState GetCommandState(PasteCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(PasteCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(PasteCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
-            _waitIndicator.Wait(
-                title: EditorFeaturesResources.Format_Paste,
-                message: EditorFeaturesResources.Formatting_pasted_text,
-                allowCancel: true,
-                action: c => ExecuteCommandWorker(args, nextHandler, c.CancellationToken));
+            using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Formatting_pasted_text))
+            {
+                ExecuteCommandWorker(args, nextHandler, context.WaitContext.UserCancellationToken);
+            }
         }
 
         private void ExecuteCommandWorker(PasteCommandArgs args, Action nextHandler, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.ReturnKey.cs
@@ -2,18 +2,20 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
     internal partial class FormatCommandHandler
     {
-        public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ReturnKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             ExecuteReturnOrTypeCommand(args, nextHandler, CancellationToken.None);
         }

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.TypeChar.cs
@@ -2,22 +2,24 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
     internal partial class FormatCommandHandler
     {
-        public CommandState GetCommandState(TypeCharCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             ExecuteCommand(args, nextHandler, CancellationToken.None);
         }

--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -4,44 +4,46 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.FormatDocument, ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.FormatDocument)]
     [Order(After = PredefinedCommandHandlerNames.Rename)]
     [Order(Before = PredefinedCommandHandlerNames.Completion)]
     internal partial class FormatCommandHandler :
-        ICommandHandler<FormatDocumentCommandArgs>,
-        ICommandHandler<FormatSelectionCommandArgs>,
-        ICommandHandler<PasteCommandArgs>,
-        ICommandHandler<TypeCharCommandArgs>,
-        ICommandHandler<ReturnKeyCommandArgs>
+        VSCommanding.ICommandHandler<FormatDocumentCommandArgs>,
+        VSCommanding.ICommandHandler<FormatSelectionCommandArgs>,
+        IChainedCommandHandler<PasteCommandArgs>,
+        IChainedCommandHandler<TypeCharCommandArgs>,
+        IChainedCommandHandler<ReturnKeyCommandArgs>
     {
-        private readonly IWaitIndicator _waitIndicator;
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
 
+        public string DisplayName => EditorFeaturesResources.Format_Command_Handler;
+
         [ImportingConstructor]
         public FormatCommandHandler(
-            IWaitIndicator waitIndicator,
             ITextUndoHistoryRegistry undoHistoryRegistry,
             IEditorOperationsFactoryService editorOperationsFactoryService)
         {
-            _waitIndicator = waitIndicator;
             _undoHistoryRegistry = undoHistoryRegistry;
             _editorOperationsFactoryService = editorOperationsFactoryService;
         }
@@ -79,17 +81,27 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
             }
         }
 
-        private static CommandState GetCommandState(ITextBuffer buffer, Func<CommandState> nextHandler)
+        private static bool CanExecuteCommand(ITextBuffer buffer)
         {
-            if (!buffer.CanApplyChangeDocumentToWorkspace())
+            return buffer.CanApplyChangeDocumentToWorkspace();
+        }
+
+        private static VSCommanding.CommandState GetCommandState(ITextBuffer buffer, Func<VSCommanding.CommandState> nextHandler)
+        {
+            if (!CanExecuteCommand(buffer))
             {
                 return nextHandler();
             }
 
-            return CommandState.Available;
+            return VSCommanding.CommandState.Available;
         }
 
-        public void ExecuteReturnOrTypeCommand(CommandArgs args, Action nextHandler, CancellationToken cancellationToken)
+        private static VSCommanding.CommandState GetCommandState(ITextBuffer buffer)
+        {
+            return CanExecuteCommand(buffer) ? VSCommanding.CommandState.Available : VSCommanding.CommandState.Unspecified;
+        }
+
+        public void ExecuteReturnOrTypeCommand(EditorCommandArgs args, Action nextHandler, CancellationToken cancellationToken)
         {
             // This method handles only return / type char
             if (!(args is ReturnKeyCommandArgs || args is TypeCharCommandArgs))

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
@@ -12,19 +11,24 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
 {
     internal abstract class AbstractSmartTokenFormatterCommandHandler :
-        ICommandHandler<ReturnKeyCommandArgs>
+        IChainedCommandHandler<ReturnKeyCommandArgs>
     {
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;
         private readonly IEditorOperationsFactoryService _editorOperationsFactoryService;
+
+        public string DisplayName => EditorFeaturesResources.Smart_Token_Formatter_Command_Handler;
 
         public AbstractSmartTokenFormatterCommandHandler(
             ITextUndoHistoryRegistry undoHistoryRegistry,
@@ -64,12 +68,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
             return true;
         }
 
-        public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ReturnKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             return nextHandler();
         }
 
-        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             var textView = args.TextView;
             var oldCaretPoint = textView.GetCaretPoint(args.SubjectBuffer);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -2,14 +2,15 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Utilities;
 
@@ -17,23 +18,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller :
         AbstractController<Controller.Session, Model, ICompletionPresenterSession, ICompletionSession>,
-        ICommandHandler<TabKeyCommandArgs>,
-        ICommandHandler<ToggleCompletionModeCommandArgs>,
-        ICommandHandler<TypeCharCommandArgs>,
-        ICommandHandler<ReturnKeyCommandArgs>,
-        ICommandHandler<InvokeCompletionListCommandArgs>,
-        ICommandHandler<CommitUniqueCompletionListItemCommandArgs>,
-        ICommandHandler<PageUpKeyCommandArgs>,
-        ICommandHandler<PageDownKeyCommandArgs>,
-        ICommandHandler<CutCommandArgs>,
-        ICommandHandler<PasteCommandArgs>,
-        ICommandHandler<BackspaceKeyCommandArgs>,
-        ICommandHandler<InsertSnippetCommandArgs>,
-        ICommandHandler<SurroundWithCommandArgs>,
-        ICommandHandler<AutomaticLineEnderCommandArgs>,
-        ICommandHandler<SaveCommandArgs>,
-        ICommandHandler<DeleteKeyCommandArgs>,
-        ICommandHandler<SelectAllCommandArgs>
+        IChainedCommandHandler<TabKeyCommandArgs>,
+        IChainedCommandHandler<ToggleCompletionModeCommandArgs>,
+        IChainedCommandHandler<TypeCharCommandArgs>,
+        IChainedCommandHandler<ReturnKeyCommandArgs>,
+        IChainedCommandHandler<InvokeCompletionListCommandArgs>,
+        IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>,
+        IChainedCommandHandler<PageUpKeyCommandArgs>,
+        IChainedCommandHandler<PageDownKeyCommandArgs>,
+        IChainedCommandHandler<CutCommandArgs>,
+        IChainedCommandHandler<PasteCommandArgs>,
+        IChainedCommandHandler<BackspaceKeyCommandArgs>,
+        IChainedCommandHandler<InsertSnippetCommandArgs>,
+        IChainedCommandHandler<SurroundWithCommandArgs>,
+        IChainedCommandHandler<AutomaticLineEnderCommandArgs>,
+        IChainedCommandHandler<SaveCommandArgs>,
+        IChainedCommandHandler<DeleteKeyCommandArgs>,
+        IChainedCommandHandler<SelectAllCommandArgs>
     {
         private static readonly object s_controllerPropertyKey = new object();
 
@@ -235,6 +236,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private const int MaxMRUSize = 10;
         private ImmutableArray<string> _recentItems = ImmutableArray<string>.Empty;
+
+        public string DisplayName => EditorFeaturesResources.Completion_Command_Handler;
 
         public void MakeMostRecentItem(string item)
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_AutomaticLineEnder.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_AutomaticLineEnder.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<AutomaticLineEnderCommandArgs>.GetCommandState(AutomaticLineEnderCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<AutomaticLineEnderCommandArgs>.GetCommandState(AutomaticLineEnderCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<AutomaticLineEnderCommandArgs>.ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<AutomaticLineEnderCommandArgs>.ExecuteCommand(AutomaticLineEnderCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -4,23 +4,25 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<BackspaceKeyCommandArgs>.GetCommandState(BackspaceKeyCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<BackspaceKeyCommandArgs>.GetCommandState(BackspaceKeyCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<BackspaceKeyCommandArgs>.ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<BackspaceKeyCommandArgs>.ExecuteCommand(BackspaceKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             ExecuteBackspaceOrDelete(args.TextView, nextHandler, isDelete: false);
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
@@ -4,22 +4,23 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<CommitUniqueCompletionListItemCommandArgs>.GetCommandState(CommitUniqueCompletionListItemCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>.GetCommandState(CommitUniqueCompletionListItemCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<CommitUniqueCompletionListItemCommandArgs>.ExecuteCommand(
-            CommitUniqueCompletionListItemCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<CommitUniqueCompletionListItemCommandArgs>.ExecuteCommand(
+            CommitUniqueCompletionListItemCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CutPaste.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CutPaste.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
@@ -9,26 +11,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
     {
         // Cut and Paste should always dismiss completion
 
-        CommandState ICommandHandler<CutCommandArgs>.GetCommandState(CutCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<CutCommandArgs>.GetCommandState(CutCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<CutCommandArgs>.ExecuteCommand(CutCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<CutCommandArgs>.ExecuteCommand(CutCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             DismissSessionIfActive();
             nextHandler();
         }
 
-        CommandState ICommandHandler<PasteCommandArgs>.GetCommandState(PasteCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PasteCommandArgs>.GetCommandState(PasteCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<PasteCommandArgs>.ExecuteCommand(PasteCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PasteCommandArgs>.ExecuteCommand(PasteCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             DismissSessionIfActive();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Delete.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Delete.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<DeleteKeyCommandArgs>.GetCommandState(DeleteKeyCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<DeleteKeyCommandArgs>.GetCommandState(DeleteKeyCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<DeleteKeyCommandArgs>.ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<DeleteKeyCommandArgs>.ExecuteCommand(DeleteKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             ExecuteBackspaceOrDelete(args.TextView, nextHandler, isDelete: true);
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
@@ -2,19 +2,21 @@
 
 using System;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<InvokeCompletionListCommandArgs>.GetCommandState(InvokeCompletionListCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InvokeCompletionListCommandArgs>.GetCommandState(InvokeCompletionListCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<InvokeCompletionListCommandArgs>.ExecuteCommand(InvokeCompletionListCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<InvokeCompletionListCommandArgs>.ExecuteCommand(InvokeCompletionListCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_NavigationKeys.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_NavigationKeys.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<PageUpKeyCommandArgs>.GetCommandState(PageUpKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PageUpKeyCommandArgs>.GetCommandState(PageUpKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        CommandState ICommandHandler<PageDownKeyCommandArgs>.GetCommandState(PageDownKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<PageDownKeyCommandArgs>.GetCommandState(PageDownKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
@@ -31,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return ChangeSelection(() => sessionOpt.PresenterSession.SelectNextItem());
         }
 
-        void ICommandHandler<PageUpKeyCommandArgs>.ExecuteCommand(PageUpKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PageUpKeyCommandArgs>.ExecuteCommand(PageUpKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!ChangeSelection(() => sessionOpt.PresenterSession.SelectPreviousPageItem()))
@@ -40,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
         }
 
-        void ICommandHandler<PageDownKeyCommandArgs>.ExecuteCommand(PageDownKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<PageDownKeyCommandArgs>.ExecuteCommand(PageDownKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!ChangeSelection(() => sessionOpt.PresenterSession.SelectNextPageItem()))

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
@@ -2,19 +2,21 @@
 
 using System;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<ReturnKeyCommandArgs>.GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<ReturnKeyCommandArgs>.GetCommandState(ReturnKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<ReturnKeyCommandArgs>.ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<ReturnKeyCommandArgs>.ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SaveCommand.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SaveCommand.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<SaveCommandArgs>.GetCommandState(SaveCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<SaveCommandArgs>.GetCommandState(SaveCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<SaveCommandArgs>.ExecuteCommand(SaveCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<SaveCommandArgs>.ExecuteCommand(SaveCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SelectAll.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SelectAll.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<SelectAllCommandArgs>.GetCommandState(SelectAllCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<SelectAllCommandArgs>.GetCommandState(SelectAllCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<SelectAllCommandArgs>.ExecuteCommand(SelectAllCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<SelectAllCommandArgs>.ExecuteCommand(SelectAllCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             DismissSessionIfActive();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SnippetCommands.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_SnippetCommands.cs
@@ -1,19 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<InsertSnippetCommandArgs>.GetCommandState(InsertSnippetCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InsertSnippetCommandArgs>.GetCommandState(InsertSnippetCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<InsertSnippetCommandArgs>.ExecuteCommand(InsertSnippetCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<InsertSnippetCommandArgs>.ExecuteCommand(InsertSnippetCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             // If the completion list is showing when the snippet picker is invoked, then the 
             // editor fails to draw the text input area of the picker until a tab or enter is 
@@ -23,13 +25,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             DismissCompletionForSnippetPicker(nextHandler);
         }
 
-        CommandState ICommandHandler<SurroundWithCommandArgs>.GetCommandState(SurroundWithCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<SurroundWithCommandArgs>.GetCommandState(SurroundWithCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<SurroundWithCommandArgs>.ExecuteCommand(SurroundWithCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<SurroundWithCommandArgs>.ExecuteCommand(SurroundWithCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             // If the completion list is showing when the snippet picker is invoked, then the 
             // editor fails to draw the text input area of the picker until a tab or enter is 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -3,24 +3,26 @@
 using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<TabKeyCommandArgs>.GetCommandState(TabKeyCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TabKeyCommandArgs>.GetCommandState(TabKeyCommandArgs args, System.Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<TabKeyCommandArgs>.ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<TabKeyCommandArgs>.ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
@@ -1,26 +1,27 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<ToggleCompletionModeCommandArgs>.GetCommandState(ToggleCompletionModeCommandArgs args, System.Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<ToggleCompletionModeCommandArgs>.GetCommandState(ToggleCompletionModeCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
 
             var isEnabled = args.SubjectBuffer.GetFeatureOnOffOption(EditorCompletionOptions.UseSuggestionMode);
-            return new CommandState(isAvailable: true, isChecked: isEnabled);
+            return new VSCommanding.CommandState(isAvailable: true, isChecked: isEnabled);
         }
 
-        void ICommandHandler<ToggleCompletionModeCommandArgs>.ExecuteCommand(ToggleCompletionModeCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<ToggleCompletionModeCommandArgs>.ExecuteCommand(ToggleCompletionModeCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -3,19 +3,21 @@
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
 
@@ -23,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             return nextHandler();
         }
 
-        void ICommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -14,14 +13,14 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Roslyn.Utilities;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal partial class Controller :
-        AbstractController<Session<Controller, Model, IQuickInfoPresenterSession>, Model, IQuickInfoPresenterSession, IQuickInfoSession>,
-        ICommandHandler<InvokeQuickInfoCommandArgs>
+        AbstractController<Session<Controller, Model, IQuickInfoPresenterSession>, Model, IQuickInfoPresenterSession, IQuickInfoSession>
     {
         private static readonly object s_quickInfoPropertyKey = new object();
 
@@ -54,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         }
 
         internal static Controller GetInstance(
-            CommandArgs args,
+            EditorCommandArgs args,
             IIntelliSensePresenter<IQuickInfoPresenterSession, IQuickInfoSession> presenter,
             IAsynchronousOperationListener asyncListener,
             IList<Lazy<IQuickInfoProvider, OrderableLanguageMetadata>> allProviders)
@@ -169,4 +168,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller_InvokeQuickInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller_InvokeQuickInfo.cs
@@ -1,37 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<InvokeQuickInfoCommandArgs>.GetCommandState(InvokeQuickInfoCommandArgs args, Func<CommandState> nextHandler)
-        {
-            AssertIsForeground();
-            return nextHandler();
-        }
-
-        void ICommandHandler<InvokeQuickInfoCommandArgs>.ExecuteCommand(InvokeQuickInfoCommandArgs args, Action nextHandler)
-        {
-            var caretPoint = args.TextView.GetCaretPoint(args.SubjectBuffer);
-            if (caretPoint.HasValue)
-            {
-                // Invoking QuickInfo from the command, so there's no session yet.
-                InvokeQuickInfo(caretPoint.Value.Position, trackMouse: false, augmentSession: null);
-            }
-        }
-
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
         public void InvokeQuickInfo(int position, bool trackMouse, IQuickInfoSession augmentSession)
         {
             AssertIsForeground();
             DismissSessionIfActive();
             StartSession(position, trackMouse, augmentSession);
         }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.cs
@@ -3,29 +3,33 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
     internal partial class Controller :
         AbstractController<Controller.Session, Model, ISignatureHelpPresenterSession, ISignatureHelpSession>,
-        ICommandHandler<TypeCharCommandArgs>,
-        ICommandHandler<InvokeSignatureHelpCommandArgs>
+        IChainedCommandHandler<TypeCharCommandArgs>,
+        IChainedCommandHandler<InvokeSignatureHelpCommandArgs>
     {
         private static readonly object s_controllerPropertyKey = new object();
 
         private readonly IList<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> _allProviders;
         private ImmutableArray<ISignatureHelpProvider> _providers;
         private IContentType _lastSeenContentType;
+
+        public string DisplayName => EditorFeaturesResources.Signature_Help_Command_Handler;
 
         public Controller(
             ITextView textView,
@@ -53,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
         }
 
         internal static Controller GetInstance(
-            CommandArgs args,
+            EditorCommandArgs args,
             IIntelliSensePresenter<ISignatureHelpPresenterSession, ISignatureHelpSession> presenter,
             IAsynchronousOperationListener asyncListener,
             IList<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> allProviders)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_InvokeSignatureHelp.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_InvokeSignatureHelp.cs
@@ -1,20 +1,22 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<InvokeSignatureHelpCommandArgs>.GetCommandState(InvokeSignatureHelpCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<InvokeSignatureHelpCommandArgs>.GetCommandState(InvokeSignatureHelpCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();
         }
 
-        void ICommandHandler<InvokeSignatureHelpCommandArgs>.ExecuteCommand(InvokeSignatureHelpCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<InvokeSignatureHelpCommandArgs>.ExecuteCommand(InvokeSignatureHelpCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             DismissSessionIfActive();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
@@ -4,16 +4,18 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 {
     internal partial class Controller
     {
-        CommandState ICommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, Func<CommandState> nextHandler)
+        VSCommanding.CommandState IChainedCommandHandler<TypeCharCommandArgs>.GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
 
@@ -21,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             return nextHandler();
         }
 
-        void ICommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler)
+        void IChainedCommandHandler<TypeCharCommandArgs>.ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Implementation/Organizing/OrganizeDocumentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Organizing/OrganizeDocumentCommandHandler.cs
@@ -3,8 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Commanding.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.OrganizeImports;
@@ -12,63 +11,60 @@ using Microsoft.CodeAnalysis.Organizing;
 using Microsoft.CodeAnalysis.RemoveUnnecessaryImports;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Organizing
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.OrganizeDocument,
-        ContentTypeNames.CSharpContentType,
-        ContentTypeNames.VisualBasicContentType,
-        ContentTypeNames.XamlContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [ContentType(ContentTypeNames.XamlContentType)]
+    [Name(PredefinedCommandHandlerNames.OrganizeDocument)]
     internal class OrganizeDocumentCommandHandler :
-        ICommandHandler<OrganizeDocumentCommandArgs>,
-        ICommandHandler<SortAndRemoveUnnecessaryImportsCommandArgs>
+        VSCommanding.ICommandHandler<OrganizeDocumentCommandArgs>,
+        VSCommanding.ICommandHandler<SortAndRemoveUnnecessaryImportsCommandArgs>
     {
-        protected readonly IWaitIndicator WaitIndicator;
+        public string DisplayName => EditorFeaturesResources.Organize_Document_Command_Handler;
 
-        [ImportingConstructor]
-        public OrganizeDocumentCommandHandler(
-            IWaitIndicator waitIndicator)
+        public VSCommanding.CommandState GetCommandState(OrganizeDocumentCommandArgs args)
         {
-            Contract.ThrowIfNull(waitIndicator);
-
-            this.WaitIndicator = waitIndicator;
+            return GetCommandState(args, _ => EditorFeaturesResources.Organize_Document);
         }
 
-        public CommandState GetCommandState(OrganizeDocumentCommandArgs args, Func<CommandState> nextHandler)
+        public bool ExecuteCommand(OrganizeDocumentCommandArgs args, CommandExecutionContext context)
         {
-            return GetCommandState(args, nextHandler, _ => EditorFeaturesResources.Organize_Document);
+            using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Organizing_document))
+            {
+                this.Organize(args.SubjectBuffer, context.WaitContext.UserCancellationToken);
+            }
+
+            return true;
         }
 
-        public void ExecuteCommand(OrganizeDocumentCommandArgs args, Action nextHandler)
+        public VSCommanding.CommandState GetCommandState(SortAndRemoveUnnecessaryImportsCommandArgs args)
         {
-            this.WaitIndicator.Wait(
-                title: EditorFeaturesResources.Organize_Document,
-                message: EditorFeaturesResources.Organizing_document,
-                allowCancel: true,
-                action: waitContext => this.Organize(args.SubjectBuffer, waitContext.CancellationToken));
+            return GetCommandState(args, o => o.SortAndRemoveUnusedImportsDisplayStringWithAccelerator);
         }
 
-        public CommandState GetCommandState(SortAndRemoveUnnecessaryImportsCommandArgs args, Func<CommandState> nextHandler)
-        {
-            return GetCommandState(args, nextHandler, o => o.SortAndRemoveUnusedImportsDisplayStringWithAccelerator);
-        }
-
-        private CommandState GetCommandState(CommandArgs args, Func<CommandState> nextHandler, Func<IOrganizeImportsService, string> descriptionString)
+        private VSCommanding.CommandState GetCommandState(EditorCommandArgs args, Func<IOrganizeImportsService, string> descriptionString)
         {
             if (IsCommandSupported(args, out var workspace))
             {
                 var organizeImportsService = workspace.Services.GetLanguageServices(args.SubjectBuffer).GetService<IOrganizeImportsService>();
-                return new CommandState(isAvailable: true, displayText: descriptionString(organizeImportsService));
+                return new VSCommanding.CommandState(isAvailable: true, displayText: descriptionString(organizeImportsService));
             }
             else
             {
-                return nextHandler();
+                return VSCommanding.CommandState.Unspecified;
             }
         }
 
-        private bool IsCommandSupported(CommandArgs args, out Workspace workspace)
+        private bool IsCommandSupported(EditorCommandArgs args, out Workspace workspace)
         {
             workspace = null;
             var document = args.SubjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
@@ -93,13 +89,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Organizing
             return workspace.Services.GetService<IDocumentSupportsFeatureService>().SupportsRefactorings(document);
         }
 
-        public void ExecuteCommand(SortAndRemoveUnnecessaryImportsCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(SortAndRemoveUnnecessaryImportsCommandArgs args, CommandExecutionContext context)
         {
-            this.WaitIndicator.Wait(
-                title: EditorFeaturesResources.Organize_Document,
-                message: EditorFeaturesResources.Organizing_document,
-                allowCancel: true,
-                action: waitContext => this.SortAndRemoveUnusedImports(args.SubjectBuffer, waitContext.CancellationToken));
+            using (context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Organizing_document))
+            {
+                this.SortAndRemoveUnusedImports(args.SubjectBuffer, context.WaitContext.UserCancellationToken);
+            }
+
+            return true;
         }
 
         private void Organize(ITextBuffer subjectBuffer, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingCancellationCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingCancellationCommandHandler.cs
@@ -1,38 +1,40 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.RenameTrackingCancellation, ContentTypeNames.RoslynContentType, ContentTypeNames.XamlContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [ContentType(ContentTypeNames.XamlContentType)]
+    [Name(PredefinedCommandHandlerNames.RenameTrackingCancellation)]
     [Order(After = PredefinedCommandHandlerNames.SignatureHelp)]
     [Order(After = PredefinedCommandHandlerNames.IntelliSense)]
     [Order(After = PredefinedCommandHandlerNames.AutomaticCompletion)]
     [Order(After = PredefinedCommandHandlerNames.Completion)]
     [Order(After = PredefinedCommandHandlerNames.QuickInfo)]
     [Order(After = PredefinedCommandHandlerNames.EventHookup)]
-    internal class RenameTrackingCancellationCommandHandler : ICommandHandler<EscapeKeyCommandArgs>
+    internal class RenameTrackingCancellationCommandHandler : VSCommanding.ICommandHandler<EscapeKeyCommandArgs>
     {
-        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
+        public string DisplayName => EditorFeaturesResources.Rename_Tracking_Cancellation_Command_Handler;
+
+        public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
         {
             var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
 
-            if (document != null &&
-                RenameTrackingDismisser.DismissVisibleRenameTracking(document.Project.Solution.Workspace, document.Id))
-            {
-                return;
-            }
-
-            nextHandler();
+            return document != null &&
+                RenameTrackingDismisser.DismissVisibleRenameTracking(document.Project.Solution.Workspace, document.Id);
         }
 
-        public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(EscapeKeyCommandArgs args)
         {
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
     }
 }

--- a/src/EditorFeatures/Core/ModernCommands/GoToImplementationCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/GoToImplementationCommandArgs.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+namespace Microsoft.CodeAnalysis.Editor.Commanding.Commands
+{
+    /// <summary>
+    /// Arguments for Go To Implementation.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal sealed class GoToImplementationCommandArgs : EditorCommandArgs
+    {
+        public GoToImplementationCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/ModernCommands/OrganizeDocumentCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/OrganizeDocumentCommandArgs.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+namespace Microsoft.CodeAnalysis.Editor.Commanding.Commands
+{
+    /// <summary>
+    /// Arguments for the Organize Document command being invoked.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal class OrganizeDocumentCommandArgs : EditorCommandArgs
+    {
+        public OrganizeDocumentCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/ModernCommands/SortAndRemoveUnnecessaryImportsCommandArgs.cs
+++ b/src/EditorFeatures/Core/ModernCommands/SortAndRemoveUnnecessaryImportsCommandArgs.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+namespace Microsoft.CodeAnalysis.Editor.Commanding.Commands
+{
+    /// <summary>
+    /// Arguments for the Sort and Remove Unused Usings command being invoked.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal class SortAndRemoveUnnecessaryImportsCommandArgs : EditorCommandArgs
+    {
+        public SortAndRemoveUnnecessaryImportsCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core/ReferenceHighlighting/NagivateToHighlightReferenceCommandHandler.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/NagivateToHighlightReferenceCommandHandler.cs
@@ -4,25 +4,33 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Outlining;
 using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.NavigateToHighlightedReference,
-       ContentTypeNames.RoslynContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(PredefinedCommandHandlerNames.NavigateToHighlightedReference)]
     internal partial class NavigateToHighlightReferenceCommandHandler :
-        ICommandHandler<NavigateToHighlightedReferenceCommandArgs>
+        VSCommanding.ICommandHandler<NavigateToNextHighlightedReferenceCommandArgs>,
+        VSCommanding.ICommandHandler<NavigateToPreviousHighlightedReferenceCommandArgs>
     {
         private readonly IOutliningManagerService _outliningManagerService;
         private readonly IViewTagAggregatorFactoryService _tagAggregatorFactory;
+
+        public string DisplayName => EditorFeaturesResources.Navigate_To_Highlight_Reference_Command_Handler;
 
         [ImportingConstructor]
         public NavigateToHighlightReferenceCommandHandler(
@@ -33,16 +41,36 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
             _tagAggregatorFactory = tagAggregatorFactory ?? throw new ArgumentNullException(nameof(tagAggregatorFactory));
         }
 
-        public CommandState GetCommandState(NavigateToHighlightedReferenceCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(NavigateToNextHighlightedReferenceCommandArgs args)
+        {
+            return GetCommandStateImpl(args);
+        }
+
+        public VSCommanding.CommandState GetCommandState(NavigateToPreviousHighlightedReferenceCommandArgs args)
+        {
+            return GetCommandStateImpl(args);
+        }
+
+        private VSCommanding.CommandState GetCommandStateImpl(EditorCommandArgs args)
         {
             using (var tagAggregator = _tagAggregatorFactory.CreateTagAggregator<NavigableHighlightTag>(args.TextView))
             {
                 var tagUnderCursor = FindTagUnderCaret(tagAggregator, args.TextView);
-                return tagUnderCursor == null ? CommandState.Unavailable : CommandState.Available;
+                return tagUnderCursor == null ? VSCommanding.CommandState.Unavailable : VSCommanding.CommandState.Available;
             }
         }
 
-        public void ExecuteCommand(NavigateToHighlightedReferenceCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(NavigateToNextHighlightedReferenceCommandArgs args, CommandExecutionContext context)
+        {
+            return ExecuteCommandImpl(args, navigateToNext: true, context);
+        }
+
+        public bool ExecuteCommand(NavigateToPreviousHighlightedReferenceCommandArgs args, CommandExecutionContext context)
+        {
+            return ExecuteCommandImpl(args, navigateToNext: false, context);
+        }
+
+        private bool ExecuteCommandImpl(EditorCommandArgs args, bool navigateToNext, CommandExecutionContext context)
         {
             using (var tagAggregator = _tagAggregatorFactory.CreateTagAggregator<NavigableHighlightTag>(args.TextView))
             {
@@ -50,21 +78,22 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
 
                 if (tagUnderCursor == null)
                 {
-                    nextHandler();
-                    return;
+                    return false;
                 }
 
                 var spans = GetTags(tagAggregator, args.TextView.TextSnapshot.GetFullSpan()).ToList();
 
                 Contract.ThrowIfFalse(spans.Any(), "We should have at least found the tag under the cursor!");
 
-                var destTag = GetDestinationTag(tagUnderCursor.Value, spans, args.Direction);
+                var destTag = GetDestinationTag(tagUnderCursor.Value, spans, navigateToNext);
 
                 if (args.TextView.TryMoveCaretToAndEnsureVisible(destTag.Start, _outliningManagerService))
                 {
                     args.TextView.SetSelection(destTag);
                 }
             }
+
+            return true;
         }
 
         private static IEnumerable<SnapshotSpan> GetTags(
@@ -79,13 +108,13 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
         private static SnapshotSpan GetDestinationTag(
             SnapshotSpan tagUnderCursor,
             List<SnapshotSpan> orderedTagSpans,
-            NavigateDirection direction)
+            bool navigateToNext)
         {
             var destIndex = orderedTagSpans.BinarySearch(tagUnderCursor, new StartComparer());
 
             Contract.ThrowIfFalse(destIndex >= 0, "Expected to find start tag in the collection");
 
-            destIndex += direction == NavigateDirection.Down ? 1 : -1;
+            destIndex += navigateToNext ? 1 : -1;
             if (destIndex < 0)
             {
                 destIndex = orderedTagSpans.Count - 1;

--- a/src/EditorFeatures/Core/Shared/Utilities/ProgressTrackerAdapter.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ProgressTrackerAdapter.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+{
+    /// <summary>
+    /// An adapter between editor's <see cref="IUIThreadOperationScope"/> (which supports reporting progress) 
+    /// and <see cref="IProgressTracker"/>.
+    /// </summary>
+    internal class ProgressTrackerAdapter : IProgressTracker
+    {
+        private readonly IUIThreadOperationScope _uiThreadOperationScope;
+        private int _completedItems;
+        private int _totalItems;
+
+        public ProgressTrackerAdapter(IUIThreadOperationScope uiThreadOperationScope)
+        {
+            Requires.NotNull(uiThreadOperationScope, nameof(uiThreadOperationScope));
+            _uiThreadOperationScope = uiThreadOperationScope;
+        }
+
+        public int CompletedItems => _completedItems;
+
+        public int TotalItems => _totalItems;
+
+        public void AddItems(int count)
+        {
+            Interlocked.Add(ref _totalItems, count);
+            ReportProgress();
+        }
+
+        public void Clear()
+        {
+            Interlocked.Exchange(ref _completedItems, 0);
+            Interlocked.Exchange(ref _totalItems, 0);
+            ReportProgress();
+        }
+
+        public void ItemCompleted()
+        {
+            Interlocked.Increment(ref _completedItems);
+            ReportProgress();
+        }
+
+        private void ReportProgress()
+        {
+            _uiThreadOperationScope.Progress.Report(new ProgressInfo(_completedItems, _totalItems));
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Shared/Utilities/WaitContextAdapter.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/WaitContextAdapter.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Editor.FindReferences;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
+{
+    /// <summary>
+    /// An adapter between Roslyn's <see cref="IWaitContext"/> and editor's <see cref="IUIThreadOperationScope"/>, 
+    /// which represent the same abstraction. The only place where it's needed so far is <see cref="FindReferencesCommandHandler"/>,
+    /// that operates within <see cref="IUIThreadOperationContext"/>, but calls to the <see cref="IFindReferencesService"/>, which
+    /// requires Roslyn's <see cref="IWaitContext"/>.
+    /// Going forward this adapter can be deleted once Roslyn's <see cref="IWaitContext"/> is retired in favor of editor's 
+    /// <see cref="IUIThreadOperationContext"/>.
+    /// </summary>
+    internal class WaitContextAdapter : IWaitContext
+    {
+        private readonly IUIThreadOperationScope _uiThreadOperationScope;
+
+        public WaitContextAdapter(IUIThreadOperationScope uiThreadOperationScope)
+        {
+            Requires.NotNull(uiThreadOperationScope, nameof(uiThreadOperationScope));
+            _uiThreadOperationScope = uiThreadOperationScope;
+        }
+
+        public CancellationToken CancellationToken => _uiThreadOperationScope.Context.UserCancellationToken;
+
+        public bool AllowCancel
+        {
+            get => _uiThreadOperationScope.AllowCancellation;
+            set => _uiThreadOperationScope.AllowCancellation = value;
+        }
+
+        public string Message
+        {
+            get => _uiThreadOperationScope.Description;
+            set => _uiThreadOperationScope.Description = value;
+        }
+
+        public CodeAnalysis.Shared.Utilities.IProgressTracker ProgressTracker => new ProgressTrackerAdapter(_uiThreadOperationScope);
+        
+        public void Dispose()
+        {
+            _uiThreadOperationScope.Dispose();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -1084,6 +1084,141 @@ Chcete pokračovat?</target>
         <target state="translated">Text pole při přejmenovávání na řádku</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -1084,6 +1084,141 @@ Möchten Sie fortfahren?</target>
         <target state="translated">Text für das Feld zur Inlineumbenennung</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">Texto del campo de cambio de nombre en línea</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -1084,6 +1084,141 @@ Voulez-vous continuer ?</target>
         <target state="translated">Texte du champ de changement de nom inline</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -1084,6 +1084,141 @@ Continuare?</target>
         <target state="translated">Ridenominazione inline - Campo di testo</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">インラインの名前変更フィールドのテキスト</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">인라인 이름 바꾸기 필드 텍스트</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -1084,6 +1084,141 @@ Czy chcesz kontynuować?</target>
         <target state="translated">Tekst pola zmiany nazwy wstawionego elementu</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -1084,6 +1084,141 @@ Deseja continuar?</target>
         <target state="translated">Texto do Campo de Renomeação Embutida</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">Текст поля "Встроенное переименование"</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -1084,6 +1084,141 @@ Devam etmek istiyor musunuz?</target>
         <target state="translated">Satır İçi Alan Metnini Yeniden Adlandır</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">内联重命名字段文本</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -1084,6 +1084,141 @@ Do you want to proceed?</source>
         <target state="translated">內嵌重新命名欄位的文字</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Call_Hierarchy_Command_Handler">
+        <source>View Call Hierarchy Command Handler</source>
+        <target state="new">View Call Hierarchy Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Automatic_Line_Ender_Command_Handler">
+        <source>Automatic Line Ender Command Handler</source>
+        <target state="new">Automatic Line Ender Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Block_Comment_Editing_Command_Handler">
+        <source>Block Comment Editing Command Handler</source>
+        <target state="new">Block Comment Editing Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Change_Signature_Command_Handler">
+        <source>Change Signature Command Handler</source>
+        <target state="new">Change Signature Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Comment_Uncomment_Selection_Command_Handler">
+        <source>Comment/Uncomment Selection Command Handler</source>
+        <target state="new">Comment/Uncomment Selection Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Completion_Command_Handler">
+        <source>Code Completion Command Handler</source>
+        <target state="new">Code Completion Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Documentation_Comment_Command_Handler">
+        <source>Documentation Comment Command Handler</source>
+        <target state="new">Documentation Comment Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Encapsulate_Field_Command_Handler">
+        <source>Encapsulate Field Command Handler</source>
+        <target state="new">Encapsulate Field Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Execute_In_Interactive_Command_Handler">
+        <source>Execute In Interactive Command Handler</source>
+        <target state="new">Execute In Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Interface_Command_Handler">
+        <source>Extract Interface Command Handler</source>
+        <target state="new">Extract Interface Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Extract_Method_Command_Handler">
+        <source>Extract Method Command Handler</source>
+        <target state="new">Extract Method Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Find_References_Command_Handler">
+        <source>Find References Command Handler</source>
+        <target state="new">Find References Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_Command_Handler">
+        <source>Format Command Handler</source>
+        <target state="new">Format Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Adjacent_Member_Command_Handler">
+        <source>Go To Adjacent Member Command Handler</source>
+        <target state="new">Go To Adjacent Member Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Definition_Command_Handler">
+        <source>Go To Definition Command Handler</source>
+        <target state="new">Go To Definition Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Go_To_Implementation_Command_Handler">
+        <source>Go To Implementation Command Handler</source>
+        <target state="new">Go To Implementation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntelliSense_Command_Handler">
+        <source>IntelliSense Command Handler</source>
+        <target state="new">IntelliSense Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Command_Handler">
+        <source>Interactive Command Handler</source>
+        <target state="new">Interactive Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Interactive_Paste_Command_Handler">
+        <source>Interactive Paste Command Handler</source>
+        <target state="new">Interactive Paste Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Navigate_To_Highlight_Reference_Command_Handler">
+        <source>Navigate To Highlighted Reference Command Handler</source>
+        <target state="new">Navigate To Highlighted Reference Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Organize_Document_Command_Handler">
+        <source>Organize Document Command Handler</source>
+        <target state="new">Organize Document Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Outlining_Command_Handler">
+        <source>Outlining Command Handler</source>
+        <target state="new">Outlining Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Command_Handler">
+        <source>Rename Command Handler</source>
+        <target state="new">Rename Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rename_Tracking_Cancellation_Command_Handler">
+        <source>Rename Tracking Cancellation Command Handler</source>
+        <target state="new">Rename Tracking Cancellation Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Signature_Help_Command_Handler">
+        <source>Signature Help Command Handler</source>
+        <target state="new">Signature Help Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Smart_Token_Formatter_Command_Handler">
+        <source>Smart Token Formatter Command Handler</source>
+        <target state="new">Smart Token Formatter Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Xml_Tag_Completion_Command_Handler">
+        <source>XML Tag Completion Command Handler</source>
+        <target state="new">XML Tag Completion Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -544,7 +544,7 @@ class Goo
         {
             var textUndoHistoryRegistry = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<ITextUndoHistoryRegistry>();
             var editorOperationsFactory = TestExportProvider.ExportProviderWithCSharpAndVisualBasic.GetExportedValue<IEditorOperationsFactoryService>();
-            var commandHandler = new CommentUncommentSelectionCommandHandler(TestWaitIndicator.Default, textUndoHistoryRegistry, editorOperationsFactory);
+            var commandHandler = new CommentUncommentSelectionCommandHandler(textUndoHistoryRegistry, editorOperationsFactory);
             var service = new MockCommentSelectionService(supportBlockComments);
 
             var trackingSpans = new List<ITrackingSpan>();

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.RenameTracking;
 using Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -28,6 +27,7 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 {
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 
         public void SendEscape()
         {
-            _commandHandler.ExecuteCommand(new EscapeKeyCommandArgs(_view, _view.TextBuffer), () => { });
+            _commandHandler.ExecuteCommand(new EscapeKeyCommandArgs(_view, _view.TextBuffer), TestCommandExecutionContext.Create());
         }
 
         public void MoveCaret(int delta)

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesCommandHandlerTests.vb
@@ -1,13 +1,13 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.FindReferences
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindUsages
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
     Public Class FindReferencesCommandHandlerTests
@@ -38,14 +38,12 @@ class C
 
                 Dim context = New FindReferencesTests.TestContext()
                 Dim commandHandler = New FindReferencesCommandHandler(
-                    workspace.GetService(Of IWaitIndicator),
                     {}, {New Lazy(Of IStreamingFindUsagesPresenter)(Function() New MockStreamingFindReferencesPresenter(context))},
                     {New Lazy(Of IAsynchronousOperationListener, FeatureMetadata)(Function() waiter, New FeatureMetadata(FeatureAttribute.FindReferences))})
 
                 Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)
                 commandHandler.ExecuteCommand(
-                    New FindReferencesCommandArgs(view, textBuffer), Sub()
-                                                                     End Sub)
+                    New FindReferencesCommandArgs(view, textBuffer), Utilities.TestCommandExecutionContext.Create())
 
                 ' Wait for the find refs to be done.
                 Await waiter.CreateWaitTask()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5,13 +5,14 @@ Imports System.Globalization
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Text.Projection
 Imports Microsoft.VisualStudio.Utilities
@@ -2470,7 +2471,7 @@ class C
                     disposableView.TextView.Caret.MoveTo(New SnapshotPoint(disposableView.TextView.TextBuffer.CurrentSnapshot, 0))
 
                     Dim editorOperations = editorOperationsFactory.GetEditorOperations(disposableView.TextView)
-                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(disposableView.TextView, state.SubjectBuffer), Sub() editorOperations.Delete())
+                    state.CompletionCommandHandler.ExecuteCommand(New DeleteKeyCommandArgs(disposableView.TextView, state.SubjectBuffer), Sub() editorOperations.Delete(), TestCommandExecutionContext.Create())
 
                     Await state.AssertNoCompletionSession()
                 End Using

--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -2,11 +2,12 @@
 
 Imports System.Text
 Imports System.Windows
-Imports Microsoft.VisualStudio.InteractiveWindow
-Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
-Imports Microsoft.CodeAnalysis.Editor.Commands
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.VisualStudio.InteractiveWindow
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
+Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
     Public Class InteractivePasteCommandhandlerTests
@@ -49,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 CopyToClipboard(clipboard, text, json, includeRepl:=True, isLineCopy:=False, isBoxCopy:=False)
 
-                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                Assert.True(handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), TestCommandExecutionContext.Create()))
 
                 Assert.Equal("a" & vbCrLf & "bc123", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using
@@ -81,9 +82,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 ]"
                 Dim text = $"a{vbCrLf}bc123"
 
-                CopyToClipboard(clipboard, Text, json, includeRepl:=False, isLineCopy:=False, isBoxCopy:=False)
+                CopyToClipboard(clipboard, text, json, includeRepl:=False, isLineCopy:=False, isBoxCopy:=False)
 
-                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() editorOperations.InsertText("p"))
+                If Not handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), TestCommandExecutionContext.Create()) Then
+                    editorOperations.InsertText("p")
+                End If
 
                 Assert.Equal("p", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using
@@ -121,7 +124,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 CopyToClipboard(clipboard, text, json, includeRepl:=True, isLineCopy:=True, isBoxCopy:=False)
 
-                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                Assert.True(handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), TestCommandExecutionContext.Create()))
 
                 Assert.Equal("line1" & vbCrLf & "InsertedLine" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using
@@ -164,7 +167,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 CopyToClipboard(clipboard, text, json, includeRepl:=True, isLineCopy:=False, isBoxCopy:=True)
 
-                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                Assert.True(handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), TestCommandExecutionContext.Create()))
 
                 Assert.Equal("lineBoxLine11" & vbCrLf & "    BoxLine2line2", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using
@@ -209,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
 
                 CopyToClipboard(clipboard, text, json, includeRepl:=True, isLineCopy:=False, isBoxCopy:=True)
 
-                handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                Assert.True(handler.ExecuteCommand(New PasteCommandArgs(textView, textView.TextBuffer), TestCommandExecutionContext.Create()))
 
                 Assert.Equal("BoxLine1" & vbCrLf & "BoxLine2" & vbCrLf & "line1" & vbCrLf & "    line2", textView.TextBuffer.CurrentSnapshot.GetText())
             End Using

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -2,23 +2,23 @@
 
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Public Class RenameCommandHandlerTests
         Private Function CreateCommandHandler(workspace As TestWorkspace) As RenameCommandHandler
             Return New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                            workspace.GetService(Of IEditorOperationsFactoryService),
-                                            workspace.GetService(Of IWaitIndicator))
+                                            workspace.GetService(Of IEditorOperationsFactoryService))
         End Function
 
         <WpfFact>
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 Dim view = workspace.Documents.Single().GetTextView()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
 
-                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."), Utilities.TestCommandExecutionContext.Create())
 
                 Dim expectedTriggerToken = workspace.CurrentSolution.Projects.Single().Documents.Single().GetSyntaxRootAsync().Result.FindToken(view.Caret.Position.BufferPosition)
                 Assert.Equal(expectedTriggerToken.Span.ToSnapshotSpan(view.TextSnapshot), view.Selection.SelectedSpans.Single())
@@ -71,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 Dim nextHandler =
                     Function()
                         delegatedToNext = True
-                        Return CommandState.Unavailable
+                        Return VSCommanding.CommandState.Unavailable
                     End Function
 
                 Dim state = handler.GetCommandState(New RenameCommandArgs(textView, textView.TextBuffer), nextHandler)
@@ -100,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 view.Caret.MoveTo(selectedSpan.End)
                 view.Selection.Select(selectedSpan, isReversed:=False)
 
-                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."), Utilities.TestCommandExecutionContext.Create())
 
                 Assert.Equal(selectedSpan, view.Selection.SelectedSpans.Single())
             End Using
@@ -126,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 view.Caret.MoveTo(selectedSpan.End)
                 view.Selection.Select(selectedSpan, isReversed:=True)
 
-                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."))
+                CreateCommandHandler(workspace).ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Throw New Exception("The operation should have been handled."), Utilities.TestCommandExecutionContext.Create())
                 Await WaitForRename(workspace)
                 Assert.Equal(selectedSpan.Span, view.Selection.SelectedSpans.Single().Span)
             End Using
@@ -151,14 +151,13 @@ End Class
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
                 Dim session = StartSession(workspace)
 
                 editorOperations.MoveLineDown(extendSelection:=False)
                 Assert.Equal(4, view.Caret.Position.VirtualSpaces)
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "p"c), Sub() editorOperations.InsertText("p"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "p"c), Sub() editorOperations.InsertText("p"), Utilities.TestCommandExecutionContext.Create())
 
                 Assert.Equal("    p", view.Caret.Position.BufferPosition.GetContainingLine.GetText())
             End Using
@@ -183,7 +182,7 @@ End Class
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
 
                 Dim commandHandler = CreateCommandHandler(workspace)
-                Dim commandState = commandHandler.GetCommandState(New RenameCommandArgs(view, view.TextBuffer), Function() New CommandState())
+                Dim commandState = commandHandler.GetCommandState(New RenameCommandArgs(view, view.TextBuffer), Function() New VSCommanding.CommandState())
 
                 Assert.True(commandState.IsAvailable)
             End Using
@@ -209,12 +208,13 @@ End Class
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
 
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, " "c), Sub() AssertEx.Fail("Space should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, " "c),
+                                              Sub() AssertEx.Fail("Space should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 session.Cancel()
             End Using
@@ -242,8 +242,7 @@ End Class
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
 
@@ -254,7 +253,9 @@ End Class
                 Dim dashboard = DirectCast(view.GetAdornmentLayer("RoslynRenameDashboard").Elements(0).Adornment, Dashboard)
                 dashboard.ShouldReceiveKeyboardNavigation = False
 
-                commandHandler.ExecuteCommand(New TabKeyCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Tab should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New TabKeyCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Tab should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Assert.Equal(3, view.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
 
@@ -287,8 +288,7 @@ Goo f;
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Assert.True(view.Selection.IsEmpty())
                 Dim session = StartSession(workspace)
@@ -299,11 +299,14 @@ Goo f;
                 view.Selection.Clear()
                 Assert.True(view.Selection.IsEmpty())
 
-                commandHandler.ExecuteCommand(New SelectAllCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Ctrl+A should not have been passed to the editor."))
+                Assert.True(commandHandler.ExecuteCommand(New SelectAllCommandArgs(view, view.TextBuffer),
+                                              Utilities.TestCommandExecutionContext.Create()))
                 Assert.Equal(identifierSpan, view.Selection.SelectedSpans.Single().Span)
                 Assert.Equal(identifierSpan.End, view.Caret.Position.BufferPosition.Position)
 
-                commandHandler.ExecuteCommand(New SelectAllCommandArgs(view, view.TextBuffer), Sub() editorOperations.SelectAll())
+                commandHandler.ExecuteCommand(New SelectAllCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.SelectAll(),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(view.TextBuffer.CurrentSnapshot.GetFullSpan(), view.Selection.SelectedSpans.Single().Span)
             End Using
         End Function
@@ -330,8 +333,7 @@ class [|$$Goo|] // comment
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Await WaitForRename(workspace)
@@ -339,7 +341,9 @@ class [|$$Goo|] // comment
                 view.Caret.MoveTo(New SnapshotPoint(view.TextSnapshot, startPosition))
 
                 ' with the caret at the start, this should delete the whole identifier
-                commandHandler.ExecuteCommand(New WordDeleteToEndCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Command should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New WordDeleteToEndCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Command should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Await VerifyTagsAreCorrect(workspace, "")
 
                 editorOperations.InsertText("this")
@@ -350,7 +354,9 @@ class [|$$Goo|] // comment
                 ' Note that the default editor handling would try to delete the '@' character, we override this behavior since
                 ' that '@' character is in a read only region during rename.
                 view.Selection.Select(New SnapshotSpan(view.TextSnapshot, Span.FromBounds(startPosition + 2, startPosition + 4)), isReversed:=True)
-                commandHandler.ExecuteCommand(New WordDeleteToStartCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Command should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New WordDeleteToStartCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Command should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Await VerifyTagsAreCorrect(workspace, "s")
             End Using
         End Function
@@ -384,8 +390,7 @@ Goo f;
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Await WaitForRename(workspace)
@@ -395,12 +400,16 @@ Goo f;
                 Assert.Equal(identifierSpan, view.Selection.SelectedSpans.Single().Span)
 
                 ' LineStart should move to the beginning of identifierSpan
-                commandHandler.ExecuteCommand(New LineStartCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Home should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New LineStartCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Home should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(0, view.Selection.SelectedSpans.Single().Span.Length)
                 Assert.Equal(startPosition, view.Caret.Position.BufferPosition.Position)
 
                 ' LineStart again should move to the beginning of the line
-                commandHandler.ExecuteCommand(New LineStartCommandArgs(view, view.TextBuffer), Sub() editorOperations.MoveToStartOfLine(extendSelection:=False))
+                commandHandler.ExecuteCommand(New LineStartCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.MoveToStartOfLine(extendSelection:=False),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(lineStart, view.Caret.Position.BufferPosition.Position)
 #End Region
 #Region "LineStartExtend"
@@ -408,11 +417,15 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, startPosition + 1))
 
                 ' LineStartExtend should move to the beginning of identifierSpan and extend the selection
-                commandHandler.ExecuteCommand(New LineStartExtendCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Shift+Home should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New LineStartExtendCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Shift+Home should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(New Span(startPosition, 1), view.Selection.SelectedSpans.Single().Span)
 
                 ' LineStartExtend again should move to the beginning of the line and extend the selection
-                commandHandler.ExecuteCommand(New LineStartExtendCommandArgs(view, view.TextBuffer), Sub() editorOperations.MoveToStartOfLine(extendSelection:=True))
+                commandHandler.ExecuteCommand(New LineStartExtendCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.MoveToStartOfLine(extendSelection:=True),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(Span.FromBounds(lineStart, startPosition + 1), view.Selection.SelectedSpans.Single().Span)
 #End Region
 #Region "LineEnd"
@@ -420,12 +433,16 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, startPosition + 1))
 
                 ' LineEnd should move to the end of identifierSpan
-                commandHandler.ExecuteCommand(New LineEndCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("End should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New LineEndCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("End should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(0, view.Selection.SelectedSpans.Single().Span.Length)
                 Assert.Equal(identifierSpan.End, view.Caret.Position.BufferPosition.Position)
 
                 ' LineEnd again should move to the end of the line
-                commandHandler.ExecuteCommand(New LineEndCommandArgs(view, view.TextBuffer), Sub() editorOperations.MoveToEndOfLine(extendSelection:=False))
+                commandHandler.ExecuteCommand(New LineEndCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.MoveToEndOfLine(extendSelection:=False),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(lineEnd, view.Caret.Position.BufferPosition.Position)
 #End Region
 #Region "LineEndExtend"
@@ -433,11 +450,15 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, startPosition + 1))
 
                 ' LineEndExtend should move to the end of identifierSpan and extend the selection
-                commandHandler.ExecuteCommand(New LineEndExtendCommandArgs(view, view.TextBuffer), Sub() AssertEx.Fail("Shift+End should not have been passed to the editor."))
+                commandHandler.ExecuteCommand(New LineEndExtendCommandArgs(view, view.TextBuffer),
+                                              Sub() AssertEx.Fail("Shift+End should not have been passed to the editor."),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(Span.FromBounds(startPosition + 1, identifierSpan.End), view.Selection.SelectedSpans.Single().Span)
 
                 ' LineEndExtend again should move to the end of the line and extend the selection
-                commandHandler.ExecuteCommand(New LineEndExtendCommandArgs(view, view.TextBuffer), Sub() editorOperations.MoveToEndOfLine(extendSelection:=True))
+                commandHandler.ExecuteCommand(New LineEndExtendCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.MoveToEndOfLine(extendSelection:=True),
+                                              Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(Span.FromBounds(startPosition + 1, lineEnd), view.Selection.SelectedSpans.Single().Span)
 #End Region
                 session.Cancel()
@@ -461,13 +482,14 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
                 Dim session = StartSession(workspace)
 
                 editorOperations.MoveToNextCharacter(extendSelection:=False)
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "$"c), Sub() editorOperations.InsertText("$"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "$"c),
+                                              Sub() editorOperations.InsertText("$"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "Goo")
 
@@ -493,8 +515,7 @@ Goo f;
                 Dim view = workspace.Documents.Single().GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Await WaitForRename(workspace)
@@ -503,7 +524,9 @@ Goo f;
                 ' Type first in the main identifier
                 view.Selection.Clear()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c), Sub() editorOperations.InsertText("B"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c),
+                                              Sub() editorOperations.InsertText("B"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Move selection and cursor to a readonly region
                 Dim span = view.TextBuffer.CurrentSnapshot.GetSpanFromBounds(0, 0)
@@ -511,7 +534,9 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, span.End))
 
                 ' Now let's type and that should commit Rename
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c),
+                                              Sub() editorOperations.InsertText("Z"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "BGoo")
 
@@ -542,8 +567,7 @@ Goo f;
                 Dim view = workspace.Documents.Single().GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 view.Selection.Clear()
@@ -552,7 +576,9 @@ Goo f;
 
                 ' Delete the first identifier char
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Delete())
+                commandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.Delete(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "oo")
                 Assert.NotNull(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -580,8 +606,7 @@ Goo f;
                 Dim view = workspace.Documents.Single().GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 view.Selection.Clear()
@@ -590,7 +615,9 @@ Goo f;
 
                 ' Delete the first identifier char
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace())
+                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.Backspace(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "Go")
                 Assert.NotNull(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -617,8 +644,7 @@ Goo f;
                 Dim view = workspace.Documents.Single().GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 view.Selection.Clear()
@@ -627,7 +653,9 @@ Goo f;
 
                 ' Type first in the main identifier
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c), Sub() editorOperations.InsertText("B"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c),
+                                              Sub() editorOperations.InsertText("B"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Move selection and cursor to a readonly region
                 Dim span = view.TextBuffer.CurrentSnapshot.GetSpanFromBounds(0, 0)
@@ -635,7 +663,9 @@ Goo f;
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, span.End))
 
                 ' Now let's type and that should commit Rename
-                commandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Delete())
+                commandHandler.ExecuteCommand(New DeleteKeyCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.Delete(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "BGoo")
 
@@ -669,8 +699,7 @@ Goo f;
                 Dim view = workspace.Documents.ElementAt(0).GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 view.Selection.Clear()
@@ -679,7 +708,9 @@ Goo f;
 
                 ' Type first in the main identifier
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c), Sub() editorOperations.InsertText("B"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c),
+                                              Sub() editorOperations.InsertText("B"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Move the cursor to the next file
                 Dim newview = workspace.Documents.ElementAt(1).GetTextView()
@@ -687,7 +718,9 @@ Goo f;
                 newview.Caret.MoveTo(New SnapshotPoint(newview.TextBuffer.CurrentSnapshot, 0))
 
                 ' Type the char at the beginning of the file
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(newview, newview.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(newview, newview.TextBuffer, "Z"c),
+                                              Sub() editorOperations.InsertText("Z"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "BGoo")
 
@@ -732,8 +765,7 @@ Goo f;
                 Dim view = workspace.Documents.ElementAt(0).GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 view.Selection.Clear()
@@ -742,7 +774,9 @@ Goo f;
 
                 ' Type first in the main identifier
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c), Sub() editorOperations.InsertText("B"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c),
+                                              Sub() editorOperations.InsertText("B"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Move the cursor to the next file
                 Dim newview = workspace.Documents.ElementAt(1).GetTextView()
@@ -750,7 +784,9 @@ Goo f;
                 newview.Caret.MoveTo(New SnapshotPoint(newview.TextBuffer.CurrentSnapshot, 0))
 
                 ' Type the char at the beginning of the file
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(newview, newview.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(newview, newview.TextBuffer, "Z"c),
+                                              Sub() editorOperations.InsertText("Z"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "BB")
 
@@ -786,13 +822,12 @@ class Program
                 Dim view = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
 
-                commandHandler.ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Exit Sub)
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"))
-                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() Exit Sub)
+                commandHandler.ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Exit Sub, Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() Exit Sub, Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "Z")
             End Using
@@ -826,14 +861,15 @@ partial class [|Program|]
                 Dim view = workspace.Documents.First(Function(d) d.Name = "Test.cs").GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim closedDocument = workspace.Documents.First(Function(d) d.Name = "Test2.cs")
                 closedDocument.CloseTextView()
                 Assert.True(workspace.IsDocumentOpen(closedDocument.Id))
-                commandHandler.ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Exit Sub)
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c), Sub() editorOperations.InsertText("Z"))
+                commandHandler.ExecuteCommand(New RenameCommandArgs(view, view.TextBuffer), Sub() Exit Sub, Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "Z"c),
+                                              Sub() editorOperations.InsertText("Z"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "Z")
             End Using
@@ -861,13 +897,14 @@ partial class [|Program|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
 
-                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer), Sub() editorOperations.OpenLineAbove())
+                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.OpenLineAbove(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' verify rename session was committed.
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -900,8 +937,7 @@ partial class [|Program|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
@@ -909,7 +945,9 @@ partial class [|Program|]
                 ' Move caret out of rename session span
                 editorOperations.MoveLineDown(extendSelection:=False)
 
-                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer), Sub() editorOperations.OpenLineAbove())
+                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.OpenLineAbove(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' verify rename session was committed.
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -942,13 +980,14 @@ partial class [|Program|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
 
-                commandHandler.ExecuteCommand(New OpenLineBelowCommandArgs(view, view.TextBuffer), Sub() editorOperations.OpenLineBelow())
+                commandHandler.ExecuteCommand(New OpenLineBelowCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.OpenLineBelow(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' verify rename session was committed.
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -979,13 +1018,14 @@ partial class [|Program|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
 
-                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer), Sub() editorOperations.OpenLineAbove())
+                commandHandler.ExecuteCommand(New OpenLineAboveCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.OpenLineAbove(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' verify rename session was committed.
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -1015,13 +1055,14 @@ partial class [|Program|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
 
-                commandHandler.ExecuteCommand(New OpenLineBelowCommandArgs(view, view.TextBuffer), Sub() editorOperations.OpenLineBelow())
+                commandHandler.ExecuteCommand(New OpenLineBelowCommandArgs(view, view.TextBuffer),
+                                              Sub() editorOperations.OpenLineBelow(),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' verify rename session was committed.
                 Assert.Null(workspace.GetService(Of IInlineRenameService).ActiveSession)
@@ -1050,8 +1091,7 @@ partial class [|Program|]
                 Dim view = workspace.Documents.Single().GetTextView()
 
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Await WaitForRename(workspace)
@@ -1060,10 +1100,11 @@ partial class [|Program|]
                 ' Type first in the main identifier
                 view.Selection.Clear()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c), Sub() editorOperations.InsertText("B"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "B"c),
+                                              Sub() editorOperations.InsertText("B"), Utilities.TestCommandExecutionContext.Create())
 
                 ' Now save the document, which should commit Rename
-                commandHandler.ExecuteCommand(New SaveCommandArgs(view, view.TextBuffer), Sub() Exit Sub)
+                commandHandler.ExecuteCommand(New SaveCommandArgs(view, view.TextBuffer), Sub() Exit Sub, Utilities.TestCommandExecutionContext.Create())
 
                 Await VerifyTagsAreCorrect(workspace, "BGoo")
 
@@ -1078,7 +1119,7 @@ partial class [|Program|]
         Public Sub MoveSelectedLinesUpDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New MoveSelectedLinesUpCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New MoveSelectedLinesUpCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1088,7 +1129,7 @@ partial class [|Program|]
         Public Sub MoveSelectedLinesDownDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New MoveSelectedLinesDownCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New MoveSelectedLinesDownCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1098,7 +1139,7 @@ partial class [|Program|]
         Public Sub ReorderParametersDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New ReorderParametersCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New ReorderParametersCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1108,7 +1149,7 @@ partial class [|Program|]
         Public Sub RemoveParametersDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New RemoveParametersCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New RemoveParametersCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1118,7 +1159,7 @@ partial class [|Program|]
         Public Sub ExtractInterfaceDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New ExtractInterfaceCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New ExtractInterfaceCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1128,7 +1169,7 @@ partial class [|Program|]
         Public Sub EncapsulateFieldDuringRename()
             VerifyCommandCommitsRenameSessionAndExecutesCommand(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New EncapsulateFieldCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New EncapsulateFieldCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1137,7 +1178,7 @@ partial class [|Program|]
         Public Async Function CutDuringRename_InsideIdentifier() As Task
             Await VerifySessionActiveAfterCutPasteInsideIdentifier(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Function
 
@@ -1146,7 +1187,7 @@ partial class [|Program|]
         Public Async Function PasteDuringRename_InsideIdentifier() As Task
             Await VerifySessionActiveAfterCutPasteInsideIdentifier(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Function
 
@@ -1155,7 +1196,7 @@ partial class [|Program|]
         Public Sub CutDuringRename_OutsideIdentifier()
             VerifySessionCommittedAfterCutPasteOutsideIdentifier(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New CutCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1164,7 +1205,7 @@ partial class [|Program|]
         Public Sub PasteDuringRename_OutsideIdentifier()
             VerifySessionCommittedAfterCutPasteOutsideIdentifier(
                 Sub(commandHandler As RenameCommandHandler, view As IWpfTextView, nextHandler As Action)
-                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler)
+                    commandHandler.ExecuteCommand(New PasteCommandArgs(view, view.TextBuffer), nextHandler, Utilities.TestCommandExecutionContext.Create())
                 End Sub)
         End Sub
 
@@ -1188,8 +1229,7 @@ class [|C$$|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
@@ -1197,7 +1237,9 @@ class [|C$$|]
                 ' Type first in the main identifier
                 view.Selection.Clear()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c), Sub() editorOperations.InsertText("D"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c),
+                                              Sub() editorOperations.InsertText("D"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Then execute the command
                 Dim commandInvokedString = "/*Command Invoked*/"
@@ -1232,8 +1274,7 @@ class [|C$$|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
@@ -1268,8 +1309,7 @@ class [|C$$|]
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim commandHandler As New RenameCommandHandler(
                     renameService,
-                    workspace.GetService(Of IEditorOperationsFactoryService),
-                    workspace.GetService(Of IWaitIndicator))
+                    workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(view)
@@ -1277,7 +1317,9 @@ class [|C$$|]
                 ' Type first in the main identifier
                 view.Selection.Clear()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c), Sub() editorOperations.InsertText("D"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "D"c),
+                                              Sub() editorOperations.InsertText("D"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Then execute the command
                 Dim commandInvokedString = "commandInvoked"

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -2,7 +2,6 @@
 
 Imports System.Collections.ObjectModel
 Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename.HighlightTags
@@ -11,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Text.Tagging
 Imports Roslyn.Utilities
@@ -566,8 +566,7 @@ class C
                 Dim renameService = workspace.GetService(Of InlineRenameService)()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim session = StartSession(workspace)
                 textBuffer.Replace(New Span(location, 3), "Goo")
@@ -593,11 +592,11 @@ class C
                 End Using
 
                 ' Delete Goo and type "as"
-                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace())
-                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace())
-                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace())
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "a"c), Sub() editorOperations.InsertText("a"))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "s"c), Sub() editorOperations.InsertText("s"))
+                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace(), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace(), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New BackspaceKeyCommandArgs(view, view.TextBuffer), Sub() editorOperations.Backspace(), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "a"c), Sub() editorOperations.InsertText("a"), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "s"c), Sub() editorOperations.InsertText("s"), Utilities.TestCommandExecutionContext.Create())
 
                 Using resolvedConflictWorkspace = CreateWorkspaceWithWaiter(
                     <Workspace>
@@ -1074,8 +1073,7 @@ End Class
                 Dim view = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim textViewService = New TextBufferAssociatedViewService()
                 Dim buffers = New Collection(Of ITextBuffer)
@@ -1090,7 +1088,9 @@ End Class
                 ' Type first in the main identifier
                 view.Selection.Clear()
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "e"c), Sub() editorOperations.InsertText("e"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "e"c),
+                                              Sub() editorOperations.InsertText("e"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Verify fixup/resolved conflict span.
                 Using resolvedConflictWorkspace = CreateWorkspaceWithWaiter(
@@ -1112,7 +1112,9 @@ End Class
                 End Using
 
                 ' Make another edit to change "New" to "Nexw" so that we have no more conflicts or escaping.
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "x"c), Sub() editorOperations.InsertText("x"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "x"c),
+                                              Sub() editorOperations.InsertText("x"),
+                                              Utilities.TestCommandExecutionContext.Create())
 
                 ' Verify resolved escaping conflict spans.
                 Using resolvedConflictWorkspace = CreateWorkspaceWithWaiter(
@@ -1154,8 +1156,7 @@ End Class
                 Dim view = workspace.Documents.Single().GetTextView()
                 Dim editorOperations = workspace.GetService(Of IEditorOperationsFactoryService).GetEditorOperations(view)
                 Dim commandHandler As New RenameCommandHandler(workspace.GetService(Of InlineRenameService),
-                                                               workspace.GetService(Of IEditorOperationsFactoryService),
-                                                               workspace.GetService(Of IWaitIndicator))
+                                                               workspace.GetService(Of IEditorOperationsFactoryService))
 
                 Dim textViewService = New TextBufferAssociatedViewService()
                 Dim buffers = New Collection(Of ITextBuffer)
@@ -1171,9 +1172,9 @@ End Class
 
                 ' Type few characters.
                 view.Caret.MoveTo(New SnapshotPoint(view.TextBuffer.CurrentSnapshot, workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "e"c), Sub() editorOperations.InsertText("e"))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "f"c), Sub() editorOperations.InsertText("f"))
-                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "g"c), Sub() editorOperations.InsertText("g"))
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "e"c), Sub() editorOperations.InsertText("e"), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "f"c), Sub() editorOperations.InsertText("f"), Utilities.TestCommandExecutionContext.Create())
+                commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, "g"c), Sub() editorOperations.InsertText("g"), Utilities.TestCommandExecutionContext.Create())
 
                 session.Commit()
                 Dim selectionLength = view.Selection.End.Position - view.Selection.Start.Position

--- a/src/EditorFeatures/TestUtilities/AbstractCommandHandlerTestState.cs
+++ b/src/EditorFeatures/TestUtilities/AbstractCommandHandlerTestState.cs
@@ -3,18 +3,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
-using Roslyn.Test.Utilities;
 using Xunit;
-using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
@@ -315,102 +316,132 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         #endregion
 
         #region command handler
-        public void SendBackspace(Action<BackspaceKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendBackspace(Action<BackspaceKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new BackspaceKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new BackspaceKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendDelete(Action<DeleteKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendDelete(Action<DeleteKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new DeleteKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new DeleteKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendWordDeleteToStart(Action<WordDeleteToStartCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendWordDeleteToStart(Action<WordDeleteToStartCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new WordDeleteToStartCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new WordDeleteToStartCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendEscape(Action<EscapeKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendEscape(Action<EscapeKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new EscapeKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new EscapeKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendUpKey(Action<UpKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public bool SendEscape(Func<EscapeKeyCommandArgs, CommandExecutionContext, bool> commandHandler)
         {
-            commandHandler(new UpKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            return commandHandler(new EscapeKeyCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
         }
 
-        public void SendDownKey(Action<DownKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendUpKey(Action<UpKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new DownKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new UpKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendTab(Action<TabKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendDownKey(Action<DownKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new TabKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new DownKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendBackTab(Action<BackTabKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendTab(Action<TabKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new BackTabKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new TabKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendReturn(Action<ReturnKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public bool SendTab(Func<TabKeyCommandArgs, CommandExecutionContext, bool> commandHandler)
         {
-            commandHandler(new ReturnKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            return commandHandler(new TabKeyCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
         }
 
-        public void SendPageUp(Action<PageUpKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendBackTab(Action<BackTabKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new PageUpKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new BackTabKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendPageDown(Action<PageDownKeyCommandArgs, Action> commandHandler, Action nextHandler)
+        public bool SendBackTab(Func<BackTabKeyCommandArgs, CommandExecutionContext, bool> commandHandler)
         {
-            commandHandler(new PageDownKeyCommandArgs(TextView, SubjectBuffer), nextHandler);
+            return commandHandler(new BackTabKeyCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
         }
 
-        public void SendCut(Action<CutCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendReturn(Action<ReturnKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new CutCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new ReturnKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendPaste(Action<PasteCommandArgs, Action> commandHandler, Action nextHandler)
+        public bool SendReturn(Func<ReturnKeyCommandArgs, CommandExecutionContext, bool> commandHandler)
         {
-            commandHandler(new PasteCommandArgs(TextView, SubjectBuffer), nextHandler);
+            return commandHandler(new ReturnKeyCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
         }
 
-        public void SendInvokeCompletionList(Action<InvokeCompletionListCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendPageUp(Action<PageUpKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new InvokeCompletionListCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new PageUpKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendCommitUniqueCompletionListItem(Action<CommitUniqueCompletionListItemCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendPageDown(Action<PageDownKeyCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new CommitUniqueCompletionListItemCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new PageDownKeyCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendInsertSnippetCommand(Action<InsertSnippetCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendCut(Action<CutCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new InsertSnippetCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new CutCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendSurroundWithCommand(Action<SurroundWithCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendPaste(Action<PasteCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new SurroundWithCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new PasteCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendInvokeSignatureHelp(Action<InvokeSignatureHelpCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendInvokeCompletionList(Action<InvokeCompletionListCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new InvokeSignatureHelpCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new InvokeCompletionListCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendTypeChar(char typeChar, Action<TypeCharCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendCommitUniqueCompletionListItem(Action<CommitUniqueCompletionListItemCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new TypeCharCommandArgs(TextView, SubjectBuffer, typeChar), nextHandler);
+            commandHandler(new CommitUniqueCompletionListItemCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendTypeChars(string typeChars, Action<TypeCharCommandArgs, Action> commandHandler)
+        public void SendInsertSnippetCommand(Action<InsertSnippetCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
+        {
+            commandHandler(new InsertSnippetCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
+        }
+
+        public bool SendInsertSnippetCommand(Func<InsertSnippetCommandArgs, CommandExecutionContext, bool> commandHandler)
+        {
+            return commandHandler(new InsertSnippetCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
+        }
+
+        public void SendSurroundWithCommand(Action<SurroundWithCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
+        {
+            commandHandler(new SurroundWithCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
+        }
+
+        public bool SendSurroundWithCommand(Func<SurroundWithCommandArgs, CommandExecutionContext, bool> commandHandler)
+        {
+            return commandHandler(new SurroundWithCommandArgs(TextView, SubjectBuffer), TestCommandExecutionContext.Create());
+        }
+
+        public void SendInvokeSignatureHelp(Action<InvokeSignatureHelpCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
+        {
+            commandHandler(new InvokeSignatureHelpCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
+        }
+
+        public void SendTypeChar(char typeChar, Action<TypeCharCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
+        {
+            commandHandler(new TypeCharCommandArgs(TextView, SubjectBuffer, typeChar), nextHandler, TestCommandExecutionContext.Create());
+        }
+
+        public void SendTypeChars(string typeChars, Action<TypeCharCommandArgs, Action, CommandExecutionContext> commandHandler)
         {
             foreach (var ch in typeChars)
             {
@@ -419,19 +450,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             }
         }
 
-        public void SendSave(Action<SaveCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendSave(Action<SaveCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new SaveCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new SaveCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendSelectAll(Action<SelectAllCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendSelectAll(Action<SelectAllCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new SelectAllCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new SelectAllCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
 
-        public void SendToggleCompletionMode(Action<ToggleCompletionModeCommandArgs, Action> commandHandler, Action nextHandler)
+        public void SendToggleCompletionMode(Action<ToggleCompletionModeCommandArgs, Action, CommandExecutionContext> commandHandler, Action nextHandler)
         {
-            commandHandler(new ToggleCompletionModeCommandArgs(TextView, SubjectBuffer), nextHandler);
+            commandHandler(new ToggleCompletionModeCommandArgs(TextView, SubjectBuffer), nextHandler, TestCommandExecutionContext.Create());
         }
         #endregion
     }

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticLineEnderTests.cs
@@ -5,14 +5,16 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Moq;
 using Roslyn.Test.Utilities;
@@ -26,8 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
         protected abstract TestWorkspace CreateWorkspace(string code);
         protected abstract Action CreateNextHandler(TestWorkspace workspace);
 
-        internal abstract ICommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
-            Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator waitIndicator,
+        internal abstract IChainedCommandHandler<AutomaticLineEnderCommandArgs> CreateCommandHandler(
             ITextUndoHistoryRegistry undoRegistry,
             IEditorOperationsFactoryService editorOperations);
 
@@ -42,14 +43,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
                 view.Caret.MoveTo(new SnapshotPoint(buffer.CurrentSnapshot, workspace.Documents.Single(d => d.CursorPosition.HasValue).CursorPosition.Value));
 
                 var commandHandler = CreateCommandHandler(
-                                        GetExportedValue<Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator>(workspace),
                                         GetExportedValue<ITextUndoHistoryRegistry>(workspace),
                                         GetExportedValue<IEditorOperationsFactoryService>(workspace));
 
                 commandHandler.ExecuteCommand(new AutomaticLineEnderCommandArgs(view, buffer),
                                                     assertNextHandlerInvoked
                                                         ? () => { nextHandlerInvoked = true; }
-                : CreateNextHandler(workspace));
+                : CreateNextHandler(workspace), TestCommandExecutionContext.Create());
 
                 Test(view, buffer, expected);
 

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -3,17 +3,20 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 {
@@ -21,7 +24,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
     {
         protected abstract char DocumentationCommentCharacter { get; }
 
-        internal abstract ICommandHandler CreateCommandHandler(IWaitIndicator waitIndicator, ITextUndoHistoryRegistry undoHistoryRegistry, IEditorOperationsFactoryService editorOperationsFactoryService);
+        internal abstract VSCommanding.ICommandHandler CreateCommandHandler(IWaitIndicator waitIndicator, ITextUndoHistoryRegistry undoHistoryRegistry, IEditorOperationsFactoryService editorOperationsFactoryService);
+
         protected abstract TestWorkspace CreateTestWorkspace(string code);
 
         protected void VerifyTypingCharacter(string initialMarkup, string expectedMarkup, bool useTabs = false, bool autoGenerateXmlDocComments = true)
@@ -29,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
             Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
-                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<TypeCharCommandArgs>;
+                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
 
                     var commandArgs = new TypeCharCommandArgs(view, view.TextBuffer, DocumentationCommentCharacter);
                     var nextHandler = CreateInsertTextHandler(view, DocumentationCommentCharacter.ToString());
 
-                    commandHandler.ExecuteCommand(commandArgs, nextHandler);
+                    commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
                 });
         }
 
@@ -45,11 +49,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                 setOptionsOpt: setOptionsOpt,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
-                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<ReturnKeyCommandArgs>;
+                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
 
                     var commandArgs = new ReturnKeyCommandArgs(view, view.TextBuffer);
                     var nextHandler = CreateInsertTextHandler(view, "\r\n");
-                    commandHandler.ExecuteCommand(commandArgs, nextHandler);
+                    commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
                 });
         }
 
@@ -58,12 +62,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
             Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
-                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<InsertCommentCommandArgs>;
+                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
 
                     var commandArgs = new InsertCommentCommandArgs(view, view.TextBuffer);
                     Action nextHandler = delegate { };
 
-                    commandHandler.ExecuteCommand(commandArgs, nextHandler);
+                    commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
                 });
         }
 
@@ -72,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
             Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
-                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<OpenLineAboveCommandArgs>;
+                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
 
                     var commandArgs = new OpenLineAboveCommandArgs(view, view.TextBuffer);
                     void nextHandler()
@@ -81,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                         editorOperations.OpenLineAbove();
                     }
 
-                    commandHandler.ExecuteCommand(commandArgs, nextHandler);
+                    commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
                 });
         }
 
@@ -90,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
             Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
-                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<OpenLineBelowCommandArgs>;
+                    var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService);
 
                     var commandArgs = new OpenLineBelowCommandArgs(view, view.TextBuffer);
                     void nextHandler()
@@ -99,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                         editorOperations.OpenLineBelow();
                     }
 
-                    commandHandler.ExecuteCommand(commandArgs, nextHandler);
+                    commandHandler.ExecuteCommand(commandArgs, nextHandler, TestCommandExecutionContext.Create());
                 });
         }
 

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractXmlTagCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractXmlTagCompletionTests.cs
@@ -3,10 +3,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -15,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 {
     public abstract class AbstractXmlTagCompletionTests
     {
-        internal abstract ICommandHandler<TypeCharCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistory);
+        internal abstract IChainedCommandHandler<TypeCharCommandArgs> CreateCommandHandler(ITextUndoHistoryRegistry undoHistory);
         protected abstract TestWorkspace CreateTestWorkspace(string initialMarkup);
 
         public void Verify(string initialMarkup, string expectedMarkup, char typeChar)
@@ -31,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                 var args = new TypeCharCommandArgs(view, view.TextBuffer, typeChar);
                 var nextHandler = CreateInsertTextHandler(view, typeChar.ToString());
 
-                commandHandler.ExecuteCommand(args, nextHandler);
+                commandHandler.ExecuteCommand(args, nextHandler, TestCommandExecutionContext.Create());
                 MarkupTestFile.GetPosition(expectedMarkup, out var expectedCode, out int expectedPosition);
 
                 Assert.Equal(expectedCode, view.TextSnapshot.GetText());

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Threading;
 

--- a/src/EditorFeatures/TestUtilities/Utilities/TestCommandExecutionContext.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/TestCommandExecutionContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Commanding;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
+{
+    internal static class TestCommandExecutionContext
+    {
+        public static CommandExecutionContext Create()
+        {
+            return new CommandExecutionContext(new TestUIThreadOperationContext());
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Utilities/TestUIThreadOperationContext.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/TestUIThreadOperationContext.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
+{
+    internal class TestUIThreadOperationContext : AbstractUIThreadOperationContext
+    {
+        CancellationTokenSource _cancellationTokenSource;
+        private readonly int _maxUpdates;
+        private int _updates;
+
+        public TestUIThreadOperationContext(int maxUpdates)
+            :base(allowCancellation: false, description: "")
+        {
+            _maxUpdates = maxUpdates;
+            _cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public TestUIThreadOperationContext()
+            : this(int.MaxValue)
+        {
+        }
+
+        public int Updates
+        {
+            get { return _updates; }
+        }
+
+        public override CancellationToken UserCancellationToken
+        {
+            get { return _cancellationTokenSource.Token; }
+        }
+
+        protected override void OnScopeProgressChanged(IUIThreadOperationScope changedScope)
+        {
+            UpdateProgress();
+        }
+
+        private void UpdateProgress()
+        {
+            var result = Interlocked.Increment(ref _updates);
+            if (result > _maxUpdates)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -5,20 +5,22 @@ Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
-Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Formatting
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.SignatureHelp
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.BraceCompletion
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Roslyn.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
@@ -79,7 +81,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Me.FormatCommandHandler = If(includeFormatCommandHandler,
                 New FormatCommandHandler(
-                    GetService(Of IWaitIndicator),
                     GetService(Of ITextUndoHistoryRegistry),
                     GetService(Of IEditorOperationsFactoryService)),
                 Nothing)
@@ -149,53 +150,53 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 #Region "IntelliSense Operations"
 
         Public Overloads Sub SendEscape()
-            MyBase.SendEscape(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendEscape(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendDownKey()
-            MyBase.SendDownKey(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendDownKey(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendUpKey()
-            MyBase.SendUpKey(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendUpKey(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
 #End Region
 
 #Region "Completion Operations"
         Public Overloads Sub SendTab()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of TabKeyCommandArgs))
-            MyBase.SendTab(Sub(a, n) handler.ExecuteCommand(a, n), Sub() EditorOperations.InsertText(vbTab))
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of TabKeyCommandArgs))
+            MyBase.SendTab(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() EditorOperations.InsertText(vbTab))
         End Sub
 
         Public Overloads Sub SendReturn()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of ReturnKeyCommandArgs))
-            MyBase.SendReturn(Sub(a, n) handler.ExecuteCommand(a, n), Sub() EditorOperations.InsertNewLine())
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of ReturnKeyCommandArgs))
+            MyBase.SendReturn(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() EditorOperations.InsertNewLine())
         End Sub
 
         Public Overloads Sub SendPageUp()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of PageUpKeyCommandArgs))
-            MyBase.SendPageUp(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of PageUpKeyCommandArgs))
+            MyBase.SendPageUp(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendCut()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of CutCommandArgs))
-            MyBase.SendCut(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of CutCommandArgs))
+            MyBase.SendCut(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendPaste()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of PasteCommandArgs))
-            MyBase.SendPaste(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of PasteCommandArgs))
+            MyBase.SendPaste(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendInvokeCompletionList()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of InvokeCompletionListCommandArgs))
-            MyBase.SendInvokeCompletionList(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of InvokeCompletionListCommandArgs))
+            MyBase.SendInvokeCompletionList(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendCommitUniqueCompletionListItem()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of CommitUniqueCompletionListItemCommandArgs))
-            MyBase.SendCommitUniqueCompletionListItem(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of CommitUniqueCompletionListItemCommandArgs))
+            MyBase.SendCommitUniqueCompletionListItem(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendSelectCompletionItem(displayText As String)
@@ -209,23 +210,23 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         Public Overloads Sub SendInsertSnippetCommand()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of InsertSnippetCommandArgs))
-            MyBase.SendInsertSnippetCommand(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of InsertSnippetCommandArgs))
+            MyBase.SendInsertSnippetCommand(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendSurroundWithCommand()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of SurroundWithCommandArgs))
-            MyBase.SendSurroundWithCommand(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of SurroundWithCommandArgs))
+            MyBase.SendSurroundWithCommand(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendSave()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of SaveCommandArgs))
-            MyBase.SendSave(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of SaveCommandArgs))
+            MyBase.SendSave(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendSelectAll()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of SelectAllCommandArgs))
-            MyBase.SendSelectAll(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of SelectAllCommandArgs))
+            MyBase.SendSelectAll(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Async Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
@@ -312,41 +313,41 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
 #Region "Signature Help and Completion Operations"
 
-        Private Sub ExecuteTypeCharCommand(args As TypeCharCommandArgs, finalHandler As Action)
-            Dim sigHelpHandler = DirectCast(SignatureHelpCommandHandler, ICommandHandler(Of TypeCharCommandArgs))
-            Dim formatHandler = DirectCast(FormatCommandHandler, ICommandHandler(Of TypeCharCommandArgs))
-            Dim compHandler = DirectCast(CompletionCommandHandler, ICommandHandler(Of TypeCharCommandArgs))
+        Private Sub ExecuteTypeCharCommand(args As TypeCharCommandArgs, finalHandler As Action, context As CommandExecutionContext)
+            Dim sigHelpHandler = DirectCast(SignatureHelpCommandHandler, VSCommanding.IChainedCommandHandler(Of TypeCharCommandArgs))
+            Dim formatHandler = DirectCast(FormatCommandHandler, VSCommanding.IChainedCommandHandler(Of TypeCharCommandArgs))
+            Dim compHandler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of TypeCharCommandArgs))
 
             If formatHandler Is Nothing Then
                 sigHelpHandler.ExecuteCommand(
                     args, Sub() compHandler.ExecuteCommand(
-                                    args, finalHandler))
+                                    args, finalHandler, context), context)
             Else
                 formatHandler.ExecuteCommand(
                     args, Sub() sigHelpHandler.ExecuteCommand(
                                     args, Sub() compHandler.ExecuteCommand(
-                                                    args, finalHandler)))
+                                                    args, finalHandler, context), context), context)
             End If
         End Sub
 
         Public Overloads Sub SendTypeChars(typeChars As String)
-            MyBase.SendTypeChars(typeChars, Sub(a, n) ExecuteTypeCharCommand(a, n))
+            MyBase.SendTypeChars(typeChars, Sub(a, n, c) ExecuteTypeCharCommand(a, n, c))
         End Sub
 
         Public Overloads Sub SendBackspace()
-            Dim compHandler = DirectCast(CompletionCommandHandler, ICommandHandler(Of BackspaceKeyCommandArgs))
-            MyBase.SendBackspace(Sub(a, n) compHandler.ExecuteCommand(a, n), AddressOf MyBase.SendBackspace)
+            Dim compHandler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of BackspaceKeyCommandArgs))
+            MyBase.SendBackspace(Sub(a, n, c) compHandler.ExecuteCommand(a, n, c), AddressOf MyBase.SendBackspace)
         End Sub
 
         Public Overloads Sub SendDelete()
-            Dim compHandler = DirectCast(CompletionCommandHandler, ICommandHandler(Of DeleteKeyCommandArgs))
-            MyBase.SendDelete(Sub(a, n) compHandler.ExecuteCommand(a, n), AddressOf MyBase.SendDelete)
+            Dim compHandler = DirectCast(CompletionCommandHandler, VSCommanding.IChainedCommandHandler(Of DeleteKeyCommandArgs))
+            MyBase.SendDelete(Sub(a, n, c) compHandler.ExecuteCommand(a, n, c), AddressOf MyBase.SendDelete)
         End Sub
 
         Public Sub SendTypeCharsToSpecificViewAndBuffer(typeChars As String, view As IWpfTextView, buffer As ITextBuffer)
             For Each ch In typeChars
                 Dim localCh = ch
-                ExecuteTypeCharCommand(New TypeCharCommandArgs(view, buffer, localCh), Sub() EditorOperations.InsertText(localCh.ToString()))
+                ExecuteTypeCharCommand(New TypeCharCommandArgs(view, buffer, localCh), Sub() EditorOperations.InsertText(localCh.ToString()), TestCommandExecutionContext.Create())
             Next
         End Sub
 #End Region
@@ -354,8 +355,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 #Region "Signature Help Operations"
 
         Public Overloads Sub SendInvokeSignatureHelp()
-            Dim handler = DirectCast(SignatureHelpCommandHandler, ICommandHandler(Of InvokeSignatureHelpCommandArgs))
-            MyBase.SendInvokeSignatureHelp(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(SignatureHelpCommandHandler, VSCommanding.IChainedCommandHandler(Of InvokeSignatureHelpCommandArgs))
+            MyBase.SendInvokeSignatureHelp(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Async Function AssertNoSignatureHelpSession(Optional block As Boolean = True) As Task

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/AutomaticLineEnderCommandHandler.vb
@@ -3,27 +3,28 @@
 Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
     ' <summary>
     ' visual basic automatic line ender command handler
     ' </summary>
-    <ExportCommandHandler(PredefinedCommandHandlerNames.AutomaticLineEnder, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.AutomaticLineEnder)>
     <Order(Before:=PredefinedCommandHandlerNames.Completion)>
     Friend Class AutomaticLineEnderCommandHandler
         Inherits AbstractAutomaticLineEnderCommandHandler
 
         <ImportingConstructor>
-        Friend Sub New(waitIndicator As IWaitIndicator,
-                       undoRegistry As ITextUndoHistoryRegistry,
+        Friend Sub New(undoRegistry As ITextUndoHistoryRegistry,
                        editorOperations As IEditorOperationsFactoryService)
 
-            MyBase.New(waitIndicator, undoRegistry, editorOperations)
+            MyBase.New(undoRegistry, editorOperations)
         End Sub
 
         Protected Overrides Sub NextAction(editorOperation As IEditorOperations, nextAction As Action)

--- a/src/EditorFeatures/VisualBasic/ChangeSignature/VisualBasicChangeSignatureCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ChangeSignature/VisualBasicChangeSignatureCommandHandler.vb
@@ -1,17 +1,15 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
+Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ChangeSignature
-    <ExportCommandHandler(PredefinedCommandHandlerNames.ChangeSignature, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.ChangeSignature)>
     Friend Class VisualBasicChangeSignatureCommandHandler
         Inherits AbstractChangeSignatureCommandHandler
-
-        <ImportingConstructor>
-        Public Sub New(waitIndicator As IWaitIndicator)
-            MyBase.New(waitIndicator)
-        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/DocumentationComments/DocumentationCommentCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/DocumentationComments/DocumentationCommentCommandHandler.vb
@@ -7,9 +7,12 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.DocumentationComments
-    <ExportCommandHandler(PredefinedCommandHandlerNames.DocumentationComments, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.DocumentationComments)>
     <Order(After:=PredefinedCommandHandlerNames.Rename)>
     <Order(After:=PredefinedCommandHandlerNames.Completion)>
     Friend Class DocumentationCommentCommandHandler

--- a/src/EditorFeatures/VisualBasic/DocumentationComments/XmlTagCompletionCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/DocumentationComments/XmlTagCompletionCommandHandler.vb
@@ -2,23 +2,25 @@
 
 Imports System.ComponentModel.Composition
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Text.Editor
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.DocumentationComments
-    <ExportCommandHandler("XmlTagCompletionCommandHandler", ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name("XmlTagCompletionCommandHandler")>
     <Order(Before:=PredefinedCommandHandlerNames.Completion)>
     Friend Class XmlTagCompletionCommandHandler
         Inherits AbstractXmlTagCompletionCommandHandler
 
         <ImportingConstructor>
-        Public Sub New(undoHistory As ITextUndoHistoryRegistry, waitIndicator As IWaitIndicator)
-            MyBase.New(undoHistory, waitIndicator)
+        Public Sub New(undoHistory As ITextUndoHistoryRegistry)
+            MyBase.New(undoHistory)
         End Sub
 
         Protected Overrides Sub TryCompleteTag(textView As ITextView, subjectBuffer As ITextBuffer, document As Document, position As SnapshotPoint, cancellationToken As CancellationToken)

--- a/src/EditorFeatures/VisualBasic/EncapsulateField/EncapsulateFieldCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/EncapsulateField/EncapsulateFieldCommandHandler.vb
@@ -1,23 +1,24 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.EncapsulateField
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EncapsulateField
-    <ExportCommandHandler(PredefinedCommandHandlerNames.EncapsulateField, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.EncapsulateField)>
     <Order(After:=PredefinedCommandHandlerNames.DocumentationComments)>
     Friend Class EncapsulateFieldCommandHandler
         Inherits AbstractEncapsulateFieldCommandHandler
 
         <ImportingConstructor>
-        Public Sub New(waitIndicator As IWaitIndicator,
-                       undoManager As ITextBufferUndoManagerProvider,
+        Public Sub New(undoManager As ITextBufferUndoManagerProvider,
                        <ImportMany> asyncListeners As IEnumerable(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata)))
-            MyBase.New(waitIndicator, undoManager, asyncListeners)
+            MyBase.New(undoManager, asyncListeners)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructCommandHandler.vb
@@ -4,27 +4,37 @@ Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeCleanup
 Imports Microsoft.CodeAnalysis.CodeCleanup.Providers
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.EndConstructGeneration
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
-    <ExportCommandHandler(PredefinedCommandHandlerNames.EndConstruct, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.EndConstruct)>
     <Order(After:=PredefinedCommandHandlerNames.Completion)>
     <Order(After:=PredefinedCommandHandlerNames.AutomaticLineEnder)>
     Friend Class EndConstructCommandHandler
-        Implements ICommandHandler(Of ReturnKeyCommandArgs)
-        Implements ICommandHandler(Of TypeCharCommandArgs)
-        Implements ICommandHandler(Of AutomaticLineEnderCommandArgs)
+        Implements IChainedCommandHandler(Of ReturnKeyCommandArgs)
+        Implements IChainedCommandHandler(Of TypeCharCommandArgs)
+        Implements IChainedCommandHandler(Of AutomaticLineEnderCommandArgs)
 
         Private ReadOnly _editorOperationsFactoryService As IEditorOperationsFactoryService
         Private ReadOnly _undoHistoryRegistry As ITextUndoHistoryRegistry
+
+        Public ReadOnly Property DisplayName As String Implements INamed.DisplayName
+            Get
+                Return VBEditorResources.End_Construct_Command_Handler
+            End Get
+        End Property
 
         <ImportingConstructor()>
         Public Sub New(editorOperationsFactoryService As IEditorOperationsFactoryService,
@@ -34,19 +44,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
             Me._undoHistoryRegistry = undoHistoryRegistry
         End Sub
 
-        Public Function GetCommandState_ReturnKeyCommandHandler(args As ReturnKeyCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of ReturnKeyCommandArgs).GetCommandState
+        Public Function GetCommandState_ReturnKeyCommandHandler(args As ReturnKeyCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of ReturnKeyCommandArgs).GetCommandState
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand_ReturnKeyCommandHandler(args As ReturnKeyCommandArgs, nextHandler As Action) Implements ICommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand_ReturnKeyCommandHandler(args As ReturnKeyCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
             ExecuteEndConstructOnReturn(args.TextView, args.SubjectBuffer, nextHandler)
         End Sub
 
-        Public Function GetCommandState_TypeCharCommandHandler(args As TypeCharCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of TypeCharCommandArgs).GetCommandState
+        Public Function GetCommandState_TypeCharCommandHandler(args As TypeCharCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of TypeCharCommandArgs).GetCommandState
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand_TypeCharCommandHandler(args As TypeCharCommandArgs, nextHandler As Action) Implements ICommandHandler(Of TypeCharCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand_TypeCharCommandHandler(args As TypeCharCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of TypeCharCommandArgs).ExecuteCommand
             nextHandler()
 
             If Not args.SubjectBuffer.GetFeatureOnOffOption(FeatureOnOffOptions.EndConstruct) Then
@@ -64,11 +74,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
             endConstructService.TryDo(args.TextView, args.SubjectBuffer, args.TypedChar, CancellationToken.None)
         End Sub
 
-        Public Function GetCommandState_AutomaticLineEnderCommandHandler(args As AutomaticLineEnderCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of AutomaticLineEnderCommandArgs).GetCommandState
-            Return CommandState.Available
+        Public Function GetCommandState_AutomaticLineEnderCommandHandler(args As AutomaticLineEnderCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of AutomaticLineEnderCommandArgs).GetCommandState
+            Return VSCommanding.CommandState.Available
         End Function
 
-        Public Sub ExecuteCommand_AutomaticLineEnderCommandHandler(args As AutomaticLineEnderCommandArgs, nextHandler As Action) Implements ICommandHandler(Of AutomaticLineEnderCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand_AutomaticLineEnderCommandHandler(args As AutomaticLineEnderCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of AutomaticLineEnderCommandArgs).ExecuteCommand
             ExecuteEndConstructOnReturn(args.TextView, args.SubjectBuffer, Sub()
                                                                                Dim operations = Me._editorOperationsFactoryService.GetEditorOperations(args.TextView)
                                                                                If operations Is Nothing Then

--- a/src/EditorFeatures/VisualBasic/ExtractInterface/ExtractInterfaceCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ExtractInterface/ExtractInterfaceCommandHandler.vb
@@ -1,9 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis.Editor.Implementation.ExtractInterface
+Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ExtractInterface
-    <ExportCommandHandler(PredefinedCommandHandlerNames.ExtractInterface, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.ExtractInterface)>
     Friend Class ExtractInterfaceCommandHandler
         Inherits AbstractExtractInterfaceCommandHandler
 

--- a/src/EditorFeatures/VisualBasic/ExtractMethod/ExtractMethodCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ExtractMethod/ExtractMethodCommandHandler.vb
@@ -1,14 +1,15 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.ExtractMethod
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ExtractMethod
-    <ExportCommandHandler(PredefinedCommandHandlerNames.ExtractMethod,
-        ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.ExtractMethod)>
     <Order(After:=PredefinedCommandHandlerNames.DocumentationComments)>
     Friend Class ExtractMethodCommandHandler
         Inherits AbstractExtractMethodCommandHandler
@@ -16,9 +17,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ExtractMethod
         <ImportingConstructor()>
         Public Sub New(undoManager As ITextBufferUndoManagerProvider,
                        editorOperationsFactoryService As IEditorOperationsFactoryService,
-                       renameService As IInlineRenameService,
-                       waitIndicator As IWaitIndicator)
-            MyBase.New(undoManager, editorOperationsFactoryService, renameService, waitIndicator)
+                       renameService As IInlineRenameService)
+            MyBase.New(undoManager, editorOperationsFactoryService, renameService)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/SmartTokenFormatterCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/SmartTokenFormatterCommandHandler.vb
@@ -10,10 +10,12 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
-    <ExportCommandHandler(PredefinedCommandHandlerNames.Indent,
-        ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.Indent)>
     <Order(After:=PredefinedCommandHandlerNames.Rename)>
     Friend Class SmartTokenFormatterCommandHandler
         Inherits AbstractSmartTokenFormatterCommandHandler

--- a/src/EditorFeatures/VisualBasic/ImplementAbstractClass/ImplementAbstractClassCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ImplementAbstractClass/ImplementAbstractClassCommandHandler.vb
@@ -7,9 +7,12 @@ Imports Microsoft.CodeAnalysis.ImplementAbstractClass
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ImplementAbstractClass
-    <ExportCommandHandler("ImplementAbstractClassCommandHandler", ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name("ImplementAbstractClassCommandHandler")>
     <Order(Before:=PredefinedCommandHandlerNames.EndConstruct)>
     <Order(After:=PredefinedCommandHandlerNames.Completion)>
     Friend Class ImplementAbstractClassCommandHandler

--- a/src/EditorFeatures/VisualBasic/ImplementInterface/ImplementInterfaceCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ImplementInterface/ImplementInterfaceCommandHandler.vb
@@ -7,9 +7,12 @@ Imports Microsoft.CodeAnalysis.ImplementInterface
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ImplementInterface
-    <ExportCommandHandler("ImplementInterfaceCommandHandler", ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name("ImplementInterfaceCommandHandler")>
     <Order(Before:=PredefinedCommandHandlerNames.EndConstruct)>
     <Order(After:=PredefinedCommandHandlerNames.Completion)>
     Friend Class ImplementInterfaceCommandHandler

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
@@ -3,16 +3,17 @@
 Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     ''' <summary>
@@ -21,101 +22,96 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     ''' <remarks>This particular command filter acts as a "wrapper" around any other command, as it
     ''' wishes to invoke the commit after whatever processed the enter is done doing what it's
     ''' doing.</remarks>
-    <ExportCommandHandler(PredefinedCommandHandlerNames.Commit, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(VSCommanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.Commit)>
     <Order(Before:=PredefinedCommandHandlerNames.EndConstruct)>
     <Order(Before:=PredefinedCommandHandlerNames.Completion)>
     Friend Class CommitCommandHandler
-        Implements ICommandHandler(Of ReturnKeyCommandArgs)
-        Implements ICommandHandler(Of PasteCommandArgs)
-        Implements ICommandHandler(Of SaveCommandArgs)
-        Implements ICommandHandler(Of FormatDocumentCommandArgs)
-        Implements ICommandHandler(Of FormatSelectionCommandArgs)
+        Implements IChainedCommandHandler(Of ReturnKeyCommandArgs)
+        Implements IChainedCommandHandler(Of PasteCommandArgs)
+        Implements IChainedCommandHandler(Of SaveCommandArgs)
+        Implements IChainedCommandHandler(Of FormatDocumentCommandArgs)
+        Implements IChainedCommandHandler(Of FormatSelectionCommandArgs)
 
         Private ReadOnly _bufferManagerFactory As CommitBufferManagerFactory
         Private ReadOnly _editorOperationsFactoryService As IEditorOperationsFactoryService
         Private ReadOnly _smartIndentationService As ISmartIndentationService
         Private ReadOnly _textUndoHistoryRegistry As ITextUndoHistoryRegistry
-        Private ReadOnly _waitIndicator As IWaitIndicator
+
+        Public ReadOnly Property DisplayName As String Implements INamed.DisplayName
+            Get
+                Return VBEditorResources.Commit_Command_Handler
+            End Get
+        End Property
 
         <ImportingConstructor()>
         Friend Sub New(
             bufferManagerFactory As CommitBufferManagerFactory,
             editorOperationsFactoryService As IEditorOperationsFactoryService,
             smartIndentationService As ISmartIndentationService,
-            textUndoHistoryRegistry As ITextUndoHistoryRegistry,
-            waitIndicator As IWaitIndicator)
+            textUndoHistoryRegistry As ITextUndoHistoryRegistry)
 
             _bufferManagerFactory = bufferManagerFactory
             _editorOperationsFactoryService = editorOperationsFactoryService
             _smartIndentationService = smartIndentationService
             _textUndoHistoryRegistry = textUndoHistoryRegistry
-            _waitIndicator = waitIndicator
         End Sub
 
-        Public Sub ExecuteCommand(args As FormatDocumentCommandArgs, nextHandler As Action) Implements ICommandHandler(Of FormatDocumentCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand(args As FormatDocumentCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of FormatDocumentCommandArgs).ExecuteCommand
             If Not args.SubjectBuffer.CanApplyChangeDocumentToWorkspace() Then
                 nextHandler()
                 Return
             End If
 
-            _waitIndicator.Wait(
-                VBEditorResources.Format_Document,
-                VBEditorResources.Formatting_Document,
-                allowCancel:=True,
-                action:=
-                Sub(waitContext)
-                    Dim buffer = args.SubjectBuffer
-                    Dim snapshot = buffer.CurrentSnapshot
+            Using context.WaitContext.AddScope(allowCancellation:=True, VBEditorResources.Formatting_Document)
+                Dim buffer = args.SubjectBuffer
+                Dim snapshot = buffer.CurrentSnapshot
 
-                    Dim wholeFile = snapshot.GetFullSpan()
-                    Dim commitBufferManager = _bufferManagerFactory.CreateForBuffer(buffer)
-                    commitBufferManager.ExpandDirtyRegion(wholeFile)
-                    commitBufferManager.CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)
-                End Sub)
+                Dim wholeFile = snapshot.GetFullSpan()
+                Dim commitBufferManager = _bufferManagerFactory.CreateForBuffer(buffer)
+                commitBufferManager.ExpandDirtyRegion(wholeFile)
+                commitBufferManager.CommitDirty(isExplicitFormat:=True, cancellationToken:=context.WaitContext.UserCancellationToken)
+            End Using
         End Sub
 
-        Public Function GetCommandState(args As FormatDocumentCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of FormatDocumentCommandArgs).GetCommandState
+        Public Function GetCommandState(args As FormatDocumentCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of FormatDocumentCommandArgs).GetCommandState
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand(args As FormatSelectionCommandArgs, nextHandler As Action) Implements ICommandHandler(Of FormatSelectionCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand(args As FormatSelectionCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of FormatSelectionCommandArgs).ExecuteCommand
             If Not args.SubjectBuffer.CanApplyChangeDocumentToWorkspace() Then
                 nextHandler()
                 Return
             End If
 
-            _waitIndicator.Wait(
-                VBEditorResources.Format_Document,
-                VBEditorResources.Formatting_Document,
-                allowCancel:=True,
-                action:=
-                Sub(waitContext)
-                    Dim buffer = args.SubjectBuffer
-                    Dim selections = args.TextView.Selection.GetSnapshotSpansOnBuffer(buffer)
+            Using context.WaitContext.AddScope(allowCancellation:=True, VBEditorResources.Formatting_Document)
+                Dim buffer = args.SubjectBuffer
+                Dim selections = args.TextView.Selection.GetSnapshotSpansOnBuffer(buffer)
 
-                    If selections.Count < 1 Then
-                        nextHandler()
-                        Return
-                    End If
+                If selections.Count < 1 Then
+                    nextHandler()
+                    Return
+                End If
 
-                    Dim snapshot = buffer.CurrentSnapshot
-                    For index As Integer = 0 To selections.Count - 1
-                        Dim textspan = CommonFormattingHelpers.GetFormattingSpan(snapshot, selections(0))
-                        Dim selectedSpan = New SnapshotSpan(snapshot, textspan.Start, textspan.Length)
-                        Dim commitBufferManager = _bufferManagerFactory.CreateForBuffer(buffer)
-                        commitBufferManager.ExpandDirtyRegion(selectedSpan)
-                        commitBufferManager.CommitDirty(isExplicitFormat:=True, cancellationToken:=waitContext.CancellationToken)
-                    Next
-                End Sub)
+                Dim snapshot = buffer.CurrentSnapshot
+                For index As Integer = 0 To selections.Count - 1
+                    Dim textspan = CommonFormattingHelpers.GetFormattingSpan(snapshot, selections(0))
+                    Dim selectedSpan = New SnapshotSpan(snapshot, textspan.Start, textspan.Length)
+                    Dim commitBufferManager = _bufferManagerFactory.CreateForBuffer(buffer)
+                    commitBufferManager.ExpandDirtyRegion(selectedSpan)
+                    commitBufferManager.CommitDirty(isExplicitFormat:=True, cancellationToken:=context.WaitContext.UserCancellationToken)
+                Next
+            End Using
 
             'We don't call nextHandler, since we have handled this command.
         End Sub
 
-        Public Function GetCommandState(args As FormatSelectionCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of FormatSelectionCommandArgs).GetCommandState
+        Public Function GetCommandState(args As FormatSelectionCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of FormatSelectionCommandArgs).GetCommandState
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand(args As ReturnKeyCommandArgs, nextHandler As Action) Implements ICommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand(args As ReturnKeyCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
             If Not args.SubjectBuffer.GetFeatureOnOffOption(FeatureOnOffOptions.PrettyListing) Then
                 nextHandler()
                 Return
@@ -210,20 +206,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Return False
         End Function
 
-        Public Function GetCommandState(args As ReturnKeyCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of ReturnKeyCommandArgs).GetCommandState
+        Public Function GetCommandState(args As ReturnKeyCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of ReturnKeyCommandArgs).GetCommandState
             ' We don't make any decision if the enter key is allowed; we just forward onto the next handler
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand(args As PasteCommandArgs, nextHandler As Action) Implements ICommandHandler(Of PasteCommandArgs).ExecuteCommand
-            _waitIndicator.Wait(
-                title:=VBEditorResources.Format_Paste,
-                message:=VBEditorResources.Formatting_pasted_text,
-                allowCancel:=True,
-                action:=Sub(waitContext) CommitOnPaste(args, nextHandler, waitContext))
+        Public Sub ExecuteCommand(args As PasteCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of PasteCommandArgs).ExecuteCommand
+            Using context.WaitContext.AddScope(allowCancellation:=True, VBEditorResources.Formatting_pasted_text)
+                CommitOnPaste(args, nextHandler, context.WaitContext.UserCancellationToken)
+            End Using
         End Sub
 
-        Private Sub CommitOnPaste(args As PasteCommandArgs, nextHandler As Action, waitContext As IWaitContext)
+        Private Sub CommitOnPaste(args As PasteCommandArgs, nextHandler As Action, cancellationToken As CancellationToken)
             Using transaction = _textUndoHistoryRegistry.GetHistory(args.TextView.TextBuffer).CreateTransaction(VBEditorResources.Paste)
                 Dim oldVersion = args.SubjectBuffer.CurrentSnapshot.Version
 
@@ -247,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 ' Did we paste content that changed the number of lines?
                 If oldVersion.Changes IsNot Nothing AndAlso oldVersion.Changes.IncludesLineChanges Then
                     Try
-                        _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
+                        _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=cancellationToken)
                     Catch ex As OperationCanceledException
                         ' If the commit was cancelled, we still want the paste to go through
                     End Try
@@ -257,32 +251,28 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             End Using
         End Sub
 
-        Public Function GetCommandState(args As PasteCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of PasteCommandArgs).GetCommandState
+        Public Function GetCommandState(args As PasteCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of PasteCommandArgs).GetCommandState
             Return nextHandler()
         End Function
 
-        Public Sub ExecuteCommand(args As SaveCommandArgs, nextHandler As Action) Implements ICommandHandler(Of SaveCommandArgs).ExecuteCommand
+        Public Sub ExecuteCommand(args As SaveCommandArgs, nextHandler As Action, context As CommandExecutionContext) Implements IChainedCommandHandler(Of SaveCommandArgs).ExecuteCommand
             If args.SubjectBuffer.GetFeatureOnOffOption(InternalFeatureOnOffOptions.FormatOnSave) Then
-                _waitIndicator.Wait(
-                    title:=VBEditorResources.Format_on_Save,
-                    message:=VBEditorResources.Formatting_Document,
-                    allowCancel:=True,
-                    action:=Sub(waitContext)
-                                Using transaction = _textUndoHistoryRegistry.GetHistory(args.TextView.TextBuffer).CreateTransaction(VBEditorResources.Format_on_Save)
-                                    _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=waitContext.CancellationToken)
+                Using context.WaitContext.AddScope(allowCancellation:=True, VBEditorResources.Formatting_Document)
+                    Using transaction = _textUndoHistoryRegistry.GetHistory(args.TextView.TextBuffer).CreateTransaction(VBEditorResources.Format_on_Save)
+                        _bufferManagerFactory.CreateForBuffer(args.SubjectBuffer).CommitDirty(isExplicitFormat:=False, cancellationToken:=context.WaitContext.UserCancellationToken)
 
-                                    ' We should only create the transaction if anything actually happened
-                                    If transaction.UndoPrimitives.Any() Then
-                                        transaction.Complete()
-                                    End If
-                                End Using
-                            End Sub)
+                        ' We should only create the transaction if anything actually happened
+                        If transaction.UndoPrimitives.Any() Then
+                            transaction.Complete()
+                        End If
+                    End Using
+                End Using
             End If
 
             nextHandler()
         End Sub
 
-        Public Function GetCommandState(args As SaveCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of SaveCommandArgs).GetCommandState
+        Public Function GetCommandState(args As SaveCommandArgs, nextHandler As Func(Of VSCommanding.CommandState)) As VSCommanding.CommandState Implements IChainedCommandHandler(Of SaveCommandArgs).GetCommandState
             Return nextHandler()
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasic/Utilities/CommandHandlers/AbstractImplementAbstractClassOrInterfaceCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/Utilities/CommandHandlers/AbstractImplementAbstractClassOrInterfaceCommandHandler.vb
@@ -2,21 +2,30 @@
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.EndConstructGeneration
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
+Imports Microsoft.VisualStudio.Utilities
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities.CommandHandlers
     Friend MustInherit Class AbstractImplementAbstractClassOrInterfaceCommandHandler
-        Implements ICommandHandler(Of ReturnKeyCommandArgs)
+        Implements VSCommanding.ICommandHandler(Of ReturnKeyCommandArgs)
 
         Private ReadOnly _editorOperationsFactoryService As IEditorOperationsFactoryService
+
+        Public ReadOnly Property DisplayName As String Implements INamed.DisplayName
+            Get
+                Return VBEditorResources.Implement_Abstract_Class_Or_Interface_Command_Handler
+            End Get
+        End Property
 
         Protected Sub New(editorOperationsFactoryService As IEditorOperationsFactoryService)
             _editorOperationsFactoryService = editorOperationsFactoryService
@@ -27,18 +36,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities.CommandHandlers
             typeSyntax As TypeSyntax,
             cancellationToken As CancellationToken) As Document
 
-        Private Sub ExecuteCommand(args As ReturnKeyCommandArgs, nextHandler As Action) Implements ICommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
+        Private Function ExecuteCommand(args As ReturnKeyCommandArgs, context As CommandExecutionContext) As Boolean Implements VSCommanding.ICommandHandler(Of ReturnKeyCommandArgs).ExecuteCommand
             Dim caretPointOpt = args.TextView.GetCaretPoint(args.SubjectBuffer)
             If caretPointOpt Is Nothing Then
-                nextHandler()
-                Return
+                Return False
             End If
 
             ' Implement interface is not cancellable.
             Dim _cancellationToken = CancellationToken.None
             If Not TryExecute(args, _cancellationToken) Then
-                nextHandler()
-                Return
+                Return False
             End If
 
             ' It's possible that there may be an end construct to generate at this position.
@@ -53,20 +60,20 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities.CommandHandlers
             ' insert a new line.
             Dim lastNonWhitespacePosition = If(caretLine.GetLastNonWhitespacePosition(), -1)
             If lastNonWhitespacePosition > caretPosition.Position Then
-                nextHandler()
-                Return
+                Return False
             End If
 
             Dim nextLine = snapshot.GetLineFromLineNumber(caretLine.LineNumber + 1)
             If Not nextLine.IsEmptyOrWhitespace() Then
                 ' If the next line is not whitespace, we'll go ahead and pass through to insert a new line.
-                nextHandler()
-                Return
+                Return False
             End If
 
             ' If the next line *is* whitespace, we're just going to move the caret down a line.
             _editorOperationsFactoryService.GetEditorOperations(args.TextView).MoveLineDown(extendSelection:=False)
-        End Sub
+
+            Return True
+        End Function
 
         Private Function TryGenerateEndConstruct(args As ReturnKeyCommandArgs, cancellationToken As CancellationToken) As Boolean
             Dim textSnapshot = args.SubjectBuffer.CurrentSnapshot
@@ -172,8 +179,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities.CommandHandlers
             Return True
         End Function
 
-        Private Function GetCommandState(args As ReturnKeyCommandArgs, nextHandler As Func(Of CommandState)) As CommandState Implements ICommandHandler(Of ReturnKeyCommandArgs).GetCommandState
-            Return nextHandler()
+        Private Function GetCommandState(args As ReturnKeyCommandArgs) As VSCommanding.CommandState Implements VSCommanding.ICommandHandler(Of ReturnKeyCommandArgs).GetCommandState
+            Return VSCommanding.CommandState.Unspecified
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/VBEditorResources.Designer.vb
+++ b/src/EditorFeatures/VisualBasic/VBEditorResources.Designer.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _
@@ -86,7 +86,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Case_Correction", resourceCulture)
             End Get
         End Property
-        
+
+        '''<summary>
+        '''  Looks up a localized string similar to Line Commit Command Handler.
+        '''</summary>
+        Friend ReadOnly Property Commit_Command_Handler() As String
+            Get
+                Return ResourceManager.GetString("Commit_Command_Handler", resourceCulture)
+            End Get
+        End Property
+
         '''<summary>
         '''  Looks up a localized string similar to Committing line.
         '''</summary>
@@ -95,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Committing_line", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Correcting word casing....
         '''</summary>
@@ -104,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Correcting_word_casing", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to End Construct.
         '''</summary>
@@ -113,7 +122,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("End_Construct", resourceCulture)
             End Get
         End Property
-        
+
+        '''<summary>
+        '''  Looks up a localized string similar to End Construct Command Handler.
+        '''</summary>
+        Friend ReadOnly Property End_Construct_Command_Handler() As String
+            Get
+                Return ResourceManager.GetString("End_Construct_Command_Handler", resourceCulture)
+            End Get
+        End Property
+
         '''<summary>
         '''  Looks up a localized string similar to Format Document.
         '''</summary>
@@ -122,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Format_Document", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Format on Save.
         '''</summary>
@@ -131,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Format_on_Save", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Format Paste.
         '''</summary>
@@ -140,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Format_Paste", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Formatting Document....
         '''</summary>
@@ -149,7 +167,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Formatting_Document", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Formatting pasted text....
         '''</summary>
@@ -158,13 +176,22 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.VBEditorResources
                 Return ResourceManager.GetString("Formatting_pasted_text", resourceCulture)
             End Get
         End Property
-        
+
         '''<summary>
         '''  Looks up a localized string similar to Generate Member.
         '''</summary>
         Friend ReadOnly Property Generate_Member() As String
             Get
                 Return ResourceManager.GetString("Generate_Member", resourceCulture)
+            End Get
+        End Property
+
+        '''<summary>
+        '''  Looks up a localized string similar to Implement Abstract Class Or Interface Command Handler.
+        '''</summary>
+        Friend ReadOnly Property Implement_Abstract_Class_Or_Interface_Command_Handler() As String
+            Get
+                Return ResourceManager.GetString("Implement_Abstract_Class_Or_Interface_Command_Handler", resourceCulture)
             End Get
         End Property
         

--- a/src/EditorFeatures/VisualBasic/VBEditorResources.resx
+++ b/src/EditorFeatures/VisualBasic/VBEditorResources.resx
@@ -180,4 +180,13 @@
   <data name="Line_commit" xml:space="preserve">
     <value>Line commit</value>
   </data>
+  <data name="Commit_Command_Handler" xml:space="preserve">
+    <value>Line Commit Command Handler</value>
+  </data>
+  <data name="End_Construct_Command_Handler" xml:space="preserve">
+    <value>End Construct Command Handler</value>
+  </data>
+  <data name="Implement_Abstract_Class_Or_Interface_Command_Handler" xml:space="preserve">
+    <value>Implement Abstract Class Or Interface Command Handler</value>
+  </data>
 </root>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.cs.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.cs.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Potvrzení změn řádku</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.de.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.de.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Zeilencommit</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.es.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.es.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Confirmación de línea</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.fr.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.fr.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Validation de ligne</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.it.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.it.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Commit riga</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ja.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ja.xlf
@@ -107,6 +107,21 @@
         <target state="translated">行コミット</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ko.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ko.xlf
@@ -107,6 +107,21 @@
         <target state="translated">줄 커밋</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.pl.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.pl.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Zatwierdzenie wiersza</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.pt-BR.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.pt-BR.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Confirmação de linha</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ru.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.ru.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Фиксация строки</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.tr.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.tr.xlf
@@ -107,6 +107,21 @@
         <target state="translated">Satır işleme</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.zh-Hans.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.zh-Hans.xlf
@@ -107,6 +107,21 @@
         <target state="translated">行提交</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.zh-Hant.xlf
+++ b/src/EditorFeatures/VisualBasic/xlf/VBEditorResources.zh-Hant.xlf
@@ -107,6 +107,21 @@
         <target state="translated">行認可</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commit_Command_Handler">
+        <source>Line Commit Command Handler</source>
+        <target state="new">Line Commit Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="End_Construct_Command_Handler">
+        <source>End Construct Command Handler</source>
+        <target state="new">End Construct Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Implement_Abstract_Class_Or_Interface_Command_Handler">
+        <source>Implement Abstract Class Or Interface Command Handler</source>
+        <target state="new">Implement Abstract Class Or Interface Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AutomaticCompletion/AutomaticLineEnderTests.vb
@@ -1,12 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Xml.Linq
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
+Imports Microsoft.VisualStudio.Commanding
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.AutomaticCompletion
@@ -241,12 +243,11 @@ End Module
         End Sub
 
         Friend Overrides Function CreateCommandHandler(
-            waitIndicator As Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator,
             undoRegistry As ITextUndoHistoryRegistry,
             editorOperations As IEditorOperationsFactoryService
-        ) As ICommandHandler(Of AutomaticLineEnderCommandArgs)
+        ) As IChainedCommandHandler(Of AutomaticLineEnderCommandArgs)
 
-            Return New AutomaticLineEnderCommandHandler(waitIndicator, undoRegistry, editorOperations)
+            Return New AutomaticLineEnderCommandHandler(undoRegistry, editorOperations)
         End Function
 
         Protected Overrides Function CreateNextHandler(workspace As TestWorkspace) As Action
@@ -259,7 +260,7 @@ End Module
 
             Return Sub()
                        endConstructor.ExecuteCommand_AutomaticLineEnderCommandHandler(
-                           New AutomaticLineEnderCommandArgs(view, buffer), Sub() Exit Sub)
+                           New AutomaticLineEnderCommandArgs(view, buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                    End Sub
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ChangeSignature
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ChangeSignature
     Partial Public Class ChangeSignatureTests
@@ -115,22 +116,13 @@ End Module
 
                 Dim textView = workspace.Documents.Single().GetTextView()
 
-                Dim handler = New VisualBasicChangeSignatureCommandHandler(TestWaitIndicator.Default)
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
+                Dim handler = New VisualBasicChangeSignatureCommandHandler()
 
-                Dim state = handler.GetCommandState(New Commands.ReorderParametersCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New ReorderParametersCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
 
-                delegatedToNext = False
-                state = handler.GetCommandState(New Commands.RemoveParametersCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                state = handler.GetCommandState(New RemoveParametersCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
             End Using
         End Sub
     End Class

--- a/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CommentSelection/VisualBasicCommentSelectionTests.vb
@@ -81,12 +81,11 @@ End Module</code>
                 SetupSelection(doc.GetTextView(), spans.Select(Function(s) Span.FromBounds(s.Start, s.End)))
 
                 Dim commandHandler = New CommentUncommentSelectionCommandHandler(
-                    TestWaitIndicator.Default,
                     workspace.ExportProvider.GetExportedValue(Of ITextUndoHistoryRegistry),
                     workspace.ExportProvider.GetExportedValue(Of IEditorOperationsFactoryService))
                 Dim textView = doc.GetTextView()
                 Dim textBuffer = doc.GetTextBuffer()
-                commandHandler.ExecuteCommand(textView, textBuffer, operation)
+                commandHandler.ExecuteCommand(textView, textBuffer, operation, TestCommandExecutionContext.Create())
 
                 Assert.Equal(expected, doc.TextBuffer.CurrentSnapshot.GetText())
             End Using

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.DocumentationComments
 Imports Microsoft.VisualStudio.Text.Operations
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DocumentationComments
     Public Class DocumentationCommentTests
@@ -1197,7 +1198,7 @@ End Class
         Friend Overrides Function CreateCommandHandler(
             waitIndicator As IWaitIndicator,
             undoHistoryRegistry As ITextUndoHistoryRegistry,
-            editorOperationsFactoryService As IEditorOperationsFactoryService) As ICommandHandler
+            editorOperationsFactoryService As IEditorOperationsFactoryService) As VSCommanding.ICommandHandler
 
             Return New DocumentationCommentCommandHandler(waitIndicator, undoHistoryRegistry, editorOperationsFactoryService)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/XmlTagCompletionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/XmlTagCompletionTests.vb
@@ -1,18 +1,18 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.DocumentationComments
+Imports Microsoft.VisualStudio.Commanding
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
-Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DocumentationComments
     Public Class XmlTagCompletionTests
         Inherits AbstractXmlTagCompletionTests
 
-        Friend Overrides Function CreateCommandHandler(undoHistory As ITextUndoHistoryRegistry) As ICommandHandler(Of TypeCharCommandArgs)
-            Return New XmlTagCompletionCommandHandler(undoHistory, TestWaitIndicator.Default)
+        Friend Overrides Function CreateCommandHandler(undoHistory As ITextUndoHistoryRegistry) As IChainedCommandHandler(Of TypeCharCommandArgs)
+            Return New XmlTagCompletionCommandHandler(undoHistory)
         End Function
 
         Protected Overrides Function CreateTestWorkspace(initialMarkup As String) As TestWorkspace

--- a/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldCommandHandlerTests.vb
@@ -2,10 +2,12 @@
 
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EncapsulateField
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EncapsulateField
@@ -150,18 +152,10 @@ End Class
 
                 Dim textView = workspace.Documents.Single().GetTextView()
 
-                Dim handler = New EncapsulateFieldCommandHandler(workspace.GetService(Of Host.IWaitIndicator), workspace.GetService(Of ITextBufferUndoManagerProvider),
+                Dim handler = New EncapsulateFieldCommandHandler(workspace.GetService(Of ITextBufferUndoManagerProvider),
                     workspace.ExportProvider.GetExportedValues(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata)))
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
-
-                Dim state = handler.GetCommandState(New Commands.EncapsulateFieldCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New EncapsulateFieldCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
             End Using
         End Sub
     End Class

--- a/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldTestState.vb
+++ b/src/EditorFeatures/VisualBasicTest/EncapsulateField/EncapsulateFieldTestState.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Shared
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
@@ -9,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EncapsulateField
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.VisualBasic.EncapsulateField
 Imports Microsoft.VisualStudio.Composition
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EncapsulateField
@@ -37,9 +37,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EncapsulateField
 
         Public Sub Encapsulate()
             Dim args = New EncapsulateFieldCommandArgs(_testDocument.GetTextView(), _testDocument.GetTextBuffer())
-            Dim commandHandler = New EncapsulateFieldCommandHandler(TestWaitIndicator.Default, Workspace.GetService(Of ITextBufferUndoManagerProvider)(),
+            Dim commandHandler = New EncapsulateFieldCommandHandler(Workspace.GetService(Of ITextBufferUndoManagerProvider)(),
                                                                     Workspace.ExportProvider.GetExportedValues(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata)))
-            commandHandler.ExecuteCommand(args, Nothing)
+            commandHandler.ExecuteCommand(args, TestCommandExecutionContext.Create())
         End Sub
 
         Public Sub AssertEncapsulateAs(expected As String)

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
@@ -2,14 +2,15 @@
 
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
 Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Moq
 Imports Roslyn.Test.EditorUtilities
@@ -236,7 +237,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
                                     workspace.ExportProvider.GetExportedValue(Of ITextUndoHistoryRegistry)())
 
                 Dim operations = factory.GetEditorOperations(view)
-                endConstructor.ExecuteCommand_ReturnKeyCommandHandler(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() operations.InsertNewLine())
+                endConstructor.ExecuteCommand_ReturnKeyCommandHandler(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() operations.InsertNewLine(), TestCommandExecutionContext.Create())
 
                 Assert.Equal(after, view.TextSnapshot.GetText())
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractInterface/ExtractInterfaceTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ExtractInterface
 Imports Microsoft.CodeAnalysis.ExtractInterface
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractInterface
     Public Class ExtractInterfaceTests
@@ -1281,16 +1282,9 @@ End Namespace
                 Dim textView = workspace.Documents.Single().GetTextView()
 
                 Dim handler = New ExtractInterfaceCommandHandler()
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
 
-                Dim state = handler.GetCommandState(New Commands.ExtractInterfaceCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New ExtractInterfaceCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
             End Using
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.vb
@@ -4,6 +4,7 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ExtractMethod
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
@@ -3384,18 +3385,10 @@ End Namespace"
                     Dim handler = New ExtractMethodCommandHandler(
                         workspace.GetService(Of ITextBufferUndoManagerProvider)(),
                         workspace.GetService(Of IEditorOperationsFactoryService)(),
-                        workspace.GetService(Of IInlineRenameService)(),
-                        workspace.GetService(Of Host.IWaitIndicator)())
-                    Dim delegatedToNext = False
-                    Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
+                        workspace.GetService(Of IInlineRenameService)())
 
-                    Dim state = handler.GetCommandState(New Commands.ExtractMethodCommandArgs(textView, textView.TextBuffer), nextHandler)
-                    Assert.True(delegatedToNext)
-                    Assert.False(state.IsAvailable)
+                    Dim state = handler.GetCommandState(New ExtractMethodCommandArgs(textView, textView.TextBuffer))
+                    Assert.True(state.IsUnspecified)
                 End Using
             End Sub
         End Class

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -1,7 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
@@ -13,6 +12,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Text.Projection
 Imports Moq

--- a/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassCommandHandlerTests.vb
@@ -1,13 +1,16 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Xml.Linq
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ImplementAbstractClass
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ImplementAbstractClass
     Public Class ImplementAbstractClassCommandHandlerTests
@@ -200,9 +203,9 @@ End Class</text>
 
             view.Caret.MoveTo(New SnapshotPoint(snapshot, cursorPosition))
 
-            Dim commandHandler As ICommandHandler(Of ReturnKeyCommandArgs) =
+            Dim commandHandler As VSCommanding.ICommandHandler(Of ReturnKeyCommandArgs) =
                 New ImplementAbstractClassCommandHandler(workspace.GetService(Of IEditorOperationsFactoryService))
-            commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), nextHandler)
+            commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), nextHandler, TestCommandExecutionContext.Create())
 
             Dim text = view.TextBuffer.CurrentSnapshot.AsText().ToString()
 

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
@@ -1,15 +1,18 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Xml.Linq
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ImplementInterface
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
+Imports VSCommanding = Microsoft.VisualStudio.Commanding
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ImplementInterface
     Public Class ImplementInterfaceCommandHandlerTests
@@ -19,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ImplementInterface
                 Dim commandHandler = MoveCaretAndCreateCommandHandler(workspace)
                 Dim view = workspace.Documents.Single().GetTextView()
 
-                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() nextHandler(view, workspace))
+                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() nextHandler(view, workspace), TestCommandExecutionContext.Create())
 
                 Dim text = view.TextBuffer.CurrentSnapshot.AsText().ToString()
 
@@ -27,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ImplementInterface
             End Using
         End Sub
 
-        Private Shared Function MoveCaretAndCreateCommandHandler(workspace As TestWorkspace) As ICommandHandler(Of ReturnKeyCommandArgs)
+        Private Shared Function MoveCaretAndCreateCommandHandler(workspace As TestWorkspace) As VSCommanding.ICommandHandler(Of ReturnKeyCommandArgs)
             Dim document = workspace.Documents.Single()
             Dim view = document.GetTextView()
             Dim cursorPosition = document.CursorPosition.Value
@@ -64,7 +67,7 @@ End Interface")
 
                 Dim nextHandlerCalled = False
                 Dim view = workspace.Documents.Single().GetTextView()
-                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() nextHandlerCalled = True)
+                commandHandler.ExecuteCommand(New ReturnKeyCommandArgs(view, view.TextBuffer), Sub() nextHandlerCalled = True, TestCommandExecutionContext.Create())
                 Assert.True(nextHandlerCalled, "Next handler wasn't called, which means the feature did run")
             End Using
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnEnterTests.vb
@@ -1,7 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Xml.Linq
-Imports Microsoft.CodeAnalysis.Editor.Commands
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
     Public Class CommitOnEnterTests
@@ -248,7 +249,7 @@ rem Hello World$$|]
                                                        </Project>
                                                    </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine())
+                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine(), TestCommandExecutionContext.Create())
                 testData.UndoHistory.Undo(count:=1)
 
                 Assert.Equal(0, testData.View.Caret.Position.BufferPosition.GetContainingLine().LineNumber)
@@ -349,7 +350,7 @@ End Module
         Private Sub AssertCommitsStatement(test As XElement, expectCommit As Boolean, Optional usedSemantics As Boolean = True)
             Using testData = CommitTestData.Create(test)
                 Dim lineNumber = testData.View.Caret.Position.BufferPosition.GetContainingLine().LineNumber
-                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine())
+                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine(), TestCommandExecutionContext.Create())
                 testData.AssertHadCommit(expectCommit)
                 If expectCommit Then
                     testData.AssertUsedSemantics(usedSemantics)

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
@@ -1,8 +1,9 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
     Public Class CommitOnMiscellaneousCommandsTests
@@ -16,7 +17,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                                                        </Project>
                                                    </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertText("  imports  system" & vbCrLf & "  imports system.text"))
+                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertText("  imports  system" & vbCrLf & "  imports system.text"),
+                                                       TestCommandExecutionContext.Create())
                 Assert.Equal("Imports System", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(0).GetText())
             End Using
         End Sub
@@ -41,8 +44,12 @@ End Class
                     </Project>
                 </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertText("t"))
-                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
+                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertText("t"),
+                                                       TestCommandExecutionContext.Create())
+                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() Exit Sub,
+                                                       TestCommandExecutionContext.Create())
                 testData.AssertHadCommit(True)
                 ' The code cleanup should not add parens after the Int, so no exception.
             End Using
@@ -61,7 +68,9 @@ End Class
                 </Workspace>)
 
                 testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
-                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertText("Class Program" & vbCrLf & "    Sub M(abc As Integer)" & vbCrLf & "        Dim a  = 7" & vbCrLf & "    End Sub" & vbCrLf & "End Class"))
+                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertText("Class Program" & vbCrLf & "    Sub M(abc As Integer)" & vbCrLf & "        Dim a  = 7" & vbCrLf & "    End Sub" & vbCrLf & "End Class"),
+                                                       TestCommandExecutionContext.Create())
                 Assert.Equal("        Dim a  = 7", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(2).GetText())
             End Using
         End Sub
@@ -77,7 +86,9 @@ End Class
                                                        </Project>
                                                    </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertText("  imports  system"))
+                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertText("  imports  system"),
+                                                       TestCommandExecutionContext.Create())
                 Assert.Equal("  imports  system", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(0).GetText())
             End Using
         End Sub
@@ -93,7 +104,7 @@ End Class
                                                    </Workspace>)
 
                 testData.Buffer.Insert(0, "  imports  system")
-                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
+                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("Imports System", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(0).GetText())
             End Using
         End Sub
@@ -114,7 +125,7 @@ End Class
                                                    </Workspace>)
                 testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
                 testData.Buffer.Insert(57, "    ")
-                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
+                testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("        Dim a     = 7", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(3).GetText())
             End Using
         End Sub
@@ -137,7 +148,7 @@ End Module
                                                        </Project>
                                                    </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
+                testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("        goo()", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(2).GetText())
             End Using
         End Sub
@@ -159,7 +170,7 @@ End Module
 
                 ' Turn off pretty listing
                 testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
-                testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
+                testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("    Sub Main()", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(1).GetText())
             End Using
         End Sub
@@ -181,7 +192,9 @@ End Module</Document>
                                                        </Project>
                                                    </Workspace>)
 
-                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertText("Console.WriteLine(""Hello World"))
+                testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertText("Console.WriteLine(""Hello World"),
+                                                       TestCommandExecutionContext.Create())
                 Assert.Equal(testData.Buffer.CurrentSnapshot.GetText(),
 <Document>Module Module1
     Sub Main()

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -61,8 +61,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                 commitManagerFactory,
                 workspace.GetService(Of IEditorOperationsFactoryService),
                 workspace.GetService(Of ISmartIndentationService),
-                textUndoHistoryRegistry,
-                workspace.GetService(Of Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator))
+                textUndoHistoryRegistry)
         End Sub
 
         Friend Sub AssertHadCommit(expectCommit As Boolean)

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitWithViewTests.vb
@@ -1,9 +1,10 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
     Public Class CommitWithViewTests
@@ -293,7 +294,9 @@ End Module
                 </Workspace>)
 
                 testData.EditorOperations.InsertText("_")
-                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer), Sub() testData.EditorOperations.InsertNewLine())
+                testData.CommandHandler.ExecuteCommand(New ReturnKeyCommandArgs(testData.View, testData.Buffer),
+                                                       Sub() testData.EditorOperations.InsertNewLine(),
+                                                       TestCommandExecutionContext.Create())
 
                 ' So far we should have had no commit
                 testData.AssertHadCommit(False)
@@ -823,7 +826,7 @@ End Module|]</Document>
                 Dim view = document.GetTextView()
                 view.Selection.Select(snapshotspan, isReversed:=False)
                 Dim selArgs = New FormatSelectionCommandArgs(view, document.GetTextBuffer())
-                testData.CommandHandler.ExecuteCommand(selArgs, Sub() Return)
+                testData.CommandHandler.ExecuteCommand(selArgs, Sub() Return, TestCommandExecutionContext.Create())
             End Using
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Organizing/OrganizeTypeDeclarationTests.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Editor.Commanding.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Organizing
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
@@ -956,22 +957,13 @@ End Namespace</element>
 
                 Dim textView = workspace.Documents.Single().GetTextView()
 
-                Dim handler = New OrganizeDocumentCommandHandler(workspace.GetService(Of Host.IWaitIndicator))
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
+                Dim handler = New OrganizeDocumentCommandHandler()
 
-                Dim state = handler.GetCommandState(New Commands.SortAndRemoveUnnecessaryImportsCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
-                delegatedToNext = False
+                Dim state = handler.GetCommandState(New SortAndRemoveUnnecessaryImportsCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
 
-                state = handler.GetCommandState(New Commands.OrganizeDocumentCommandArgs(textView, textView.TextBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                state = handler.GetCommandState(New OrganizeDocumentCommandArgs(textView, textView.TextBuffer))
+                Assert.True(state.IsUnspecified)
             End Using
         End Sub
     End Class

--- a/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
+++ b/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveCompletionCommandHandler.cs
@@ -2,12 +2,14 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.Completion, PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    [Name(PredefinedCommandHandlerNames.Completion)]
     [Order(After = PredefinedCommandHandlerNames.SignatureHelp)]
     internal sealed class InteractiveCompletionCommandHandler : AbstractCompletionCommandHandler
     {

--- a/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveIntelliSenseCommandHandler.cs
+++ b/src/Interactive/EditorFeatures/Core/CommandHandlers/InteractiveIntelliSenseCommandHandler.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.InteractiveWindow.Commands;
+using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.IntelliSense, PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(PredefinedInteractiveCommandsContentTypes.InteractiveCommandContentTypeName)]
+    [Name(PredefinedCommandHandlerNames.IntelliSense)]
     internal sealed class InteractiveIntelliSenseCommandHandler : AbstractIntelliSenseCommandHandler
     {
         [ImportingConstructor]

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ISendToInteractiveSubmissionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/ISendToInteractiveSubmissionProvider.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.Interactive
 {
     internal interface ISendToInteractiveSubmissionProvider
     {
-        string GetSelectedText(IEditorOptions editorOptions, CommandArgs args, CancellationToken cancellationToken);
+        string GetSelectedText(IEditorOptions editorOptions, EditorCommandArgs args, CancellationToken cancellationToken);
     }
 }

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/SendToInteractiveSubmissionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/SendToInteractiveSubmissionProvider.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Roslyn.Utilities;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Interactive
 {
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         /// <summary>Returns whether the submission can be parsed in interactive.</summary>
         protected abstract bool CanParseSubmission(string code);
 
-        string ISendToInteractiveSubmissionProvider.GetSelectedText(IEditorOptions editorOptions, CommandArgs args, CancellationToken cancellationToken)
+        string ISendToInteractiveSubmissionProvider.GetSelectedText(IEditorOptions editorOptions, EditorCommandArgs args, CancellationToken cancellationToken)
         {
             IEnumerable<SnapshotSpan> selectedSpans = args.TextView.Selection.IsEmpty
                 ? GetExpandedLineAsync(editorOptions, args, cancellationToken).WaitAndGetResult(cancellationToken)
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         }
 
         /// <summary>Returns the span for the selected line. Extends it if it is a part of a multi line statement or declaration.</summary>
-        private Task<IEnumerable<SnapshotSpan>> GetExpandedLineAsync(IEditorOptions editorOptions, CommandArgs args, CancellationToken cancellationToken)
+        private Task<IEnumerable<SnapshotSpan>> GetExpandedLineAsync(IEditorOptions editorOptions, EditorCommandArgs args, CancellationToken cancellationToken)
         {
             IEnumerable<SnapshotSpan> selectedSpans = GetSelectedLine(args.TextView);
             var candidateSubmission = GetSubmissionFromSelectedSpans(editorOptions, selectedSpans);
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
 
         private async Task<IEnumerable<SnapshotSpan>> GetExecutableSyntaxTreeNodeSelectionAsync(
             TextSpan selectionSpan,
-            CommandArgs args,
+            EditorCommandArgs args,
             ITextSnapshot snapshot,
             CancellationToken cancellationToken)
         {
@@ -70,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 .Select(span => new SnapshotSpan(snapshot, span.Start, span.Length));
         }
 
-        private async Task<IEnumerable<SnapshotSpan>> ExpandSelectionAsync(IEnumerable<SnapshotSpan> selectedSpans, CommandArgs args, CancellationToken cancellationToken)
+        private async Task<IEnumerable<SnapshotSpan>> ExpandSelectionAsync(IEnumerable<SnapshotSpan> selectedSpans, EditorCommandArgs args, CancellationToken cancellationToken)
         {
             var selectedSpansStart = selectedSpans.Min(span => span.Start);
             var selectedSpansEnd = selectedSpans.Max(span => span.End);

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -144,7 +144,6 @@ Public Class BuildDevDivInsertionFiles
         "Microsoft.VisualStudio.LanguageServices.dll",
         "Microsoft.VisualStudio.LanguageServices.Implementation.dll",
         "Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
-        "Microsoft.VisualStudio.Platform.VSEditor.Interop.dll",
         "Roslyn.Compilers.Test.Resources.dll",
         "Roslyn.Hosting.Diagnostics.dll",
         "Roslyn.Test.PdbUtilities.dll"
@@ -289,7 +288,6 @@ Public Class BuildDevDivInsertionFiles
         "Microsoft.VisualStudio.LanguageServices.Implementation.dll",
         "Microsoft.VisualStudio.LanguageServices.SolutionExplorer.dll",
         "Microsoft.VisualStudio.LanguageServices.VisualBasic.dll",
-        "Microsoft.VisualStudio.Platform.VSEditor.Interop.dll",
         "Moq.dll",
         "csc.exe",
         "csc.exe.config",
@@ -838,7 +836,6 @@ Public Class BuildDevDivInsertionFiles
         add("UnitTests\CSharpCompilerEmitTest\Microsoft.DiaSymReader.dll")
         add("UnitTests\CSharpCompilerEmitTest\Microsoft.DiaSymReader.Native.amd64.dll")
         add("UnitTests\CSharpCompilerEmitTest\Microsoft.DiaSymReader.Native.x86.dll")
-        add("UnitTests\EditorServicesTest\Microsoft.VisualStudio.Platform.VSEditor.Interop.dll")
         add("Vsix\ExpressionEvaluatorPackage\Microsoft.VisualStudio.Debugger.Engine.dll")
         add("Vsix\VisualStudioIntegrationTestSetup\Microsoft.Diagnostics.Runtime.dll")
         add("Exes\Toolset\System.AppContext.dll")

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -196,6 +196,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Generate Event Subscription Command Handler.
+        /// </summary>
+        internal static string Event_Hookup_Command_Handler {
+            get {
+                return ResourceManager.GetString("Event_Hookup_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extract Method.
         /// </summary>
         internal static string Extract_Method {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -531,4 +531,7 @@
   <data name="Show_name_suggestions" xml:space="preserve">
     <value>Show name s_uggestions</value>
   </data>
+  <data name="Event_Hookup_Command_Handler" xml:space="preserve">
+    <value>Generate Event Subscription Command Handler</value>
+  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/EventCompletion/HACK_EventHookupDismissalOnBufferChangePreventerService.cs
+++ b/src/VisualStudio/CSharp/Impl/EventCompletion/HACK_EventHookupDismissalOnBufferChangePreventerService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EventHookup
             HACK_SetShimQuickInfoSessionWorker(textView, null);
         }
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
         private void HACK_SetShimQuickInfoSessionWorker(ITextView textView, IQuickInfoSession quickInfoSession)
         {
             var properties = textView.Properties.PropertyList;
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EventHookup
             public event EventHandler ApplicableToSpanChanged;
             public event EventHandler PresenterChanged;
 #pragma warning restore 67
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
             public PropertyCollection Properties
             {
                 get

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
@@ -30,13 +31,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
     /// Because we are explicitly asking the user to tab, so we should handle the tab command before
     /// Automatic Completion.
     /// </summary>
-    [ExportCommandHandler(PredefinedCommandHandlerNames.EventHookup, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.EventHookup)]
     [Order(Before = PredefinedCommandHandlerNames.AutomaticCompletion)]
     internal partial class EventHookupCommandHandler : ForegroundThreadAffinitizedObject
     {
         private readonly IInlineRenameService _inlineRenameService;
         private readonly AggregateAsynchronousOperationListener _asyncListener;
-        private readonly Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator _waitIndicator;
 
         internal readonly EventHookupSessionManager EventHookupSessionManager;
 
@@ -49,15 +51,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         [ImportingConstructor]
         public EventHookupCommandHandler(
             IInlineRenameService inlineRenameService,
-            Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator waitIndicator,
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
             IQuickInfoBroker quickInfoBroker,
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
             [Import(AllowDefault = true)] IHACK_EventHookupDismissalOnBufferChangePreventerService prematureDismissalPreventer,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
             _inlineRenameService = inlineRenameService;
-            _waitIndicator = waitIndicator;
             _prematureDismissalPreventer = prematureDismissalPreventer;
             _asyncListener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.EventHookup);
 

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_SessionCancellingCommands.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_SessionCancellingCommands.cs
@@ -1,24 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.LanguageServices.CSharp;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     internal partial class EventHookupCommandHandler :
-        ICommandHandler<EscapeKeyCommandArgs>
+        VSCommanding.ICommandHandler<EscapeKeyCommandArgs>
     {
-        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
+        public string DisplayName => CSharpVSResources.Event_Hookup_Command_Handler;
+
+        public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             EventHookupSessionManager.CancelAndDismissExistingSessions();
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(EscapeKeyCommandArgs args)
         {
             AssertIsForeground();
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_ShadowedCommands.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_ShadowedCommands.cs
@@ -1,25 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Editor.Commands;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
-    internal partial class EventHookupCommandHandler : ICommandHandler<InvokeCompletionListCommandArgs>
+    internal partial class EventHookupCommandHandler : VSCommanding.ICommandHandler<InvokeCompletionListCommandArgs>
     {
-        public void ExecuteCommand(InvokeCompletionListCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(InvokeCompletionListCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (EventHookupSessionManager.QuickInfoSession == null || EventHookupSessionManager.QuickInfoSession.IsDismissed)
             {
-                nextHandler();
+                return false;
             }
+
+            return true;
         }
 
-        public CommandState GetCommandState(InvokeCompletionListCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(InvokeCompletionListCommandArgs args)
         {
             AssertIsForeground();
-            return nextHandler();
+            return VSCommanding.CommandState.Unspecified;
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TabKeyCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -10,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Formatting;
@@ -20,15 +18,18 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
-    internal partial class EventHookupCommandHandler : ICommandHandler<TabKeyCommandArgs>
+    internal partial class EventHookupCommandHandler : IChainedCommandHandler<TabKeyCommandArgs>
     {
-        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler, CommandExecutionContext cotext)
         {
             AssertIsForeground();
             if (!args.SubjectBuffer.GetFeatureOnOffOption(InternalFeatureOnOffOptions.EventHookup))
@@ -47,12 +48,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
             HandleTabWorker(args.TextView, args.SubjectBuffer, nextHandler, CancellationToken.None);
         }
 
-        public CommandState GetCommandState(TabKeyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(TabKeyCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             if (EventHookupSessionManager.CurrentSession != null)
             {
-                return CommandState.Available;
+                return VSCommanding.CommandState.Available;
             }
             else
             {

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TypeCharCommand.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler_TypeCharCommand.cs
@@ -2,18 +2,20 @@
 
 using System;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
-    internal partial class EventHookupCommandHandler : ICommandHandler<TypeCharCommandArgs>
+    internal partial class EventHookupCommandHandler : IChainedCommandHandler<TypeCharCommandArgs>
     {
-        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler)
+        public void ExecuteCommand(TypeCharCommandArgs args, Action nextHandler, CommandExecutionContext context)
         {
             AssertIsForeground();
             nextHandler();
@@ -65,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
             return position - 2 >= 0 && subjectBuffer.CurrentSnapshot.GetText(position - 2, 2) == "+=";
         }
 
-        public CommandState GetCommandState(TypeCharCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(TypeCharCommandArgs args, Func<VSCommanding.CommandState> nextHandler)
         {
             AssertIsForeground();
             return nextHandler();

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSource.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSource.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     internal sealed class EventHookupQuickInfoSource : IQuickInfoSource
@@ -102,4 +102,4 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSourceProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSourceProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     /// <summary>
@@ -39,4 +39,4 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         }
     }
 }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
     internal sealed partial class EventHookupSessionManager : ForegroundThreadAffinitizedObject
     {
         private readonly IHACK_EventHookupDismissalOnBufferChangePreventerService _prematureDismissalPreventer;
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
         private readonly IQuickInfoBroker _quickInfoBroker;
 
         internal EventHookupSession CurrentSession { get; set; }
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
             _prematureDismissalPreventer = prematureDismissalPreventer;
             _quickInfoBroker = quickInfoBroker;
         }
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 
         internal void EventHookupFoundInSession(EventHookupSession analyzedSession)
         {

--- a/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpSyncClassViewCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/ObjectBrowser/CSharpSyncClassViewCommandHandler.cs
@@ -2,18 +2,20 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser
 {
-    [ExportCommandHandler(PredefinedCommandHandlerNames.ClassView, ContentTypeNames.CSharpContentType)]
+    [Export(typeof(Commanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.ClassView)]
     internal class CSharpSyncClassViewCommandHandler : AbstractSyncClassViewCommandHandler
     {
         [ImportingConstructor]
-        private CSharpSyncClassViewCommandHandler(SVsServiceProvider serviceProvider, IWaitIndicator waitIndicator)
-            : base(serviceProvider, waitIndicator)
+        private CSharpSyncClassViewCommandHandler(SVsServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
         }
     }

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetCommandHandler.cs
@@ -1,26 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Snippets;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
 {
-    [ExportCommandHandler("CSharp Snippets", ContentTypeNames.CSharpContentType)]
-    [Order(After = PredefinedCommandHandlerNames.Completion)]
-    [Order(After = PredefinedCommandHandlerNames.IntelliSense)]
+    [Export(typeof(ICommandHandler))]
+    [ContentType(CodeAnalysis.Editor.ContentTypeNames.CSharpContentType)]
+    [Name("CSharp Snippets")]
+    [Order(After = CodeAnalysis.Editor.PredefinedCommandHandlerNames.Completion)]
+    [Order(After = CodeAnalysis.Editor.PredefinedCommandHandlerNames.IntelliSense)]
     internal sealed class SnippetCommandHandler :
         AbstractSnippetCommandHandler,
         ICommandHandler<SurroundWithCommandArgs>
@@ -31,36 +31,35 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         {
         }
 
-        public void ExecuteCommand(SurroundWithCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(SurroundWithCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
-            InvokeInsertionUI(args.TextView, args.SubjectBuffer, nextHandler, surroundWith: true);
+            return TryInvokeInsertionUI(args.TextView, args.SubjectBuffer, surroundWith: true);
         }
 
-        public CommandState GetCommandState(SurroundWithCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(SurroundWithCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!CodeAnalysis.Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
@@ -77,12 +76,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
             return expansionClient;
         }
 
-        protected override void InvokeInsertionUI(ITextView textView, ITextBuffer subjectBuffer, Action nextHandler, bool surroundWith = false)
+        protected override bool TryInvokeInsertionUI(ITextView textView, ITextBuffer subjectBuffer, bool surroundWith = false)
         {
             if (!TryGetExpansionManager(out var expansionManager))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             expansionManager.InvokeInsertionUI(
@@ -97,6 +95,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
                 fIncludeNULLKind: 0,
                 bstrPrefixText: surroundWith ? CSharpVSResources.Surround_With : CSharpVSResources.Insert_Snippet,
                 bstrCompletionChar: null);
+
+            return true;
         }
 
         protected override bool IsSnippetExpansionContext(Document document, int startPosition, CancellationToken cancellationToken)

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Zobrazovat návr_hy názvů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Namensv_orschläge anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Mostrar s_ugerencias de nombres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Afficher les s_uggestions de nom</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Mostra s_uggerimenti per nomi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -692,6 +692,11 @@
         <target state="translated">名前の提案を表示(_U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -692,6 +692,11 @@
         <target state="translated">이름 제안 표시(_U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Pokaż s_ugestie dotyczące nazwy</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Mostrar s_ugestões de nomes</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Показывать в_арианты имен</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -692,6 +692,11 @@
         <target state="translated">Ad ö_nerilerini göster</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -692,6 +692,11 @@
         <target state="translated">显示名称建议(_U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -692,6 +692,11 @@
         <target state="translated">顯示名稱建議(_U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Event_Hookup_Command_Handler">
+        <source>Generate Event Subscription Command Handler</source>
+        <target state="new">Generate Event Subscription Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveCommandHandlerTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveCommandHandlerTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using Xunit;
 using Roslyn.Test.Utilities;
+using Xunit;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
 {
@@ -176,7 +176,7 @@ $@"#define DEF
             using (var workspace = InteractiveWindowCommandHandlerTestState.CreateTestState(code))
             {
                 PrepareSubmissionBuffer(submissionBuffer, workspace);
-                Assert.Equal(CommandState.Available, workspace.GetStateForExecuteInInteractive());
+                Assert.Equal(VSCommanding.CommandState.Available, workspace.GetStateForExecuteInInteractive());
 
                 workspace.Evaluator.OnExecute += appendSubmission;
                 workspace.ExecuteInInteractive();

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveWindowCommandHandlerTestState.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/InteractiveWindowCommandHandlerTestState.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Editor.Commands;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.Interactive;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
-using System.Xml.Linq;
-using Microsoft.VisualStudio.Text;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
 {
@@ -30,9 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
 
         public TestInteractiveEvaluator Evaluator => TestHost.Evaluator;
 
-        private ICommandHandler<ExecuteInInteractiveCommandArgs> ExecuteInInteractiveCommandHandler => _commandHandler;
+        private VSCommanding.ICommandHandler<ExecuteInInteractiveCommandArgs> ExecuteInInteractiveCommandHandler => _commandHandler;
 
-        private ICommandHandler<CopyToInteractiveCommandArgs> CopyToInteractiveCommandHandler => _commandHandler;
+        private VSCommanding.ICommandHandler<CopyToInteractiveCommandArgs> CopyToInteractiveCommandHandler => _commandHandler;
 
         public InteractiveWindowCommandHandlerTestState(XElement workspaceElement)
             : base(workspaceElement)
@@ -63,27 +64,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive.Commands
         public void SendCopyToInteractive()
         {
             var copyToInteractiveArgs = new CopyToInteractiveCommandArgs(TextView, SubjectBuffer);
-            CopyToInteractiveCommandHandler.ExecuteCommand(copyToInteractiveArgs, () => { });
-        }
-
-        public CommandState GetStateForCopyToInteractive()
-        {
-            var copyToInteractiveArgs = new CopyToInteractiveCommandArgs(TextView, SubjectBuffer);
-            return CopyToInteractiveCommandHandler.GetCommandState(
-                copyToInteractiveArgs, () => { return CommandState.Unavailable; });
+            CopyToInteractiveCommandHandler.ExecuteCommand(copyToInteractiveArgs, TestCommandExecutionContext.Create());
         }
 
         public void ExecuteInInteractive()
         {
             var executeInInteractiveArgs = new ExecuteInInteractiveCommandArgs(TextView, SubjectBuffer);
-            ExecuteInInteractiveCommandHandler.ExecuteCommand(executeInInteractiveArgs, () => { });
+            ExecuteInInteractiveCommandHandler.ExecuteCommand(executeInInteractiveArgs, TestCommandExecutionContext.Create());
         }
 
-        public CommandState GetStateForExecuteInInteractive()
+        public VSCommanding.CommandState GetStateForExecuteInInteractive()
         {
             var executeInInteractiveArgs = new ExecuteInInteractiveCommandArgs(TextView, SubjectBuffer);
-            return ExecuteInInteractiveCommandHandler.GetCommandState(
-                executeInInteractiveArgs, () => { return CommandState.Unavailable; });
+            return ExecuteInInteractiveCommandHandler.GetCommandState(executeInInteractiveArgs);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyCommandHandler.cs
@@ -1,85 +1,94 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.SymbolMapping;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
+using VSCommanding = Microsoft.VisualStudio.Commanding;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
 {
-    [ExportCommandHandler("CallHierarchy", ContentTypeNames.CSharpContentType, ContentTypeNames.VisualBasicContentType)]
+    [Export(typeof(VSCommanding.ICommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [Name("CallHierarchy")]
     [Order(After = PredefinedCommandHandlerNames.DocumentationComments)]
-    internal class CallHierarchyCommandHandler : ICommandHandler<ViewCallHierarchyCommandArgs>
+    internal class CallHierarchyCommandHandler : VSCommanding.ICommandHandler<ViewCallHierarchyCommandArgs>
     {
         private readonly ICallHierarchyPresenter _presenter;
         private readonly CallHierarchyProvider _provider;
-        private readonly IWaitIndicator _waitIndicator;
+
+        public string DisplayName => EditorFeaturesResources.View_Call_Hierarchy_Command_Handler;
 
         [ImportingConstructor]
-        public CallHierarchyCommandHandler([ImportMany] IEnumerable<ICallHierarchyPresenter> presenters, CallHierarchyProvider provider, IWaitIndicator waitIndicator)
+        public CallHierarchyCommandHandler([ImportMany] IEnumerable<ICallHierarchyPresenter> presenters, CallHierarchyProvider provider)
         {
             _presenter = presenters.FirstOrDefault();
             _provider = provider;
-            _waitIndicator = waitIndicator;
         }
 
-        public void ExecuteCommand(ViewCallHierarchyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ViewCallHierarchyCommandArgs args, CommandExecutionContext context)
         {
-            AddRootNode(args);
+            AddRootNode(args, context);
+            return true;
         }
 
-        private void AddRootNode(ViewCallHierarchyCommandArgs args)
+        private void AddRootNode(ViewCallHierarchyCommandArgs args, CommandExecutionContext context)
         {
-            _waitIndicator.Wait(EditorFeaturesResources.Call_Hierarchy, EditorFeaturesResources.Computing_Call_Hierarchy_Information, allowCancel: true, action: waitcontext =>
+            using (var waitScope = context.WaitContext.AddScope(allowCancellation: true, EditorFeaturesResources.Computing_Call_Hierarchy_Information))
+            {
+                var cancellationToken = context.WaitContext.UserCancellationToken;
+                var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                if (document == null)
                 {
-                    var cancellationToken = waitcontext.CancellationToken;
-                    var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                    if (document == null)
+                    return;
+                }
+
+                var workspace = document.Project.Solution.Workspace;
+                var semanticModel = document.GetSemanticModelAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
+                var caretPosition = args.TextView.Caret.Position.BufferPosition.Position;
+                var symbolUnderCaret = SymbolFinder.FindSymbolAtPositionAsync(semanticModel, caretPosition, workspace, cancellationToken)
+                    .WaitAndGetResult(cancellationToken);
+
+                if (symbolUnderCaret != null)
+                {
+                    // Map symbols so that Call Hierarchy works from metadata-as-source
+                    var mappingService = document.Project.Solution.Workspace.Services.GetService<ISymbolMappingService>();
+                    var mapping = mappingService.MapSymbolAsync(document, symbolUnderCaret, cancellationToken).WaitAndGetResult(cancellationToken);
+
+                    if (mapping.Symbol != null)
                     {
-                        return;
-                    }
-
-                    var workspace = document.Project.Solution.Workspace;
-                    var semanticModel = document.GetSemanticModelAsync(waitcontext.CancellationToken).WaitAndGetResult(cancellationToken);
-
-                    var caretPosition = args.TextView.Caret.Position.BufferPosition.Position;
-                    var symbolUnderCaret = SymbolFinder.FindSymbolAtPositionAsync(semanticModel, caretPosition, workspace, cancellationToken)
-                        .WaitAndGetResult(cancellationToken);
-
-                    if (symbolUnderCaret != null)
-                    {
-                        // Map symbols so that Call Hierarchy works from metadata-as-source
-                        var mappingService = document.Project.Solution.Workspace.Services.GetService<ISymbolMappingService>();
-                        var mapping = mappingService.MapSymbolAsync(document, symbolUnderCaret, waitcontext.CancellationToken).WaitAndGetResult(cancellationToken);
-
-                        if (mapping.Symbol != null)
+                        var node = _provider.CreateItem(mapping.Symbol, mapping.Project, SpecializedCollections.EmptyEnumerable<Location>(), cancellationToken).WaitAndGetResult(cancellationToken);
+                        if (node != null)
                         {
-                            var node = _provider.CreateItem(mapping.Symbol, mapping.Project, SpecializedCollections.EmptyEnumerable<Location>(), cancellationToken).WaitAndGetResult(cancellationToken);
-                            if (node != null)
-                            {
-                                _presenter.PresentRoot((CallHierarchyItem)node);
-                            }
+                            _presenter.PresentRoot((CallHierarchyItem)node);
                         }
                     }
-                    else
-                    {
-                        var notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
-                        notificationService.SendNotification(EditorFeaturesResources.Cursor_must_be_on_a_member_name, severity: NotificationSeverity.Information);
-                    }
-                });
+                }
+                else
+                {
+                    // We are about to show a modal UI dialog so we should take over the command execution
+                    // wait context. That means the command system won't attempt to show its own wait dialog 
+                    // and also will take it into consideration when measuring command handling duration.
+                    waitScope.Context.TakeOwnership();
+                    var notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
+                    notificationService.SendNotification(EditorFeaturesResources.Cursor_must_be_on_a_member_name, severity: NotificationSeverity.Information);
+                }
+            }
         }
 
-        public CommandState GetCommandState(ViewCallHierarchyCommandArgs args, Func<CommandState> nextHandler)
+        public VSCommanding.CommandState GetCommandState(ViewCallHierarchyCommandArgs args)
         {
-            return CommandState.Available;
+            return VSCommanding.CommandState.Available;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/CommandBindings.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CommandBindings.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Editor.Commanding;
+using Microsoft.VisualStudio.LanguageServices;
+
+namespace Microsoft.VisualStudio.Editor.Implementation
+{
+    internal sealed class CommandBindings
+    {
+        [Export]
+        [CommandBinding(Guids.RoslynGroupIdString, ID.RoslynCommands.GoToImplementation, typeof(GoToImplementationCommandArgs))]
+        internal CommandBindingDefinition gotoImplementationCommandBinding;
+
+        [Export]
+        [CommandBinding(Guids.CSharpGroupIdString, ID.CSharpCommands.OrganizeRemoveAndSort, typeof(SortAndRemoveUnnecessaryImportsCommandArgs))]
+        internal CommandBindingDefinition organizeRemoveAndSortCommandBinding;
+
+        [Export]
+        [CommandBinding(Guids.CSharpGroupIdString, ID.CSharpCommands.ContextOrganizeRemoveAndSort, typeof(SortAndRemoveUnnecessaryImportsCommandArgs))]
+        internal CommandBindingDefinition contextOrganizeRemoveAndSortCommandBinding;
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ClassView/AbstractSyncClassViewCommandHandler.cs
@@ -2,16 +2,15 @@
 
 using System;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Editor.Commands;
-using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
@@ -22,94 +21,89 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassVi
         private const string ClassView = "Class View";
 
         private readonly IServiceProvider _serviceProvider;
-        private readonly IWaitIndicator _waitIndicator;
+
+        public string DisplayName => ServicesVSResources.Sync_Class_View_Command_Handler;
 
         protected AbstractSyncClassViewCommandHandler(
-            SVsServiceProvider serviceProvider,
-            IWaitIndicator waitIndicator)
+            SVsServiceProvider serviceProvider)
         {
             Contract.ThrowIfNull(serviceProvider);
-            Contract.ThrowIfNull(waitIndicator);
 
             _serviceProvider = serviceProvider;
-            _waitIndicator = waitIndicator;
         }
 
-        public void ExecuteCommand(SyncClassViewCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(SyncClassViewCommandArgs args, CommandExecutionContext context)
         {
             this.AssertIsForeground();
 
             var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer) ?? -1;
             if (caretPosition < 0)
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             var snapshot = args.SubjectBuffer.CurrentSnapshot;
 
-            _waitIndicator.Wait(
-                title: string.Format(ServicesVSResources.Synchronize_0, ClassView),
-                message: string.Format(ServicesVSResources.Synchronizing_with_0, ClassView),
-                allowCancel: true,
-                action: context =>
+            using (var waitScope = context.WaitContext.AddScope(allowCancellation: true, string.Format(ServicesVSResources.Synchronizing_with_0, ClassView)))
+            {
+                var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                if (document == null)
                 {
-                    var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                    if (document == null)
-                    {
-                        return;
-                    }
+                    return true;
+                }
 
-                    var syntaxFactsService = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
-                    if (syntaxFactsService == null)
-                    {
-                        return;
-                    }
+                var syntaxFactsService = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
+                if (syntaxFactsService == null)
+                {
+                    return true;
+                }
 
-                    var libraryService = document.Project.LanguageServices.GetService<ILibraryService>();
-                    if (libraryService == null)
-                    {
-                        return;
-                    }
+                var libraryService = document.Project.LanguageServices.GetService<ILibraryService>();
+                if (libraryService == null)
+                {
+                    return true;
+                }
 
-                    var semanticModel = document
-                        .GetSemanticModelAsync(context.CancellationToken)
-                        .WaitAndGetResult(context.CancellationToken);
+                var userCancellationToken = context.WaitContext.UserCancellationToken;
+                var semanticModel = document
+                    .GetSemanticModelAsync(userCancellationToken)
+                    .WaitAndGetResult(userCancellationToken);
 
-                    var root = semanticModel.SyntaxTree
-                        .GetRootAsync(context.CancellationToken)
-                        .WaitAndGetResult(context.CancellationToken);
+                var root = semanticModel.SyntaxTree
+                    .GetRootAsync(userCancellationToken)
+                    .WaitAndGetResult(userCancellationToken);
 
-                    var memberDeclaration = syntaxFactsService.GetContainingMemberDeclaration(root, caretPosition);
+                var memberDeclaration = syntaxFactsService.GetContainingMemberDeclaration(root, caretPosition);
 
-                    var symbol = memberDeclaration != null
-                        ? semanticModel.GetDeclaredSymbol(memberDeclaration, context.CancellationToken)
-                        : null;
+                var symbol = memberDeclaration != null
+                    ? semanticModel.GetDeclaredSymbol(memberDeclaration, userCancellationToken)
+                    : null;
 
-                    while (symbol != null && !IsValidSymbolToSynchronize(symbol))
-                    {
-                        symbol = symbol.ContainingSymbol;
-                    }
+                while (symbol != null && !IsValidSymbolToSynchronize(symbol))
+                {
+                    symbol = symbol.ContainingSymbol;
+                }
 
-                    IVsNavInfo navInfo = null;
-                    if (symbol != null)
-                    {
-                        navInfo = libraryService.NavInfoFactory.CreateForSymbol(symbol, document.Project, semanticModel.Compilation, useExpandedHierarchy: true);
-                    }
+                IVsNavInfo navInfo = null;
+                if (symbol != null)
+                {
+                    navInfo = libraryService.NavInfoFactory.CreateForSymbol(symbol, document.Project, semanticModel.Compilation, useExpandedHierarchy: true);
+                }
 
-                    if (navInfo == null)
-                    {
-                        navInfo = libraryService.NavInfoFactory.CreateForProject(document.Project);
-                    }
+                if (navInfo == null)
+                {
+                    navInfo = libraryService.NavInfoFactory.CreateForProject(document.Project);
+                }
 
-                    if (navInfo == null)
-                    {
-                        return;
-                    }
+                if (navInfo == null)
+                {
+                    return true;
+                }
 
-                    var navigationTool = _serviceProvider.GetService<SVsClassView, IVsNavigationTool>();
-                    navigationTool.NavigateToNavInfo(navInfo);
-                });
+                var navigationTool = _serviceProvider.GetService<SVsClassView, IVsNavigationTool>();
+                navigationTool.NavigateToNavInfo(navInfo);
+                return true;
+            }
         }
 
         private static bool IsValidSymbolToSynchronize(ISymbol symbol) =>
@@ -119,9 +113,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassVi
             symbol.Kind == SymbolKind.NamedType ||
             symbol.Kind == SymbolKind.Property;
 
-        public CommandState GetCommandState(SyncClassViewCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(SyncClassViewCommandArgs args)
         {
-            return nextHandler();
+            return Commanding.CommandState.Unspecified;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetCommandHandler.cs
@@ -4,18 +4,18 @@ using System;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
@@ -33,6 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
         protected readonly IVsEditorAdaptersFactoryService EditorAdaptersFactoryService;
         protected readonly SVsServiceProvider ServiceProvider;
 
+        public string DisplayName => ServicesVSResources.Snippet_Command_Handler;
+
         public AbstractSnippetCommandHandler(IVsEditorAdaptersFactoryService editorAdaptersFactoryService, SVsServiceProvider serviceProvider)
         {
             this.EditorAdaptersFactoryService = editorAdaptersFactoryService;
@@ -41,26 +43,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         protected abstract AbstractSnippetExpansionClient GetSnippetExpansionClient(ITextView textView, ITextBuffer subjectBuffer);
         protected abstract bool IsSnippetExpansionContext(Document document, int startPosition, CancellationToken cancellationToken);
-        protected abstract void InvokeInsertionUI(ITextView textView, ITextBuffer subjectBuffer, Action nextHandler, bool surroundWith = false);
+        protected abstract bool TryInvokeInsertionUI(ITextView textView, ITextBuffer subjectBuffer, bool surroundWith = false);
 
         protected virtual bool TryInvokeSnippetPickerOnQuestionMark(ITextView textView, ITextBuffer textBuffer)
         {
             return false;
         }
 
-        public void ExecuteCommand(TabKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(TabKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             if (args.TextView.Properties.TryGetProperty(typeof(AbstractSnippetExpansionClient), out AbstractSnippetExpansionClient snippetExpansionClient) &&
                 snippetExpansionClient.TryHandleTab())
             {
-                return;
+                return true;
             }
 
             // Insert snippet/show picker only if we don't have a selection: the user probably wants to indent instead
@@ -68,170 +69,166 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             {
                 if (TryHandleTypedSnippet(args.TextView, args.SubjectBuffer))
                 {
-                    return;
+                    return true;
                 }
 
                 if (TryInvokeSnippetPickerOnQuestionMark(args.TextView, args.SubjectBuffer))
                 {
-                    return;
+                    return true;
                 }
             }
 
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(TabKeyCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(TabKeyCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
         }
 
-        public void ExecuteCommand(ReturnKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(ReturnKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             if (args.TextView.Properties.TryGetProperty(typeof(AbstractSnippetExpansionClient), out AbstractSnippetExpansionClient snippetExpansionClient) &&
                 snippetExpansionClient.TryHandleReturn())
             {
-                return;
+                return true;
             }
 
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(ReturnKeyCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(ReturnKeyCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
         }
 
-        public void ExecuteCommand(EscapeKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(EscapeKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             if (args.TextView.Properties.TryGetProperty(typeof(AbstractSnippetExpansionClient), out AbstractSnippetExpansionClient snippetExpansionClient) &&
                 snippetExpansionClient.TryHandleEscape())
             {
-                return;
+                return true;
             }
 
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(EscapeKeyCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(EscapeKeyCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
         }
 
-        public void ExecuteCommand(BackTabKeyCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(BackTabKeyCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
             if (args.TextView.Properties.TryGetProperty(typeof(AbstractSnippetExpansionClient), out AbstractSnippetExpansionClient snippetExpansionClient) &&
                 snippetExpansionClient.TryHandleBackTab())
             {
-                return;
+                return true;
             }
 
-            nextHandler();
+            return false;
         }
 
-        public CommandState GetCommandState(BackTabKeyCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(BackTabKeyCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
         }
 
-        public void ExecuteCommand(InsertSnippetCommandArgs args, Action nextHandler)
+        public bool ExecuteCommand(InsertSnippetCommandArgs args, CommandExecutionContext context)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                nextHandler();
-                return;
+                return false;
             }
 
-            InvokeInsertionUI(args.TextView, args.SubjectBuffer, nextHandler);
+            return TryInvokeInsertionUI(args.TextView, args.SubjectBuffer);
         }
 
-        public CommandState GetCommandState(InsertSnippetCommandArgs args, Func<CommandState> nextHandler)
+        public CommandState GetCommandState(InsertSnippetCommandArgs args)
         {
             AssertIsForeground();
 
             if (!AreSnippetsEnabled(args))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
             {
-                return nextHandler();
+                return CommandState.Unspecified;
             }
 
             return CommandState.Available;
@@ -297,7 +294,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             return expansionManager != null;
         }
 
-        protected static bool AreSnippetsEnabled(CommandArgs args)
+        protected static bool AreSnippetsEnabled(EditorCommandArgs args)
         {
             return args.SubjectBuffer.GetFeatureOnOffOption(InternalFeatureOnOffOptions.Snippets) &&
                 // TODO (https://github.com/dotnet/roslyn/issues/5107): enable in interactive

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -2188,6 +2188,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Snippet Command Handler.
+        /// </summary>
+        internal static string Snippet_Command_Handler {
+            get {
+                return ResourceManager.GetString("Snippet_Command_Handler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Some naming rules are incomplete. Please complete or remove them..
         /// </summary>
         internal static string Some_naming_rules_are_incomplete_Please_complete_or_remove_them {
@@ -2283,6 +2292,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Symbol_Specification_Title_colon {
             get {
                 return ResourceManager.GetString("Symbol_Specification_Title_colon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sync Class View Command Handler.
+        /// </summary>
+        internal static string Sync_Class_View_Command_Handler {
+            get {
+                return ResourceManager.GetString("Sync_Class_View_Command_Handler", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -986,6 +986,12 @@ Additional information: {1}</value>
   <data name="Search_found_no_results" xml:space="preserve">
     <value>Search found no results</value>
   </data>
+  <data name="Snippet_Command_Handler" xml:space="preserve">
+    <value>Snippet Command Handler</value>
+  </data>
+  <data name="Sync_Class_View_Command_Handler" xml:space="preserve">
+    <value>Sync Class View Command Handler</value>
+  </data>
   <data name="Restore_Visual_Studio_keybindings" xml:space="preserve">
     <value>Restore Visual Studio keybindings</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1498,6 +1498,16 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <target state="translated">Právní doložka pro dekompilátor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1498,6 +1498,16 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <target state="translated">Rechtlicher Hinweis zum Decompiler</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1498,6 +1498,16 @@ Estoy de acuerdo con todo lo anterior:</target>
         <target state="translated">Aviso legal del Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1498,6 +1498,16 @@ Je suis d'accord avec tout ce qui précède :</target>
         <target state="translated">Décompileur - Mention légale</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1498,6 +1498,16 @@ L'utente accetta le condizioni sopra riportate:</target>
         <target state="translated">Note legali sul decompilatore</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1498,6 +1498,16 @@ I agree to all of the foregoing:</source>
         <target state="translated">デコンパイラの法的通知</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1498,6 +1498,16 @@ I agree to all of the foregoing:</source>
         <target state="translated">디컴파일러 법적 고지 사항</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1498,6 +1498,16 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <target state="translated">Informacje prawne dotyczące Dekompilatora</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1498,6 +1498,16 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <target state="translated">Aviso Legal do Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1498,6 +1498,16 @@ I agree to all of the foregoing:</source>
         <target state="translated">Юридическая информация для декомпилятора</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1498,6 +1498,16 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <target state="translated">Derleme Ayırıcı Yasal Bildirim</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1498,6 +1498,16 @@ I agree to all of the foregoing:</source>
         <target state="translated">Decompiler 法律声明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1498,6 +1498,16 @@ I agree to all of the foregoing:</source>
         <target state="translated">解編程式的法律聲明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Snippet_Command_Handler">
+        <source>Snippet Command Handler</source>
+        <target state="new">Snippet Command Handler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sync_Class_View_Command_Handler">
+        <source>Sync Class View Command Handler</source>
+        <target state="new">Sync Class View Command Handler</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Test/ClassView/MockSyncClassViewCommandHandler.vb
+++ b/src/VisualStudio/Core/Test/ClassView/MockSyncClassViewCommandHandler.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
 Imports Microsoft.VisualStudio.Shell
 
@@ -8,8 +7,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
     Friend Class MockSyncClassViewCommandHandler
         Inherits AbstractSyncClassViewCommandHandler
 
-        Public Sub New(serviceProvider As SVsServiceProvider, waitIndicator As IWaitIndicator)
-            MyBase.New(serviceProvider, waitIndicator)
+        Public Sub New(serviceProvider As SVsServiceProvider)
+            MyBase.New(serviceProvider)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
+++ b/src/VisualStudio/Core/Test/ClassView/SyncClassViewTests.vb
@@ -1,10 +1,9 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.Editor.Commands
-Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.Utilities.VsNavInfo
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
@@ -870,11 +869,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ClassView
 
                 Dim navigationTool = New MockNavigationTool(canonicalNodes:=Nothing, presentationNodes:=presentationNodes)
                 Dim serviceProvider = New MockServiceProvider(navigationTool)
-                Dim commandHandler = New MockSyncClassViewCommandHandler(serviceProvider, workspace.GetService(Of IWaitIndicator))
+                Dim commandHandler = New MockSyncClassViewCommandHandler(serviceProvider)
 
                 commandHandler.ExecuteCommand(
-                    args:=New SyncClassViewCommandArgs(textView, subjectBuffer),
-                    nextHandler:=Sub() Exit Sub)
+                    args:=New SyncClassViewCommandArgs(textView, subjectBuffer), TestCommandExecutionContext.Create())
 
                 navigationTool.VerifyNavInfo()
             End Using

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -6,7 +6,6 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
@@ -15,6 +14,7 @@ Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.SignatureHelp
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Extensions
@@ -22,6 +22,8 @@ Imports Microsoft.VisualStudio.LanguageServices.VisualBasic
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.BraceCompletion
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.TextManager
 
@@ -150,44 +152,44 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 #Region "IntelliSense Operations"
 
         Public Overloads Sub SendEscape()
-            MyBase.SendEscape(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendEscape(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendDownKey()
-            MyBase.SendDownKey(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendDownKey(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendUpKey()
-            MyBase.SendUpKey(Sub(a, n) IntelliSenseCommandHandler.ExecuteCommand(a, n), Sub() Return)
+            MyBase.SendUpKey(Sub(a, n, c) IntelliSenseCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
 #End Region
 
 #Region "Completion Operations"
         Public Overloads Sub SendTab()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of TabKeyCommandArgs))
-            MyBase.SendTab(Sub(a, n) handler.ExecuteCommand(a, n), Sub() EditorOperations.InsertText(vbTab))
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of TabKeyCommandArgs))
+            MyBase.SendTab(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() EditorOperations.InsertText(vbTab))
         End Sub
 
         Public Overloads Sub SendReturn()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of ReturnKeyCommandArgs))
-            MyBase.SendReturn(Sub(a, n) handler.ExecuteCommand(a, n), Sub() EditorOperations.InsertNewLine())
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of ReturnKeyCommandArgs))
+            MyBase.SendReturn(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() EditorOperations.InsertNewLine())
             Me._context.RebuildSpans()
         End Sub
 
         Public Overloads Sub SendPageUp()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of PageUpKeyCommandArgs))
-            MyBase.SendPageUp(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of PageUpKeyCommandArgs))
+            MyBase.SendPageUp(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendInvokeCompletionList()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of InvokeCompletionListCommandArgs))
-            MyBase.SendInvokeCompletionList(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of InvokeCompletionListCommandArgs))
+            MyBase.SendInvokeCompletionList(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendCommitUniqueCompletionListItem()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of CommitUniqueCompletionListItemCommandArgs))
-            MyBase.SendCommitUniqueCompletionListItem(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of CommitUniqueCompletionListItemCommandArgs))
+            MyBase.SendCommitUniqueCompletionListItem(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Overloads Sub SendSelectCompletionItemThroughPresenterSession(item As CompletionItem)
@@ -196,8 +198,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
         End Sub
 
         Public Overloads Sub SendToggleCompletionMode()
-            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of ToggleCompletionModeCommandArgs))
-            MyBase.SendToggleCompletionmode(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(CompletionCommandHandler, IChainedCommandHandler(Of ToggleCompletionModeCommandArgs))
+            MyBase.SendToggleCompletionMode(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Async Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
@@ -279,23 +281,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
 
 #Region "Signature Help and Completion Operations"
 
-        Private Sub ExecuteCommand(Of TCommandArgs As CommandArgs)(args As TCommandArgs, finalHandler As Action)
-            Dim sigHelpHandler = DirectCast(SignatureHelpCommandHandler, ICommandHandler(Of TCommandArgs))
-            Dim compHandler = DirectCast(DirectCast(CompletionCommandHandler, Object), ICommandHandler(Of TCommandArgs))
+        Private Sub ExecuteCommand(Of TCommandArgs As EditorCommandArgs)(args As TCommandArgs, finalHandler As Action, context As CommandExecutionContext)
+            Dim sigHelpHandler = DirectCast(SignatureHelpCommandHandler, IChainedCommandHandler(Of TCommandArgs))
+            Dim compHandler = DirectCast(DirectCast(CompletionCommandHandler, Object), IChainedCommandHandler(Of TCommandArgs))
 
-            sigHelpHandler.ExecuteCommand(args, Sub() compHandler.ExecuteCommand(args, finalHandler))
+            sigHelpHandler.ExecuteCommand(args, Sub() compHandler.ExecuteCommand(args, finalHandler, context), context)
         End Sub
 
         Public Overloads Sub SendTypeChars(typeChars As String)
-            MyBase.SendTypeChars(typeChars, Sub(a, n) ExecuteCommand(a, n))
+            MyBase.SendTypeChars(typeChars, Sub(a, n, c) ExecuteCommand(a, n, c))
         End Sub
 #End Region
 
 #Region "Signature Help Operations"
 
         Public Overloads Sub SendInvokeSignatureHelp()
-            Dim handler = DirectCast(SignatureHelpCommandHandler, ICommandHandler(Of InvokeSignatureHelpCommandArgs))
-            MyBase.SendInvokeSignatureHelp(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+            Dim handler = DirectCast(SignatureHelpCommandHandler, IChainedCommandHandler(Of InvokeSignatureHelpCommandArgs))
+            MyBase.SendInvokeSignatureHelp(Sub(a, n, c) handler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
 
         Public Sub SendSelectSignatureHelpItemThroughPresenterSession(item As SignatureHelpItem)

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetCommandHandlerTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetCommandHandlerTests.vb
@@ -3,6 +3,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
@@ -228,23 +229,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
 
             Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.CSharp)
             Using testState
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
-
                 Dim handler = testState.SnippetCommandHandler
-                Dim state = handler.GetCommandState(New Commands.InsertSnippetCommandArgs(testState.TextView, testState.SubjectBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New InsertSnippetCommandArgs(testState.TextView, testState.SubjectBuffer))
+                Assert.True(state.IsUnspecified)
 
                 testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
 
-                delegatedToNext = False
-                testState.SendInsertSnippetCommand(AddressOf handler.ExecuteCommand, nextHandler)
-                Assert.True(delegatedToNext)
+                Assert.False(testState.SendInsertSnippetCommand(AddressOf handler.ExecuteCommand))
 
                 Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
                 Assert.Equal("for", testState.SubjectBuffer.CurrentSnapshot.GetText())
@@ -257,23 +248,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
 
             Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.CSharp)
             Using testState
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
-
                 Dim handler = CType(testState.SnippetCommandHandler, CSharp.Snippets.SnippetCommandHandler)
-                Dim state = handler.GetCommandState(New Commands.SurroundWithCommandArgs(testState.TextView, testState.SubjectBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New SurroundWithCommandArgs(testState.TextView, testState.SubjectBuffer))
+                Assert.True(state.IsUnspecified)
 
                 testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
 
-                delegatedToNext = False
-                testState.SendSurroundWithCommand(AddressOf handler.ExecuteCommand, nextHandler)
-                Assert.True(delegatedToNext)
+                Assert.False(testState.SendSurroundWithCommand(AddressOf handler.ExecuteCommand))
 
                 Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
                 Assert.Equal("for", testState.SubjectBuffer.CurrentSnapshot.GetText())

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -5,18 +5,19 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.CommandHandlers
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 Imports Microsoft.CodeAnalysis.Editor.Shared.Options
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.BraceCompletion
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.TextManager.Interop
 Imports Moq
@@ -114,29 +115,37 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
         End Function
 
         Friend Overloads Sub SendTabToCompletion()
-            Dim handler = DirectCast(_completionCommandHandler, ICommandHandler(Of TabKeyCommandArgs))
+            Dim handler = DirectCast(_completionCommandHandler, IChainedCommandHandler(Of TabKeyCommandArgs))
 
             SendTab(AddressOf handler.ExecuteCommand, AddressOf SendTab)
         End Sub
 
         Friend Overloads Sub SendTab()
-            SendTab(AddressOf SnippetCommandHandler.ExecuteCommand, Function() EditorOperations.InsertText("    "))
+            If Not SendTab(AddressOf SnippetCommandHandler.ExecuteCommand) Then
+                EditorOperations.InsertText("    ")
+            End If
         End Sub
 
         Friend Overloads Sub SendBackTab()
-            SendBackTab(AddressOf SnippetCommandHandler.ExecuteCommand, Function() EditorOperations.Unindent())
+            If Not SendBackTab(AddressOf SnippetCommandHandler.ExecuteCommand) Then
+                EditorOperations.Unindent()
+            End If
         End Sub
 
         Friend Overloads Sub SendReturn()
-            SendReturn(AddressOf SnippetCommandHandler.ExecuteCommand, Function() EditorOperations.InsertNewLine())
+            If Not SendReturn(AddressOf SnippetCommandHandler.ExecuteCommand) Then
+                EditorOperations.InsertNewLine()
+            End If
         End Sub
 
         Friend Overloads Sub SendEscape()
-            SendEscape(AddressOf SnippetCommandHandler.ExecuteCommand, Function() EditorOperations.InsertText("EscapePassedThrough!"))
+            If Not SendEscape(AddressOf SnippetCommandHandler.ExecuteCommand) Then
+                EditorOperations.InsertText("EscapePassedThrough!")
+            End If
         End Sub
 
         Public Overloads Sub SendTypeChars(typeChars As String)
-            Dim handler = DirectCast(_completionCommandHandler, ICommandHandler(Of TypeCharCommandArgs))
+            Dim handler = DirectCast(_completionCommandHandler, IChainedCommandHandler(Of TypeCharCommandArgs))
             MyBase.SendTypeChars(typeChars, AddressOf handler.ExecuteCommand)
         End Sub
 

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetCommandHandlerTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetCommandHandlerTests.vb
@@ -2,7 +2,9 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
@@ -383,23 +385,13 @@ End Class
 
             Dim testState = SnippetTestState.CreateSubmissionTestState(markup, LanguageNames.VisualBasic)
             Using testState
-                Dim delegatedToNext = False
-                Dim nextHandler =
-                    Function()
-                        delegatedToNext = True
-                        Return CommandState.Unavailable
-                    End Function
-
                 Dim handler = testState.SnippetCommandHandler
-                Dim state = handler.GetCommandState(New Commands.InsertSnippetCommandArgs(testState.TextView, testState.SubjectBuffer), nextHandler)
-                Assert.True(delegatedToNext)
-                Assert.False(state.IsAvailable)
+                Dim state = handler.GetCommandState(New InsertSnippetCommandArgs(testState.TextView, testState.SubjectBuffer))
+                Assert.True(state.IsUnspecified)
 
                 testState.SnippetExpansionClient.TryInsertExpansionReturnValue = True
 
-                delegatedToNext = False
-                testState.SendInsertSnippetCommand(AddressOf handler.ExecuteCommand, nextHandler)
-                Assert.True(delegatedToNext)
+                Assert.False(testState.SendInsertSnippetCommand(AddressOf handler.ExecuteCommand))
 
                 Assert.False(testState.SnippetExpansionClient.TryInsertExpansionCalled)
                 Assert.Equal("for", testState.SubjectBuffer.CurrentSnapshot.GetText())

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -209,9 +209,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public string GetQuickInfo()
             => ExecuteOnActiveView(view =>
             {
-#pragma warning disable CS0618 // IQuickInfo* is obsolete
+#pragma warning disable CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
                 var broker = GetComponentModelService<IQuickInfoBroker>();
-#pragma warning restore CS0618 // IQuickInfo* is obsolete
+#pragma warning restore CS0618 // IQuickInfo* is obsolete, tracked by https://github.com/dotnet/roslyn/issues/24094
 
                 var sessions = broker.GetSessions(view);
                 if (sessions.Count != 1)

--- a/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
@@ -2,7 +2,6 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
 Imports Microsoft.CodeAnalysis.Editor.Implementation.Notification
@@ -10,9 +9,11 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.CodeAnalysis.SymbolMapping
+Imports Microsoft.VisualStudio.Commanding
 Imports Microsoft.VisualStudio.Language.CallHierarchy
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
+Imports Microsoft.VisualStudio.Text.Editor.Commanding.Commands
 Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
@@ -95,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
             notificationService.NotificationCallback = Sub(message, title, severity) NotificationMessage = message
 
             _presenter = New MockCallHierarchyPresenter()
-            _commandHandler = New CallHierarchyCommandHandler({_presenter}, provider, TestWaitIndicator.Default)
+            _commandHandler = New CallHierarchyCommandHandler({_presenter}, provider)
         End Sub
 
         Private Shared Function CreateExportProvider(additionalTypes As IEnumerable(Of Type)) As VisualStudio.Composition.ExportProvider
@@ -118,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
 
         Friend Function GetRoot() As CallHierarchyItem
             Dim args = New ViewCallHierarchyCommandArgs(_textView, _subjectBuffer)
-            _commandHandler.ExecuteCommand(args, Sub() Exit Sub)
+            _commandHandler.ExecuteCommand(args, TestCommandExecutionContext.Create())
             Return _presenter.PresentedRoot
         End Function
 

--- a/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicSyncClassViewCommandHandler.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ObjectBrowser/VisualBasicSyncClassViewCommandHandler.vb
@@ -2,18 +2,20 @@
 
 Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis.Editor
-Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ClassView
 Imports Microsoft.VisualStudio.Shell
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ObjectBrowser
-    <ExportCommandHandler(PredefinedCommandHandlerNames.ClassView, ContentTypeNames.VisualBasicContentType)>
+    <Export(GetType(Commanding.ICommandHandler))>
+    <ContentType(ContentTypeNames.VisualBasicContentType)>
+    <Name(PredefinedCommandHandlerNames.ClassView)>
     Friend Class VisualBasicSyncClassViewCommandHandler
         Inherits AbstractSyncClassViewCommandHandler
 
         <ImportingConstructor>
-        Private Sub New(serviceProvider As SVsServiceProvider, waitIndicator As IWaitIndicator)
-            MyBase.New(serviceProvider, waitIndicator)
+        Private Sub New(serviceProvider As SVsServiceProvider)
+            MyBase.New(serviceProvider)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
+++ b/src/VisualStudio/VisualBasic/Repl/VisualBasicInteractiveCommandHandler.vb
@@ -1,7 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
-Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Interactive
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Interactive
@@ -12,7 +11,6 @@ Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Interactive
 
-    <ExportCommandHandler("Interactive Command Handler")>
     Friend NotInheritable Class VisualBasicInteractiveCommandHandler
         Inherits InteractiveCommandHandler
 


### PR DESCRIPTION
<details><summary>Ask Mode template</summary>

### Customer scenario

This change migrates all Roslyn command handlers to the new editor commanding system, which is based on Roslyn's commanding, see [Modern Editor Commanding API Spec](https://github.com/Microsoft/vs-editor-api/wiki/Modern-Editor-Commanding-API-Revisited).

Besides other benefits, migrating to the new editor commanding allows the editor to diagnose typing performance in a more fine grained way, for example it will be now possible to measure/collect traces of individual command handlers introducing typing delays.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/24194 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/513714
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/511623

### Risk

This change affects execution of every Roslyn commands handler, but the risk is mitigated by the fact that the new editor commanding is designed and implemented based on existing Roslyn commanding and preserves command handling semantics and design principles as is so most command handlers are migrated by just changing the namespace of interface they implement and the way they are exported.

### Performance impact

According to RPS results, this change introduces a _below degrade bar_ regression in C# typing scenario, caused by the new editor commanding infrastructure:
1. Half the regression is the cost of initialization/disposal of VS threaded wait dialog which is RPS machine setup specific issue (code markers writing to a file) and will not affect customers.
2. We are doing a bit more work in the new editor commanding than Roslyn used to because of a more generalized projection-aware approach to ordering command handlers. We plan to address that by making focused optimizations on the editor side in Preview 4.

### Validation
The following validation was performed:
1. Roslyn unit, integration tests are passing
2. DDRITs are passing
3. RPS is passing (see perf impact notes above)
4. Manual regression testing by the Editor, Roslyn, TypeScript, WebTools, F# and XAML teams on a validation build, no regressions found.
5. I prototyped migrating VS for Mac to the new editor bits + Roslyn build of this PR and confirmed no issues or leaked WPF dependencies. Current Razor support in VS for Mac can be straightforwardly migrated from using Roslyn commanding to the new editor commanding.

</details>

-------------------------------------
This change migrates all Roslyn command handlers to the new platform's commanding system, which is based on Roslyn's commanding, see [Modern Editor Commanding API Spec](https://github.com/Microsoft/vs-editor-api/wiki/Modern-Editor-Commanding-API-Revisited).

 The migration strategy is to keep Roslyn commanding infrastructure in place as is, but migrate all C#/VB command handlers over. Given that the migration mostly required pretty boilerplate changes:
1. Namespace changes, e.g. all common editor *CommandArgs classes are now in Microsoft.VisualStudio.Text.Editor.Commanding.Commands namespace.
2. Different way to export a command handler
3. Independent command handlers are migrated to a simpler ICommandHandler interface that doesn't require dealing with next handler chain.
4. Command handlers requiring access to the next handler are migrated to IChainedCommandHandler with no change in semantics.
5. Existing Roslyn commanding infrastructure is left intact as languages such as TypeScript still depend on it. That unfortunately required a lot of verbose name qualifications to resolve name conflicts, any suggestions to improve readability are welcome.
6. Platform command handlers are required to provide their display name.
7. Platform's command handlers are executed in a shared wait context that is provided to handlers via CommandExecutionContext argument. It contains cancellation token and also allows handlers to push a wait scope with their own cancellability flag, description and progress tracker. So all _waitIndicator.Wait() are replaced with context.WaitContext.AddScope().
8. Some Roslyn commands are Roslyn specific and stay in Roslyn (e.g. SortAndRemoveUnnecessaryImportsCommandArgs). Those required creating new CommandArgs classes deriving from Platform's EditorCommandArgs and exporting VS specific command bindings.


  