### PR TITLE
Use binary log in microbuild

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -1,6 +1,2 @@
 @echo off
-if "%*" == "" (
-    powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" -build
-) else (
-    powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" %*
-)
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build\scripts\build.ps1" -build %*

--- a/build/scripts/cibuild.cmd
+++ b/build/scripts/cibuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build.ps1" -cibuild -build -restore -bootstrap %*
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\build.ps1" -cibuild -build -restore -bootstrap -binaryLog %*

--- a/src/Tools/MicroBuild/microbuild.ps1
+++ b/src/Tools/MicroBuild/microbuild.ps1
@@ -130,7 +130,7 @@ try {
     $configDir = Join-Path $binariesDir $config
     $setupDir = Join-Path $repoDir "src\Setup"
 
-    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -official:$official -msbuildDir $msbuildDir -release:$release -sign -pack -testDesktop:$testDesktop }
+    Exec-Block { & (Join-Path $scriptDir "build.ps1") -restore:$restore -buildAll -official:$official -msbuildDir $msbuildDir -release:$release -sign -pack -testDesktop:$testDesktop -binaryLog }
 
     Exec-Block { & (Join-Path $PSScriptRoot "run-gitlink.ps1") -config $config }
     Build-InsertionItems


### PR DESCRIPTION
[this is a cherry-pick of @jaredpar's change from master]

This enables the generation of binary logs for our build when running in Microbuild.
Having the logs available helps in post-build debugging of errors. We tend to get a
number of microbuild only failures that are impossible to track down without logging
like this.

Once this is merged i will be adding a task to our VSTS build definition to publish
these post build.