### PR TITLE
Remove vs-integration tests from master-vs-deps branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -214,27 +214,6 @@ commitPullList.each { isPr ->
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 
-// VS Integration Tests
-commitPullList.each { isPr ->
-  ['debug', 'release'].each { configuration ->
-    ['vs-integration'].each { buildTarget ->
-      def jobName = Utilities.getFullJobName(projectName, "windows_${configuration}_${buildTarget}", isPr)
-      def myJob = job(jobName) {
-        description("Windows ${configuration} tests on ${buildTarget}")
-        steps {
-          batchFile(""".\\build\\scripts\\cibuild.cmd ${(configuration == 'debug') ? '-debug' : '-release'} -testVsi""")
-        }
-      }
-
-      def triggerPhraseOnly = false
-      def triggerPhraseExtra = ""
-      Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-dev15-3')
-      Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
-      addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
-    }
-  }
-}
-
 JobReport.Report.generateJobReport(out)
 
 // Make the call to generate the help job


### PR DESCRIPTION
The tests are dependent on 15.5 but this branch has been updated to 15.6 so the tests are now failing.  Removing until they are fixed.
