### PR TITLE
UseInferredMemberName: only field initializers in anonymous object creation

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -40,6 +40,21 @@ End Class
         End Function
 
         <Fact>
+        <WorkItem(23659, "https://github.com/dotnet/roslyn/issues/23659")>
+        Public Async Function TestBug() As Task
+            Await TestMissingAsync(
+"
+Public Class C
+    Public Property P As Integer
+
+    Sub M(p As Integer)
+        Dim f = New C With { [|.P|] = p }
+    End Sub
+End Class
+", New TestParameters(s_parseOptions))
+        End Function
+
+        <Fact>
         Public Async Function TestInferredTupleName2() As Task
             Await TestAsync(
 "

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -41,7 +41,7 @@ End Class
 
         <Fact>
         <WorkItem(23659, "https://github.com/dotnet/roslyn/issues/23659")>
-        Public Async Function TestBug() As Task
+        Public Async Function TestMissingForObjectCreation() As Task
             Await TestMissingAsync(
 "
 Public Class C

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -62,6 +62,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
 
         Private Sub ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
                                               optionSet As OptionSet, syntaxTree As SyntaxTree)
+            If Not fieldInitializer.Parent.Parent.IsKind(SyntaxKind.AnonymousObjectCreationExpression) Then
+                Return
+            End If
 
             If Not optionSet.GetOption(CodeStyleOptions.PreferInferredAnonymousTypeMemberNames, context.Compilation.Language).Value OrElse
                 Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer) Then


### PR DESCRIPTION
…should trigger

### Customer scenario
The VB InferredMemberNames analyzer should not trigger on field initializers in object creation, only in anonymous object creation.

```
Dim f = New Foo With {
    .Bar = bar ' <-- Incorrect suggestion to use inferred member name
}
```

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23659

### Workarounds, if any
Don't invoke the fixer.

### Risk
### Performance impact
Low. The fix is localized to the VB InferredMemberName analyzer. Just adding a check.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customers.