### PR TITLE
Fix hang in compiler server

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -416,7 +416,19 @@ namespace Microsoft.CodeAnalysis.CommandLine
             {
                 try
                 {
-                    Process.Start(expectedPath, processArguments);
+                    var startInfo = new ProcessStartInfo()
+                    {
+                        FileName = expectedPath,
+                        Arguments = processArguments,
+                        UseShellExecute = false,
+                        WorkingDirectory = clientDir,
+                        RedirectStandardInput = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true
+                    };
+
+                    Process.Start(startInfo);
                     return true;
                 }
                 catch


### PR DESCRIPTION
### Customer scenario

The dotnet CLI has been seeing a hang from VBCSCompiler in their build
on non-Windows platforms. The cause is this:

    1. dotnet build starts a child process to do `dotnet pack` and
    redirects its output to a buffer.
    2. `dotnet pack` starts a child process to do `compile`.
    3. `compile` starts vbcscompiler because one is not already running.
    4. VBCSCompiler inherits the output handles from (1).
    5. VBCSCompiler process finishes and processes (1) and (2) exit.
    6. The parent `dotnet build` process  is waiting for (1) to exit,
    which it has, but also to see EOF on its output stream. Because that
    stream has been captured and held open by VBCSCompiler, the EOF
    never comes.
    7. `dotnet build` hangs.

This change fixes the problem by creating new streams for input and
output for the compiler server process. This isn't quite what we do on
Windows -- on Windows we create invalid handles for the input and output
-- but it's as close as we can get using the portable APIs in
System.Diagnostics.Process.

### Bugs this fixes

Fixes #23734

### Workarounds, if any

Disable the compiler server.

### Risk

The change is only for the compiler server on non-Windows platforms and changes the process start code to as closely match the Windows version as possible.

### Performance impact

None, just changing some perf-irrelevent process start options.

### Is this a regression from a previous update?

No.

### Root cause analysis

This bug needs multiple intermediate dotnet processes to appear. I haven't been able to repro this in a unit test yet, but I have done manually testing with the CLI.

### How was the bug found?

Found in CLI build
