### PR TITLE
Update Microsoft.DiaSymReader.Native to 1.7.0 stable

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -38,7 +38,7 @@
     <MicrosoftDiaSymReaderVersion>1.2.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta1-62221-01</MicrosoftDiaSymReaderConverterVersion>
     <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta1-62221-01</MicrosoftDiaSymReaderConverterXmlVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.7.0-beta-25631</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.4.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetIBCMerge>4.7.2-alpha-00001</MicrosoftDotNetIBCMerge>
     <MicrosoftDotNetVersionToolsVersion>1.0.27-prerelease-01811-02</MicrosoftDotNetVersionToolsVersion>


### PR DESCRIPTION
### Customer scenario

Update Microsoft.DiaSymReader.Native to the release version that shipped with 15.5. 
This change only affects nuget package ```Microsoft.Net.Compilers``` published from the servicing branch. It does not affect VS since Microsoft.DiaSymReader.Native binaries are not being inserted into VS, they flow in the opposite direction.

### Bugs this fixes

n/a

### Workarounds, if any

n/a

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?