### PR TITLE
Suppress analyzer for properties with explicit interface implementation

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -22,12 +22,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
         protected override bool SupportsPropertyInitializer(Compilation compilation)
             => ((CSharpCompilation)compilation).LanguageVersion >= LanguageVersion.CSharp6;
 
+        protected override bool CanExplicitInterfaceImplementationsBeFixed()
+            => false;
+
         protected override void AnalyzeCompilationUnit(
             SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults)
             => AnalyzeMembers(context, ((CompilationUnitSyntax)root).Members, analysisResults);
 
         private void AnalyzeMembers(
-            SemanticModelAnalysisContext context, 
+            SemanticModelAnalysisContext context,
             SyntaxList<MemberDeclarationSyntax> members,
             List<AnalysisResult> analysisResults)
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -1003,7 +1003,7 @@ partial class Class
 
         [WorkItem(23735, "https://github.com/dotnet/roslyn/issues/23735")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
-        public async Task ExplicitInterfaceImplementation()
+        public async Task ExplicitInterfaceImplementationGetterOnly()
         {
             await TestMissingInRegularAndScriptAsync(@"
 namespace RoslynSandbox
@@ -1025,6 +1025,36 @@ namespace RoslynSandbox
         object IFoo.Bar
         {
             get { return bar; }
+        }
+    }
+}");
+        }
+
+        [WorkItem(23735, "https://github.com/dotnet/roslyn/issues/23735")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task ExplicitInterfaceImplementationGetterAndSetter()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+namespace RoslynSandbox
+{
+    public interface IFoo
+    {
+        object Bar { get; set; }
+    }
+
+    class Foo : IFoo
+    {
+        public Foo(object bar)
+        {
+            this.bar = bar;
+        }
+
+        object [|bar|];
+
+        object IFoo.Bar
+        {
+            get { return bar; }
+            set { bar = value; }
         }
     }
 }");

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -1000,5 +1000,34 @@ partial class Class
     int Q { get; }
 }", fixAllActionEquivalenceKey: FeaturesResources.Use_auto_property);
         }
