### PR TITLE
Ignore escape analysis for erroneous field access nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2051,7 +2051,11 @@ moreArguments:
                     var fieldAccess = (BoundFieldAccess)expr;
                     var fieldSymbol = fieldAccess.FieldSymbol;
 
-                    Debug.Assert(!fieldSymbol.IsStatic && fieldSymbol.ContainingType.IsByRefLikeType);
+                    if (fieldSymbol.IsStatic || !fieldSymbol.ContainingType.IsByRefLikeType)
+                    {
+                        // Already an error state.
+                        return Binder.ExternalScope;
+                    }
 
                     // for ref-like fields defer to the receiver.
                     return GetValEscape(fieldAccess.ReceiverOpt, scopeOfTheContainingExpression);
@@ -2333,7 +2337,11 @@ moreArguments:
                     var fieldAccess = (BoundFieldAccess)expr;
                     var fieldSymbol = fieldAccess.FieldSymbol;
 
-                    Debug.Assert(!fieldSymbol.IsStatic && fieldSymbol.ContainingType.IsByRefLikeType);
+                    if (fieldSymbol.IsStatic || !fieldSymbol.ContainingType.IsByRefLikeType)
+                    {
+                        // Already an error state.
+                        return true;
+                    }
 
                     // for ref-like fields defer to the receiver.
                     return CheckValEscape(node, fieldAccess.ReceiverOpt, escapeFrom, escapeTo, true, diagnostics);


### PR DESCRIPTION
### Customer scenario

Using fields or definitions with erroneous escape scope, in local statements will hit asserts in the C# compiler. or hang VS.

```csharp
using System;

namespace CSharp72TestApp
{
    public ref struct Point
    {
    }
    class Program
    {
        public static readonly Point rwp = new Point();

        static void PrintNormal()
        {
            var tmp = rwp;
        }
    }
}
```

### Bugs this fixes

Fixes #23627

### Workarounds, if any

None.

### Risk

Minimal. It is short circuiting erroneous symbols in the binder escape analysis.

### Performance impact

Minimal.

### Is this a regression from a previous update?

No. This bug shipped with ref structs.

### Root cause analysis

Using fields or definitions with erroneous escape scope will emit errors, but any uses of these symbols later will fail the checks done in the binder, causing asserts to fire or VS to NRE.

### How was the bug found?

Customer report.

### Test documentation updated?

---