### PR TITLE
fixed issue where same analyzer reference is installed in both vsix a…

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -9,6 +9,7 @@ using Roslyn.Utilities;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -283,6 +284,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             return language == LanguageNames.CSharp ? csharpMessage : vbMessage;
+        }
+
+        public static void AppendAnalyzerMap(this Dictionary<string, DiagnosticAnalyzer> analyzerMap, IEnumerable<DiagnosticAnalyzer> analyzers)
+        {
+            foreach (var analyzer in analyzers)
+            {
+                // user might have included exact same analyzer twice as project analyzers explicitly. we consider them as one
+                analyzerMap[analyzer.GetAnalyzerId()] = analyzer;
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var analyzerMap = pooledObject.Object;
 
-                    AppendAnalyzerMap(analyzerDriver.Analyzers.Where(a => !a.IsOpenFileOnly(project.Solution.Workspace)), analyzerMap);
+                    analyzerMap.AppendAnalyzerMap(analyzerDriver.Analyzers.Where(a => !a.IsOpenFileOnly(project.Solution.Workspace)));
                     if (analyzerMap.Count == 0)
                     {
                         return DiagnosticAnalysisResultMap.Create(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty, ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>.Empty);
@@ -216,15 +216,6 @@ This data should always be correct as we're never persisting the data between se
                     {
                         _hostDiagnosticUpdateSourceOpt?.ReportAnalyzerDiagnostic(analyzer, diagnostic, project);
                     }
-                }
-            }
-
-            private void AppendAnalyzerMap(IEnumerable<DiagnosticAnalyzer> analyzers, Dictionary<string, DiagnosticAnalyzer> analyzerMap)
-            {
-                foreach (var analyzer in analyzers)
-                {
-                    // user might have included exact same analyzer twice as project analyzers explicitly. we consider them as one
-                    analyzerMap[analyzer.GetAnalyzerId()] = analyzer;
                 }
             }
         }


### PR DESCRIPTION
…nd nuget. deduplication in inproc analyzer manager wasn't present in OOP case.

this doesn't address our workitem to merge those two. that work is a separate work item. this just follow what we currently do in proc.

### Customer scenario

if a user installs same analyzer reference to VS in both vsix and nuget, OOP will crash due to duplicated analyzers being installed.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/23766

### Workarounds, if any

uninstall either vsix or nuget to remove duplicated analyzers.

### Risk

low, it won't cause new crash. functionality-wise, we already do this in proc. OOP missed doing this dedup.

### Performance impact

performance-wise, it does about same amount of work as it used to.

### Is this a regression from a previous update?

No

### Root cause analysis

when same analyzer reference is installed from both vsix and nuget, inproc has a logic to dedup those references. OOP missed that logic and ends up try to create map with same key causing a crash. this add that same dedup logic to OOP.

### How was the bug found?

dogfooding
