### PR TITLE
WIP: Reduce memory consumption of LongestCommonSubsequence (#23808)

### DIFF
--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -13,73 +13,154 @@ namespace Microsoft.CodeAnalysis.Differencing
     /// </summary>
     internal abstract class LongestCommonSubsequence<TSequence>
     {
-        private const int DeleteCost = 1;
-        private const int InsertCost = 1;
-        private const int UpdateCost = 2;
-
-        protected abstract bool ItemsEqual(TSequence oldSequence, int oldIndex, TSequence newSequence, int newIndex);
-
-        protected IEnumerable<KeyValuePair<int, int>> GetMatchingPairs(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
+        // VArray struct enables array indexing in range [-d...d].
+        private struct VArray
         {
-            int[,] d = ComputeCostMatrix(oldSequence, oldLength, newSequence, newLength);
-            int i = oldLength;
-            int j = newLength;
+            private readonly int[] _array;
 
-            while (i != 0 && j != 0)
+            public VArray(int d)
             {
-                if (d[i, j] == d[i - 1, j] + DeleteCost)
+                _array = new int[2 * d + 1];
+            }
+
+            public void CopyFrom(VArray otherVArray)
+            {
+                int copyDelta = Offset - otherVArray.Offset;
+                if (copyDelta >= 0)
                 {
-                    i--;
-                }
-                else if (d[i, j] == d[i, j - 1] + InsertCost)
-                {
-                    j--;
+                    Array.Copy(otherVArray._array, 0, _array, copyDelta, otherVArray._array.Length);
                 }
                 else
                 {
-                    i--;
-                    j--;
-                    yield return new KeyValuePair<int, int>(i, j);
+                    Array.Copy(otherVArray._array, -copyDelta, _array, 0, _array.Length);
+                }
+            }
+
+            public int this[int index]
+            {
+                get
+                {
+                    return _array[index + Offset];
+                }
+                set
+                {
+                    _array[index + Offset] = value;
+                }
+            }
+
+            private int Offset
+            {
+                get
+                {
+                    return _array.Length / 2;
                 }
             }
         }
 
+        protected abstract bool ItemsEqual(TSequence oldSequence, int oldIndex, TSequence newSequence, int newIndex);
+
+        // TODO: Consolidate return types between GetMatchingPairs and GetEdit to avoid duplicated code (https://github.com/dotnet/roslyn/issues/16864)
+        protected IEnumerable<KeyValuePair<int, int>> GetMatchingPairs(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
+        {
+            Stack<VArray> stackOfVs = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
+
+            int x = oldLength;
+            int y = newLength;
+
+            while (x > 0 || y > 0)
+            {
+                VArray currentV = stackOfVs.Pop();
+                int d = stackOfVs.Count;
+                int k = x - y;
+
+                // "snake" == single delete or insert followed by 0 or more diagonals
+                // snake end point is in V
+                int yEnd = currentV[k];
+                int xEnd = yEnd + k;
+
+                // does the snake first go down (insert) or right(delete)?
+                bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                int kPrev = right ? k - 1 : k + 1;
+
+                // snake start point
+                int yStart = currentV[kPrev];
+                int xStart = yStart + kPrev;
+
+                // snake mid point
+                int yMid = right ? yStart : yStart + 1;
+                int xMid = yMid + k;
+
+                // return the matching pairs between (xMid, yMid) and (xEnd, yEnd) = diagonal part of the snake
+                while (xEnd > xMid)
+                {
+                    Debug.Assert(yEnd > yMid);
+                    xEnd--;
+                    yEnd--;
+                    yield return new KeyValuePair<int, int>(xEnd, yEnd);
+                }
+
+                x = xStart;
+                y = yStart;
+            }
+
+        }
+
         protected IEnumerable<SequenceEdit> GetEdits(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            int[,] d = ComputeCostMatrix(oldSequence, oldLength, newSequence, newLength);
-            int i = oldLength;
-            int j = newLength;
+            Stack<VArray> stackOfVs = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
 
-            while (i != 0 && j != 0)
-            {
-                if (d[i, j] == d[i - 1, j] + DeleteCost)
-                {
-                    i--;
-                    yield return new SequenceEdit(i, -1);
-                }
-                else if (d[i, j] == d[i, j - 1] + InsertCost)
-                {
-                    j--;
-                    yield return new SequenceEdit(-1, j);
-                }
-                else
-                {
-                    i--;
-                    j--;
-                    yield return new SequenceEdit(i, j);
-                }
-            }
+            int x = oldLength;
+            int y = newLength;
 
-            while (i > 0)
+            while (x > 0 || y > 0)
             {
-                i--;
-                yield return new SequenceEdit(i, -1);
-            }
+                VArray currentV = stackOfVs.Pop();
+                int d = stackOfVs.Count;
+                int k = x - y;
 
-            while (j > 0)
-            {
-                j--;
-                yield return new SequenceEdit(-1, j);
+                // "snake" == single delete or insert followed by 0 or more diagonals
+                // snake end point is in V
+                int yEnd = currentV[k];
+                int xEnd = yEnd + k;
+
+                // does the snake first go down (insert) or right(delete)?
+                bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                int kPrev = right ? k - 1 : k + 1;
+
+                // snake start point
+                int yStart = currentV[kPrev];
+                int xStart = yStart + kPrev;
+
+                // snake mid point
+                int yMid = right ? yStart : yStart + 1;
+                int xMid = yMid + k;
+
+                // return the matching pairs between (xMid, yMid) and (xEnd, yEnd) = diagonal part of the snake
+                while (xEnd > xMid)
+                {
+                    Debug.Assert(yEnd > yMid);
+                    xEnd--;
+                    yEnd--;
+                    yield return new SequenceEdit(xEnd, yEnd);
+                }
+
+                // return the insert/delete between (xStart, yStart) and (xMid, yMid) = the vertical/horizontal part of the snake
+                if (xMid > 0 || yMid > 0)
+                {
+                    if (xStart == xMid)
+                    {
+                        // insert
+                        yield return new SequenceEdit(-1, --yMid);
+                    }
+                    else
+                    {
+                        // delete
+                        yield return new SequenceEdit(--xMid, -1);
+                    }
+                }
+
+                x = xStart;
+                y = yStart;
             }
         }
 
@@ -121,57 +202,101 @@ namespace Microsoft.CodeAnalysis.Differencing
         }
 
         /// <summary>
-        /// Calculates costs of all paths in an edit graph starting from vertex (0,0) and ending in vertex (lengthA, lengthB). 
+        /// Calculates a list of "V arrays" using Eugene W. Myers O(ND) Difference Algoritm
         /// </summary>
         /// <remarks>
-        /// The edit graph for A and B has a vertex at each point in the grid (i,j), i in [0, lengthA] and j in [0, lengthB].
         /// 
+        /// The algorithm was inspired by Myers' Diff Algorithm described in an article by Nicolas Butler:
+        /// https://www.codeproject.com/articles/42279/investigating-myers-diff-algorithm-part-of
+        /// The author has approved the use of his code from the article under the Apache 2.0 license.
+        /// 
+        /// The algorithm works on an imaginary edit graph for A and B which has a vertex at each point in the grid(i, j), i in [0, lengthA] and j in [0, lengthB].
         /// The vertices of the edit graph are connected by horizontal, vertical, and diagonal directed edges to form a directed acyclic graph.
         /// Horizontal edges connect each vertex to its right neighbor. 
         /// Vertical edges connect each vertex to the neighbor below it.
         /// Diagonal edges connect vertex (i,j) to vertex (i-1,j-1) if <see cref="ItemsEqual"/>(sequenceA[i-1],sequenceB[j-1]) is true.
         /// 
-        /// Editing starts with S = []. 
-        /// Move along horizontal edge (i-1,j)-(i,j) represents the fact that sequenceA[i-1] is not added to S.
-        /// Move along vertical edge (i,j-1)-(i,j) represents an insert of sequenceB[j-1] to S.
-        /// Move along diagonal edge (i-1,j-1)-(i,j) represents an addition of sequenceB[j-1] to S via an acceptable 
-        /// change of sequenceA[i-1] to sequenceB[j-1].
+        /// Move right along horizontal edge (i-1,j)-(i,j) represents a delete of sequenceA[i-1].
+        /// Move down along vertical edge (i,j-1)-(i,j) represents an insert of sequenceB[j-1].
+        /// Move along diagonal edge (i-1,j-1)-(i,j) represents an match of sequenceA[i-1] to sequenceB[j-1].
+        /// The number of diagonal edges on the path from (0,0) to (lengthA, lengthB) is the length of the longest common sub.
+        ///
+        /// The function does not actually allocate this graph. Instead it uses Eugene W. Myers' O(ND) Difference Algoritm to calculate a list of "V arrays" and returns it in a Stack. 
+        /// A "V array" is a list of end points of so called "snakes". 
+        /// A "snake" is a path with a single horizontal (delete) or vertical (insert) move followed by 0 or more diagonals (matching pairs).
         /// 
-        /// In every vertex the cheapest outgoing edge is selected. 
-        /// The number of diagonal edges on the path from (0,0) to (lengthA, lengthB) is the length of the longest common subsequence.
+        /// Unlike the algorithm in the article this implementation stores 'y' indexes and prefers 'right' moves instead of 'down' moves in ambiguous situations
+        /// to preserve the behavior of the original diff algorithm (deletes first, inserts after).
+        /// 
+        /// The number of items in the list is the length of the shortest edit script = the number of inserts/edits between the two sequences = D. 
+        /// The list can be used to determine the matching pairs in the sequences (GetMatchingPairs method) or the full editing script (GetEdits method).
+        /// 
+        /// The algorithm uses O(ND) time and memory where D is the number of delete/inserts and N is the sum of lengths of the two sequences.
+        /// 
+        /// VArrays store just the y index because x can be calculated: x = y + k.
         /// </remarks>
-        private int[,] ComputeCostMatrix(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
+        private Stack<VArray> ComputeEditPaths(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            var la = oldLength + 1;
-            var lb = newLength + 1;
+            Stack<VArray> stackOfVs = new Stack<VArray>();
 
-            // TODO: Optimization possible: O(ND) time, O(N) space
-            // EUGENE W. MYERS: An O(ND) Difference Algorithm and Its Variations
-            var d = new int[la, lb];
+            // special-case: the first "snake" to start at (-1,0 )
+            VArray previousV = new VArray(1);
+            VArray currentV;
 
-            d[0, 0] = 0;
-            for (int i = 1; i <= oldLength; i++)
+            bool reachedEnd= false;
+
+            for (int d = 0; d <= oldLength + newLength && !reachedEnd; d++)
             {
-                d[i, 0] = d[i - 1, 0] + DeleteCost;
-            }
-
-            for (int j = 1; j <= newLength; j++)
-            {
-                d[0, j] = d[0, j - 1] + InsertCost;
-            }
-
-            for (int i = 1; i <= oldLength; i++)
-            {
-                for (int j = 1; j <= newLength; j++)
+                // V is in range [-d...d] => use d to offset the k-based array indices to non-negative values
+                if (d == 0)
                 {
-                    int m1 = d[i - 1, j - 1] + (ItemsEqual(oldSequence, i - 1, newSequence, j - 1) ? 0 : UpdateCost);
-                    int m2 = d[i - 1, j] + DeleteCost;
-                    int m3 = d[i, j - 1] + InsertCost;
-                    d[i, j] = Math.Min(Math.Min(m1, m2), m3);
+                    currentV = previousV;
                 }
-            }
+                else
+                {
+                    currentV = new VArray(d);
+                    currentV.CopyFrom(previousV);
+                }
 
-            return d;
+                for (int k = -d; k <= d; k += 2)
+                {
+                    // down or right? 
+                    bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                    int kPrev = right ? k - 1 : k + 1;
+
+                    // start point
+                    int yStart = currentV[kPrev];
+                    int xStart = yStart + kPrev;
+
+                    // mid point
+                    int yMid = right ? yStart : yStart + 1;
+                    int xMid = yMid + k;
+
+                    // end point
+                    int xEnd = xMid;
+                    int yEnd = yMid;
+
+                    // follow diagonal
+                    while (xEnd < oldLength && yEnd < newLength && ItemsEqual(oldSequence, xEnd, newSequence, yEnd))
+                    {
+                        xEnd++;
+                        yEnd++;
+                    }
+
+                    // save end point
+                    currentV[k] = yEnd;
+                    Debug.Assert(xEnd == yEnd + k);
+
+                    // check for solution
+                    if (xEnd >= oldLength && yEnd >= newLength)
+                    {
+                        reachedEnd = true;
+                    }
+                }
+                stackOfVs.Push(currentV);
+                previousV = currentV;
+            }
+            return stackOfVs;
         }
     }
 }

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.0, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.0);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
         }
 
 
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.75, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(1.0, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.75, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.6, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.4, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
         }
 
         [Fact]
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.556, lcs.ComputeDistance(str1, str2), precision: 3);
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.556, 3);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.6, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.429, lcs.ComputeDistance(str1, str2), precision: 3);
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.429, 3);
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
-            Assert.Equal(0.5, lcs.ComputeDistance(str1, str2));
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -67,8 +67,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependentTypeFinderTests.cs" />
-    <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
-    <Compile Include="Differencing\LongestCommonSubsequenceTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="ExtensionOrdererTests.cs" />
     <Compile Include="Host\WorkspaceServices\TestProjectCacheService.cs" />

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -67,6 +67,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependentTypeFinderTests.cs" />
+    <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
+    <Compile Include="Differencing\LongestCommonSubsequenceTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="ExtensionOrdererTests.cs" />
     <Compile Include="Host\WorkspaceServices\TestProjectCacheService.cs" />


### PR DESCRIPTION
* Add tests for LongestCommonSubsequence class

* Add more tests for LongestCommonSubsequence

* Reduce memory consumption of LongestCommonSubsequence

Changed implementation of LongestCommonSubsequence to use a less memory-intensive algorithm.
The old algorithm allocated O(oldSequence.Length * newSequence.Length) of memory.
The new algorithm is O((oldSequence.Length + newSequence.Length) * (# of inserts and deletes))
in both time and space.

Modified LongestCommonSubsequenceTest to use string compare.

Fixes issue #9497

* Changed VArray to struct and other code review feedback changes

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
