### PR TITLE
Fix publish-assets.ps1 to call the right helper function

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -147,7 +147,7 @@ function Normalize-BranchName([string]$branchName) {
 
 try {
     . (Join-Path $PSScriptRoot "..\..\..\build\scripts\build-utils.ps1")
-    $dotnet = Ensure-DotnetExe
+    $dotnet = Ensure-DotnetSdk
     $nugetDir = Join-Path $configDir "NuGet"
 
     if ($configDir -eq "") {


### PR DESCRIPTION
Ensure-DotnetExe should be Ensure-DotnetSdk.