### PR TITLE
Only the compiler analyzer can use CS or BC prefix for diagnostics

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -888,6 +888,36 @@ public class B
                      .WithLocation(1, 1));
         }
 
+        [Fact, WorkItem(23667, "https://github.com/dotnet/roslyn/issues/23667")]
+        public void TestReportingDiagnosticWithCSharpCompilerId()
+        {
+            string source = @"";
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerWithCSharpCompilerDiagnosticId() };
+            string message = new ArgumentException(string.Format(CodeAnalysisResources.CompilerDiagnosticIdReported, AnalyzerWithCSharpCompilerDiagnosticId.Descriptor.Id), "diagnostic").Message;
+
+            CreateCompilationWithMscorlib45(source)
+                .VerifyDiagnostics()
+                .VerifyAnalyzerDiagnostics(analyzers, null, null, logAnalyzerExceptionAsDiagnostics: true,
+                     expected: Diagnostic("AD0001")
+                     .WithArguments("Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers+AnalyzerWithCSharpCompilerDiagnosticId", "System.ArgumentException", message)
+                     .WithLocation(1, 1));
+        }
+
+        [Fact, WorkItem(23667, "https://github.com/dotnet/roslyn/issues/23667")]
+        public void TestReportingDiagnosticWithBasicCompilerId()
+        {
+            string source = @"";
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerWithBasicCompilerDiagnosticId() };
+            string message = new ArgumentException(string.Format(CodeAnalysisResources.CompilerDiagnosticIdReported, AnalyzerWithBasicCompilerDiagnosticId.Descriptor.Id), "diagnostic").Message;
+
+            CreateCompilationWithMscorlib45(source)
+                .VerifyDiagnostics()
+                .VerifyAnalyzerDiagnostics(analyzers, null, null, logAnalyzerExceptionAsDiagnostics: true,
+                     expected: Diagnostic("AD0001")
+                     .WithArguments("Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers+AnalyzerWithBasicCompilerDiagnosticId", "System.ArgumentException", message)
+                     .WithLocation(1, 1));
+        }
+
         [Fact, WorkItem(7173, "https://github.com/dotnet/roslyn/issues/7173")]
         public void TestReportingDiagnosticWithInvalidLocation()
         {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -406,6 +406,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reported diagnostic has an ID &apos;{0}&apos;, which only a compiler should be reporting..
+        /// </summary>
+        internal static string CompilerDiagnosticIdReported {
+            get {
+                return ResourceManager.GetString("CompilerDiagnosticIdReported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to constructor.
         /// </summary>
         internal static string Constructor {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -446,6 +446,9 @@
   <data name="InvalidDiagnosticIdReported" xml:space="preserve">
     <value>Reported diagnostic has an ID '{0}', which is not a valid identifier.</value>
   </data>
+  <data name="CompilerDiagnosticIdReported" xml:space="preserve">
+    <value>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</value>
+  </data>
   <data name="InvalidDiagnosticLocationReported" xml:space="preserve">
     <value>Reported diagnostic '{0}' has a source location in file '{1}', which is not part of the compilation being analyzed.</value>
   </data>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -168,10 +168,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
-            if (diagnostic.Id.StartsWith("CS", StringComparison.Ordinal)||
-                diagnostic.Id.StartsWith("BC", StringComparison.Ordinal))
+            if (IsCompilerReservedDiagnostic(diagnostic.Id))
             {
-                // Only the compiler analyzer should produce diagnostics with CS or BC prefixes
                 throw new ArgumentException(string.Format(CodeAnalysisResources.CompilerDiagnosticIdReported, diagnostic.Id), nameof(diagnostic));
             }
 
@@ -184,6 +182,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     return true;
                 }
+            }
+
+            return false;
+        }
+
+        private static bool IsCompilerReservedDiagnostic(string id)
+        {
+            // Only the compiler analyzer should produce diagnostics with CS or BC prefixes (followed by digit)
+            if (id.Length >= 3 && (id.StartsWith("CS", StringComparison.Ordinal) || id.StartsWith("BC", StringComparison.Ordinal)))
+            {
+                char thirdChar = id[2];
+                return thirdChar >= '0' && thirdChar <= '9';
             }
 
             return false;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -168,6 +168,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return true;
             }
 
+            if (diagnostic.Id.StartsWith("CS", StringComparison.Ordinal)||
+                diagnostic.Id.StartsWith("BC", StringComparison.Ordinal))
+            {
+                // Only the compiler analyzer should produce diagnostics with CS or BC prefixes
+                throw new ArgumentException(string.Format(CodeAnalysisResources.CompilerDiagnosticIdReported, diagnostic.Id), nameof(diagnostic));
+            }
+
             // Get all the supported diagnostics and scan them linearly to see if the reported diagnostic is supported by the analyzer.
             // The linear scan is okay, given that this runs only if a diagnostic is being reported and a given analyzer is quite unlikely to have hundreds of thousands of supported diagnostics.
             var supportedDescriptors = GetSupportedDiagnosticDescriptors(analyzer, analyzerExecutor);

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.cs.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.de.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.es.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.fr.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.it.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ja.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ko.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pl.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.pt-BR.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.ru.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.tr.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hans.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
+++ b/src/Compilers/Core/Portable/xlf/CodeAnalysisResources.zh-Hant.xlf
@@ -828,6 +828,11 @@
         <target state="new">Warning: Could not enable multicore JIT due to exception: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CompilerDiagnosticIdReported">
+        <source>Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</source>
+        <target state="new">Reported diagnostic has an ID '{0}', which only a compiler should be reporting.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.SymbolSearch;
 
@@ -122,7 +123,8 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
                 CS0616,
                 CS1580,
                 CS1581,
-                CS8129);
+                CS8129,
+                IDEDiagnosticIds.UnboundIdentifierId);
 
         public static ImmutableArray<string> FixableDiagnosticIds =
             FixableTypeIds.Concat(ImmutableArray.Create(

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.AddImports;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -153,6 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             switch (diagnosticId)
             {
                 case CS0103:
+                case IDEDiagnosticIds.UnboundIdentifierId:
                 case CS0246:
                 case CS0305:
                 case CS0308:

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.GenerateMember;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.GenerateType;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateType
 
         public override ImmutableArray<string> FixableDiagnosticIds
         {
-            get { return ImmutableArray.Create(CS0103, CS0117, CS0234, CS0246, CS0305, CS0308, CS0426, CS0616); }
+            get { return ImmutableArray.Create(CS0103, CS0117, CS0234, CS0246, CS0305, CS0308, CS0426, CS0616, IDEDiagnosticIds.UnboundIdentifierId); }
         }
 
         protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -10,19 +10,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class CSharpUnboundIdentifiersDiagnosticAnalyzer : UnboundIdentifiersDiagnosticAnalyzerBase<SyntaxKind, SimpleNameSyntax, QualifiedNameSyntax, IncompleteMemberSyntax, LambdaExpressionSyntax>
     {
-        private const string NameNotInContext = "CS0103";
-        private readonly LocalizableString _nameNotInContextMessageFormat = new LocalizableResourceString(nameof(CSharpFeaturesResources.The_name_0_does_not_exist_in_the_current_context), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+        private readonly LocalizableString _nameNotInContextMessageFormat =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources.The_name_0_does_not_exist_in_the_current_context), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
 
-        private const string ConstructorOverloadResolutionFailure = "CS1729";
-        private readonly LocalizableString _constructorOverloadResolutionFailureMessageFormat = new LocalizableResourceString(nameof(CSharpFeaturesResources._0_does_not_contain_a_constructor_that_takes_that_many_arguments), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
+        private readonly LocalizableString _constructorOverloadResolutionFailureMessageFormat =
+            new LocalizableResourceString(nameof(CSharpFeaturesResources._0_does_not_contain_a_constructor_that_takes_that_many_arguments), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
 
         private static readonly ImmutableArray<SyntaxKind> s_kindsOfInterest = ImmutableArray.Create(SyntaxKind.IncompleteMember, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression);
 
         protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => s_kindsOfInterest;
 
-        protected override DiagnosticDescriptor DiagnosticDescriptor => GetDiagnosticDescriptor(NameNotInContext, _nameNotInContextMessageFormat);
+        protected override DiagnosticDescriptor DiagnosticDescriptor => GetDiagnosticDescriptor(IDEDiagnosticIds.UnboundIdentifierId, _nameNotInContextMessageFormat);
 
-        protected override DiagnosticDescriptor DiagnosticDescriptor2 => GetDiagnosticDescriptor(ConstructorOverloadResolutionFailure, _constructorOverloadResolutionFailureMessageFormat);
+        protected override DiagnosticDescriptor DiagnosticDescriptor2 => GetDiagnosticDescriptor(IDEDiagnosticIds.UnboundConstructorId, _constructorOverloadResolutionFailureMessageFormat);
 
         protected override bool ConstructorDoesNotExist(SyntaxNode node, SymbolInfo info, SemanticModel model)
         {

--- a/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeFixes.GenerateMember;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
         public const string CS7036 = nameof(CS7036); // CS7036: There is no argument given that corresponds to the required formal parameter 'v' of 'C.C(int)'
 
         public static readonly ImmutableArray<string> AllDiagnosticIds = 
-            ImmutableArray.Create(CS0122, CS1729, CS1739, CS1503, CS7036);
+            ImmutableArray.Create(CS0122, CS1729, CS1739, CS1503, CS7036, IDEDiagnosticIds.UnboundConstructorId);
 
         public static readonly ImmutableArray<string> TooManyArgumentsDiagnosticIds =
             ImmutableArray.Create(CS1729);

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -70,5 +70,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string ErrorReadingRulesetId = "IDE1004";
         public const string InvokeDelegateWithConditionalAccessId = "IDE1005";
         public const string NamingRuleId = "IDE1006";
+        public const string UnboundIdentifierId = "IDE1007";
+        public const string UnboundConstructorId = "IDE1008";
     }
 }

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportCodeFixProvider.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.AddImport
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Packaging
 Imports Microsoft.CodeAnalysis.SymbolSearch
 
@@ -100,7 +101,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30451, BC30456, BC32042, BC36593, BC32045, BC30389, BC31504, BC32016, BC36610, BC36719, BC30512, BC30390, BC42309, BC30182)
+                Return ImmutableArray.Create(BC30002, BC30451, BC30456, BC32042, BC36593, BC32045, BC30389, BC31504, BC32016, BC36610,
+                                             BC36719, BC30512, BC30390, BC42309, BC30182, IDEDiagnosticIds.UnboundIdentifierId)
             End Get
         End Property
     End Class

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -5,6 +5,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.AddImport
 Imports Microsoft.CodeAnalysis.AddImports
 Imports Microsoft.CodeAnalysis.CaseCorrection
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
@@ -88,6 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
         Protected Overrides Function CanAddImportForNamespace(diagnosticId As String, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnosticId
                 Case VisualBasicAddImportCodeFixProvider.BC30002,
+                     IDEDiagnosticIds.UnboundIdentifierId,
                      VisualBasicAddImportCodeFixProvider.BC30451
                     Exit Select
                 Case Else
@@ -120,6 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 diagnosticId As String, node As SyntaxNode, ByRef nameNode As SimpleNameSyntax) As Boolean
             Select Case diagnosticId
                 Case VisualBasicAddImportCodeFixProvider.BC30002,
+                     IDEDiagnosticIds.UnboundIdentifierId,
                      VisualBasicAddImportCodeFixProvider.BC30451,
                      VisualBasicAddImportCodeFixProvider.BC32042,
                      VisualBasicAddImportCodeFixProvider.BC32045,

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
@@ -6,6 +6,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.GenerateMember
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.GenerateType
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -26,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateType
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30182, BC30451, BC30456, BC32042, BC32043, BC32045, BC40056)
+                Return ImmutableArray.Create(BC30002, IDEDiagnosticIds.UnboundIdentifierId, BC30182, BC30451, BC30456, BC32042, BC32043, BC32045, BC40056)
             End Get
         End Property
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/Spellcheck/VisualBasicSpellCheckCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/Spellcheck/VisualBasicSpellCheckCodeFixProvider.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.SpellCheck
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -36,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.Spellcheck
 
         Public NotOverridable Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30451, BC30456, BC32045)
+                Return ImmutableArray.Create(BC30002, IDEDiagnosticIds.UnboundIdentifierId, BC30451, BC30456, BC32045)
             End Get
         End Property
 

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicUnboundIdentifiersDiagnosticAnalyzer.vb
@@ -10,9 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics
     Friend NotInheritable Class VisualBasicUnboundIdentifiersDiagnosticAnalyzer
         Inherits UnboundIdentifiersDiagnosticAnalyzerBase(Of SyntaxKind, SimpleNameSyntax, QualifiedNameSyntax, IncompleteMemberSyntax, LambdaExpressionSyntax)
 
-        Private Const s_undefinedType1 As String = "BC30002"
         Private ReadOnly _messageFormat As LocalizableString = New LocalizableResourceString(NameOf(VBFeaturesResources.Type_0_is_not_defined), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources.VBFeaturesResources))
-        Private Const s_undefinedType2 As String = "BC30057"
         Private ReadOnly _messageFormat2 As LocalizableString = New LocalizableResourceString(NameOf(VBFeaturesResources.Too_many_arguments_to_0), VBFeaturesResources.ResourceManager, GetType(VBFeaturesResources.VBFeaturesResources))
 
 
@@ -31,13 +29,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics
 
         Protected Overrides ReadOnly Property DiagnosticDescriptor As DiagnosticDescriptor
             Get
-                Return GetDiagnosticDescriptor(s_undefinedType1, _messageFormat)
+                Return GetDiagnosticDescriptor(IDEDiagnosticIds.UnboundIdentifierId, _messageFormat)
             End Get
         End Property
 
         Protected Overrides ReadOnly Property DiagnosticDescriptor2 As DiagnosticDescriptor
             Get
-                Return GetDiagnosticDescriptor(s_undefinedType2, _messageFormat2)
+                Return GetDiagnosticDescriptor(IDEDiagnosticIds.UnboundConstructorId, _messageFormat2)
             End Get
         End Property
 

--- a/src/Features/VisualBasic/Portable/FullyQualify/VisualBasicFullyQualifyCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/FullyQualify/VisualBasicFullyQualifyCodeFixProvider.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CaseCorrection
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.FullyQualify
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -43,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.FullyQualify
 
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
-                Return ImmutableArray.Create(BC30002, BC30451, BC30561, BC40056, BC32045)
+                Return ImmutableArray.Create(BC30002, IDEDiagnosticIds.UnboundIdentifierId, BC30451, BC30561, BC40056, BC32045)
             End Get
         End Property
 

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
@@ -6,6 +6,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeFixes.GenerateMember
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -21,8 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
         Friend Const BC30387 As String = "BC30387" ' error BC32006: Class 'Derived' must declare a 'Sub New' because its base class 'Base' does not have an accessible 'Sub New' that can be called with no arguments. 
         Friend Const BC30516 As String = "BC30516" ' error BC30516: Overload resolution failed because no accessible 'Blah' accepts this number of arguments.
 
-        Friend Shared ReadOnly AllDiagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(BC30057, BC30272, BC30274, BC30389, BC30455, BC32006, BC30512, BC30387, BC30516)
-        Friend Shared ReadOnly TooManyArgumentsDiagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(BC30057)
+        Friend Shared ReadOnly AllDiagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(BC30057, IDEDiagnosticIds.UnboundConstructorId, BC30272, BC30274, BC30389, BC30455, BC32006, BC30512, BC30387, BC30516)
+        Friend Shared ReadOnly TooManyArgumentsDiagnosticIds As ImmutableArray(Of String) = ImmutableArray.Create(BC30057, IDEDiagnosticIds.UnboundConstructorId)
     End Class
 
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.GenerateConstructor), [Shared]>

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -462,6 +462,44 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class AnalyzerWithCSharpCompilerDiagnosticId : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+                "CS101",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(compilationContext =>
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None)));
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class AnalyzerWithBasicCompilerDiagnosticId : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+                "BC101",
+                "Title1",
+                "Message1",
+                "Category1",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(compilationContext =>
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None)));
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         public sealed class AnalyzerWithInvalidDiagnosticSpan : DiagnosticAnalyzer
         {
             private readonly TextSpan _badSpan;


### PR DESCRIPTION
### Customer scenario
Some analyzer (such as the UnboundIdentifier analyzer in the linked issue) produce similar diagnostics (ID and message) to the compiler's.
That is extremely confusing and leads to wasting time in investigation.

In the screenshot below, the red squiggles on `nameof` are actually produced by an analyzer, which makes a "CS0107" diagnostic...
![image](https://user-images.githubusercontent.com/12466233/33857919-a7eaaa5a-de82-11e7-9025-efc8295904c4.png)

### Bugs this fixes
Fixes part of https://github.com/dotnet/roslyn/issues/23667
Fixes part of https://github.com/dotnet/roslyn/issues/22615

### Workarounds, if any
Not applicable.

### Risk
Low. This PR modifies the analyzer infrastructure to catch when non-compiler analyzers produce a diagnostic starting with "CS" or "BC". A couple of such faulty analyzers are updated to produce distinct diagnostics instead (with correct "IDE" prefix).

### Performance impact
Low. Just an additional validation on diagnostics.

### Is this a regression from a previous update?
No.

### How was the bug found?
Some customer reported issues caused me to hit this problem during investigation.
