### PR TITLE
Removing the rename command target from Roslyn as it will be part of core editor platform

### DIFF
--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -361,11 +361,6 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_SNIPPETS" />
     </CommandPlacement>
 
-    <!-- Add Rename to the editor context menu below the Refactor item. -->
-    <CommandPlacement guid="guidVSStd2K" id="ECMD_RENAME" priority="0x0150">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_LANGUAGE"/>
-    </CommandPlacement>
-
     <!-- Analyzer node entries -->
     <CommandPlacement guid="guidVSStd97" id="cmdidPropSheetOrProperties" priority="200">
       <Parent guid="guidRoslynGrpId" id="grpAnalyzerProperties" />


### PR DESCRIPTION
<details>

Roslyn currently includes a command placement for Rename command it its package so the rename command would show up in editor context menu.  However, rename should/will be part of Core Editor platform. The change to add this in core editor is [here](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/98591?_a=overview)

### Customer scenario
Customer should not see any change 

### Bugs this fixes

[Link](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_queries/edit/535999/?triage=true)

### Workarounds, if any

None

### Risk

None
### Performance impact

None
### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

</details>