+
+        [WorkItem(23735, "https://github.com/dotnet/roslyn/issues/23735")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task ExplicitInterfaceImplementation()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+namespace RoslynSandbox
+{
+    public interface IFoo
+    {
+        object Bar { get; }
+    }
+
+    class Foo : IFoo
+    {
+        public Foo(object bar)
+        {
+            this.bar = bar;
+        }
+
+        readonly object [|bar|];
+
+        object IFoo.Bar
+        {
+            get { return bar; }
+        }
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
+++ b/src/EditorFeatures/VisualBasic/UseAutoProperty/UseAutoPropertyAnalyzer.vb
@@ -21,6 +21,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UseAutoProperty
             Return DirectCast(compilation, VisualBasicCompilation).LanguageVersion >= LanguageVersion.VisualBasic10
         End Function
 
+        Protected Overrides Function CanExplicitInterfaceImplementationsBeFixed() As Boolean
+            Return True
+        End Function
+
         Protected Overrides Sub AnalyzeCompilationUnit(context As SemanticModelAnalysisContext, root As SyntaxNode, analysisResults As List(Of AnalysisResult))
             AnalyzeMembers(context, DirectCast(root, CompilationUnitSyntax).Members, analysisResults)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -557,7 +557,7 @@ End Class")
         <WorkItem(23735, "https://github.com/dotnet/roslyn/issues/23735")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
         Public Async Function ExplicitInterfaceImplementation() As Task
-            Await TestMissingInRegularAndScriptAsync("
+            Await TestInRegularAndScriptAsync("
 Namespace RoslynSandbox
     Public Interface IFoo
         ReadOnly Property Bar() As Object
@@ -576,6 +576,23 @@ Namespace RoslynSandbox
 
         Public Sub New(bar As Object)
             _bar = bar
+        End Sub
+    End Class
+End Namespace
+",
+"
+Namespace RoslynSandbox
+    Public Interface IFoo
+        ReadOnly Property Bar() As Object
+    End Interface
+
+    Friend Class Foo
+        Implements IFoo
+
+		Private ReadOnly Property Bar() As Object Implements IFoo.Bar
+
+        Public Sub New(bar As Object)
+            Me.Bar = bar
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -581,7 +581,5 @@ Namespace RoslynSandbox
 End Namespace
 ")
         End Function
-
-
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -553,5 +553,35 @@ end class")
     Public Property [|P|] As Integer
 End Class")
         End Function
+
+        <WorkItem(23735, "https://github.com/dotnet/roslyn/issues/23735")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)>
+        Public Async Function ExplicitInterfaceImplementation() As Task
+            Await TestMissingInRegularAndScriptAsync("
+Namespace RoslynSandbox
+    Public Interface IFoo
+        ReadOnly Property Bar() As Object
+    End Interface
+
+    Friend Class Foo
+        Implements IFoo
+
+        Private [|_bar|] As Object
+
+		Private ReadOnly Property Bar() As Object Implements IFoo.Bar
+            Get
+                Return _bar
+            End Get
+        End Property
+
+        Public Sub New(bar As Object)
+            _bar = bar
+        End Sub
+    End Class
+End Namespace
+")
+        End Function
+
+
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         protected abstract void AnalyzeCompilationUnit(SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults);
         protected abstract bool SupportsReadOnlyProperties(Compilation compilation);
         protected abstract bool SupportsPropertyInitializer(Compilation compilation);
+        protected abstract bool CanExplicitInterfaceImplementationsBeFixed();
         protected abstract TExpression GetFieldInitializer(TVariableDeclarator variable, CancellationToken cancellationToken);
         protected abstract TExpression GetGetterExpression(IMethodSymbol getMethod, CancellationToken cancellationToken);
         protected abstract TExpression GetSetterExpression(IMethodSymbol setMethod, SemanticModel semanticModel, CancellationToken cancellationToken);
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 return;
             }
 
-            if (property.ExplicitInterfaceImplementations.Length != 0)
+            if (!CanExplicitInterfaceImplementationsBeFixed() && property.ExplicitInterfaceImplementations.Length != 0)
             {
                 return;
             }

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -113,6 +113,11 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 return;
             }
 
+            if (property.ExplicitInterfaceImplementations.Length != 0)
+            {
+                return;
+            }
+
             var containingType = property.ContainingType;
             if (containingType == null)
             {


### PR DESCRIPTION
### Customer scenario

"Use auto property" code fix is provided for properties explicit interface implementations. The code fix generated invalid code. This fix suppress the code fixer for those properties.

### Bugs this fixes

Fixes #23735 

### Workarounds, if any

Don't use the code fix.

### Risk

Low.

### Performance impact

The change causes an allocation of an immutable array on each "AnalyzeProperty" run.

### Is this a regression from a previous update?

No.

### Root cause analysis

Case wasn't covered by unit tests.

### How was the bug found?

Customer reported

### Test documentation updated?

No.

### Remark

As discussed in https://github.com/dotnet/roslyn/issues/23735#issuecomment-351719968 there are cases where the analyzer actually could fix explicit implemented properties too, but this would probably do more harm than good. It would only work for read/write properties and every access to the backing field needs to be replaced by a cast to the interface:

```C#
namespace RoslynSandbox
{
    public interface IFoo
    {
        object Bar
        {
            get;
            set;
        }
    }
    internal class Foo : IFoo
    {
        private object bar;

        object IFoo.Bar
        {
            get
            {
                return this.bar;
            }
            set
            {
                this.bar = value;
            }
        }

        private void M()
        {
            this.bar = null;
        }
    }
}
```

```C#
namespace RoslynSandbox
{
    public interface IFoo
    {
        object Bar
        {
            get;
            set;
        }
    }
    internal class Foo : IFoo
    {
        object IFoo.Bar
        {
            get;
            set;
        }

        private void M()
        {
            ((IFoo)this).Bar = null;
        }
    }
}
```

