### PR TITLE
Publish all relevant VSIX projects

### DIFF
--- a/src/Setup/Vsix/myget_org-extensions.config
+++ b/src/Setup/Vsix/myget_org-extensions.config
@@ -5,4 +5,9 @@
  -->
 <extensions>
   <extension id="Microsoft.VisualStudio.IntegrationTest.Setup" path="Vsix\VisualStudioIntegrationTestSetup" />
+  <extension id="Roslyn.VisualStudio.DiagnosticsWindow" path="Vsix\VisualStudioDiagnosticsWindow" />
+  <extension id="Roslyn.Compilers.Extension" path="Vsix\CompilerExtension" />
+  <extension id="ExpressionEvaluatorPackage" path="Vsix\ExpressionEvaluatorPackage" />
+  <extension id="Roslyn.VisualStudio.Setup" path="Vsix\VisualStudioSetup" />
+  <extension id="Roslyn.VisualStudio.InteractiveComponents" path="Vsix\VisualStudioInteractiveComponents" />
 </extensions>


### PR DESCRIPTION
Need to publish the individual VSIX projects which used to represent our
uber VSIX package. The LUT + project system still use these for their
integration tests.

