### PR TITLE
fixed OOP from crashing when renaming solution.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -40,18 +40,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             public void OnAfterWorkingFolderChange()
             {
                 this.AssertIsForeground();
-                RegisterPrimarySolution();
+                RegisterPrimarySolution(update: true);
             }
 
             public void OnSolutionAdded(SolutionInfo solutionInfo)
             {
                 this.AssertIsForeground();
-                RegisterPrimarySolution();
+                RegisterPrimarySolution(update: false);
             }
 
-            private void RegisterPrimarySolution()
+            private void RegisterPrimarySolution(bool update)
             {
                 this.AssertIsForeground();
+
                 _currentSolutionId = _workspace.CurrentSolution.Id;
                 var solutionId = _currentSolutionId;
 
@@ -59,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 _session.TryInvokeAsync(
                     nameof(IRemoteHostService.RegisterPrimarySolutionId),
-                    new object[] { solutionId, storageLocation }, CancellationToken.None).Wait(CancellationToken.None);
+                    new object[] { solutionId, storageLocation, update }, CancellationToken.None).Wait(CancellationToken.None);
             }
 
             public void OnBeforeWorkingFolderChange()

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.DebugUtil;
+using Microsoft.CodeAnalysis.Remote.Storage;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.TodoComments;
 using Nerdbank;
@@ -63,6 +64,29 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 Assert.Equal(
                     await solution.State.GetChecksumAsync(CancellationToken.None),
                     await PrimaryWorkspace.Workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None));
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public void TestRemoteHostRegisterPrimarySolutionId()
+        {
+            using (var remoteHostService = CreateService())
+            {
+                var solutionId = SolutionId.CreateNewId();
+                var path = @"c:\test";
+
+                remoteHostService.RegisterPrimarySolutionId(solutionId, path, update: false, cancellationToken: CancellationToken.None);
+                Assert.Equal(path + @"\Server", RemotePersistentStorageLocationService.GetStorageLocation(solutionId));
+
+                path = path + "1";
+                remoteHostService.RegisterPrimarySolutionId(solutionId, path, update: true, cancellationToken: CancellationToken.None);
+                Assert.Equal(path + @"\Server", RemotePersistentStorageLocationService.GetStorageLocation(solutionId));
+
+                path = path + "2";
+                remoteHostService.RegisterPrimarySolutionId(solutionId, path, update: true, cancellationToken: CancellationToken.None);
+                Assert.Equal(path + @"\Server", RemotePersistentStorageLocationService.GetStorageLocation(solutionId));
+
+                remoteHostService.UnregisterPrimarySolutionId(solutionId, synchronousShutdown: true, cancellationToken: CancellationToken.None);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Remote
         Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken);
         Task SynchronizeGlobalAssetsAsync(Checksum[] checksums, CancellationToken cancellationToken);
 
-        void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken);
+        void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, bool update, CancellationToken cancellationToken);
         void UnregisterPrimarySolutionId(SolutionId solutionId, bool synchronousShutdown, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
+++ b/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
@@ -16,7 +16,13 @@ namespace Microsoft.CodeAnalysis.Remote.Storage
 
         public string GetStorageLocation(Solution solution)
         {
-            _idToStorageLocation.TryGetValue(solution.Id, out var result);
+            return GetStorageLocation(solution.Id);
+        }
+
+        // internal for testing
+        internal static string GetStorageLocation(SolutionId solutionId)
+        {
+            _idToStorageLocation.TryGetValue(solutionId, out var result);
             return result;
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -113,13 +113,22 @@ namespace Microsoft.CodeAnalysis.Remote
             }, cancellationToken);
         }
 
-        public void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken)
+        public void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, bool update, CancellationToken cancellationToken)
         {
             RunService(_ =>
             {
+                // save working folder location info first
+                RemotePersistentStorageLocationService.UpdateStorageLocation(solutionId, storageLocation);
+
+                if(update)
+                {
+                    // if we are just updating storage, don't register primary workspace
+                    return;
+                }
+
+                // and register new primary solution for persistent service
                 var persistentStorageService = GetPersistentStorageService();
                 persistentStorageService?.RegisterPrimarySolution(solutionId);
-                RemotePersistentStorageLocationService.UpdateStorageLocation(solutionId, storageLocation);
             }, cancellationToken);
         }
 


### PR DESCRIPTION
<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
