### PR TITLE
Remove obsolete duplicate APIs from type symbols.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case TypeKind.TypeParameter:
                         return false;
                     case TypeKind.Array:
-                        type = ((ArrayTypeSymbol)type).BaseType;
+                        type = ((ArrayTypeSymbol)type).BaseTypeNoUseSiteDiagnostics;
                         continue;
                     default:
                         return true;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     NamedTypeSymbol eventRegistrationTokenTable_T = ((PEModuleSymbol)(this.ContainingModule)).EventRegistrationTokenTable_T;
                     if (eventRegistrationTokenTable_T == candidateAssociatedFieldType.OriginalDefinition &&
-                        _eventType == ((NamedTypeSymbol)candidateAssociatedFieldType).TypeArguments[0])
+                        _eventType == ((NamedTypeSymbol)candidateAssociatedFieldType).TypeArgumentsNoUseSiteDiagnostics[0])
                     {
                         return candidateAssociatedField;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -48,19 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract ImmutableArray<TypeParameterSymbol> TypeParameters { get; }
 
         /// <summary>
-        /// Returns the type arguments that have been substituted for the type parameters. 
-        /// If nothing has been substituted for a give type parameters,
-        /// then the type parameter itself is consider the type argument.
-        /// </summary>
-        public ImmutableArray<TypeSymbol> TypeArguments
-        {
-            get
-            {
-                return TypeArgumentsNoUseSiteDiagnostics;
-            }
-        }
-
-        /// <summary>
         /// Returns custom modifiers for the type argument that has been substituted for the type parameter. 
         /// The modifiers correspond to the type argument at the same ordinal within the <see cref="TypeArgumentsNoUseSiteDiagnostics"/>
         /// array.
@@ -79,6 +66,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool HasTypeArgumentsCustomModifiers { get; }
 
+        /// <summary>
+        /// Returns the type arguments that have been substituted for the type parameters. 
+        /// If nothing has been substituted for a give type parameters,
+        /// then the type parameter itself is consider the type argument.
+        /// </summary>
         internal abstract ImmutableArray<TypeSymbol> TypeArgumentsNoUseSiteDiagnostics { get; }
 
         internal ImmutableArray<TypeSymbol> TypeArgumentsWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
             {
-                if (ContainingType.BaseType is MissingMetadataTypeSymbol)
+                if (ContainingType.BaseTypeNoUseSiteDiagnostics is MissingMetadataTypeSymbol)
                 {
                     // System_Attribute is missing. Don't generate anything
                     return;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var regularElements = Math.Min(currentType.Arity, TupleTypeSymbol.RestPosition - 1);
-                tupleElementTypes.AddRange(currentType.TypeArguments, regularElements);
+                tupleElementTypes.AddRange(currentType.TypeArgumentsNoUseSiteDiagnostics, regularElements);
 
                 if (currentType.Arity == TupleTypeSymbol.RestPosition)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -71,14 +71,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Duplicates and cycles are removed, although the collection may include
         /// redundant constraints where one constraint is a base type of another.
         /// </summary>
-        public ImmutableArray<TypeSymbol> ConstraintTypes
-        {
-            get
-            {
-                return this.ConstraintTypesNoUseSiteDiagnostics;
-            }
-        }
-
         internal ImmutableArray<TypeSymbol> ConstraintTypesNoUseSiteDiagnostics
         {
             get
@@ -255,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
+        internal sealed override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved = null)
         {
             return ImmutableArray<NamedTypeSymbol>.Empty;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -145,14 +145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// (for example, interfaces), null is returned. Also the special class System.Object
         /// always has a BaseType of null.
         /// </summary>
-        public NamedTypeSymbol BaseType
-        {
-            get
-            {
-                return BaseTypeNoUseSiteDiagnostics;
-            }
-        }
-
         internal abstract NamedTypeSymbol BaseTypeNoUseSiteDiagnostics { get; }
 
         internal NamedTypeSymbol BaseTypeWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -184,14 +176,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Gets the set of interfaces that this type directly implements. This set does not include
         /// interfaces that are base interfaces of directly implemented interfaces.
         /// </summary>
-        public ImmutableArray<NamedTypeSymbol> Interfaces
-        {
-            get
-            {
-                return InterfacesNoUseSiteDiagnostics();
-            }
-        }
-
         internal abstract ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved = null);
 
         /// <summary>
@@ -207,14 +191,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Note: When interfaces specified on the same inheritance level differ by tuple names only,
         /// only the last one will be listed here.
         /// </summary>
-        public ImmutableArray<NamedTypeSymbol> AllInterfaces
-        {
-            get
-            {
-                return AllInterfacesNoUseSiteDiagnostics;
-            }
-        }
-
         internal ImmutableArray<NamedTypeSymbol> AllInterfacesNoUseSiteDiagnostics
         {
             get

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -327,7 +327,7 @@ public class RefersToLibAttribute : C
             Assert.Equal("System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(C))", attribute.ToString());
 
             var derived = (NamedTypeSymbol)newLibComp.GetMember("Derived");
-            var c = derived.BaseType; // get C
+            var c = derived.BaseType(); // get C
             Assert.Equal("C", c.ToTestDisplayString());
             Assert.False(c.IsErrorType());
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Dynamic.cs
@@ -166,41 +166,41 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 ValidateDynamicAttribute(_base2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Derived<T> : Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>
-                Assert.True(_derivedClass.BaseType.ContainsDynamic());
+                Assert.True(_derivedClass.BaseType().ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 0B 00 00 00 * 00 01 00 00 01 00 00 01 00 01 01 * 00 00 )
                 _expectedTransformFlags = new bool[] { false, true, false, false, true, false, false, true, false, true, true };
                 ValidateDynamicAttribute(_derivedClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Outer<T> : Base1<dynamic>
-                Assert.True(_outerClass.BaseType.ContainsDynamic());
+                Assert.True(_outerClass.BaseType().ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
                 ValidateDynamicAttribute(_outerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Inner<U, V> : Base2<dynamic, V>
-                Assert.True(_innerClass.BaseType.ContainsDynamic());
+                Assert.True(_innerClass.BaseType().ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 03 00 00 00 * 00 01 00 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true, false };
                 ValidateDynamicAttribute(_innerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class InnerInner<W> : Base1<dynamic> { }
-                Assert.True(_innerInnerClass.BaseType.ContainsDynamic());
+                Assert.True(_innerInnerClass.BaseType().ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
                 ValidateDynamicAttribute(_innerInnerClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Outer2<T> : Base1<dynamic>
-                Assert.True(_outer2Class.BaseType.ContainsDynamic());
+                Assert.True(_outer2Class.BaseType().ContainsDynamic());
                 //   .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 02 00 00 00 * 00 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, true };
                 ValidateDynamicAttribute(_outer2Class.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
 
                 // public class Inner2<U, V> : Base0
-                Assert.False(_inner2Class.BaseType.ContainsDynamic());
+                Assert.False(_inner2Class.BaseType().ContainsDynamic());
                 ValidateDynamicAttribute(_inner2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class InnerInner2<W> : Base0 { }
-                Assert.False(_innerInner2Class.BaseType.ContainsDynamic());
+                Assert.False(_innerInner2Class.BaseType().ContainsDynamic());
                 ValidateDynamicAttribute(_innerInner2Class.GetAttributes(), expectedDynamicAttribute: false);
 
                 // public class Inner3<U>
@@ -434,7 +434,7 @@ public delegate dynamic[] MyDelegate(dynamic[] x);
                 // .custom instance void [System.Core]System.Runtime.CompilerServices.DynamicAttribute::.ctor(bool[]) = ( 01 00 14 00 00 00 * 00 00 00 00 00 00 00 01 00 00 01 00 00 01 00 00 00 00 01 01 * 00 00 ) 
                 _expectedTransformFlags = new bool[] { false, false, false, false, false, false, false, true, false, false, true, false, false, true, false, false, false, false, true, true };
                 Assert.False(_unsafeClass.ContainsDynamic());
-                Assert.True(_unsafeClass.BaseType.ContainsDynamic());
+                Assert.True(_unsafeClass.BaseType().ContainsDynamic());
                 ValidateDynamicAttribute(_unsafeClass.GetAttributes(), expectedDynamicAttribute: true, expectedTransformFlags: _expectedTransformFlags);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -244,7 +244,7 @@ class C
                 var srcType = srcTypes[i];
                 var peType = peTypes[i];
 
-                Assert.Equal(ToTestString(srcType.BaseType), ToTestString(peType.BaseType));
+                Assert.Equal(ToTestString(srcType.BaseType()), ToTestString(peType.BaseType()));
 
                 var srcMembers = srcType.GetMembers()
                     .Where(m => !m.Name.Contains("k__BackingField"))
@@ -272,7 +272,7 @@ class C
                     break;
                 case SymbolKind.NamedType:
                     var namedType = (NamedTypeSymbol)symbol;
-                    typeSymbols.Add(namedType.BaseType ?? namedType);
+                    typeSymbols.Add(namedType.BaseType() ?? namedType);
                     break;
                 case SymbolKind.Field:
                     typeSymbols.Add(((FieldSymbol)symbol).Type);
@@ -399,7 +399,7 @@ class C
                 ValidateTupleNameAttribute(_base2Class.GetAttributes(), expectedTupleNamesAttribute: false);
 
                 // public class Outer<T> : Base1<(int key, int val)>
-                Assert.True(_outerClass.BaseType.ContainsTuple());
+                Assert.True(_outerClass.BaseType().ContainsTuple());
                 var expectedElementNames = new[] { "key", "val" };
                 ValidateTupleNameAttribute(_outerClass.GetAttributes(),
                     expectedTupleNamesAttribute: true,
@@ -473,7 +473,7 @@ class C
                 var field6Type = Assert.IsType<ConstructedNamedTypeSymbol>(field6.Type);
                 Assert.Equal("Base1", field6Type.Name);
                 Assert.Equal(1, field6Type.TypeParameters.Length);
-                var firstTuple = field6Type.TypeArguments.Single();
+                var firstTuple = field6Type.TypeArguments().Single();
                 Assert.True(firstTuple.IsTupleType);
                 Assert.True(firstTuple.TupleElementNames.IsDefault);
                 Assert.Equal(2, firstTuple.TupleElementTypes.Length);
@@ -923,8 +923,8 @@ public interface I3<T>
                 void verifyTupleImpls(NamedTypeSymbol t, string[] tupleNames)
                 {
                     var typeParam = t.TypeParameters.Single();
-                    var constraint = (NamedTypeSymbol)typeParam.ConstraintTypes.Single();
-                    var typeArg = constraint.TypeArguments.Single();
+                    var constraint = (NamedTypeSymbol)typeParam.ConstraintTypes().Single();
+                    var typeArg = constraint.TypeArguments().Single();
                     Assert.True(typeArg.IsTupleType);
                     Assert.Equal(tupleNames, typeArg.TupleElementNames);
                 }
@@ -1022,8 +1022,8 @@ public interface I3 : I1<(int c, int d)> {}";
 
                 void VerifyTupleImpls(NamedTypeSymbol t, string[] tupleNames)
                 {
-                    var interfaceImpl = t.Interfaces.Single();
-                    var typeArg = interfaceImpl.TypeArguments.Single();
+                    var interfaceImpl = t.Interfaces().Single();
+                    var typeArg = interfaceImpl.TypeArguments().Single();
                     Assert.True(typeArg.IsTupleType);
                     Assert.Equal(tupleNames, typeArg.TupleElementNames);
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -587,7 +587,7 @@ public class C
                 {
                     Assert.Equal(Accessibility.Private, container.DeclaredAccessibility);
                     Assert.True(container.IsStatic);
-                    Assert.Equal(SpecialType.System_Object, container.BaseType.SpecialType);
+                    Assert.Equal(SpecialType.System_Object, container.BaseType().SpecialType);
                     AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(container.GetAttributes()));
 
                     var members = container.GetMembers();
@@ -823,8 +823,8 @@ public class C
                 Assert.Equal(4, d.TypeParameters.Length);
                 Assert.True(d.IsSealed);
                 Assert.Equal(CharSet.Ansi, d.MarshallingCharSet);
-                Assert.Equal(SpecialType.System_MulticastDelegate, d.BaseType.SpecialType);
-                Assert.Equal(0, d.Interfaces.Length);
+                Assert.Equal(SpecialType.System_MulticastDelegate, d.BaseType().SpecialType);
+                Assert.Equal(0, d.Interfaces().Length);
                 AssertEx.SetEqual(new[] { "CompilerGeneratedAttribute" }, GetAttributeNames(d.GetAttributes()));
 
                 // members:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenImplicitImplementationTests.cs
@@ -771,7 +771,7 @@ class C1 : IBase1, IBase2
             Action<ModuleSymbol> validator = module =>
             {
                 var typeSymbol = module.GlobalNamespace.GetTypeMembers("C1").Single();
-                Assert.True(typeSymbol.Interfaces.All(iface => iface.Name == "IBase" || iface.Name == "IBase1" || iface.Name == "IBase2"));
+                Assert.True(typeSymbol.Interfaces().All(iface => iface.Name == "IBase" || iface.Name == "IBase1" || iface.Name == "IBase2"));
             };
 
             CompileAndVerify(source, sourceSymbolValidator: validator, symbolValidator: validator, expectedSignatures: new[]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterfaceImplementation.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInterfaceImplementation.cs
@@ -2731,9 +2731,9 @@ public class D : B<char>, I<char>
 
             var global = comp.GlobalNamespace;
             var derivedType = global.GetMember<NamedTypeSymbol>("D");
-            var interfaceType = derivedType.Interfaces.Single();
+            var interfaceType = derivedType.Interfaces().Single();
             Assert.Equal(global.GetMember<NamedTypeSymbol>("I"), interfaceType.OriginalDefinition);
-            var baseType = derivedType.BaseType;
+            var baseType = derivedType.BaseType();
             Assert.Equal(global.GetMember<NamedTypeSymbol>("B"), baseType.OriginalDefinition);
 
             var baseMethods = Enumerable.Range(1, 4).Select(i => baseType.GetMember<MethodSymbol>("M" + i)).ToArray();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3858,8 +3858,8 @@ class Program
                 var classB = globalNamespace.GetMember<NamedTypeSymbol>("DerivedNonVirtual");
                 var classC = globalNamespace.GetMember<NamedTypeSymbol>("Derived2Override");
 
-                Assert.Equal(classA, classB.BaseType);
-                Assert.Equal(classB, classC.BaseType);
+                Assert.Equal(classA, classB.BaseType());
+                Assert.Equal(classB, classC.BaseType());
 
                 var methodA = classA.GetMember<MethodSymbol>("M");
                 var methodB = classB.GetMember<MethodSymbol>("M");
@@ -3961,7 +3961,7 @@ class B : A
                 var classA = globalNamespace.GetMember<NamedTypeSymbol>("A");
                 var classB = globalNamespace.GetMember<NamedTypeSymbol>("B");
 
-                Assert.Equal(classA, classB.BaseType);
+                Assert.Equal(classA, classB.BaseType());
 
                 var fooA = classA.GetMember<MethodSymbol>("Foo");
                 var fooB = classB.GetMember<MethodSymbol>("Foo");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -359,11 +359,11 @@ public class C4 : C3
             CompileAndVerify(comp, symbolValidator: m =>
             {
                 var c = m.GlobalNamespace.GetTypeMember("C");
-                Assert.Equal(1, c.Interfaces.Length);
-                NamedTypeSymbol iface = c.Interfaces[0];
+                Assert.Equal(1, c.Interfaces().Length);
+                NamedTypeSymbol iface = c.Interfaces()[0];
                 Assert.True(iface.IsGenericType);
-                Assert.Equal(1, iface.TypeArguments.Length);
-                TypeSymbol typeArg = iface.TypeArguments[0];
+                Assert.Equal(1, iface.TypeArguments().Length);
+                TypeSymbol typeArg = iface.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -371,13 +371,13 @@ public class C4 : C3
                 Assert.Equal(new[] { "key", "val" }, typeArg.TupleElementNames);
 
                 var c2 = m.GlobalNamespace.GetTypeMember("C2");
-                var @base = c2.BaseType;
+                var @base = c2.BaseType();
                 Assert.Equal("Base", @base.Name);
-                Assert.Equal(1, @base.Interfaces.Length);
-                iface = @base.Interfaces[0];
+                Assert.Equal(1, @base.Interfaces().Length);
+                iface = @base.Interfaces()[0];
                 Assert.True(iface.IsGenericType);
-                Assert.Equal(1, iface.TypeArguments.Length);
-                typeArg = iface.TypeArguments[0];
+                Assert.Equal(1, iface.TypeArguments().Length);
+                typeArg = iface.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -385,11 +385,11 @@ public class C4 : C3
                 Assert.Equal(new[] { "x", "y" }, typeArg.TupleElementNames);
 
                 var c3 = m.GlobalNamespace.GetTypeMember("C3");
-                Assert.Equal(2, c3.Interfaces.Length);
-                iface = c3.Interfaces[0];
+                Assert.Equal(2, c3.Interfaces().Length);
+                iface = c3.Interfaces()[0];
                 Assert.True(iface.IsGenericType);
-                Assert.Equal(1, iface.TypeArguments.Length);
-                typeArg = iface.TypeArguments[0];
+                Assert.Equal(1, iface.TypeArguments().Length);
+                typeArg = iface.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -397,11 +397,11 @@ public class C4 : C3
                 Assert.Equal(new[] { "key", "val" }, typeArg.TupleElementNames);
 
                 var d = m.GlobalNamespace.GetTypeMember("C3");
-                Assert.Equal(2, d.Interfaces.Length);
-                iface = d.Interfaces[0];
+                Assert.Equal(2, d.Interfaces().Length);
+                iface = d.Interfaces()[0];
                 Assert.True(iface.IsGenericType);
-                Assert.Equal(1, iface.TypeArguments.Length);
-                typeArg = iface.TypeArguments[0];
+                Assert.Equal(1, iface.TypeArguments().Length);
+                typeArg = iface.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -561,11 +561,11 @@ public struct TestEnumerable : IEnumerable<(int key, int val)>
                 var c = m.GlobalNamespace.GetTypeMember("C");
                 Assert.Equal(1, c.TypeParameters.Length);
                 var param = c.TypeParameters[0];
-                Assert.Equal(1, param.ConstraintTypes.Length);
-                var constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes[0]);
+                Assert.Equal(1, param.ConstraintTypes().Length);
+                var constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes()[0]);
                 Assert.True(constraint.IsGenericType);
-                Assert.Equal(1, constraint.TypeArguments.Length);
-                TypeSymbol typeArg = constraint.TypeArguments[0];
+                Assert.Equal(1, constraint.TypeArguments().Length);
+                TypeSymbol typeArg = constraint.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -577,11 +577,11 @@ public struct TestEnumerable : IEnumerable<(int key, int val)>
                 var c2 = m.GlobalNamespace.GetTypeMember("C2");
                 Assert.Equal(1, c2.TypeParameters.Length);
                 param = c2.TypeParameters[0];
-                Assert.Equal(1, param.ConstraintTypes.Length);
-                constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes[0]);
+                Assert.Equal(1, param.ConstraintTypes().Length);
+                constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes()[0]);
                 Assert.True(constraint.IsGenericType);
-                Assert.Equal(1, constraint.TypeArguments.Length);
-                typeArg = constraint.TypeArguments[0];
+                Assert.Equal(1, constraint.TypeArguments().Length);
+                typeArg = constraint.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
@@ -877,7 +877,7 @@ references: s_valueTupleRefs);
             Assert.Equal(base1, field2Type.OriginalDefinition);
             Assert.True(field2Type.IsGenericType);
 
-            var first = field2Type.TypeArguments[0];
+            var first = field2Type.TypeArguments()[0];
             Assert.True(first.IsTupleType);
             Assert.Equal(1, first.TupleElementTypes.Length);
             Assert.True(first.TupleElementNames.IsDefault);
@@ -3214,7 +3214,7 @@ class C
             AssertTupleTypeEquality(mTuple);
             Assert.False(mTuple.IsImplicitlyDeclared);
             Assert.Equal("Predefined type 'System.ValueTuple`2' is not defined or imported", mTuple.GetUseSiteDiagnostic().GetMessage(CultureInfo.InvariantCulture));
-            Assert.Null(mTuple.BaseType);
+            Assert.Null(mTuple.BaseType());
             Assert.False(((TupleTypeSymbol)mTuple).UnderlyingDefinitionToMemberMap.Any());
 
             var mFirst = (FieldSymbol)mTuple.GetMembers("first").Single();
@@ -10439,7 +10439,7 @@ class C
                          m2Tuple.MemberNames.ToArray());
             Assert.Equal(0, m1Tuple.Arity);
             Assert.True(m1Tuple.TypeParameters.IsEmpty);
-            Assert.Equal("System.ValueType", m1Tuple.BaseType.ToTestDisplayString());
+            Assert.Equal("System.ValueType", m1Tuple.BaseType().ToTestDisplayString());
             Assert.Null(m1Tuple.ComImportCoClass);
             Assert.False(m1Tuple.HasTypeArgumentsCustomModifiers);
             Assert.False(m1Tuple.IsComImport);
@@ -10450,7 +10450,7 @@ class C
             Assert.True(m1Tuple.GetTypeMembers().IsEmpty);
             Assert.True(m1Tuple.GetTypeMembers("C9").IsEmpty);
             Assert.True(m1Tuple.GetTypeMembers("C9", 0).IsEmpty);
-            Assert.Equal(6, m1Tuple.Interfaces.Length);
+            Assert.Equal(6, m1Tuple.Interfaces().Length);
             Assert.Equal(m1Tuple.TupleUnderlyingType.GetEarlyAttributeDecodingMembers().Select(m => m.Name).ToArray(),
                          m1Tuple.GetEarlyAttributeDecodingMembers().Select(m => m.Name).ToArray());
             Assert.Equal("System.Int32 (System.Int32, System.Int32).Item1", m1Tuple.GetEarlyAttributeDecodingMembers("Item1").Single().ToTestDisplayString());
@@ -11699,7 +11699,7 @@ class C
                          m2Tuple.MemberNames.ToArray());
             Assert.Equal(0, m1Tuple.Arity);
             Assert.True(m1Tuple.TypeParameters.IsEmpty);
-            Assert.Equal("System.ValueType", m1Tuple.BaseType.ToTestDisplayString());
+            Assert.Equal("System.ValueType", m1Tuple.BaseType().ToTestDisplayString());
             Assert.Null(m1Tuple.ComImportCoClass);
             Assert.False(m1Tuple.HasTypeArgumentsCustomModifiers);
             Assert.False(m1Tuple.IsComImport);
@@ -11710,7 +11710,7 @@ class C
             Assert.True(m1Tuple.GetTypeMembers().IsEmpty);
             Assert.True(m1Tuple.GetTypeMembers("C9").IsEmpty);
             Assert.True(m1Tuple.GetTypeMembers("C9", 0).IsEmpty);
-            Assert.True(m1Tuple.Interfaces.IsEmpty);
+            Assert.True(m1Tuple.Interfaces().IsEmpty);
             Assert.Equal(m1Tuple.TupleUnderlyingType.GetEarlyAttributeDecodingMembers().Select(m => m.Name).ToArray(),
                          m1Tuple.GetEarlyAttributeDecodingMembers().Select(m => m.Name).ToArray());
             Assert.Equal("System.Int32 (System.Int32, System.Int32).Item1", m1Tuple.GetEarlyAttributeDecodingMembers("Item1").Single().ToTestDisplayString());
@@ -12087,7 +12087,7 @@ partial class C
             AssertTupleTypeEquality(m10Tuple);
 
             Assert.Equal("System.ObsoleteAttribute", m10Tuple.GetAttributes().Single().ToString());
-            Assert.Equal("I1", m10Tuple.Interfaces.Single().ToTestDisplayString());
+            Assert.Equal("I1", m10Tuple.Interfaces().Single().ToTestDisplayString());
 
             var m102Tuple = (NamedTypeSymbol)c.GetMember<MethodSymbol>("M102").ReturnType;
             AssertTupleTypeEquality(m102Tuple);
@@ -13026,7 +13026,7 @@ static class Test4
                          m3TupleArray.ToTestDisplayString());
 
             Assert.Equal("System.Collections.Generic.IList<System.ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, T>>",
-                         m3TupleArray.Interfaces[0].ToTestDisplayString());
+                         m3TupleArray.Interfaces()[0].ToTestDisplayString());
 
             var m3 = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "M3").Single();
             symbolInfo = model.GetSymbolInfo(m3);
@@ -13036,26 +13036,26 @@ static class Test4
                          m3TupleArray.ToTestDisplayString());
 
             Assert.Equal("System.Collections.Generic.IList<(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32)>",
-                         m3TupleArray.Interfaces[0].ToTestDisplayString());
+                         m3TupleArray.Interfaces()[0].ToTestDisplayString());
 
             var m4TupleList = (NamedTypeSymbol)test.GetMember<MethodSymbol>("M4").ReturnType;
-            Assert.False(m4TupleList.TypeArguments[0].IsTupleType);
+            Assert.False(m4TupleList.TypeArguments()[0].IsTupleType);
             Assert.Equal("System.Collections.Generic.List<System.ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, T>>",
                          m4TupleList.ToTestDisplayString());
 
             Assert.Equal("System.Collections.Generic.IList<System.ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, T>>",
-                         m4TupleList.Interfaces[0].ToTestDisplayString());
+                         m4TupleList.Interfaces()[0].ToTestDisplayString());
 
             var m4 = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "M4").Single();
             symbolInfo = model.GetSymbolInfo(m4);
             m4TupleList = (NamedTypeSymbol)((MethodSymbol)symbolInfo.Symbol).ReturnType;
-            Assert.True(m4TupleList.TypeArguments[0].IsTupleType);
+            Assert.True(m4TupleList.TypeArguments()[0].IsTupleType);
             Assert.Equal("System.Collections.Generic.List<(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32)>",
                          m4TupleList.ToTestDisplayString());
 
             var m5 = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "M5").Single();
             symbolInfo = model.GetSymbolInfo(m5);
-            var m5Tuple = ((MethodSymbol)symbolInfo.Symbol).TypeParameters[0].ConstraintTypes.Single();
+            var m5Tuple = ((MethodSymbol)symbolInfo.Symbol).TypeParameters[0].ConstraintTypes().Single();
             Assert.True(m5Tuple.IsTupleType);
             Assert.Equal("(System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32)",
                          m5Tuple.ToTestDisplayString());
@@ -13181,7 +13181,7 @@ interface ITest2<T> : ValueTuple<int, int, int, int, int, int, int, T> where T :
             var v1Type = ((LocalSymbol)symbolInfo.Symbol).Type;
             Assert.Equal("Test1<(System.Int32, System.Int32)>", v1Type.ToTestDisplayString());
 
-            var v1Tuple = v1Type.BaseType;
+            var v1Tuple = v1Type.BaseType();
             Assert.False(v1Tuple.IsTupleType);
             Assert.Equal("System.Object",
                          v1Tuple.ToTestDisplayString());
@@ -13190,7 +13190,7 @@ interface ITest2<T> : ValueTuple<int, int, int, int, int, int, int, T> where T :
             symbolInfo = model.GetSymbolInfo(v2);
             var v2Type = ((LocalSymbol)symbolInfo.Symbol).Type;
             Assert.Equal("ITest2<(System.Int32, System.Int32)>", v2Type.ToTestDisplayString());
-            Assert.True(v2Type.Interfaces.IsEmpty);
+            Assert.True(v2Type.Interfaces().IsEmpty);
         }
 
         [Fact]
@@ -18508,7 +18508,7 @@ public class Derived : Base
             var m3 = comp.GetMember<MethodSymbol>("Derived.M3").ReturnType;
             Assert.Equal("(System.Int32 notA, System.Int32 notB)[]", m3.ToTestDisplayString());
             Assert.Equal(new[] { "System.Collections.Generic.IList<(System.Int32 notA, System.Int32 notB)>" },
-                         m3.Interfaces.SelectAsArray(t => t.ToTestDisplayString()));
+                         m3.Interfaces().SelectAsArray(t => t.ToTestDisplayString()));
         }
 
         [Fact]
@@ -22621,7 +22621,7 @@ class C
                     "System.Collections.Generic.IEnumerable<(System.Int32, System.Int32)>",
                     "System.Collections.Generic.IEnumerable<(System.String a, System.String b)>",
                     "System.Collections.IEnumerable" },
-                collectionSymbol.AllInterfaces.Select(i => i.ToTestDisplayString()));
+                collectionSymbol.AllInterfaces().Select(i => i.ToTestDisplayString()));
 
             CompileAndVerify(comp, expectedOutput: "hello");
         }
@@ -22684,7 +22684,7 @@ class C
                     "System.Collections.Generic.IEnumerable<(System.Int32 a, System.Int32 b)>",
                     "System.Collections.Generic.IEnumerable<T>",
                     "System.Collections.IEnumerable" },
-                derivedSymbol.AllInterfaces.Select(i => i.ToTestDisplayString()));
+                derivedSymbol.AllInterfaces().Select(i => i.ToTestDisplayString()));
 
             var collection = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ElementAt(3);
             var collectionSymbol = (model.GetDeclaredSymbol(collection) as LocalSymbol)?.Type;
@@ -22693,9 +22693,9 @@ class C
             Assert.Equal(new[] {
                     "System.Collections.Generic.IEnumerable<(System.Int32 notA, System.Int32 notB)>",
                     "System.Collections.IEnumerable" },
-                collectionSymbol.AllInterfaces.Select(i => i.ToTestDisplayString()));
+                collectionSymbol.AllInterfaces().Select(i => i.ToTestDisplayString()));
 
-            Assert.Empty(derivedSymbol.AsUnboundGenericType().AllInterfaces);
+            Assert.Empty(derivedSymbol.AsUnboundGenericType().AllInterfaces());
         }
 
         [Fact]
@@ -22765,7 +22765,7 @@ class C
             Assert.Equal(new[] {
                     "System.Collections.Generic.IEnumerable<System.Int32>",
                     "System.Collections.IEnumerable" },
-                collectionSymbol.AllInterfaces.Select(i => i.ToTestDisplayString()));
+                collectionSymbol.AllInterfaces().Select(i => i.ToTestDisplayString()));
         }
 
         [Fact]
@@ -22840,7 +22840,7 @@ class C
                     "System.Collections.Generic.IEnumerable<(System.Int32 a, System.Int32 b)>",
                     "System.Collections.Generic.IEnumerable<(System.String notA, System.String notB)>",
                     "System.Collections.IEnumerable" },
-                collectionSymbol.AllInterfaces.Select(i => i.ToTestDisplayString()));
+                collectionSymbol.AllInterfaces().Select(i => i.ToTestDisplayString()));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -5018,7 +5018,7 @@ public class DerivingClass<T> : BaseClass<T>
                 Assert.False(b.IsErrorType());
                 Assert.Equal("sourceMod.dll", b.ContainingModule.Name);
 
-                var a = b.BaseType;
+                var a = b.BaseType();
                 Assert.Equal("A", a.Name);
                 Assert.False(a.IsErrorType());
                 Assert.Equal("refMod.netmodule", a.ContainingModule.Name);

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTestBase.cs
@@ -62,9 +62,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 elem.Add(new XAttribute("Of", typeParams));
             }
 
-            if (t.BaseType != null)
+            if (t.BaseType() != null)
             {
-                elem.Add(new XAttribute("base", t.BaseType.ToTestDisplayString()));
+                elem.Add(new XAttribute("base", t.BaseType().ToTestDisplayString()));
             }
 
             var fields = t.GetMembers().Where(m => m.Kind == SymbolKind.Field).OrderBy(f => f.Name).Cast<FieldSymbol>();

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -287,9 +287,9 @@ abstract public class B : I2, I3
                 Assert.Equal(TypeKind.Class, classA.TypeKind);
                 Assert.Equal(TypeKind.Class, classB.TypeKind);
 
-                Assert.Same(i1, classA.Interfaces.Single());
+                Assert.Same(i1, classA.Interfaces().Single());
 
-                var interfaces = classB.Interfaces;
+                var interfaces = classB.Interfaces();
                 Assert.Same(i2, interfaces[0]);
                 Assert.Same(i3, interfaces[1]);
 
@@ -325,15 +325,15 @@ class C : I1 { }
                 var c = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
 
                 // Order is important - should be pre-order depth-first with declaration order at each level
-                Assert.True(i1.Interfaces.SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i2, i3, i4, i5, i6, i7)));
-                Assert.True(i2.Interfaces.SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i3, i4)));
-                Assert.False(i3.Interfaces.Any());
-                Assert.False(i4.Interfaces.Any());
-                Assert.True(i5.Interfaces.SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i6, i7)));
-                Assert.False(i6.Interfaces.Any());
-                Assert.False(i7.Interfaces.Any());
+                Assert.True(i1.Interfaces().SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i2, i3, i4, i5, i6, i7)));
+                Assert.True(i2.Interfaces().SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i3, i4)));
+                Assert.False(i3.Interfaces().Any());
+                Assert.False(i4.Interfaces().Any());
+                Assert.True(i5.Interfaces().SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i6, i7)));
+                Assert.False(i6.Interfaces().Any());
+                Assert.False(i7.Interfaces().Any());
 
-                Assert.True(c.Interfaces.SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i1, i2, i3, i4, i5, i6, i7)));
+                Assert.True(c.Interfaces().SequenceEqual(ImmutableArray.Create<NamedTypeSymbol>(i1, i2, i3, i4, i5, i6, i7)));
             });
         }
 
@@ -745,13 +745,13 @@ class Derived<T, U> : Base<T, U>
                 var derivedType = module.GlobalNamespace.GetTypeMembers("Derived").Single();
                 Assert.Equal(derivedType.Arity, 2);
 
-                var baseType = derivedType.BaseType;
+                var baseType = derivedType.BaseType();
                 Assert.Equal(baseType.Name, "Base");
                 Assert.Equal(baseType.Arity, 2);
 
-                Assert.Equal(derivedType.BaseType, baseType);
-                Assert.Same(baseType.TypeArguments[0], derivedType.TypeParameters[0]);
-                Assert.Same(baseType.TypeArguments[1], derivedType.TypeParameters[1]);
+                Assert.Equal(derivedType.BaseType(), baseType);
+                Assert.Same(baseType.TypeArguments()[0], derivedType.TypeParameters[0]);
+                Assert.Same(baseType.TypeArguments()[1], derivedType.TypeParameters[1]);
             };
             CompileAndVerify(source: source, sourceSymbolValidator: validator, symbolValidator: validator);
         }
@@ -1242,7 +1242,7 @@ class C : B<string>
                 VerifyAutoProperty(q, isFromSource);
 
                 var classC = module.GlobalNamespace.GetTypeMembers("C").Single();
-                p = classC.BaseType.GetProperty("P");
+                p = classC.BaseType().GetProperty("P");
                 VerifyAutoProperty(p, isFromSource);
                 Assert.Equal(p.Type.SpecialType, SpecialType.System_String);
                 Assert.Equal(p.GetMethod.AssociatedSymbol, p);
@@ -1355,7 +1355,7 @@ class C : B<string>
 
         private void CheckEnumType(NamedTypeSymbol type, Accessibility declaredAccessibility, SpecialType underlyingType)
         {
-            Assert.Equal(type.BaseType.SpecialType, SpecialType.System_Enum);
+            Assert.Equal(type.BaseType().SpecialType, SpecialType.System_Enum);
             Assert.Equal(type.EnumUnderlyingType.SpecialType, underlyingType);
             Assert.Equal(type.DeclaredAccessibility, declaredAccessibility);
             Assert.True(type.IsSealed);

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1164,8 +1164,8 @@ class UsePia4
 
                     var itest1 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("ITest1").Single();
                     Assert.Equal(TypeKind.Interface, itest1.TypeKind);
-                    Assert.Null(itest1.BaseType);
-                    Assert.Equal(0, itest1.Interfaces.Length);
+                    Assert.Null(itest1.BaseType());
+                    Assert.Equal(0, itest1.Interfaces().Length);
                     Assert.True(itest1.IsComImport);
                     Assert.False(itest1.IsSerializable);
                     Assert.False(itest1.IsSealed);
@@ -1186,8 +1186,8 @@ class UsePia4
 
                     var test2 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("Test2").Single();
                     Assert.Equal(TypeKind.Struct, test2.TypeKind);
-                    Assert.Equal(SpecialType.System_ValueType, test2.BaseType.SpecialType);
-                    Assert.Same(itest1, test2.Interfaces.Single());
+                    Assert.Equal(SpecialType.System_ValueType, test2.BaseType().SpecialType);
+                    Assert.Same(itest1, test2.Interfaces().Single());
                     Assert.False(test2.IsComImport);
                     Assert.False(test2.IsSerializable);
                     Assert.True(test2.IsSealed);
@@ -1207,7 +1207,7 @@ class UsePia4
 
                     var itest3 = module.GlobalNamespace.GetTypeMembers("ITest3").Single();
                     Assert.Equal(TypeKind.Interface, itest3.TypeKind);
-                    Assert.Same(itest1, itest3.Interfaces.Single());
+                    Assert.Same(itest1, itest3.Interfaces().Single());
                     Assert.True(itest3.IsComImport);
                     Assert.False(itest3.IsSerializable);
                     Assert.False(itest3.IsSealed);
@@ -1244,7 +1244,7 @@ class UsePia4
 
                     var itest8 = module.GlobalNamespace.GetTypeMembers("ITest8").Single();
                     Assert.Equal(TypeKind.Interface, itest8.TypeKind);
-                    Assert.Same(itest8, module.GlobalNamespace.GetTypeMembers("UsePia1").Single().Interfaces.Single());
+                    Assert.Same(itest8, module.GlobalNamespace.GetTypeMembers("UsePia1").Single().Interfaces().Single());
 
                     var test9 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("Test9").Single();
                     Assert.Equal(TypeKind.Enum, test9.TypeKind);
@@ -1327,7 +1327,7 @@ class UsePia4
 
                     var test11 = (PENamedTypeSymbol)module.GlobalNamespace.GetTypeMembers("Test11").Single();
                     Assert.Equal(TypeKind.Delegate, test11.TypeKind);
-                    Assert.Equal(SpecialType.System_MulticastDelegate, test11.BaseType.SpecialType);
+                    Assert.Equal(SpecialType.System_MulticastDelegate, test11.BaseType().SpecialType);
 
                     // TypDefName: Test11  (02000012)
                     // Flags     : [Public] [AutoLayout] [Class] [Sealed] [AnsiClass]  (00000101)
@@ -1730,36 +1730,36 @@ interface UsePia5 : ITest29
                     Assert.False(t1.HasConstructorConstraint);
                     Assert.False(t1.HasValueTypeConstraint);
                     Assert.False(t1.HasReferenceTypeConstraint);
-                    Assert.Equal(0, t1.ConstraintTypes.Length);
+                    Assert.Equal(0, t1.ConstraintTypes().Length);
                     Assert.Equal(VarianceKind.None, t1.Variance);
 
                     var t2 = m21.TypeParameters[1];
                     Assert.False(t2.HasConstructorConstraint);
                     Assert.False(t2.HasValueTypeConstraint);
                     Assert.False(t2.HasReferenceTypeConstraint);
-                    Assert.Equal(1, t2.ConstraintTypes.Length);
-                    Assert.Same(itest28, t2.ConstraintTypes[0]);
+                    Assert.Equal(1, t2.ConstraintTypes().Length);
+                    Assert.Same(itest28, t2.ConstraintTypes()[0]);
                     Assert.Equal(VarianceKind.None, t2.Variance);
 
                     var t5 = m21.TypeParameters[2];
                     Assert.True(t5.HasConstructorConstraint);
                     Assert.False(t5.HasValueTypeConstraint);
                     Assert.False(t5.HasReferenceTypeConstraint);
-                    Assert.Equal(0, t5.ConstraintTypes.Length);
+                    Assert.Equal(0, t5.ConstraintTypes().Length);
                     Assert.Equal(VarianceKind.None, t5.Variance);
 
                     var t6 = m21.TypeParameters[3];
                     Assert.False(t6.HasConstructorConstraint);
                     Assert.True(t6.HasValueTypeConstraint);
                     Assert.False(t6.HasReferenceTypeConstraint);
-                    Assert.Equal(0, t6.ConstraintTypes.Length);
+                    Assert.Equal(0, t6.ConstraintTypes().Length);
                     Assert.Equal(VarianceKind.None, t6.Variance);
 
                     var t7 = m21.TypeParameters[4];
                     Assert.False(t7.HasConstructorConstraint);
                     Assert.False(t7.HasValueTypeConstraint);
                     Assert.True(t7.HasReferenceTypeConstraint);
-                    Assert.Equal(0, t7.ConstraintTypes.Length);
+                    Assert.Equal(0, t7.ConstraintTypes().Length);
                     Assert.Equal(VarianceKind.None, t7.Variance);
                 };
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -6081,7 +6081,7 @@ class C2 : C1, I1, I2
             var comp = CreateStandardCompilation(text);
             var c2Type = comp.Assembly.Modules[0].GlobalNamespace.GetTypeMembers("C2").Single();
             comp.VerifyDiagnostics(DiagnosticDescription.None);
-            Assert.True(c2Type.Interfaces.All(iface => iface.Name == "I1" || iface.Name == "I2"));
+            Assert.True(c2Type.Interfaces().All(iface => iface.Name == "I1" || iface.Name == "I2"));
         }
         [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -709,7 +709,7 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
             while (type.IsTupleType)
             {
                 var underlyingType = type.TupleUnderlyingType;
-                var typeArgs = underlyingType.TypeArguments;
+                var typeArgs = underlyingType.TypeArguments();
                 if (typeArgs.Length < 8)
                 {
                     return underlyingType;
@@ -883,7 +883,7 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
             Assert.Equal("A<System.Int32, System.Threading.Tasks.Task>", normalized.ToTestDisplayString());
 
             type = compilation.GetMember<FieldSymbol>("C.F1").Type;
-            Assert.Equal(TypeKind.Error, ((NamedTypeSymbol)type).TypeArguments[0].TypeKind);
+            Assert.Equal(TypeKind.Error, ((NamedTypeSymbol)type).TypeArguments()[0].TypeKind);
             normalized = type.NormalizeTaskTypes(compilation);
             Assert.Equal("MyTask<B>", type.ToTestDisplayString());
             Assert.Equal("System.Threading.Tasks.Task<B>", normalized.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -378,7 +378,7 @@ namespace Goo
 
             var b = goo.GetTypeMembers("B").Single();
             Assert.Equal("Goo.B", b.ToTestDisplayString());
-            Assert.Same(a, b.BaseType);
+            Assert.Same(a, b.BaseType());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -3031,7 +3031,7 @@ public class MyClass : Outer.base1
 ";
             var comp = CreateStandardCompilation(text);
             var type1 = comp.SourceModule.GlobalNamespace.GetMembers("MyClass").Single() as NamedTypeSymbol;
-            var b = type1.BaseType;
+            var b = type1.BaseType();
             var errs = comp.GetDiagnostics();
             Assert.Equal(1, errs.Count());
             Assert.Equal(122, errs.First().Code);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -5389,7 +5389,7 @@ class C2<T> : E2<T> { }";
             Assert.Throws<InvalidOperationException>(() => type.Construct(objectType)); // non-generic type
 
             // Non-generic error type.
-            type = type.BaseType;
+            type = type.BaseType();
             Assert.False(type.IsGenericType);
             Assert.True(type.IsErrorType());
             Assert.Throws<InvalidOperationException>(() => type.Construct(objectType)); // non-generic type
@@ -5403,7 +5403,7 @@ class C2<T> : E2<T> { }";
             Assert.Throws<InvalidOperationException>(() => type.Construct(objectType).Construct(objectType)); // constructed type
 
             // Generic error type.
-            type = type.BaseType.ConstructedFrom;
+            type = type.BaseType().ConstructedFrom;
             Assert.True(type.IsGenericType);
             Assert.True(type.IsErrorType());
             Assert.Throws<ArgumentException>(() => type.Construct(new TypeSymbol[] { null })); // null type arg

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -205,7 +205,7 @@ class A : L
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
-            var abase = a.BaseType;
+            var abase = a.BaseType();
             Assert.Equal("B.R", abase.ToTestDisplayString());
 
             var b = global.GetTypeMembers("B", 0).Single();
@@ -214,7 +214,7 @@ class A : L
             var v = a.GetMembers("v").Single() as FieldSymbol;
             var s = v.Type;
             Assert.Equal("B.R.Q.S", s.ToTestDisplayString());
-            var sbase = s.BaseType;
+            var sbase = s.BaseType();
             Assert.Equal("B.R.Q", sbase.ToTestDisplayString());
         }
 
@@ -336,7 +336,7 @@ public class B {
             var cbasetype = info.Symbol as NamedTypeSymbol;
 
             var c = comp.GlobalNamespace.GetTypeMembers("C", 1).Single();
-            Assert.Equal(c.BaseType, cbasetype);
+            Assert.Equal(c.BaseType(), cbasetype);
         }
 
         [Fact]
@@ -365,7 +365,7 @@ class A<T> {}
             var bt = b.TypeParameters.First();
 
             Assert.Equal(a.OriginalDefinition, at2.OriginalDefinition);
-            Assert.Equal(b.TypeParameters.First(), at2.TypeArguments.First());
+            Assert.Equal(b.TypeParameters.First(), at2.TypeArguments().First());
         }
 
         [Fact]
@@ -3359,7 +3359,7 @@ class Program
             Assert.Equal(SymbolKind.NamedType, newSymbol.Kind);
             Assert.Equal("System.Collections.Generic.List<T>", newSymbol.ToTestDisplayString());
 
-            Assert.False(((NamedTypeSymbol)newSymbol).TypeArguments.Single().IsErrorType());
+            Assert.False(((NamedTypeSymbol)newSymbol).TypeArguments().Single().IsErrorType());
             Assert.True(newSymbol.Equals(oldSymbol));
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4637,7 +4637,7 @@ class C : A<object>.B<> { }";
             var decl = (ClassDeclarationSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.ClassDeclaration));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            type = type.BaseType;
+            type = type.BaseType();
             Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<object>.B<?>");
         }
 
@@ -4652,7 +4652,7 @@ class C : A<,,>.B<object> { }";
             var decl = (ClassDeclarationSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.ClassDeclaration));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            type = type.BaseType;
+            type = type.BaseType();
             Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<?, ?, ?>.B<object>");
         }
 
@@ -4667,7 +4667,7 @@ class C : A<>.B<> { }";
             var decl = (ClassDeclarationSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.ClassDeclaration));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            type = type.BaseType;
+            type = type.BaseType();
             Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<?>.B<?>");
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -9165,23 +9165,23 @@ class Program
             Assert.Equal("B", type.Name);
             Assert.True(type.IsUnboundGenericType);
             Assert.False(type.IsErrorType());
-            Assert.True(type.TypeArguments[0].IsErrorType());
+            Assert.True(type.TypeArguments()[0].IsErrorType());
 
             var constructedFrom = type.ConstructedFrom;
             Assert.Equal(constructedFrom, constructedFrom.ConstructedFrom);
             Assert.Equal(constructedFrom, constructedFrom.TypeParameters[0].ContainingSymbol);
-            Assert.Equal(constructedFrom.TypeArguments[0], constructedFrom.TypeParameters[0]);
+            Assert.Equal(constructedFrom.TypeArguments()[0], constructedFrom.TypeParameters[0]);
             Assert.Equal(type.ContainingSymbol, constructedFrom.ContainingSymbol);
             Assert.Equal(type.TypeParameters[0], constructedFrom.TypeParameters[0]);
-            Assert.False(constructedFrom.TypeArguments[0].IsErrorType());
+            Assert.False(constructedFrom.TypeArguments()[0].IsErrorType());
             Assert.NotEqual(type, constructedFrom);
             Assert.False(constructedFrom.IsUnboundGenericType);
             var a = type.ContainingType;
             Assert.Equal(constructedFrom, a.GetTypeMembers("B").Single());
             Assert.NotEqual(type.TypeParameters[0], type.OriginalDefinition.TypeParameters[0]); // alpha renamed
-            Assert.Null(type.BaseType);
-            Assert.Empty(type.Interfaces);
-            Assert.NotNull(constructedFrom.BaseType);
+            Assert.Null(type.BaseType());
+            Assert.Empty(type.Interfaces());
+            Assert.NotNull(constructedFrom.BaseType());
             Assert.Empty(type.GetMembers());
             Assert.NotEmpty(constructedFrom.GetMembers());
             Assert.True(a.IsUnboundGenericType);

--- a/src/Compilers/CSharp/Test/Symbol/DeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DeclarationTests.cs
@@ -298,7 +298,7 @@ public class B
             Assert.Equal(1, countedTree.AccessCount);
 
             // Getting the interfaces will cause us to do some more binding of the current type.
-            var interfaces = type.Interfaces;
+            var interfaces = type.Interfaces();
             Assert.Equal(1, countedTree.AccessCount);
 
             // Now bind the members.

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -1522,7 +1522,7 @@ class B<T, T>
             var compilation = CreateCompilationWithMscorlibAndDocumentationComments(source);
             var crefSyntax = GetCrefSyntaxes(compilation).Single();
 
-            var expectedSymbol = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("B").TypeArguments[0];
+            var expectedSymbol = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("B").TypeArguments()[0];
             var actualSymbol = GetReferencedSymbol(crefSyntax, compilation,
                 // (3,20): warning CS1723: XML comment has cref attribute 'T' that refers to a type parameter
                 // /// See <see cref="T"/>.
@@ -1662,7 +1662,7 @@ class A<T, U>
             Assert.False(actualWinner.IsDefinition);
 
             var actualParameterType = actualWinner.GetParameters().Single().Type;
-            AssertEx.All(actualWinner.ContainingType.TypeArguments, typeParam => typeParam == actualParameterType); //CONSIDER: Would be different in Dev11.
+            AssertEx.All(actualWinner.ContainingType.TypeArguments(), typeParam => typeParam == actualParameterType); //CONSIDER: Would be different in Dev11.
             Assert.Equal(1, ((TypeParameterSymbol)actualParameterType).Ordinal);
 
             Assert.Equal(2, actualCandidates.Length);
@@ -1700,8 +1700,8 @@ class A<T>
             Assert.False(actualWinner.IsDefinition);
 
             var actualParameterType = actualWinner.GetParameters().Single().Type;
-            Assert.Equal(actualParameterType, actualWinner.ContainingType.TypeArguments.Single());
-            Assert.Equal(actualParameterType, actualWinner.ContainingType.ContainingType.TypeArguments.Single());
+            Assert.Equal(actualParameterType, actualWinner.ContainingType.TypeArguments().Single());
+            Assert.Equal(actualParameterType, actualWinner.ContainingType.ContainingType.TypeArguments().Single());
 
             Assert.Equal(2, actualCandidates.Length);
             Assert.Equal(actualWinner, actualCandidates[0]);
@@ -5515,7 +5515,7 @@ class C<T>
             NamedTypeSymbol referencedType = (NamedTypeSymbol)model.GetSymbolInfo(cref).Symbol;
             Assert.NotNull(referencedType);
 
-            var crefTypeParam = referencedType.TypeArguments.Single();
+            var crefTypeParam = referencedType.TypeArguments().Single();
             Assert.IsType<CrefTypeParameterSymbol>(crefTypeParam);
 
             var sourceTypeParam = referencedType.TypeParameters.Single();

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
@@ -86,7 +86,7 @@ class C : M.N.O
 ";
             var comp = CreateStandardCompilation(source);
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            var symbol = type.BaseType;
+            var symbol = type.BaseType();
             Assert.Equal(SymbolKind.ErrorType, symbol.Kind);
             Assert.Equal("!:M.N.O", symbol.GetDocumentationCommentId());
         }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2359,7 +2359,7 @@ public class X : GC1<BOGUS> {}
 
             Func<NamespaceSymbol, Symbol> findSymbol = global =>
                 global.GetTypeMembers("X", 0).Single().
-                BaseType;
+                BaseType();
 
             var format = new SymbolDisplayFormat(
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -1700,7 +1700,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
             var namedType = type as NamedTypeSymbol;
             Assert.NotNull(namedType);
 
-            var objType = namedType.BaseType;
+            var objType = namedType.BaseType();
             Assert.NotNull(objType);
             Assert.Equal("System.Object", objType.ToTestDisplayString());
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ArrayTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ArrayTypeSymbolTests.cs
@@ -27,7 +27,7 @@ public class X
 ", new[] { MinCorlibRef });
 
             var field = c.GlobalNamespace.GetMember<NamedTypeSymbol>("X").GetMember<FieldSymbol>("A");
-            Assert.Equal(0, field.Type.Interfaces.Length);
+            Assert.Equal(0, field.Type.Interfaces().Length);
             c.VerifyDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
@@ -168,13 +168,13 @@ namespace NS.NS1 {
 
             var ns1 = ns.GetMembers("NS1").Single() as NamespaceSymbol;
             var type1 = ns1.GetTypeMembers("A").SingleOrDefault() as NamedTypeSymbol;
-            Assert.Equal(1, type1.Interfaces.Length);
-            Assert.Equal("IGoo", type1.Interfaces[0].Name);
+            Assert.Equal(1, type1.Interfaces().Length);
+            Assert.Equal("IGoo", type1.Interfaces()[0].Name);
 
             var ns2 = ns.GetMembers("NS2").Single() as NamespaceSymbol;
             var type2 = ns2.GetTypeMembers("C").SingleOrDefault() as NamedTypeSymbol;
-            Assert.NotNull(type2.BaseType);
-            Assert.Equal("NS.NS1.B", type2.BaseType.ToTestDisplayString());
+            Assert.NotNull(type2.BaseType());
+            Assert.Equal("NS.NS1.B", type2.BaseType().ToTestDisplayString());
         }
 
         [Fact]
@@ -330,7 +330,7 @@ namespace NS
             var globalNS = compilation.SourceModule.GlobalNamespace;
             var ns1 = globalNS.GetMembers("NS").Single() as NamespaceSymbol;
             var type1 = ns1.GetTypeMembers("C").First() as NamedTypeSymbol;
-            var b = type1.BaseType;
+            var b = type1.BaseType();
         }
 
         [WorkItem(540785, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540785")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -2270,7 +2270,7 @@ public class C5 :
 
             Assert.Same(retval1.OriginalDefinition, type2);
 
-            var args1 = retval1.ContainingType.TypeArguments.Concat(retval1.TypeArguments);
+            var args1 = retval1.ContainingType.TypeArguments().Concat(retval1.TypeArguments());
             var params1 = retval1.ContainingType.TypeParameters.Concat(retval1.TypeParameters);
 
             Assert.Same(params1[0], type1.TypeParameters[0]);
@@ -2295,7 +2295,7 @@ public class C5 :
             Assert.Same(retval3.OriginalDefinition, type6);
             Assert.Same(retval3.ContainingAssembly, asm5[1]);
 
-            var args3 = retval3.TypeArguments;
+            var args3 = retval3.TypeArguments();
             var params3 = retval3.TypeParameters;
 
             Assert.Same(params3[0], type6.TypeParameters[0]);
@@ -2414,15 +2414,15 @@ public class C5 :
             Assert.Equal(0, type3.Arity);
             Assert.Equal(1, typeC6.Arity);
 
-            Assert.NotNull(type3.BaseType);
-            Assert.Equal("System.Object", type3.BaseType.ToTestDisplayString());
+            Assert.NotNull(type3.BaseType());
+            Assert.Equal("System.Object", type3.BaseType().ToTestDisplayString());
 
             Assert.Equal(Accessibility.Public, type3.DeclaredAccessibility);
             Assert.Equal(Accessibility.Internal, typeC302.DeclaredAccessibility);
 
-            Assert.Equal(0, type3.Interfaces.Length);
-            Assert.Equal(1, typeC301.Interfaces.Length);
-            Assert.Equal("I1", typeC301.Interfaces.Single().Name);
+            Assert.Equal(0, type3.Interfaces().Length);
+            Assert.Equal(1, typeC301.Interfaces().Length);
+            Assert.Equal("I1", typeC301.Interfaces().Single().Name);
 
             Assert.False(type3.IsAbstract);
             Assert.True(typeC301.IsAbstract);
@@ -2430,13 +2430,13 @@ public class C5 :
             Assert.False(type3.IsSealed);
             Assert.False(type3.IsStatic);
 
-            Assert.Equal(0, type3.TypeArguments.Length);
+            Assert.Equal(0, type3.TypeArguments().Length);
             Assert.Equal(0, type3.TypeParameters.Length);
 
             var localC6Params = typeC6.TypeParameters;
             Assert.Equal(1, localC6Params.Length);
-            Assert.Equal(1, typeC6.TypeArguments.Length);
-            Assert.Same(localC6Params[0], typeC6.TypeArguments[0]);
+            Assert.Equal(1, typeC6.TypeArguments().Length);
+            Assert.Same(localC6Params[0], typeC6.TypeArguments()[0]);
 
             Assert.Same(((RetargetingNamedTypeSymbol)type3).UnderlyingNamedType,
                 asm3.GlobalNamespace.GetTypeMembers("C3").Single());
@@ -2448,10 +2448,10 @@ public class C5 :
             var localC6_T = localC6Params[0];
             var foo3TypeParam = foo3TypeParams[0];
 
-            Assert.Equal(0, localC6_T.ConstraintTypes.Length);
+            Assert.Equal(0, localC6_T.ConstraintTypes().Length);
 
-            Assert.Equal(1, foo3TypeParam.ConstraintTypes.Length);
-            Assert.Same(type4, foo3TypeParam.ConstraintTypes.Single());
+            Assert.Equal(1, foo3TypeParam.ConstraintTypes().Length);
+            Assert.Same(type4, foo3TypeParam.ConstraintTypes().Single());
 
             Assert.Same(typeC6, localC6_T.ContainingSymbol);
             Assert.False(foo3TypeParam.HasConstructorConstraint);
@@ -2508,8 +2508,8 @@ public class C5 :
 
             var typeC5 = c5.Assembly.GlobalNamespace.GetTypeMembers("C5").Single();
 
-            Assert.Same(asm5[1], typeC5.BaseType.ContainingAssembly);
-            Assert.Equal("ns1.C304.C305", typeC5.BaseType.ToTestDisplayString());
+            Assert.Same(asm5[1], typeC5.BaseType().ContainingAssembly);
+            Assert.Equal("ns1.C304.C305", typeC5.BaseType().ToTestDisplayString());
             Assert.NotEqual(SymbolKind.ErrorType, typeC5.Kind);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -286,8 +286,8 @@ class CL3
             var test = cl3.GetMember<MethodSymbol>("Test");
             Assert.Equal("void CL3.Test(System.Int32 modopt(System.Runtime.CompilerServices.IsConst) modopt(System.Runtime.CompilerServices.IsLong) x)", test.ToTestDisplayString());
 
-            var withModifiers = cl3.BaseType.BaseType;
-            var withoutModifiers = withModifiers.OriginalDefinition.Construct(withModifiers.TypeArguments);
+            var withModifiers = cl3.BaseType().BaseType();
+            var withoutModifiers = withModifiers.OriginalDefinition.Construct(withModifiers.TypeArguments());
             Assert.True(withModifiers.HasTypeArgumentsCustomModifiers);
             Assert.False(withoutModifiers.HasTypeArgumentsCustomModifiers);
             Assert.True(withoutModifiers.Equals(withModifiers, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
@@ -1361,7 +1361,7 @@ class Module1
             var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
 
             var cl2 = compilation.GetTypeByMetadataName("CL2");
-            Assert.Equal("System.Int32 modopt(System.Runtime.CompilerServices.IsConst) modopt(System.Runtime.CompilerServices.IsLong) CL1<System.Int32 modopt(System.Runtime.CompilerServices.IsLong)>.Test", cl2.BaseType.GetMember("Test").ToTestDisplayString());
+            Assert.Equal("System.Int32 modopt(System.Runtime.CompilerServices.IsConst) modopt(System.Runtime.CompilerServices.IsLong) CL1<System.Int32 modopt(System.Runtime.CompilerServices.IsLong)>.Test", cl2.BaseType().GetMember("Test").ToTestDisplayString());
 
             CompileAndVerify(compilation, expectedOutput: "123");
         }
@@ -1446,9 +1446,9 @@ class Module1
 ";
             var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseExe);
 
-            var base1 = compilation.GetTypeByMetadataName("CL2").BaseType;
-            var base2 = compilation.GetTypeByMetadataName("CL3").BaseType;
-            var base3 = compilation.GetTypeByMetadataName("CL4").BaseType;
+            var base1 = compilation.GetTypeByMetadataName("CL2").BaseType();
+            var base2 = compilation.GetTypeByMetadataName("CL3").BaseType();
+            var base3 = compilation.GetTypeByMetadataName("CL4").BaseType();
 
             Assert.True(base1.HasTypeArgumentsCustomModifiers);
             Assert.True(base2.HasTypeArgumentsCustomModifiers);
@@ -1702,8 +1702,8 @@ interface ITest4<T, U>
 ";
             var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseDll);
 
-            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst) modopt(System.Runtime.CompilerServices.IsLong)>", compilation.GetTypeByMetadataName("ITest1`1").Interfaces.First().ToTestDisplayString());
-            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest2`1").Interfaces.First().ToTestDisplayString());
+            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst) modopt(System.Runtime.CompilerServices.IsLong)>", compilation.GetTypeByMetadataName("ITest1`1").Interfaces().First().ToTestDisplayString());
+            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest2`1").Interfaces().First().ToTestDisplayString());
 
             compilation.VerifyDiagnostics(
     // (2,11): error CS0695: 'ITest3<T, U>' cannot implement both 'ITest0<T>' and 'ITest0<U>' because they may unify for some type parameter substitutions
@@ -1744,8 +1744,8 @@ interface ITest4<T, U>
 ";
             var compilation = CreateCompilationWithCustomILSource(source, ilSource, options: TestOptions.ReleaseDll);
 
-            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsLong) modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest1`1").Interfaces.First().ToTestDisplayString());
-            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest2`1").Interfaces.First().ToTestDisplayString());
+            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsLong) modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest1`1").Interfaces().First().ToTestDisplayString());
+            Assert.Equal("ITest0<T modopt(System.Runtime.CompilerServices.IsConst)>", compilation.GetTypeByMetadataName("ITest2`1").Interfaces().First().ToTestDisplayString());
 
             compilation.VerifyDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ErrorTypeSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ErrorTypeSymbolTests.cs
@@ -64,7 +64,7 @@ class C7 : A<string>.B<object> { }";
             var allTypes = compilation.GlobalNamespace.GetTypeMembers();
 
             // Get base class for each type named "C?".
-            var types = new[] { "C1", "C2", "C3", "C4", "C5", "C6", "C7" }.Select(name => allTypes.First(t => t.Name == name).BaseType).ToArray();
+            var types = new[] { "C1", "C2", "C3", "C4", "C5", "C6", "C7" }.Select(name => allTypes.First(t => t.Name == name).BaseType()).ToArray();
             foreach (var type in types)
             {
                 var constructedFrom = type.ConstructedFrom;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -4682,25 +4682,25 @@ abstract class E : D, IB
 
                 var method = type.GetMember<MethodSymbol>("M1");
                 var typeParameter = method.TypeParameters[0];
-                Assert.Equal("IA<A<T1>.B<object>>", typeParameter.ConstraintTypes[0].ToDisplayString());
+                Assert.Equal("IA<A<T1>.B<object>>", typeParameter.ConstraintTypes()[0].ToDisplayString());
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, 0);
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveInterfacesNoUseSiteDiagnostics[0], 1);
-                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes[0], 1);
+                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes()[0], 1);
                 typeParameter = method.TypeParameters[1];
-                Assert.Equal("A<T2[]>.B<T1>", typeParameter.ConstraintTypes[0].ToDisplayString());
+                Assert.Equal("A<T2[]>.B<T1>", typeParameter.ConstraintTypes()[0].ToDisplayString());
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, 2);
-                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes[0], 2);
+                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes()[0], 2);
 
                 method = type.GetMethod("IB.M2");
                 typeParameter = method.TypeParameters[0];
-                Assert.Equal("IA<A<X>.B<object>>", typeParameter.ConstraintTypes[0].ToDisplayString());
+                Assert.Equal("IA<A<X>.B<object>>", typeParameter.ConstraintTypes()[0].ToDisplayString());
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, 0);
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveInterfacesNoUseSiteDiagnostics[0], 1);
-                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes[0], 1);
+                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes()[0], 1);
                 typeParameter = method.TypeParameters[1];
-                Assert.Equal("A<Y[]>.B<X>", typeParameter.ConstraintTypes[0].ToDisplayString());
+                Assert.Equal("A<Y[]>.B<X>", typeParameter.ConstraintTypes()[0].ToDisplayString());
                 CheckTypeParameterContainingSymbols(method, typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, 2);
-                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes[0], 2);
+                CheckTypeParameterContainingSymbols(method, typeParameter.ConstraintTypes()[0], 2);
             };
             CompileAndVerify(
                 source: source,
@@ -4980,13 +4980,13 @@ interface I6<U> : I3<I<U>, I<U>> { }";
                 method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I3").GetMember<MethodSymbol>("M");
                 CheckConstraints(method.TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object", "I<T>", "I<U>");
 
-                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I4").Interfaces[0].GetMember<MethodSymbol>("M");
+                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I4").Interfaces()[0].GetMember<MethodSymbol>("M");
                 CheckConstraints(method.TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object", "T");
 
-                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I5").Interfaces[0].GetMember<MethodSymbol>("M");
+                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I5").Interfaces()[0].GetMember<MethodSymbol>("M");
                 CheckConstraints(method.TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object", "I<object>", "I<T>");
 
-                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I6").Interfaces[0].GetMember<MethodSymbol>("M");
+                method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("I6").Interfaces()[0].GetMember<MethodSymbol>("M");
                 CheckConstraints(method.TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object", "I<I<U>>");
             };
             CompileAndVerify(
@@ -5305,13 +5305,13 @@ class D0 : D<object>
             var compilation = CreateCompilationWithCustomILSource(csharpSource, ilSource).VerifyDiagnostics();
             var @namespace = compilation.GlobalNamespace;
             var type = @namespace.GetMember<NamedTypeSymbol>("I0");
-            CheckConstraints(type.Interfaces[0].GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
+            CheckConstraints(type.Interfaces()[0].GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("A1");
             CheckConstraints(type.GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("A2");
             CheckConstraints(type.GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("I1");
-            CheckConstraints(type.Interfaces[0].GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
+            CheckConstraints(type.Interfaces()[0].GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("B0");
             CheckConstraints(type.GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("B1");
@@ -5325,7 +5325,7 @@ class D0 : D<object>
             type = @namespace.GetMember<NamedTypeSymbol>("C2");
             CheckConstraints(type.GetMethod("I<System.Object>.M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
             type = @namespace.GetMember<NamedTypeSymbol>("D0");
-            CheckConstraints(type.BaseType.GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
+            CheckConstraints(type.BaseType().GetMember<MethodSymbol>("M").TypeParameters[0], TypeParameterConstraintKind.None, false, false, "object", "object");
         }
 
         /// <summary>
@@ -5549,11 +5549,11 @@ End Module",
             Assert.Equal(constraints, Utils.GetTypeParameterConstraints(typeParameter));
             Assert.Equal(typeParameter.IsValueType, isValueType);
             Assert.Equal(typeParameter.IsReferenceType, isReferenceType);
-            Assert.Null(typeParameter.BaseType);
-            Assert.Equal(typeParameter.Interfaces.Length, 0);
+            Assert.Null(typeParameter.BaseType());
+            Assert.Equal(typeParameter.Interfaces().Length, 0);
             Utils.CheckSymbol(typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, effectiveBaseClassDescription);
             Utils.CheckSymbol(typeParameter.DeducedBaseTypeNoUseSiteDiagnostics, deducedBaseTypeDescription);
-            Utils.CheckSymbols(typeParameter.ConstraintTypes, constraintTypeDescriptions);
+            Utils.CheckSymbols(typeParameter.ConstraintTypes(), constraintTypeDescriptions);
         }
 
         [WorkItem(545327, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545327")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -26,8 +26,8 @@ namespace N
             var n = ((NamespaceSymbol)c.Assembly.GlobalNamespace.GetMembers("N").Single());
             var implicitClass = ((NamedTypeSymbol)n.GetMembers().Single());
             Assert.Equal(0, implicitClass.GetAttributes().Length);
-            Assert.Equal(0, implicitClass.Interfaces.Length);
-            Assert.Equal(c.ObjectType, implicitClass.BaseType);
+            Assert.Equal(0, implicitClass.Interfaces().Length);
+            Assert.Equal(c.ObjectType, implicitClass.BaseType());
             Assert.Equal(0, implicitClass.Arity);
             Assert.True(implicitClass.IsImplicitlyDeclared);
             Assert.Equal(SyntaxKind.NamespaceDeclaration, implicitClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind());
@@ -39,8 +39,8 @@ namespace N
             n = ((NamespaceSymbol)c2.GlobalNamespace.GetMembers("N").Single());
             implicitClass = ((NamedTypeSymbol)n.GetMembers().Single());
             Assert.IsType<CSharp.Symbols.Retargeting.RetargetingNamedTypeSymbol>(implicitClass);
-            Assert.Equal(0, implicitClass.Interfaces.Length);
-            Assert.Equal(c2.ObjectType, implicitClass.BaseType);
+            Assert.Equal(0, implicitClass.Interfaces().Length);
+            Assert.Equal(c2.ObjectType, implicitClass.BaseType());
         }
 
         [Fact]
@@ -55,8 +55,8 @@ void Goo()
 
             var scriptClass = ((NamedTypeSymbol)c.Assembly.GlobalNamespace.GetMembers().Single());
             Assert.Equal(0, scriptClass.GetAttributes().Length);
-            Assert.Equal(0, scriptClass.Interfaces.Length);
-            Assert.Null(scriptClass.BaseType);
+            Assert.Equal(0, scriptClass.Interfaces().Length);
+            Assert.Null(scriptClass.BaseType());
             Assert.Equal(0, scriptClass.Arity);
             Assert.True(scriptClass.IsImplicitlyDeclared);
             Assert.Equal(SyntaxKind.CompilationUnit, scriptClass.DeclaringSyntaxReferences.Single().GetSyntax().Kind());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -573,18 +573,18 @@ class Class2 : BaseClass //does not declare interface
             var interfaceMethod = @interface.GetMembers("Method").Single();
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("BaseClass").Single();
-            Assert.False(baseClass.AllInterfaces.Contains(@interface));
+            Assert.False(baseClass.AllInterfaces().Contains(@interface));
 
             var baseClassMethod = (MethodSymbol)baseClass.GetMembers("Method").Single();
             Assert.Equal(MethodKind.Ordinary, baseClassMethod.MethodKind);
 
             var class1 = (NamedTypeSymbol)global.GetMembers("Class1").Single();
-            Assert.Same(baseClass, class1.BaseType);
-            Assert.True(class1.Interfaces.Contains(@interface));
+            Assert.Same(baseClass, class1.BaseType());
+            Assert.True(class1.Interfaces().Contains(@interface));
 
             var class2 = (NamedTypeSymbol)global.GetMembers("Class2").Single();
-            Assert.Same(baseClass, class2.BaseType);
-            Assert.False(class2.AllInterfaces.Contains(@interface));
+            Assert.Same(baseClass, class2.BaseType());
+            Assert.False(class2.AllInterfaces().Contains(@interface));
 
             Assert.Null(baseClass.FindImplementationForInterfaceMember(interfaceMethod));
             Assert.Same(baseClassMethod, class1.FindImplementationForInterfaceMember(interfaceMethod));
@@ -623,17 +623,17 @@ class Class2 : BaseClass //does not declare interface
             var interfaceIndexer = @interface.Indexers.Single();
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("BaseClass").Single();
-            Assert.False(baseClass.AllInterfaces.Contains(@interface));
+            Assert.False(baseClass.AllInterfaces().Contains(@interface));
 
             var baseClassIndexer = baseClass.Indexers.Single();
 
             var class1 = (NamedTypeSymbol)global.GetMembers("Class1").Single();
-            Assert.Same(baseClass, class1.BaseType);
-            Assert.True(class1.Interfaces.Contains(@interface));
+            Assert.Same(baseClass, class1.BaseType());
+            Assert.True(class1.Interfaces().Contains(@interface));
 
             var class2 = (NamedTypeSymbol)global.GetMembers("Class2").Single();
-            Assert.Same(baseClass, class2.BaseType);
-            Assert.False(class2.AllInterfaces.Contains(@interface));
+            Assert.Same(baseClass, class2.BaseType());
+            Assert.False(class2.AllInterfaces().Contains(@interface));
 
             Assert.Null(baseClass.FindImplementationForInterfaceMember(interfaceIndexer));
             Assert.Same(baseClassIndexer, class1.FindImplementationForInterfaceMember(interfaceIndexer));
@@ -831,17 +831,17 @@ class DeclaringClass2 : NonDeclaringClass2, Interface
 
             var declaring1 = (NamedTypeSymbol)global.GetMembers("DeclaringClass1").Single();
             Assert.True(declaring1.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(@interface));
-            Assert.Equal(nonDeclaring1, declaring1.BaseType);
+            Assert.Equal(nonDeclaring1, declaring1.BaseType());
 
             var nonDeclaring2 = (NamedTypeSymbol)global.GetMembers("NonDeclaringClass2").Single();
             Assert.False(nonDeclaring2.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(@interface));
-            Assert.Equal(declaring1, nonDeclaring2.BaseType);
+            Assert.Equal(declaring1, nonDeclaring2.BaseType());
 
             var nonDeclaring2Method = nonDeclaring2.GetMembers("Method").Single();
 
             var declaring2 = (NamedTypeSymbol)global.GetMembers("DeclaringClass2").Single();
             Assert.True(declaring2.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(@interface));
-            Assert.Equal(nonDeclaring2, declaring2.BaseType);
+            Assert.Equal(nonDeclaring2, declaring2.BaseType());
 
             Assert.Null(nonDeclaring1.FindImplementationForInterfaceMember(interfaceMethod));
             Assert.Equal(nonDeclaring1Method, declaring1.FindImplementationForInterfaceMember(interfaceMethod));
@@ -869,12 +869,12 @@ class DeclaringClass2 : NonDeclaringClass2, Interface
             var interfaceMethod = @interface.GetMembers("Method1").Single();
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("BaseDeclaresInterface").Single();
-            Assert.True(baseClass.Interfaces.Contains(@interface));
+            Assert.True(baseClass.Interfaces().Contains(@interface));
             Assert.Null(baseClass.FindImplementationForInterfaceMember(interfaceMethod));
 
             var derivedClass = (NamedTypeSymbol)global.GetMembers("DerivedExplicitlyImplementsInterface").Single();
             Assert.False(derivedClass.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(@interface));
-            Assert.True(derivedClass.AllInterfaces.Contains(@interface));
+            Assert.True(derivedClass.AllInterfaces().Contains(@interface));
 
             var derivedClassMethod = derivedClass.GetMembers("I1.Method1").Single();
             Assert.Same(derivedClassMethod, derivedClass.FindImplementationForInterfaceMember(interfaceMethod));
@@ -912,7 +912,7 @@ public class Derived : Base, Interface
             var interfacePropertySetter = interfaceProperty.SetMethod;
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("Base").Single();
-            Assert.False(baseClass.AllInterfaces.Contains(@interface));
+            Assert.False(baseClass.AllInterfaces().Contains(@interface));
 
             var baseClassMethod = (MethodSymbol)baseClass.GetMembers("Method").Single();
             var baseClassProperty = (PropertySymbol)baseClass.GetMembers("Property").Single();
@@ -925,7 +925,7 @@ public class Derived : Base, Interface
             Assert.False(baseClassPropertySetter.IsVirtual);
 
             var derivedClass = (SourceNamedTypeSymbol)global.GetMembers("Derived").Single();
-            Assert.True(derivedClass.Interfaces.Contains(@interface));
+            Assert.True(derivedClass.Interfaces().Contains(@interface));
 
             Assert.Same(baseClassMethod, derivedClass.FindImplementationForInterfaceMember(interfaceMethod));
             Assert.Same(baseClassProperty, derivedClass.FindImplementationForInterfaceMember(interfaceProperty));
@@ -981,7 +981,7 @@ public class Derived : Base, Interface
             var interfacePropertySetter = interfaceProperty.SetMethod;
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("Base").Single();
-            Assert.False(baseClass.AllInterfaces.Contains(@interface));
+            Assert.False(baseClass.AllInterfaces().Contains(@interface));
 
             var baseClassMethod = (MethodSymbol)baseClass.GetMembers("Method").Single();
             var baseClassProperty = (PropertySymbol)baseClass.GetMembers("Property").Single();
@@ -994,7 +994,7 @@ public class Derived : Base, Interface
             Assert.False(baseClassPropertySetter.IsVirtual);
 
             var derivedClass = (SourceNamedTypeSymbol)global.GetMembers("Derived").Single();
-            Assert.True(derivedClass.Interfaces.Contains(@interface));
+            Assert.True(derivedClass.Interfaces().Contains(@interface));
 
             Assert.Same(baseClassMethod, derivedClass.FindImplementationForInterfaceMember(interfaceMethod));
             Assert.Same(baseClassProperty, derivedClass.FindImplementationForInterfaceMember(interfaceProperty));
@@ -1144,8 +1144,8 @@ public class c2 : c1, I1
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
             var type = comp.GlobalNamespace.GetTypeMembers("c2").Single();
-            Assert.NotEmpty(type.Interfaces);
-            Assert.True(type.Interfaces.Any(@interface => @interface.Name == "I1"));
+            Assert.NotEmpty(type.Interfaces());
+            Assert.True(type.Interfaces().Any(@interface => @interface.Name == "I1"));
         }
 
         [Fact]
@@ -1585,7 +1585,7 @@ static class Program
             comp.VerifyDiagnostics();
 
             var typeSymbol = comp.GlobalNamespace.GetTypeMembers("C1").Single();
-            var interfaceSymbol = typeSymbol.Interfaces.First();
+            var interfaceSymbol = typeSymbol.Interfaces().First();
             var gooMethod = typeSymbol.GetMember<MethodSymbol>("Goo");
 
             var interfaceMembers = interfaceSymbol.GetMembers().OfType<MethodSymbol>();
@@ -1636,14 +1636,14 @@ class C : B, I { }
 
             var classC = global.GetMember<SourceNamedTypeSymbol>("C");
 
-            Assert.Equal(@interface, classA.AllInterfaces.Single());
-            Assert.Equal(@interface, classB.AllInterfaces.Single());
-            Assert.Equal(@interface, classC.AllInterfaces.Single());
+            Assert.Equal(@interface, classA.AllInterfaces().Single());
+            Assert.Equal(@interface, classB.AllInterfaces().Single());
+            Assert.Equal(@interface, classC.AllInterfaces().Single());
 
-            Assert.Equal(0, classB.Interfaces.Length);
+            Assert.Equal(0, classB.Interfaces().Length);
 
-            Assert.Equal(classB, classC.BaseType);
-            Assert.Equal(classA, classB.BaseType);
+            Assert.Equal(classB, classC.BaseType());
+            Assert.Equal(classA, classB.BaseType());
 
             Assert.Equal(classAMethod, classA.FindImplementationForInterfaceMember(interfaceMethod));
 
@@ -1696,14 +1696,14 @@ class C : B, I { }
 
             var classC = global.GetMember<SourceNamedTypeSymbol>("C");
 
-            Assert.Equal(@interface, classA.AllInterfaces.Single());
-            Assert.Equal(@interface, classB.AllInterfaces.Single());
-            Assert.Equal(@interface, classC.AllInterfaces.Single());
+            Assert.Equal(@interface, classA.AllInterfaces().Single());
+            Assert.Equal(@interface, classB.AllInterfaces().Single());
+            Assert.Equal(@interface, classC.AllInterfaces().Single());
 
-            Assert.Equal(0, classB.Interfaces.Length);
+            Assert.Equal(0, classB.Interfaces().Length);
 
-            Assert.Equal(classB, classC.BaseType);
-            Assert.Equal(classA, classB.BaseType);
+            Assert.Equal(classB, classC.BaseType());
+            Assert.Equal(classA, classB.BaseType());
 
             Assert.Equal(classAMethod, classA.FindImplementationForInterfaceMember(interfaceMethod));
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
@@ -93,12 +93,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // 18 members
             Assert.Equal(18, class1.GetMembers().Length);
             Assert.Equal(0, class1.GetTypeMembers().Length);
-            Assert.Equal(0, class1.Interfaces.Length);
+            Assert.Equal(0, class1.Interfaces().Length);
 
             var fullName = "Microsoft.Runtime.Hosting.StrongNameHelpers";
             // Internal: Assert.Equal(fullName, class1.GetFullNameWithoutGenericArgs());
             Assert.Equal(fullName, class1.ToTestDisplayString());
-            Assert.Equal(0, class1.TypeArguments.Length);
+            Assert.Equal(0, class1.TypeArguments().Length);
             Assert.Equal(0, class1.TypeParameters.Length);
 
             Assert.Empty(compilation.GetDeclarationDiagnostics());
@@ -143,12 +143,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(4, type1.GetTypeMembers().Length);
             // IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, 
             // IDictionary, ICollection, IEnumerable, ISerializable, IDeserializationCallback
-            Assert.Equal(8, type1.Interfaces.Length);
+            Assert.Equal(8, type1.Interfaces().Length);
 
             var fullName = "System.Collections.Generic.Dictionary<TKey, TValue>";
             // Internal Assert.Equal(fullName, class1.GetFullNameWithoutGenericArgs());
             Assert.Equal(fullName, type1.ToTestDisplayString());
-            Assert.Equal(2, type1.TypeArguments.Length);
+            Assert.Equal(2, type1.TypeArguments().Length);
             Assert.Equal(2, type1.TypeParameters.Length);
 
             Assert.Empty(compilation.GetDeclarationDiagnostics());
@@ -191,12 +191,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(6, type1.GetMembers().Length);
             Assert.Equal(0, type1.GetTypeMembers().Length);
             // ICollection<T>, IEnumerable<T>, IEnumerable
-            Assert.Equal(3, type1.Interfaces.Length);
+            Assert.Equal(3, type1.Interfaces().Length);
 
             var fullName = "System.Collections.Generic.IList<T>";
             // Internal Assert.Equal(fullName, class1.GetFullNameWithoutGenericArgs());
             Assert.Equal(fullName, type1.ToTestDisplayString());
-            Assert.Equal(1, type1.TypeArguments.Length);
+            Assert.Equal(1, type1.TypeArguments().Length);
             Assert.Equal(1, type1.TypeParameters.Length);
 
             Assert.Empty(compilation.GetDeclarationDiagnostics());
@@ -239,12 +239,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // 4 method + 1 synthesized ctor, 2 get_<Prop> method, 2 Properties, 2 fields
             Assert.Equal(11, type1.GetMembers().Length);
             Assert.Equal(0, type1.GetTypeMembers().Length);
-            Assert.Equal(0, type1.Interfaces.Length);
+            Assert.Equal(0, type1.Interfaces().Length);
 
             var fullName = "System.Runtime.Serialization.StreamingContext";
             // Internal Assert.Equal(fullName, class1.GetFullNameWithoutGenericArgs());
             Assert.Equal(fullName, type1.ToTestDisplayString());
-            Assert.Equal(0, type1.TypeArguments.Length);
+            Assert.Equal(0, type1.TypeArguments().Length);
             Assert.Equal(0, type1.TypeParameters.Length);
 
             Assert.Empty(compilation.GetDeclarationDiagnostics());
@@ -283,13 +283,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(TypeKind.Array, type3.TypeKind);
 
             Assert.Equal("EventData", type2.ElementType.Name);
-            Assert.Equal("Array", type2.BaseType.Name);
+            Assert.Equal("Array", type2.BaseType().Name);
             Assert.Equal("Object", type3.ElementType.Name);
             Assert.Equal("System.Diagnostics.Eventing.EventProviderBase.EventData[]", type2.ToTestDisplayString());
             Assert.Equal("System.Object[]", type3.ToTestDisplayString());
 
-            Assert.Equal(1, type2.Interfaces.Length);
-            Assert.Equal(1, type3.Interfaces.Length);
+            Assert.Equal(1, type2.Interfaces().Length);
+            Assert.Equal(1, type3.Interfaces().Length);
             // bug
             // Assert.False(type2.IsDefinition);
             Assert.False(type2.IsNamespace);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/BaseTypeResolution.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/BaseTypeResolution.cs
@@ -57,10 +57,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var collections = ((NamespaceSymbol)sys[0]).GetMembers("Collections");
             var generic = ((NamespaceSymbol)collections[0]).GetMembers("Generic");
             var dictionary = ((NamespaceSymbol)generic[0]).GetMembers("Dictionary");
-            var @base = ((NamedTypeSymbol)dictionary[0]).BaseType;
+            var @base = ((NamedTypeSymbol)dictionary[0]).BaseType();
 
             AssertBaseType(@base, "System.Object");
-            Assert.Null(@base.BaseType);
+            Assert.Null(@base.BaseType());
 
             var concurrent = ((NamespaceSymbol)collections[0]).GetMembers("Concurrent");
 
@@ -78,10 +78,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                 }
             }
 
-            @base = orderablePartitioner.BaseType;
+            @base = orderablePartitioner.BaseType();
 
             AssertBaseType(@base, "System.Collections.Concurrent.Partitioner<TSource>");
-            Assert.Same(((NamedTypeSymbol)@base).TypeArguments[0], orderablePartitioner.TypeParameters[0]);
+            Assert.Same(((NamedTypeSymbol)@base).TypeArguments()[0], orderablePartitioner.TypeParameters[0]);
 
             var partitioners = ((NamespaceSymbol)concurrent[0]).GetMembers("Partitioner");
             NamedTypeSymbol partitioner = null;
@@ -109,13 +109,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var varTC3 = module1.GlobalNamespace.GetTypeMembers("TC3").Single();
             var varTC4 = module1.GlobalNamespace.GetTypeMembers("TC4").Single();
 
-            AssertBaseType(varTC2.BaseType, "C1<TC2_T1>.C2<TC2_T2>");
-            AssertBaseType(varTC3.BaseType, "C1<TC3_T1>.C3");
-            AssertBaseType(varTC4.BaseType, "C1<TC4_T1>.C3.C4<TC4_T2>");
+            AssertBaseType(varTC2.BaseType(), "C1<TC2_T1>.C2<TC2_T2>");
+            AssertBaseType(varTC3.BaseType(), "C1<TC3_T1>.C3");
+            AssertBaseType(varTC4.BaseType(), "C1<TC4_T1>.C3.C4<TC4_T2>");
 
             var varC1 = module1.GlobalNamespace.GetTypeMembers("C1").Single();
-            AssertBaseType(varC1.BaseType, "System.Object");
-            Assert.Equal(0, varC1.Interfaces.Length);
+            AssertBaseType(varC1.BaseType(), "System.Object");
+            Assert.Equal(0, varC1.Interfaces().Length);
 
             var varTC5 = module2.GlobalNamespace.GetTypeMembers("TC5").Single();
             var varTC6 = module2.GlobalNamespace.GetTypeMembers("TC6").Single();
@@ -123,33 +123,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var varTC8 = module2.GlobalNamespace.GetTypeMembers("TC8").Single();
             var varTC9 = varTC6.GetTypeMembers("TC9").Single();
 
-            AssertBaseType(varTC5.BaseType, "C1<TC5_T1>.C2<TC5_T2>");
-            AssertBaseType(varTC6.BaseType, "C1<TC6_T1>.C3");
-            AssertBaseType(varTC7.BaseType, "C1<TC7_T1>.C3.C4<TC7_T2>");
-            AssertBaseType(varTC8.BaseType, "C1<System.Type>");
-            AssertBaseType(varTC9.BaseType, "TC6<TC6_T1>");
+            AssertBaseType(varTC5.BaseType(), "C1<TC5_T1>.C2<TC5_T2>");
+            AssertBaseType(varTC6.BaseType(), "C1<TC6_T1>.C3");
+            AssertBaseType(varTC7.BaseType(), "C1<TC7_T1>.C3.C4<TC7_T2>");
+            AssertBaseType(varTC8.BaseType(), "C1<System.Type>");
+            AssertBaseType(varTC9.BaseType(), "TC6<TC6_T1>");
 
             var varCorTypes = module2.GlobalNamespace.GetMembers("CorTypes").OfType<NamespaceSymbol>().Single();
 
             var varCorTypes_Derived = varCorTypes.GetTypeMembers("Derived").Single();
-            AssertBaseType(varCorTypes_Derived.BaseType,
+            AssertBaseType(varCorTypes_Derived.BaseType(),
                            "CorTypes.NS.Base<System.Boolean, System.SByte, System.Byte, System.Int16, System.UInt16, System.Int32, System.UInt32, System.Int64, System.UInt64, System.Single, System.Double, System.Char, System.String, System.IntPtr, System.UIntPtr, System.Object>");
 
             var varCorTypes_Derived1 = varCorTypes.GetTypeMembers("Derived1").Single();
-            AssertBaseType(varCorTypes_Derived1.BaseType,
+            AssertBaseType(varCorTypes_Derived1.BaseType(),
                            "CorTypes.Base<System.Int32[], System.Double[,]>");
 
             var varI101 = module1.GlobalNamespace.GetTypeMembers("I101").Single();
             var varI102 = module1.GlobalNamespace.GetTypeMembers("I102").Single();
 
             var varC203 = module1.GlobalNamespace.GetTypeMembers("C203").Single();
-            Assert.Equal(1, varC203.Interfaces.Length);
-            Assert.Same(varI101, varC203.Interfaces[0]);
+            Assert.Equal(1, varC203.Interfaces().Length);
+            Assert.Same(varI101, varC203.Interfaces()[0]);
 
             var varC204 = module1.GlobalNamespace.GetTypeMembers("C204").Single();
-            Assert.Equal(2, varC204.Interfaces.Length);
-            Assert.Same(varI101, varC204.Interfaces[0]);
-            Assert.Same(varI102, varC204.Interfaces[1]);
+            Assert.Equal(2, varC204.Interfaces().Length);
+            Assert.Same(varI101, varC204.Interfaces()[0]);
+            Assert.Same(varI102, varC204.Interfaces()[1]);
         }
 
         private void TestBaseTypeResolutionHelper3(AssemblySymbol[] assemblies)
@@ -160,10 +160,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var varCorTypes = module2.GlobalNamespace.GetMembers("CorTypes").OfType<NamespaceSymbol>().Single();
 
             var varCorTypes_Derived = varCorTypes.GetTypeMembers("Derived").Single();
-            AssertBaseType(varCorTypes_Derived.BaseType,
+            AssertBaseType(varCorTypes_Derived.BaseType(),
                            "CorTypes.NS.Base<System.Boolean,System.SByte,System.Byte,System.Int16,System.UInt16,System.Int32,System.UInt32,System.Int64,System.UInt64,System.Single,System.Double,System.Char,System.String,System.IntPtr,System.UIntPtr,System.Object>");
 
-            foreach (var arg in varCorTypes_Derived.BaseType.TypeArguments)
+            foreach (var arg in varCorTypes_Derived.BaseType().TypeArguments())
             {
                 Assert.IsType<MissingMetadataTypeSymbol>(arg);
             }
@@ -177,13 +177,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var module0 = assemblies[1].Modules[0];
 
             var derived1 = module0.GlobalNamespace.GetTypeMembers("Derived1").Single();
-            var base1 = derived1.BaseType;
+            var base1 = derived1.BaseType();
 
             var derived2 = module0.GlobalNamespace.GetTypeMembers("Derived2").Single();
-            var base2 = derived2.BaseType;
+            var base2 = derived2.BaseType();
 
             var derived3 = module0.GlobalNamespace.GetTypeMembers("Derived3").Single();
-            var base3 = derived3.BaseType;
+            var base3 = derived3.BaseType();
 
             AssertBaseType(base1, "Class1");
             AssertBaseType(base2, "Class2");
@@ -217,49 +217,49 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var bases = new HashSet<NamedTypeSymbol>();
 
             var localTC1 = module0.GlobalNamespace.GetTypeMembers("TC1").Single();
-            var base1 = localTC1.BaseType;
+            var base1 = localTC1.BaseType();
             bases.Add(base1);
             Assert.NotEqual(SymbolKind.ErrorType, base1.Kind);
             Assert.Equal("SomeName.Dummy", base1.ToTestDisplayString());
 
             var localTC2 = module0.GlobalNamespace.GetTypeMembers("TC2").Single();
-            var base2 = localTC2.BaseType;
+            var base2 = localTC2.BaseType();
             bases.Add(base2);
             Assert.NotEqual(SymbolKind.ErrorType, base2.Kind);
             Assert.Equal("somEnamE", base2.ToTestDisplayString());
 
             var localTC3 = module0.GlobalNamespace.GetTypeMembers("TC3").Single();
-            var base3 = localTC3.BaseType;
+            var base3 = localTC3.BaseType();
             bases.Add(base3);
             Assert.NotEqual(SymbolKind.ErrorType, base3.Kind);
             Assert.Equal("somEnamE1", base3.ToTestDisplayString());
 
             var localTC4 = module0.GlobalNamespace.GetTypeMembers("TC4").Single();
-            var base4 = localTC4.BaseType;
+            var base4 = localTC4.BaseType();
             bases.Add(base4);
             Assert.NotEqual(SymbolKind.ErrorType, base4.Kind);
             Assert.Equal("SomeName1", base4.ToTestDisplayString());
 
             var localTC5 = module0.GlobalNamespace.GetTypeMembers("TC5").Single();
-            var base5 = localTC5.BaseType;
+            var base5 = localTC5.BaseType();
             bases.Add(base5);
             Assert.NotEqual(SymbolKind.ErrorType, base5.Kind);
             Assert.Equal("somEnamE2.OtherName", base5.ToTestDisplayString());
 
             var localTC6 = module0.GlobalNamespace.GetTypeMembers("TC6").Single();
-            var base6 = localTC6.BaseType;
+            var base6 = localTC6.BaseType();
             bases.Add(base6);
             Assert.NotEqual(SymbolKind.ErrorType, base6.Kind);
             Assert.Equal("SomeName2.OtherName", base6.ToTestDisplayString());
 
             var localTC7 = module0.GlobalNamespace.GetTypeMembers("TC7").Single();
-            var base7 = localTC7.BaseType;
+            var base7 = localTC7.BaseType();
             bases.Add(base7);
             Assert.NotEqual(SymbolKind.ErrorType, base7.Kind);
             Assert.Equal("NestingClass.somEnamE3", base7.ToTestDisplayString());
 
             var localTC8 = module0.GlobalNamespace.GetTypeMembers("TC8").Single();
-            var base8 = localTC8.BaseType;
+            var base8 = localTC8.BaseType();
             bases.Add(base8);
             Assert.NotEqual(SymbolKind.ErrorType, base8.Kind);
             Assert.Equal("NestingClass.SomeName3", base8.ToTestDisplayString());
@@ -336,11 +336,11 @@ class Test2 : M4
             var test1 = compilation1.GetTypeByMetadataName("Test1");
             var test2 = compilation1.GetTypeByMetadataName("Test2");
 
-            Assert.False(test1.BaseType.IsErrorType());
-            Assert.False(test1.BaseType.BaseType.IsErrorType());
-            Assert.False(test2.BaseType.IsErrorType());
-            Assert.False(test2.BaseType.BaseType.IsErrorType());
-            Assert.False(test2.BaseType.BaseType.BaseType.IsErrorType());
+            Assert.False(test1.BaseType().IsErrorType());
+            Assert.False(test1.BaseType().BaseType().IsErrorType());
+            Assert.False(test2.BaseType().IsErrorType());
+            Assert.False(test2.BaseType().BaseType().IsErrorType());
+            Assert.False(test2.BaseType().BaseType().BaseType().IsErrorType());
 
             var compilationDef2 = @"
 public class M3 : M1
@@ -356,19 +356,19 @@ public class M4 : M2
             var m3 = compilation2.GetTypeByMetadataName("M3");
             var m4 = compilation2.GetTypeByMetadataName("M4");
 
-            Assert.False(m3.BaseType.IsErrorType());
-            Assert.False(m3.BaseType.BaseType.IsErrorType());
-            Assert.False(m4.BaseType.IsErrorType());
-            Assert.False(m4.BaseType.BaseType.IsErrorType());
+            Assert.False(m3.BaseType().IsErrorType());
+            Assert.False(m3.BaseType().BaseType().IsErrorType());
+            Assert.False(m4.BaseType().IsErrorType());
+            Assert.False(m4.BaseType().BaseType().IsErrorType());
 
             var compilation3 = CreateStandardCompilation(compilationDef2, new MetadataReference[] { crossRefModule2 }, TestOptions.ReleaseDll);
 
             m3 = compilation3.GetTypeByMetadataName("M3");
             m4 = compilation3.GetTypeByMetadataName("M4");
 
-            Assert.True(m3.BaseType.IsErrorType());
-            Assert.False(m4.BaseType.IsErrorType());
-            Assert.True(m4.BaseType.BaseType.IsErrorType());
+            Assert.True(m3.BaseType().IsErrorType());
+            Assert.False(m4.BaseType().IsErrorType());
+            Assert.True(m4.BaseType().BaseType().IsErrorType());
 
             // Expected:
             //error CS0246: The type or namespace name 'M1' could not be found (are you missing a using directive or an

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/DynamicTransformsTests.cs
@@ -50,20 +50,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             CommonTestInitialization();
 
             // public class Base0 { }
-            Assert.Equal(_objectType, _base0Class.BaseType);
+            Assert.Equal(_objectType, _base0Class.BaseType());
             Assert.False(_base0Class.ContainsDynamic());
 
             // public class Base1<T> { }
-            Assert.Equal(_objectType, _base1Class.BaseType);
+            Assert.Equal(_objectType, _base1Class.BaseType());
             Assert.False(_base1Class.ContainsDynamic());
 
             // public class Base2<T, U> { }
-            Assert.Equal(_objectType, _base2Class.BaseType);
+            Assert.Equal(_objectType, _base2Class.BaseType());
             Assert.False(_base2Class.ContainsDynamic());
 
             // public class Derived<T> : Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic> where T : Derived<T> { ... }
             Assert.False(_derivedClass.ContainsDynamic());
-            Assert.True(_derivedClass.BaseType.ContainsDynamic());
+            Assert.True(_derivedClass.BaseType().ContainsDynamic());
 
             // Outer<dynamic>
             var outerClassOfDynamic = _outerClass.Construct(s_dynamicType);
@@ -79,39 +79,39 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             // Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int>[], dynamic>.InnerInner<dynamic>
             var memberInnerInnerOfDynamic = memberComplicatedInner.GetTypeMember("InnerInner").Construct(s_dynamicType);
 
-            Assert.Equal(memberInnerInnerOfDynamic, _derivedClass.BaseType);
+            Assert.Equal(memberInnerInnerOfDynamic, _derivedClass.BaseType());
 
             // public class Outer<T> : Base1<dynamic>
             Assert.False(_outerClass.ContainsDynamic());
-            Assert.True(_outerClass.BaseType.ContainsDynamic());
+            Assert.True(_outerClass.BaseType().ContainsDynamic());
             var base1OfDynamic = _base1Class.Construct(s_dynamicType);
-            Assert.Equal(base1OfDynamic, _outerClass.BaseType);
+            Assert.Equal(base1OfDynamic, _outerClass.BaseType());
 
             // public class Inner<U, V> : Base2<dynamic, V>
             Assert.False(_innerClass.ContainsDynamic());
-            Assert.True(_innerClass.BaseType.ContainsDynamic());
+            Assert.True(_innerClass.BaseType().ContainsDynamic());
             var base2OfDynamicV = _base2Class.Construct(s_dynamicType, _innerClass.TypeParameters[1]);
-            Assert.Equal(base2OfDynamicV, _innerClass.BaseType);
+            Assert.Equal(base2OfDynamicV, _innerClass.BaseType());
 
             // public class InnerInner<W> : Base1<dynamic> { }
             Assert.False(_innerInnerClass.ContainsDynamic());
-            Assert.True(_innerInnerClass.BaseType.ContainsDynamic());
-            Assert.Equal(base1OfDynamic, _innerInnerClass.BaseType);
+            Assert.True(_innerInnerClass.BaseType().ContainsDynamic());
+            Assert.Equal(base1OfDynamic, _innerInnerClass.BaseType());
 
             // public class Outer2<T> : Base1<dynamic>
             Assert.False(_outer2Class.ContainsDynamic());
-            Assert.True(_outer2Class.BaseType.ContainsDynamic());
-            Assert.Equal(base1OfDynamic, _outer2Class.BaseType);
+            Assert.True(_outer2Class.BaseType().ContainsDynamic());
+            Assert.Equal(base1OfDynamic, _outer2Class.BaseType());
 
             // public class Inner2<U, V> : Base0
             Assert.False(_inner2Class.ContainsDynamic());
-            Assert.False(_inner2Class.BaseType.ContainsDynamic());
-            Assert.Equal(_base0Class, _inner2Class.BaseType);
+            Assert.False(_inner2Class.BaseType().ContainsDynamic());
+            Assert.Equal(_base0Class, _inner2Class.BaseType());
 
             // public class InnerInner2<W> : Base0 { }
             Assert.False(_innerInner2Class.ContainsDynamic());
-            Assert.False(_innerInner2Class.BaseType.ContainsDynamic());
-            Assert.Equal(_base0Class, _innerInner2Class.BaseType);
+            Assert.False(_innerInner2Class.BaseType().ContainsDynamic());
+            Assert.Equal(_base0Class, _innerInner2Class.BaseType());
 
             // public class Inner3<U>
             Assert.False(_inner3Class.ContainsDynamic());
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             // public unsafe class UnsafeClass<T> : Base2<int*[], Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int*[][]>[], dynamic>.InnerInner<dynamic>[][]> { }
             var unsafeClass = _assembly.Modules[0].GlobalNamespace.GetMember<NamedTypeSymbol>("UnsafeClass");
             Assert.False(unsafeClass.ContainsDynamic());
-            Assert.True(unsafeClass.BaseType.ContainsDynamic());
+            Assert.True(unsafeClass.BaseType().ContainsDynamic());
 
             var unsafeClassTypeParam = unsafeClass.TypeParameters[0];
             // T[]
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             // Base2<int*[], Outer<dynamic>.Inner<Outer<dynamic>.Inner<T[], dynamic>.InnerInner<int*[][]>[], dynamic>.InnerInner<dynamic>[][]>
             var baseType = _base2Class.Construct(arrayOfPointerToInt, complicatedInnerInnerArrayOfArray);
 
-            Assert.Equal(baseType, unsafeClass.BaseType);
+            Assert.Equal(baseType, unsafeClass.BaseType());
         }
 
         [Fact]
@@ -551,11 +551,11 @@ str";
             CompileAndVerify(compilation, expectedOutput: expectedOutput);
 
             var classDerived = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            var field1 = classDerived.BaseType.GetMember<FieldSymbol>("field1");
+            var field1 = classDerived.BaseType().GetMember<FieldSymbol>("field1");
             Assert.False(field1.Type.ContainsDynamic());
 
             var classDerived2 = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived2");
-            field1 = classDerived.BaseType.GetMember<FieldSymbol>("field1");
+            field1 = classDerived.BaseType().GetMember<FieldSymbol>("field1");
             Assert.False(field1.Type.ContainsDynamic());
 
             var classB = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("B");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -1425,7 +1425,7 @@ class Class2 : Class1
 
             CompileAndVerify(CreateCompilationWithCustomILSource(csSource, ilSource), symbolValidator: module =>
             {
-                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType;
+                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType();
                 Assert.Equal("Class1", class1.ToTestDisplayString());
 
                 var field1 = class1.GetField("d1");
@@ -1452,7 +1452,7 @@ class Class2 : Class1
 
             CompileAndVerify(CreateCompilationWithCustomILSource(csSource, ilSource), symbolValidator: module =>
             {
-                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType;
+                var class1 = module.GlobalNamespace.GetTypeMember("Class2").BaseType();
                 Assert.Equal("Class1", class1.ToTestDisplayString());
 
                 var field1 = class1.GetField("d1");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Class").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classEvent = (EventSymbol)@class.GetMembers("Interface.Event").Single();
 
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Generic").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceEvent = (EventSymbol)substitutedInterface.GetMembers("Event").Single();
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Constructed").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceEvent = (EventSymbol)substitutedInterface.GetMembers("Event").Single();
@@ -290,12 +290,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var refInterface = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IGenericInterface").Single();
             Assert.Equal(TypeKind.Interface, defInterface.TypeKind);
-            Assert.True(refInterface.Interfaces.Contains(defInterface));
+            Assert.True(refInterface.Interfaces().Contains(defInterface));
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IndirectImplementation").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var classInterfacesConstructedFrom = @class.Interfaces.Select(i => i.ConstructedFrom);
+            var classInterfacesConstructedFrom = @class.Interfaces().Select(i => i.ConstructedFrom);
             Assert.Equal(2, classInterfacesConstructedFrom.Count());
             Assert.Contains(defInterface, classInterfacesConstructedFrom);
             Assert.Contains(refInterface, classInterfacesConstructedFrom);
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(1, innerClass.Arity);
             Assert.Equal(TypeKind.Class, innerClass.TypeKind);
-            Assert.Equal(@interface, innerClass.Interfaces.Single().ConstructedFrom);
+            Assert.Equal(@interface, innerClass.Interfaces().Single().ConstructedFrom);
 
             var innerClassEvent = (EventSymbol)innerClass.GetMembers(methodName).Single();
             var innerClassImplementingEvent = innerClassEvent.ExplicitInterfaceImplementations.Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingGenericTypeParameters.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingGenericTypeParameters.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(0, objectType.Arity);
             Assert.Equal(0, objectType.TypeParameters.Length);
-            Assert.Equal(0, objectType.TypeArguments.Length);
+            Assert.Equal(0, objectType.TypeArguments().Length);
 
             assembly = MetadataTestHelpers.GetSymbolForReference(TestReferences.SymbolsTests.MDTestLib1);
             module0 = assembly.Modules[0];
@@ -33,11 +33,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(1, varC1.Arity);
             Assert.Equal(1, varC1.TypeParameters.Length);
-            Assert.Equal(1, varC1.TypeArguments.Length);
+            Assert.Equal(1, varC1.TypeArguments().Length);
 
             var varC1_T = varC1.TypeParameters[0];
 
-            Assert.Equal(varC1_T, varC1.TypeArguments[0]);
+            Assert.Equal(varC1_T, varC1.TypeArguments()[0]);
 
             Assert.NotNull(varC1_T.EffectiveBaseClassNoUseSiteDiagnostics);
             Assert.Equal(assembly, varC1_T.ContainingAssembly);
@@ -70,12 +70,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(TypeKind.TypeParameter, varC1_T.TypeKind);
             Assert.Equal(VarianceKind.None, varC1_T.Variance);
             Assert.Same(module0, varC1_T.Locations.Single().MetadataModule);
-            Assert.Equal(0, varC1_T.ConstraintTypes.Length);
+            Assert.Equal(0, varC1_T.ConstraintTypes().Length);
 
             var varC2 = varC1.GetTypeMembers("C2").Single();
             Assert.Equal(1, varC2.Arity);
             Assert.Equal(1, varC2.TypeParameters.Length);
-            Assert.Equal(1, varC2.TypeArguments.Length);
+            Assert.Equal(1, varC2.TypeArguments().Length);
 
             var varC2_T = varC2.TypeParameters[0];
 
@@ -85,12 +85,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var varC3 = varC1.GetTypeMembers("C3").Single();
             Assert.Equal(0, varC3.Arity);
             Assert.Equal(0, varC3.TypeParameters.Length);
-            Assert.Equal(0, varC3.TypeArguments.Length);
+            Assert.Equal(0, varC3.TypeArguments().Length);
 
             var varC4 = varC3.GetTypeMembers("C4").Single();
             Assert.Equal(1, varC4.Arity);
             Assert.Equal(1, varC4.TypeParameters.Length);
-            Assert.Equal(1, varC4.TypeArguments.Length);
+            Assert.Equal(1, varC4.TypeArguments().Length);
 
             var varC4_T = varC4.TypeParameters[0];
 
@@ -101,13 +101,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(2, varTC2.Arity);
             Assert.Equal(2, varTC2.TypeParameters.Length);
-            Assert.Equal(2, varTC2.TypeArguments.Length);
+            Assert.Equal(2, varTC2.TypeArguments().Length);
 
             var varTC2_T1 = varTC2.TypeParameters[0];
             var varTC2_T2 = varTC2.TypeParameters[1];
 
-            Assert.Equal(varTC2_T1, varTC2.TypeArguments[0]);
-            Assert.Equal(varTC2_T2, varTC2.TypeArguments[1]);
+            Assert.Equal(varTC2_T1, varTC2.TypeArguments()[0]);
+            Assert.Equal(varTC2_T2, varTC2.TypeArguments()[1]);
 
             Assert.Equal("TC2_T1", varTC2_T1.Name);
             Assert.Equal(varTC2, varTC2_T1.ContainingType);
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.False(varT.HasReferenceTypeConstraint);
             Assert.False(varT.HasValueTypeConstraint);
             Assert.Equal(VarianceKind.None, varT.Variance);
-            Assert.Equal(0, varT.ConstraintTypes.Length);
+            Assert.Equal(0, varT.ConstraintTypes().Length);
 
             var varC103 = module0.GlobalNamespace.GetTypeMembers("C103").Single();
             varT = varC103.TypeParameters[0];
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.True(varT.HasReferenceTypeConstraint);
             Assert.False(varT.HasValueTypeConstraint);
             Assert.Equal(VarianceKind.None, varT.Variance);
-            Assert.Equal(0, varT.ConstraintTypes.Length);
+            Assert.Equal(0, varT.ConstraintTypes().Length);
 
             var varC104 = module0.GlobalNamespace.GetTypeMembers("C104").Single();
             varT = varC104.TypeParameters[0];
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.False(varT.HasReferenceTypeConstraint);
             Assert.True(varT.HasValueTypeConstraint);
             Assert.Equal(VarianceKind.None, varT.Variance);
-            Assert.Equal(0, varT.ConstraintTypes.Length);
+            Assert.Equal(0, varT.ConstraintTypes().Length);
 
             var varC105 = module0.GlobalNamespace.GetTypeMembers("C105").Single();
             varT = varC105.TypeParameters[0];
@@ -174,14 +174,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var varC201 = module0.GlobalNamespace.GetTypeMembers("C201").Single();
             varT = varC201.TypeParameters[0];
-            Assert.Equal(1, varT.ConstraintTypes.Length);
-            Assert.Same(varI101, varT.ConstraintTypes.ElementAt(0));
+            Assert.Equal(1, varT.ConstraintTypes().Length);
+            Assert.Same(varI101, varT.ConstraintTypes().ElementAt(0));
 
             var localC202 = module0.GlobalNamespace.GetTypeMembers("C202").Single();
             varT = localC202.TypeParameters[0];
-            Assert.Equal(2, varT.ConstraintTypes.Length);
-            Assert.Same(varI101, varT.ConstraintTypes.ElementAt(0));
-            Assert.Same(varI102, varT.ConstraintTypes.ElementAt(1));
+            Assert.Equal(2, varT.ConstraintTypes().Length);
+            Assert.Same(varI101, varT.ConstraintTypes().ElementAt(0));
+            Assert.Same(varI102, varT.ConstraintTypes().ElementAt(1));
         }
 
         [Fact, WorkItem(619267, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/619267")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -151,8 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var basicC1_M11 = (MethodSymbol)basicC1.GetMembers("M11").Single();
             Assert.Equal("T3 C1.M11<T2, T3>(T2 x)", basicC1_M11.ToTestDisplayString());
-            Assert.Equal(0, basicC1_M11.TypeParameters[0].ConstraintTypes.Length);
-            Assert.Same(basicC1, basicC1_M11.TypeParameters[1].ConstraintTypes.Single());
+            Assert.Equal(0, basicC1_M11.TypeParameters[0].ConstraintTypes().Length);
+            Assert.Same(basicC1, basicC1_M11.TypeParameters[1].ConstraintTypes().Single());
 
             var basicC1_M12 = (MethodSymbol)basicC1.GetMembers("M12").Single();
             Assert.Equal(0, basicC1_M12.TypeArguments.Length);
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Class").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("Interface.Method").Single();
             Assert.Equal(MethodKind.ExplicitInterfaceImplementation, classMethod.MethodKind);
@@ -416,8 +416,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("C").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(interface1));
-            Assert.True(@class.Interfaces.Contains(interface2));
+            Assert.True(@class.Interfaces().Contains(interface1));
+            Assert.True(@class.Interfaces().Contains(interface2));
 
             var classMethod = (MethodSymbol)@class.GetMembers("Method").Single();   //  the method is considered to be Ordinary 
             Assert.Equal(MethodKind.Ordinary, classMethod.MethodKind);              //  because it has name without '.'
@@ -449,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Generic").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceMethod = (MethodSymbol)substitutedInterface.GetMembers("Method").Last(); //this assumes decl order
@@ -485,7 +485,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Constructed").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceMethod = (MethodSymbol)substitutedInterface.GetMembers("Method").Last(); //this assumes decl order
@@ -518,8 +518,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("InterfaceCycleSuccess").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(cyclicInterface));
-            Assert.True(@class.Interfaces.Contains(implementedInterface));
+            Assert.True(@class.Interfaces().Contains(cyclicInterface));
+            Assert.True(@class.Interfaces().Contains(implementedInterface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("Method").Single();   //  the method is considered to be Ordinary 
             Assert.Equal(MethodKind.Ordinary, classMethod.MethodKind);              //  because it has name without '.'
@@ -541,7 +541,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("InterfaceCycleFailure").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(cyclicInterface));
+            Assert.True(@class.Interfaces().Contains(cyclicInterface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("Method").Single();
             //we couldn't find an interface method that's explicitly implemented, so we have no reason to believe the method isn't ordinary
@@ -574,12 +574,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var refInterface = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IGenericInterface").Single();
             Assert.Equal(TypeKind.Interface, defInterface.TypeKind);
-            Assert.True(refInterface.Interfaces.Contains(defInterface));
+            Assert.True(refInterface.Interfaces().Contains(defInterface));
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IndirectImplementation").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var classInterfacesConstructedFrom = @class.Interfaces.Select(i => i.ConstructedFrom);
+            var classInterfacesConstructedFrom = @class.Interfaces().Select(i => i.ConstructedFrom);
             Assert.Equal(2, classInterfacesConstructedFrom.Count());
             Assert.Contains(defInterface, classInterfacesConstructedFrom);
             Assert.Contains(refInterface, classInterfacesConstructedFrom);
@@ -608,7 +608,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var derivedClass = (NamedTypeSymbol)globalNamespace.GetTypeMembers("ExplicitlyImplementsAClass").Single();
             Assert.Equal(TypeKind.Class, derivedClass.TypeKind);
-            Assert.Equal(baseClass, derivedClass.BaseType);
+            Assert.Equal(baseClass, derivedClass.BaseType());
 
             var derivedClassMethod = (MethodSymbol)derivedClass.GetMembers("Method").Single();
             Assert.Equal(MethodKind.Ordinary, derivedClassMethod.MethodKind);
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("ExplicitlyImplementsUnrelatedInterfaceMethods").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.Equal(0, @class.AllInterfaces.Length);
+            Assert.Equal(0, @class.AllInterfaces().Length);
 
             var classMethod = (MethodSymbol)@class.GetMembers("Method1").Single();
             Assert.Equal(MethodKind.Ordinary, classMethod.MethodKind);
@@ -666,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("ExplicitlyImplementsUnrelatedInterfaceMethods").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.Equal(0, @class.AllInterfaces.Length);
+            Assert.Equal(0, @class.AllInterfaces().Length);
 
             var classMethod = (MethodSymbol)@class.GetMembers("Method2").Single();
             Assert.Equal(MethodKind.Ordinary, classMethod.MethodKind);
@@ -729,7 +729,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(1, innerClass.Arity);
             Assert.Equal(TypeKind.Class, innerClass.TypeKind);
-            Assert.Equal(@interface, innerClass.Interfaces.Single().ConstructedFrom);
+            Assert.Equal(@interface, innerClass.Interfaces().Single().ConstructedFrom);
 
             var innerClassMethod = (MethodSymbol)innerClass.GetMembers(methodName).Single();
             var innerClassImplementingMethod = innerClassMethod.ExplicitInterfaceImplementations.Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingProperties.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingProperties.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Class").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classProperty = (PropertySymbol)@class.GetMembers("Interface.Property").Single();
 
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Generic").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceProperty = (PropertySymbol)substitutedInterface.GetMembers("Property").Single();
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("Constructed").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceProperty = (PropertySymbol)substitutedInterface.GetMembers("Property").Single();
@@ -125,12 +125,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var refInterface = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IGenericInterface").Single();
             Assert.Equal(TypeKind.Interface, defInterface.TypeKind);
-            Assert.True(refInterface.Interfaces.Contains(defInterface));
+            Assert.True(refInterface.Interfaces().Contains(defInterface));
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IndirectImplementation").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var classInterfacesConstructedFrom = @class.Interfaces.Select(i => i.ConstructedFrom);
+            var classInterfacesConstructedFrom = @class.Interfaces().Select(i => i.ConstructedFrom);
             Assert.Equal(2, classInterfacesConstructedFrom.Count());
             Assert.Contains(defInterface, classInterfacesConstructedFrom);
             Assert.Contains(refInterface, classInterfacesConstructedFrom);
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(1, innerClass.Arity);
             Assert.Equal(TypeKind.Class, innerClass.TypeKind);
-            Assert.Equal(@interface, innerClass.Interfaces.Single().ConstructedFrom);
+            Assert.Equal(@interface, innerClass.Interfaces().Single().ConstructedFrom);
 
             var innerClassProperty = (PropertySymbol)innerClass.GetMembers(methodName).Single();
             var innerClassImplementingProperty = innerClassProperty.ExplicitInterfaceImplementations.Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/MissingTypeReferences.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/MissingTypeReferences.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var localTC10 = module0.GlobalNamespace.GetTypeMembers("TC10").Single();
 
-            MissingMetadataTypeSymbol @base = (MissingMetadataTypeSymbol)localTC10.BaseType;
+            MissingMetadataTypeSymbol @base = (MissingMetadataTypeSymbol)localTC10.BaseType();
             Assert.Equal(SymbolKind.ErrorType, @base.Kind);
             Assert.False(@base.IsNamespace);
             Assert.True(@base.IsType);
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal("mscorlib", @base.ContainingAssembly.Identity.Name);
 
             var localTC8 = module0.GlobalNamespace.GetTypeMembers("TC8").Single();
-            var genericBase = (ErrorTypeSymbol)localTC8.BaseType;
+            var genericBase = (ErrorTypeSymbol)localTC8.BaseType();
             Assert.Equal("C1<System.Type[missing]>[missing]", genericBase.ToTestDisplayString());
 
             @base = (MissingMetadataTypeSymbol)genericBase.ConstructedFrom;
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal("MDTestLib1", @base.ContainingAssembly.Identity.Name);
 
             var localTC7 = module0.GlobalNamespace.GetTypeMembers("TC7").Single();
-            genericBase = (ErrorTypeSymbol)localTC7.BaseType;
+            genericBase = (ErrorTypeSymbol)localTC7.BaseType();
             @base = (MissingMetadataTypeSymbol)genericBase.OriginalDefinition;
 
             Assert.Equal("C1<TC7_T1>[missing].C3[missing].C4<TC7_T2>[missing]", genericBase.ToTestDisplayString());
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal("C1<TC7_T1>[missing].C3[missing].C4<>[missing]", constructedFrom.ToTestDisplayString());
 
             Assert.Same(constructedFrom, constructedFrom.Construct(constructedFrom.TypeParameters.ToArray()));
-            Assert.Equal(genericBase, constructedFrom.Construct(genericBase.TypeArguments));
+            Assert.Equal(genericBase, constructedFrom.Construct(genericBase.TypeArguments()));
 
             genericBase = (ErrorTypeSymbol)genericBase.ContainingSymbol;
             Assert.Equal("C1<TC7_T1>[missing].C3[missing]", genericBase.ToTestDisplayString());
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assembly2 = (MetadataOrSourceAssemblySymbol)assemblies[1];
 
             NamedTypeSymbol localTC = module1.GlobalNamespace.GetTypeMembers("TC1").Single();
-            var @base = (MissingMetadataTypeSymbol)localTC.BaseType;
+            var @base = (MissingMetadataTypeSymbol)localTC.BaseType();
             Assert.Equal(SymbolKind.ErrorType, @base.Kind);
             Assert.False(@base.IsNamespace);
             Assert.True(@base.IsType);
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.NotNull(@base.ContainingAssembly);
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC2").Single();
-            @base = (MissingMetadataTypeSymbol)localTC.BaseType;
+            @base = (MissingMetadataTypeSymbol)localTC.BaseType();
             Assert.Equal(SymbolKind.ErrorType, @base.Kind);
             Assert.False(@base.IsNamespace);
             Assert.True(@base.IsType);
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.NotNull(@base.ContainingAssembly);
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC3").Single();
-            @base = (MissingMetadataTypeSymbol)localTC.BaseType;
+            @base = (MissingMetadataTypeSymbol)localTC.BaseType();
             Assert.Equal(SymbolKind.ErrorType, @base.Kind);
             Assert.False(@base.IsNamespace);
             Assert.True(@base.IsType);
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.NotNull(@base.ContainingModule);
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC4").Single();
-            var genericBase = localTC.BaseType;
+            var genericBase = localTC.BaseType();
             Assert.Equal(SymbolKind.ErrorType, genericBase.Kind);
             Assert.Equal("MissingC4<T1, S1>[missing]", genericBase.ToTestDisplayString());
 
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var missingC4 = @base;
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC5").Single();
-            genericBase = localTC.BaseType;
+            genericBase = localTC.BaseType();
             Assert.Equal("MissingC4<T1, S1>[missing].MissingC5<U1, V1, W1>[missing]", genericBase.ToTestDisplayString());
 
             @base = (MissingMetadataTypeSymbol)genericBase.OriginalDefinition;
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC6").Single();
 
-            genericBase = localTC.BaseType;
+            genericBase = localTC.BaseType();
             Assert.Equal("C6.MissingC7<U, V>[missing]", genericBase.ToTestDisplayString());
             Assert.Equal(SymbolKind.NamedType, genericBase.ContainingSymbol.Kind);
 
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var missingC7 = @base;
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC7").Single();
-            genericBase = localTC.BaseType;
+            genericBase = localTC.BaseType();
             Assert.Equal("C6.MissingC7<U, V>[missing].MissingC8[missing]", genericBase.ToTestDisplayString());
             Assert.Equal(SymbolKind.ErrorType, genericBase.ContainingSymbol.Kind);
 
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var missingC8 = @base;
 
             localTC = module1.GlobalNamespace.GetTypeMembers("TC8").Single();
-            genericBase = localTC.BaseType;
+            genericBase = localTC.BaseType();
             Assert.Equal("C6.MissingC7<U, V>[missing].MissingC8[missing].MissingC9[missing]", genericBase.ToTestDisplayString());
             Assert.Equal(SymbolKind.ErrorType, genericBase.ContainingSymbol.Kind);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
@@ -1232,7 +1232,7 @@ public interface I7
             Assert.NotEqual(SymbolKind.ErrorType, varI5.Kind);
             Assert.NotEqual(SymbolKind.ErrorType, varI6.Kind);
             Assert.NotEqual(SymbolKind.ErrorType, varI5_Foo.ReturnType.Kind);
-            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI5_Foo.ReturnType).TypeArguments[0].Kind);
+            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI5_Foo.ReturnType).TypeArguments()[0].Kind);
             Assert.Equal("System.Collections.Generic.List<I6>", varI5_Foo.ReturnType.ToTestDisplayString());
 
             var varI7 = varC_Library2.SourceModule.GlobalNamespace.GetTypeMembers("I7").Single();
@@ -1240,11 +1240,11 @@ public interface I7
             var varI7_Bar = varI7.GetMembers("Bar").OfType<MethodSymbol>().Single();
 
             Assert.NotEqual(SymbolKind.ErrorType, varI7_Foo.ReturnType.Kind);
-            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI7_Foo.ReturnType).TypeArguments[0].Kind);
+            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI7_Foo.ReturnType).TypeArguments()[0].Kind);
             Assert.Equal("System.Collections.Generic.List<I5>", varI7_Foo.ReturnType.ToTestDisplayString());
 
             Assert.NotEqual(SymbolKind.ErrorType, varI7_Bar.ReturnType.Kind);
-            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI7_Bar.ReturnType).TypeArguments[0].Kind);
+            Assert.NotEqual(SymbolKind.ErrorType, ((NamedTypeSymbol)varI7_Bar.ReturnType).TypeArguments()[0].Kind);
             Assert.Equal("System.Collections.Generic.List<I1>", varI7_Bar.ReturnType.ToTestDisplayString());
 
             var varI1 = varC_Pia1.SourceModule.GlobalNamespace.GetTypeMembers("I1").Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPiaInstantiationOfGenericClassAndStruct.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPiaInstantiationOfGenericClassAndStruct.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             NamedTypeSymbol classLocalType1 = localConsumer1.SourceModule.GlobalNamespace.GetTypeMembers("NoPIAGenerics").Single();
             var localField = classLocalType1.GetMembers("field").OfType<FieldSymbol>().Single();
 
-            Assert.Equal(SymbolKind.ErrorType, localField.Type.BaseType.Kind);
-            Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localField.Type.BaseType);
+            Assert.Equal(SymbolKind.ErrorType, localField.Type.BaseType().Kind);
+            Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localField.Type.BaseType());
         }
 
         [Fact]
@@ -90,10 +90,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             Assert.Equal(SymbolKind.NamedType, importedField.Type.Kind);
 
-            var outer = ((NamedTypeSymbol)importedField.Type).TypeArguments.Single();
+            var outer = ((NamedTypeSymbol)importedField.Type).TypeArguments().Single();
             Assert.Equal(SymbolKind.NamedType, outer.Kind);
 
-            var inner = ((NamedTypeSymbol)outer).TypeArguments.Single();
+            var inner = ((NamedTypeSymbol)outer).TypeArguments().Single();
             Assert.Equal(SymbolKind.ErrorType, inner.Kind);
         }
 
@@ -133,13 +133,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 if (m.Parameters.Length > 0)
                 {
-                    Assert.Equal(SymbolKind.ErrorType, m.Parameters.Where(arg => arg.Name == "c1").Select(arg => arg).Single().Type.BaseType.Kind);
-                    Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(m.Parameters.Where(arg => arg.Name == "c1").Select(arg => arg).Single().Type.BaseType);
+                    Assert.Equal(SymbolKind.ErrorType, m.Parameters.Where(arg => arg.Name == "c1").Select(arg => arg).Single().Type.BaseType().Kind);
+                    Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(m.Parameters.Where(arg => arg.Name == "c1").Select(arg => arg).Single().Type.BaseType());
                 }
                 if (m.ReturnType.TypeKind != TypeKind.Struct)
                 {
-                    Assert.Equal(SymbolKind.ErrorType, m.ReturnType.BaseType.Kind);
-                    Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(m.ReturnType.BaseType);
+                    Assert.Equal(SymbolKind.ErrorType, m.ReturnType.BaseType().Kind);
+                    Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(m.ReturnType.BaseType());
                 }
             }
         }
@@ -386,8 +386,8 @@ public class NoPIAGenerics
             NamedTypeSymbol classLocalType = localConsumer.GlobalNamespace.GetTypeMembers("NoPIAGenerics").Single();
             var localField = classLocalType.GetMembers("myclass").OfType<FieldSymbol>().Single();
 
-            Assert.Equal(SymbolKind.ErrorType, localField.Type.BaseType.Kind);
-            Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localField.Type.BaseType);
+            Assert.Equal(SymbolKind.ErrorType, localField.Type.BaseType().Kind);
+            Assert.IsType<NoPiaIllegalGenericInstantiationSymbol>(localField.Type.BaseType());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeForwarders.cs
@@ -42,15 +42,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var assembly3 = (MetadataOrSourceAssemblySymbol)assemblies[2];
 
             var derived1 = module1.GlobalNamespace.GetTypeMembers("Derived").Single();
-            var base1 = derived1.BaseType;
+            var base1 = derived1.BaseType();
             BaseTypeResolution.AssertBaseType(base1, "Base");
 
             var derived4 = module1.GlobalNamespace.GetTypeMembers("GenericDerived").Single();
-            var base4 = derived4.BaseType;
+            var base4 = derived4.BaseType();
             BaseTypeResolution.AssertBaseType(base4, "GenericBase<K>");
 
             var derived6 = module1.GlobalNamespace.GetTypeMembers("GenericDerived1").Single();
-            var base6 = derived6.BaseType;
+            var base6 = derived6.BaseType();
             BaseTypeResolution.AssertBaseType(base6, "GenericBase<K>.NestedGenericBase<L>");
 
             Assert.Equal(assembly3, base1.ContainingAssembly);
@@ -70,16 +70,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(2, assembly3.EmittedNameToTypeMapCount);
 
             var derived2 = module2.GlobalNamespace.GetTypeMembers("Derived").Single();
-            var base2 = derived2.BaseType;
+            var base2 = derived2.BaseType();
             BaseTypeResolution.AssertBaseType(base2, "Base");
             Assert.Same(base2, base1);
 
             var derived3 = module2.GlobalNamespace.GetTypeMembers("GenericDerived").Single();
-            var base3 = derived3.BaseType;
+            var base3 = derived3.BaseType();
             BaseTypeResolution.AssertBaseType(base3, "GenericBase<S>");
 
             var derived5 = module2.GlobalNamespace.GetTypeMembers("GenericDerived1").Single();
-            var base5 = derived5.BaseType;
+            var base5 = derived5.BaseType();
             BaseTypeResolution.AssertBaseType(base5, "GenericBase<S1>.NestedGenericBase<S2>");
         }
 
@@ -184,7 +184,7 @@ class Derived : Base
             Assert.Equal(baseType, ilAssembly2.ResolveForwardedType("Base"));
 
             var derivedType = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            Assert.Equal(baseType, derivedType.BaseType);
+            Assert.Equal(baseType, derivedType.BaseType());
 
             // All forwards resolve to the same type, so there's no issue.
             compilation.VerifyDiagnostics();
@@ -429,7 +429,7 @@ class Derived : Base
             Assert.Equal(baseType, ilAssembly3.ResolveForwardedType("Base"));
 
             var derivedType = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            Assert.Equal(baseType, derivedType.BaseType);
+            Assert.Equal(baseType, derivedType.BaseType());
 
             // Find the type even though there's a cycle.
             compilation.VerifyDiagnostics();
@@ -1725,7 +1725,7 @@ public class Forwarded<T>
                         var context = CreateStandardCompilation("", new[] { r1, r2, r3 }, options: TestOptions.ReleaseDll);
 
                         var forwarded = context.GetTypeByMetadataName("Forwarded`1");
-                        var resolved = context.GetTypeByMetadataName("B").BaseType.OriginalDefinition;
+                        var resolved = context.GetTypeByMetadataName("B").BaseType().OriginalDefinition;
 
                         Assert.NotNull(forwarded);
                         Assert.False(resolved.IsErrorType());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeKindTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/TypeKindTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                                select t).Single();
 
             Assert.Equal(TypeKind.Interface, ienumerable.TypeKind);
-            Assert.Null(ienumerable.BaseType);
+            Assert.Null(ienumerable.BaseType());
 
             var typeCode = (from t in system.GetTypeMembers()
                             where t.Name.Equals("TypeCode")

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
@@ -81,12 +81,12 @@ class Derived2 : Base<int>
             var baseClassMethod2 = (MethodSymbol)baseClass.GetMembers("Method").Last();
 
             var derivedClass1 = global.GetTypeMembers("Derived1").Single();
-            var substitutedBaseClass = derivedClass1.BaseType;
+            var substitutedBaseClass = derivedClass1.BaseType();
             var substitutedBaseClassMethod1 = (MethodSymbol)substitutedBaseClass.GetMembers("Method").First();
             var substitutedBaseClassMethod2 = (MethodSymbol)substitutedBaseClass.GetMembers("Method").Last();
 
             var derivedClass2 = global.GetTypeMembers("Derived2").Single();
-            var constructedBaseClass = derivedClass2.BaseType;
+            var constructedBaseClass = derivedClass2.BaseType();
             var constructedBaseClassMethod1 = (MethodSymbol)constructedBaseClass.GetMembers("Method").First();
             var constructedBaseClassMethod2 = (MethodSymbol)constructedBaseClass.GetMembers("Method").Last();
 
@@ -141,12 +141,12 @@ class Derived2 : Base<int>
             var baseClassMethod2 = (MethodSymbol)baseClass.GetMembers("Method").Last();
 
             var derivedClass1 = global.GetTypeMembers("Derived1").Single();
-            var substitutedBaseClass = derivedClass1.BaseType;
+            var substitutedBaseClass = derivedClass1.BaseType();
             var substitutedBaseClassMethod1 = (MethodSymbol)substitutedBaseClass.GetMembers("Method").First();
             var substitutedBaseClassMethod2 = (MethodSymbol)substitutedBaseClass.GetMembers("Method").Last();
 
             var derivedClass2 = global.GetTypeMembers("Derived2").Single();
-            var constructedBaseClass = derivedClass2.BaseType;
+            var constructedBaseClass = derivedClass2.BaseType();
             var constructedBaseClassMethod1 = (MethodSymbol)constructedBaseClass.GetMembers("Method").First();
             var constructedBaseClassMethod2 = (MethodSymbol)constructedBaseClass.GetMembers("Method").Last();
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetExplicitInterfaceImplementation.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetExplicitInterfaceImplementation.cs
@@ -141,11 +141,11 @@ public  class D : C
             var interfaceV2Event4 = (EventSymbol)interfaceV2.GetMembers("Event4").Single();
 
             var classD = globalNamespace2.GetTypeMembers("D").Single();
-            var retargetedClassC = classD.BaseType;
+            var retargetedClassC = classD.BaseType();
 
             Assert.IsType<RetargetingNamedTypeSymbol>(retargetedClassC);
 
-            Assert.Equal(interfaceV2, retargetedClassC.Interfaces.Single());
+            Assert.Equal(interfaceV2, retargetedClassC.Interfaces().Single());
 
             var retargetedClassCMethod1 = (MethodSymbol)retargetedClassC.GetMembers("Interface1.Method1").Single();
             {
@@ -391,9 +391,9 @@ public  class D3 : C3
             var classD2 = globalNamespace2.GetTypeMembers("D2").Single();
             var classD3 = globalNamespace2.GetTypeMembers("D3").Single();
 
-            var retargetedClassC1 = classD1.BaseType;
-            var retargetedClassC2 = classD2.BaseType;
-            var retargetedClassC3 = classD3.BaseType;
+            var retargetedClassC1 = classD1.BaseType();
+            var retargetedClassC2 = classD2.BaseType();
+            var retargetedClassC3 = classD3.BaseType();
 
             var retargetedClassC1Method1 = (MethodSymbol)retargetedClassC1.GetMembers("Interface2<S>.Method1").Single();
             var retargetedClassC1Method1Impl = retargetedClassC1Method1.ExplicitInterfaceImplementations.Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -338,18 +338,18 @@ public enum E
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(0, sourceType.Interfaces.Length); // Always returns an empty list for enums.
-            Assert.Equal(TypeKind.Error, sourceType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Enum, sourceType.BaseType.SpecialType);
+            Assert.Equal(0, sourceType.Interfaces().Length); // Always returns an empty list for enums.
+            Assert.Equal(TypeKind.Error, sourceType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Enum, sourceType.BaseType().SpecialType);
             Assert.Equal(TypeKind.Error, sourceType.EnumUnderlyingType.TypeKind);
             Assert.Equal(SpecialType.System_Int32, sourceType.EnumUnderlyingType.SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             retargetingAssembly.SetCorLibrary(MissingCorLibrarySymbol.Instance); // Need to do this explicitly since our retargeting assembly wasn't constructed using the real mechanism.
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Equal(TypeKind.Error, retargetingType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Enum, retargetingType.BaseType.SpecialType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Equal(TypeKind.Error, retargetingType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Enum, retargetingType.BaseType().SpecialType);
             Assert.Equal(TypeKind.Error, retargetingType.EnumUnderlyingType.TypeKind);
             Assert.Equal(SpecialType.System_Int32, retargetingType.EnumUnderlyingType.SpecialType);
         }
@@ -375,18 +375,18 @@ public enum E : short
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(0, sourceType.Interfaces.Length); // Always returns an empty list for enums.
-            Assert.Equal(TypeKind.Error, sourceType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Enum, sourceType.BaseType.SpecialType);
+            Assert.Equal(0, sourceType.Interfaces().Length); // Always returns an empty list for enums.
+            Assert.Equal(TypeKind.Error, sourceType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Enum, sourceType.BaseType().SpecialType);
             Assert.Equal(TypeKind.Error, sourceType.EnumUnderlyingType.TypeKind);
             Assert.Equal(SpecialType.System_Int16, sourceType.EnumUnderlyingType.SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             retargetingAssembly.SetCorLibrary(MissingCorLibrarySymbol.Instance); // Need to do this explicitly since our retargeting assembly wasn't constructed using the real mechanism.
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Equal(TypeKind.Error, retargetingType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Enum, retargetingType.BaseType.SpecialType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Equal(TypeKind.Error, retargetingType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Enum, retargetingType.BaseType().SpecialType);
             Assert.Equal(TypeKind.Error, retargetingType.EnumUnderlyingType.TypeKind);
             Assert.Equal(SpecialType.System_Int16, retargetingType.EnumUnderlyingType.SpecialType);
         }
@@ -407,13 +407,13 @@ public class Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, sourceType.Interfaces.Length);
-            Assert.Equal(SpecialType.System_Object, sourceType.BaseType.SpecialType);
+            Assert.Equal(0, sourceType.Interfaces().Length);
+            Assert.Equal(SpecialType.System_Object, sourceType.BaseType().SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Equal(SpecialType.System_Object, retargetingType.BaseType.SpecialType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Equal(SpecialType.System_Object, retargetingType.BaseType().SpecialType);
         }
 
         [Fact]
@@ -435,15 +435,15 @@ public class Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, sourceType.Interfaces.Length);
-            Assert.Equal(TypeKind.Error, sourceType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Int16, sourceType.BaseType.SpecialType);
+            Assert.Equal(0, sourceType.Interfaces().Length);
+            Assert.Equal(TypeKind.Error, sourceType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, sourceType.BaseType().SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Equal(TypeKind.Error, retargetingType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_Int16, retargetingType.BaseType.SpecialType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Equal(TypeKind.Error, retargetingType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, retargetingType.BaseType().SpecialType);
         }
 
         [Fact]
@@ -462,13 +462,13 @@ public struct Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, sourceType.Interfaces.Length);
-            Assert.Equal(SpecialType.System_ValueType, sourceType.BaseType.SpecialType);
+            Assert.Equal(0, sourceType.Interfaces().Length);
+            Assert.Equal(SpecialType.System_ValueType, sourceType.BaseType().SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Equal(SpecialType.System_ValueType, retargetingType.BaseType.SpecialType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Equal(SpecialType.System_ValueType, retargetingType.BaseType().SpecialType);
         }
 
         [Fact]
@@ -494,17 +494,17 @@ public struct Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(TypeKind.Error, sourceType.Interfaces.Single().TypeKind);
-            Assert.Equal(SpecialType.System_Int16, sourceType.Interfaces.Single().SpecialType);
-            Assert.Equal(TypeKind.Error, sourceType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_ValueType, sourceType.BaseType.SpecialType);
+            Assert.Equal(TypeKind.Error, sourceType.Interfaces().Single().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, sourceType.Interfaces().Single().SpecialType);
+            Assert.Equal(TypeKind.Error, sourceType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_ValueType, sourceType.BaseType().SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(TypeKind.Error, retargetingType.Interfaces.Single().TypeKind);
-            Assert.Equal(SpecialType.System_Int16, retargetingType.Interfaces.Single().SpecialType);
-            Assert.Equal(TypeKind.Error, retargetingType.BaseType.TypeKind);
-            Assert.Equal(SpecialType.System_ValueType, retargetingType.BaseType.SpecialType);
+            Assert.Equal(TypeKind.Error, retargetingType.Interfaces().Single().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, retargetingType.Interfaces().Single().SpecialType);
+            Assert.Equal(TypeKind.Error, retargetingType.BaseType().TypeKind);
+            Assert.Equal(SpecialType.System_ValueType, retargetingType.BaseType().SpecialType);
         }
 
         [Fact]
@@ -523,13 +523,13 @@ public interface Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, sourceType.Interfaces.Length);
-            Assert.Null(sourceType.BaseType);
+            Assert.Equal(0, sourceType.Interfaces().Length);
+            Assert.Null(sourceType.BaseType());
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(0, retargetingType.Interfaces.Length);
-            Assert.Null(retargetingType.BaseType);
+            Assert.Equal(0, retargetingType.Interfaces().Length);
+            Assert.Null(retargetingType.BaseType());
         }
 
         [Fact]
@@ -552,15 +552,15 @@ public interface Test : short { }
 
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(TypeKind.Error, sourceType.Interfaces.Single().TypeKind);
-            Assert.Equal(SpecialType.System_Int16, sourceType.Interfaces.Single().SpecialType);
-            Assert.Null(sourceType.BaseType);
+            Assert.Equal(TypeKind.Error, sourceType.Interfaces().Single().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, sourceType.Interfaces().Single().SpecialType);
+            Assert.Null(sourceType.BaseType());
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
-            Assert.Equal(TypeKind.Error, retargetingType.Interfaces.Single().TypeKind);
-            Assert.Equal(SpecialType.System_Int16, retargetingType.Interfaces.Single().SpecialType);
-            Assert.Null(retargetingType.BaseType);
+            Assert.Equal(TypeKind.Error, retargetingType.Interfaces().Single().TypeKind);
+            Assert.Equal(SpecialType.System_Int16, retargetingType.Interfaces().Single().SpecialType);
+            Assert.Null(retargetingType.BaseType());
         }
 
         [Fact]
@@ -583,12 +583,12 @@ public class C<T> where T : int
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var sourceTypeParameter = sourceType.TypeParameters.Single();
-            Assert.Equal(0, sourceTypeParameter.ConstraintTypes.Length);
+            Assert.Equal(0, sourceTypeParameter.ConstraintTypes().Length);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var retargetingTypeParameter = retargetingType.TypeParameters.Single();
-            Assert.Equal(0, retargetingTypeParameter.ConstraintTypes.Length);
+            Assert.Equal(0, retargetingTypeParameter.ConstraintTypes().Length);
         }
 
         [Fact]
@@ -620,14 +620,14 @@ public class C<T> where T : int
             var sourceAssembly = (SourceAssemblySymbol)comp.Assembly;
             var sourceType = sourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var sourceTypeParameter = sourceType.TypeParameters.Single();
-            var sourceTypeParameterConstraint = sourceTypeParameter.ConstraintTypes.Single();
+            var sourceTypeParameterConstraint = sourceTypeParameter.ConstraintTypes().Single();
             Assert.Equal(TypeKind.Error, sourceTypeParameterConstraint.TypeKind);
             Assert.Equal(SpecialType.System_Int32, sourceTypeParameterConstraint.SpecialType);
 
             var retargetingAssembly = new RetargetingAssemblySymbol(sourceAssembly, isLinked: false);
             var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var retargetingTypeParameter = retargetingType.TypeParameters.Single();
-            var retargetingTypeParameterConstraint = retargetingTypeParameter.ConstraintTypes.Single();
+            var retargetingTypeParameterConstraint = retargetingTypeParameter.ConstraintTypes().Single();
             Assert.Equal(TypeKind.Error, retargetingTypeParameterConstraint.TypeKind);
             Assert.Equal(SpecialType.System_Int32, retargetingTypeParameterConstraint.SpecialType);
         }
@@ -817,8 +817,8 @@ class C1<T>
         public void CheckTypes(TypeSymbol a, TypeSymbol b)
         {
             Assert.Equal(a.Name, b.Name);
-            CheckSymbols(a.BaseType, b.BaseType, false);
-            CheckSymbols(a.Interfaces, b.Interfaces, false);
+            CheckSymbols(a.BaseType(), b.BaseType(), false);
+            CheckSymbols(a.Interfaces(), b.Interfaces(), false);
             CheckSymbols(a.GetMembers(), b.GetMembers(), true);
         }
 
@@ -828,7 +828,7 @@ class C1<T>
             Assert.Equal(a.HasConstructorConstraint, b.HasConstructorConstraint);
             Assert.Equal(a.HasReferenceTypeConstraint, b.HasReferenceTypeConstraint);
             Assert.Equal(a.HasValueTypeConstraint, b.HasValueTypeConstraint);
-            CheckSymbols(a.ConstraintTypes, b.ConstraintTypes, false);
+            CheckSymbols(a.ConstraintTypes(), b.ConstraintTypes(), false);
         }
     }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -31,12 +31,12 @@ class Y : X {}
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
             var y = global.GetTypeMembers("Y", 0).Single();
-            Assert.NotEqual(y, x.BaseType);
-            Assert.NotEqual(x, y.BaseType);
-            Assert.Equal(SymbolKind.ErrorType, x.BaseType.Kind);
-            Assert.Equal(SymbolKind.ErrorType, y.BaseType.Kind);
-            Assert.Equal("Y", x.BaseType.Name);
-            Assert.Equal("X", y.BaseType.Name);
+            Assert.NotEqual(y, x.BaseType());
+            Assert.NotEqual(x, y.BaseType());
+            Assert.Equal(SymbolKind.ErrorType, x.BaseType().Kind);
+            Assert.Equal(SymbolKind.ErrorType, y.BaseType().Kind);
+            Assert.Equal("Y", x.BaseType().Name);
+            Assert.Equal("X", y.BaseType().Name);
         }
 
         [Fact]
@@ -51,12 +51,12 @@ class Y : X.n {}
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
             var y = global.GetTypeMembers("Y", 0).Single();
-            Assert.NotEqual(y, x.BaseType);
-            Assert.NotEqual(x, y.BaseType);
-            Assert.Equal(SymbolKind.ErrorType, x.BaseType.Kind);
-            Assert.Equal(SymbolKind.ErrorType, y.BaseType.Kind);
-            Assert.Equal("n", x.BaseType.Name);
-            Assert.Equal("n", y.BaseType.Name);
+            Assert.NotEqual(y, x.BaseType());
+            Assert.NotEqual(x, y.BaseType());
+            Assert.Equal(SymbolKind.ErrorType, x.BaseType().Kind);
+            Assert.Equal(SymbolKind.ErrorType, y.BaseType().Kind);
+            Assert.Equal("n", x.BaseType().Name);
+            Assert.Equal("n", y.BaseType().Name);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ class C4 : C1 {}
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("C4", 0).Single();
 
-            var x_base_base = x.BaseType.BaseType as ErrorTypeSymbol;
+            var x_base_base = x.BaseType().BaseType() as ErrorTypeSymbol;
             var er = x_base_base.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'C2' is invalid. It contains a circular base class dependency.",
@@ -99,9 +99,9 @@ class A<T>
             var a = global.GetTypeMembers("A", 1).Single();
             var b = a.GetTypeMembers("B", 0).Single();
             var e = a.GetTypeMembers("E", 0).Single();
-            Assert.NotEqual(e, e.BaseType);
+            Assert.NotEqual(e, e.BaseType());
 
-            var x_base = e.BaseType as ErrorTypeSymbol;
+            var x_base = e.BaseType() as ErrorTypeSymbol;
             var er = x_base.ErrorInfo;
 
             Assert.Equal("error CS0146: Circular base class dependency involving 'A<A<T>.E>.E' and 'A<T>.E'",
@@ -128,9 +128,9 @@ class B {
             var a = global.GetTypeMembers("A", 1).Single();
             var b = global.GetTypeMembers("B", 0).Single();
             var d = b.GetTypeMembers("D", 0).Single();
-            Assert.NotEqual(d, d.BaseType);
+            Assert.NotEqual(d, d.BaseType());
 
-            var x_base = d.BaseType as ErrorTypeSymbol;
+            var x_base = d.BaseType() as ErrorTypeSymbol;
             var er = x_base.ErrorInfo;
 
             Assert.Equal("error CS0146: Circular base class dependency involving 'A<int>.C' and 'B.D'",
@@ -153,7 +153,7 @@ class A : object, A.IC
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var ic = a.GetTypeMembers("IC", 0).Single();
-            Assert.Equal(a.Interfaces[0], ic);
+            Assert.Equal(a.Interfaces()[0], ic);
 
             var diagnostics = comp.GetDeclarationDiagnostics();
             Assert.Equal(0, diagnostics.Count());
@@ -177,10 +177,10 @@ class A : object, A.B.B.IC
             var a = global.GetTypeMembers("A", 0).Single();
             var b = a.GetTypeMembers("B", 0).Single();
             var ic = b.GetTypeMembers("IC", 0).Single();
-            Assert.NotEqual(b, b.BaseType);
-            Assert.NotEqual(a, b.BaseType);
-            Assert.Equal(SymbolKind.ErrorType, a.Interfaces[0].Kind);
-            Assert.NotEqual(ic, a.Interfaces[0]);
+            Assert.NotEqual(b, b.BaseType());
+            Assert.NotEqual(a, b.BaseType());
+            Assert.Equal(SymbolKind.ErrorType, a.Interfaces()[0].Kind);
+            Assert.NotEqual(ic, a.Interfaces()[0]);
 
             var diagnostics = comp.GetDeclarationDiagnostics();
             Assert.Equal(2, diagnostics.Count());
@@ -229,9 +229,9 @@ class W : B.X { }
             var global = comp.GlobalNamespace;
             var z = global.GetTypeMembers("Z", 0).Single();
             var w = global.GetTypeMembers("W", 0).Single();
-            var zBase = z.BaseType;
+            var zBase = z.BaseType();
             Assert.Equal("Y", zBase.Name);
-            var wBase = w.BaseType;
+            var wBase = w.BaseType();
             Assert.Equal("X", wBase.Name);
         }
 
@@ -258,7 +258,7 @@ class C : A {
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
 
-            //var aBase = a.BaseType;
+            //var aBase = a.BaseType();
             //Assert.True(aBase.IsErrorType());
             //Assert.Equal("B", aBase.Name);
 
@@ -295,7 +295,7 @@ class B<T> : A {
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
 
-            //var aBase = a.BaseType;
+            //var aBase = a.BaseType();
             //Assert.True(aBase.IsErrorType());
             //Assert.Equal("B", aBase.Name);
 
@@ -458,10 +458,10 @@ class C : A, I<C.B> {}
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var c = global.GetTypeMembers("C", 0).Single();
-            var cBase = c.BaseType;
+            var cBase = c.BaseType();
             Assert.False(cBase.IsErrorType());
             Assert.Equal("A", cBase.Name);
-            Assert.True(c.Interfaces.Single().TypeArguments.Single().IsErrorType()); //can't see base of C while evaluating C.B
+            Assert.True(c.Interfaces().Single().TypeArguments().Single().IsErrorType()); //can't see base of C while evaluating C.B
         }
 
         [Fact]
@@ -476,8 +476,8 @@ class E : I<E> {}
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var e = global.GetTypeMembers("E", 0).Single();
-            Assert.Equal(1, e.Interfaces.Length);
-            Assert.Equal("I<E>", e.Interfaces[0].ToTestDisplayString());
+            Assert.Equal(1, e.Interfaces().Length);
+            Assert.Equal("I<E>", e.Interfaces()[0].ToTestDisplayString());
         }
 
         [Fact]
@@ -494,8 +494,8 @@ class G : I<G.H> {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var g = global.GetTypeMembers("G", 0).Single();
-            Assert.Equal(1, g.Interfaces.Length);
-            Assert.Equal("I<G.H>", g.Interfaces[0].ToTestDisplayString());
+            Assert.Equal(1, g.Interfaces().Length);
+            Assert.Equal("I<G.H>", g.Interfaces()[0].ToTestDisplayString());
         }
 
         [Fact]
@@ -514,8 +514,8 @@ class J : I<J.K.L> {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var j = global.GetTypeMembers("J", 0).Single();
-            Assert.Equal(1, j.Interfaces.Length);
-            Assert.Equal("I<J.K.L>", j.Interfaces[0].ToTestDisplayString());
+            Assert.Equal(1, j.Interfaces().Length);
+            Assert.Equal("I<J.K.L>", j.Interfaces()[0].ToTestDisplayString());
         }
 
         [Fact]
@@ -528,7 +528,7 @@ class J : I<J.K.L> {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var m = global.GetTypeMembers("M", 0).Single();
-            Assert.True(m.BaseType.IsErrorType());
+            Assert.True(m.BaseType().IsErrorType());
         }
 
         [Fact]
@@ -543,8 +543,8 @@ class O : N<O> {}
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var o = global.GetTypeMembers("O", 0).Single();
-            Assert.False(o.BaseType.IsErrorType());
-            Assert.Equal("N<O>", o.BaseType.ToTestDisplayString());
+            Assert.False(o.BaseType().IsErrorType());
+            Assert.Equal("N<O>", o.BaseType().ToTestDisplayString());
         }
 
         [Fact]
@@ -561,8 +561,8 @@ class P : N<P.Q> {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var p = global.GetTypeMembers("P", 0).Single();
-            Assert.False(p.BaseType.IsErrorType());
-            Assert.Equal("N<P.Q>", p.BaseType.ToTestDisplayString());
+            Assert.False(p.BaseType().IsErrorType());
+            Assert.Equal("N<P.Q>", p.BaseType().ToTestDisplayString());
         }
 
         [Fact]
@@ -581,7 +581,7 @@ class R : N<R.S.T>{
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var r = global.GetTypeMembers("R", 0).Single();
-            var rBase = r.BaseType;
+            var rBase = r.BaseType();
             Assert.False(rBase.IsErrorType());
             Assert.Equal("N<R.S.T>", rBase.ToTestDisplayString());
         }
@@ -600,7 +600,7 @@ class U : U.I
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var u = global.GetTypeMembers("U", 0).Single();
-            var ifaces = u.Interfaces;
+            var ifaces = u.Interfaces();
             Assert.Equal(1, ifaces.Length);
             Assert.False(ifaces[0].IsErrorType());
             Assert.Equal("U.I", ifaces[0].ToTestDisplayString());
@@ -621,12 +621,12 @@ class C : IX {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var c = global.GetTypeMembers("C", 0).Single();
-            var ifaces = c.Interfaces;
+            var ifaces = c.Interfaces();
             Assert.Equal(1, ifaces.Length);
             Assert.False(ifaces[0].IsErrorType());
             Assert.Equal("IX", ifaces[0].ToTestDisplayString());
             var ix = ifaces[0];
-            var ixFaces = ix.Interfaces;
+            var ixFaces = ix.Interfaces();
             Assert.Equal(1, ixFaces.Length);
             Assert.False(ixFaces[0].IsErrorType());
             Assert.Equal("C.IY", ixFaces[0].ToTestDisplayString());
@@ -646,7 +646,7 @@ class Y : X {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
-            var ifaces = x.Interfaces;
+            var ifaces = x.Interfaces();
             Assert.Equal(1, ifaces.Length);
             Assert.False(ifaces[0].IsErrorType());
             Assert.Equal("Y.I", ifaces[0].ToTestDisplayString());
@@ -665,7 +665,7 @@ class B : G {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var b = global.GetTypeMembers("B", 0).Single();
-            Assert.True(b.BaseType.IsErrorType());
+            Assert.True(b.BaseType().IsErrorType());
         }
 
         [Fact]
@@ -682,7 +682,7 @@ class B : G {
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var z = global.GetTypeMembers("Z", 1).Single();
-            Assert.True(z.BaseType.IsErrorType());
+            Assert.True(z.BaseType().IsErrorType());
         }
 
         [Fact]
@@ -992,7 +992,7 @@ interface I4 : I1 {}
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("I4", 0).Single();
 
-            var x_base_base = x.Interfaces.First().Interfaces.First() as ErrorTypeSymbol;
+            var x_base_base = x.Interfaces().First().Interfaces().First() as ErrorTypeSymbol;
             var er = x_base_base.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'I2' is invalid. It contains a circular base class dependency.",
@@ -1015,8 +1015,8 @@ public class ClassB : ClassA {}
             var B1 = global1.GetTypeMembers("ClassB", 0).Single();
             var A1 = global1.GetTypeMembers("ClassA", 0).Single();
 
-            var B_base = B1.BaseType;
-            var A_base = A1.BaseType;
+            var B_base = B1.BaseType();
+            var A_base = A1.BaseType();
             Assert.True(B1.IsFromCompilation(comp));
             Assert.IsAssignableFrom<PENamedTypeSymbol>(B_base);
             Assert.IsAssignableFrom<PENamedTypeSymbol>(A_base);
@@ -1035,9 +1035,9 @@ public class ClassC : ClassB {}
 
             Assert.IsType<Retargeting.RetargetingNamedTypeSymbol>(B2);
             Assert.Same(B1, ((Retargeting.RetargetingNamedTypeSymbol)B2).UnderlyingNamedType);
-            Assert.Same(C.BaseType, B2);
+            Assert.Same(C.BaseType(), B2);
 
-            var errorBase = B2.BaseType as ErrorTypeSymbol;
+            var errorBase = B2.BaseType() as ErrorTypeSymbol;
             var er = errorBase.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'ClassA' is invalid. It contains a circular base class dependency.",
@@ -1045,7 +1045,7 @@ public class ClassC : ClassB {}
 
             var A2 = global.GetTypeMembers("ClassA", 0).Single();
 
-            var errorBase1 = A2.BaseType as ErrorTypeSymbol;
+            var errorBase1 = A2.BaseType() as ErrorTypeSymbol;
             er = errorBase1.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'ClassB' is invalid. It contains a circular base class dependency.",
@@ -1071,8 +1071,8 @@ public class ClassC : ClassB {}
             var B1 = global1.GetTypeMembers("ClassB", 0).Distinct().Single();
             var A1 = global1.GetTypeMembers("ClassA", 0).Single();
 
-            var B_base = B1.BaseType;
-            var A_base = A1.BaseType;
+            var B_base = B1.BaseType();
+            var A_base = A1.BaseType();
             Assert.IsAssignableFrom<PENamedTypeSymbol>(B1);
             Assert.IsAssignableFrom<PENamedTypeSymbol>(B_base);
             Assert.IsAssignableFrom<PENamedTypeSymbol>(A_base);
@@ -1097,9 +1097,9 @@ public class ClassC : ClassB {}
             Assert.NotEqual(B1, B2);
             Assert.Same(((PEModuleSymbol)B1.ContainingModule).Module, ((PEModuleSymbol)B2.ContainingModule).Module);
             Assert.Equal(((PENamedTypeSymbol)B1).Handle, ((PENamedTypeSymbol)B2).Handle);
-            Assert.Same(C.BaseType, B2);
+            Assert.Same(C.BaseType(), B2);
 
-            var errorBase = B2.BaseType as ErrorTypeSymbol;
+            var errorBase = B2.BaseType() as ErrorTypeSymbol;
             var er = errorBase.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'ClassA' is invalid. It contains a circular base class dependency.",
@@ -1107,7 +1107,7 @@ public class ClassC : ClassB {}
 
             var A2 = global.GetTypeMembers("ClassA", 0).Single();
 
-            var errorBase1 = A2.BaseType as ErrorTypeSymbol;
+            var errorBase1 = A2.BaseType() as ErrorTypeSymbol;
             er = errorBase1.ErrorInfo;
 
             Assert.Equal("error CS0268: Imported type 'ClassB' is invalid. It contains a circular base class dependency.",
@@ -1130,8 +1130,8 @@ public class ClassB : ClassA {}
             var B1 = global1.GetTypeMembers("ClassB", 0).Single();
             var A1 = global1.GetTypeMembers("ClassA", 0).Single();
 
-            var B_base = B1.BaseType;
-            var A_base = A1.BaseType;
+            var B_base = B1.BaseType();
+            var A_base = A1.BaseType();
 
             Assert.True(B1.IsFromCompilation(comp));
 
@@ -1166,8 +1166,8 @@ public class ClassC : ClassB {}
 
             Assert.IsType<Retargeting.RetargetingNamedTypeSymbol>(B2);
             Assert.Same(B1, ((Retargeting.RetargetingNamedTypeSymbol)B2).UnderlyingNamedType);
-            Assert.Same(C.BaseType, B2);
-            Assert.Same(B2.BaseType, A2);
+            Assert.Same(C.BaseType(), B2);
+            Assert.Same(B2.BaseType(), A2);
         }
 
 
@@ -1189,8 +1189,8 @@ public class ClassC : ClassB {}
             var B1 = global1.GetTypeMembers("ClassB", 0).Distinct().Single();
             var A1 = global1.GetTypeMembers("ClassA", 0).Single();
 
-            var B_base = B1.BaseType;
-            var A_base = A1.BaseType;
+            var B_base = B1.BaseType();
+            var A_base = A1.BaseType();
             Assert.IsAssignableFrom<PENamedTypeSymbol>(B1);
 
             var errorBase = B_base as ErrorTypeSymbol;
@@ -1225,12 +1225,12 @@ public class ClassC : ClassB {}
             Assert.NotEqual(B1, B2);
             Assert.Same(((PEModuleSymbol)B1.ContainingModule).Module, ((PEModuleSymbol)B2.ContainingModule).Module);
             Assert.Equal(((PENamedTypeSymbol)B1).Handle, ((PENamedTypeSymbol)B2).Handle);
-            Assert.Same(C.BaseType, B2);
+            Assert.Same(C.BaseType(), B2);
 
             var A2 = global.GetTypeMembers("ClassA", 0).Single();
 
-            Assert.IsAssignableFrom<PENamedTypeSymbol>(A2.BaseType);
-            Assert.IsAssignableFrom<PENamedTypeSymbol>(B2.BaseType);
+            Assert.IsAssignableFrom<PENamedTypeSymbol>(A2.BaseType());
+            Assert.IsAssignableFrom<PENamedTypeSymbol>(B2.BaseType());
         }
 
         [Fact]
@@ -1258,8 +1258,8 @@ namespace N
             var b = a.GetTypeMembers("B", 1).Single();
             var d = a.GetTypeMembers("D", 0).Single();
             Assert.Equal(Accessibility.Private, d.DeclaredAccessibility);
-            Assert.Equal(d.OriginalDefinition, b.BaseType.OriginalDefinition);
-            Assert.NotEqual(d, b.BaseType);
+            Assert.Equal(d.OriginalDefinition, b.BaseType().OriginalDefinition);
+            Assert.NotEqual(d, b.BaseType());
         }
 
         [Fact]
@@ -1281,7 +1281,7 @@ namespace N2 {
             var n2 = global.GetMembers("N2").Single() as NamespaceSymbol;
             var a = n1.GetTypeMembers("A", 0).Single();
             var b = n2.GetTypeMembers("B", 0).Single();
-            Assert.Equal(a, b.BaseType);
+            Assert.Equal(a, b.BaseType());
         }
 
         [Fact]
@@ -1303,9 +1303,9 @@ namespace N2 {
             var n2 = global.GetMembers("N2").Single() as NamespaceSymbol;
             var a = n1.GetTypeMembers("A", 1).Single();
             var b = n2.GetTypeMembers("B", 0).Single();
-            var bt = b.BaseType;
-            Assert.Equal(a, b.BaseType.OriginalDefinition);
-            Assert.Equal(b, (b.BaseType as NamedTypeSymbol).TypeArguments[0]);
+            var bt = b.BaseType();
+            Assert.Equal(a, b.BaseType().OriginalDefinition);
+            Assert.Equal(b, (b.BaseType() as NamedTypeSymbol).TypeArguments()[0]);
         }
 
         [Fact]
@@ -1319,7 +1319,7 @@ class D : global::N.C {}";
             var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var d = global.GetMembers("D").Single() as NamedTypeSymbol;
-            Assert.NotEqual(SymbolKind.ErrorType, d.BaseType.Kind);
+            Assert.NotEqual(SymbolKind.ErrorType, d.BaseType().Kind);
         }
 
         [Fact]
@@ -1336,8 +1336,8 @@ class C : G<C[,][]>
             var global = comp.GlobalNamespace;
             var g = global.GetTypeMembers("G", 1).Single();
             var c = global.GetTypeMembers("C", 0).Single();
-            Assert.Equal(g, c.BaseType.OriginalDefinition);
-            var garg = c.BaseType.TypeArguments[0];
+            Assert.Equal(g, c.BaseType().OriginalDefinition);
+            var garg = c.BaseType().TypeArguments()[0];
             Assert.Equal(SymbolKind.ArrayType, garg.Kind);
             var carr1 = garg as ArrayTypeSymbol;
             var carr2 = carr1.ElementType as ArrayTypeSymbol;
@@ -1384,16 +1384,16 @@ partial class Broken {
             var b = n2.GetTypeMembers("B", 0).Single();
             var x = global.GetTypeMembers("X", 0).Single();
             var a1 = x.GetTypeMembers("A1", 0).Single();
-            Assert.Equal(a, a1.BaseType);
+            Assert.Equal(a, a1.BaseType());
             var b1 = x.GetTypeMembers("B1", 0).Single();
-            Assert.Equal(b, b1.BaseType);
+            Assert.Equal(b, b1.BaseType());
             var broken = global.GetTypeMembers("Broken", 0).Single();
             var a2 = broken.GetTypeMembers("A2", 0).Single();
-            Assert.NotEqual(a, a2.BaseType);
-            Assert.Equal(SymbolKind.ErrorType, a2.BaseType.Kind);
+            Assert.NotEqual(a, a2.BaseType());
+            Assert.Equal(SymbolKind.ErrorType, a2.BaseType().Kind);
             var b2 = broken.GetTypeMembers("B2", 0).Single();
-            Assert.NotEqual(b, b2.BaseType);
-            Assert.Equal(SymbolKind.ErrorType, b2.BaseType.Kind);
+            Assert.NotEqual(b, b2.BaseType());
+            Assert.Equal(SymbolKind.ErrorType, b2.BaseType().Kind);
         }
 
         [Fact]
@@ -1412,9 +1412,9 @@ public class B : N { }
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var b = global.GetTypeMembers("B", 0).Single();
-            var abase = a.BaseType;
+            var abase = a.BaseType();
             Assert.Equal(SymbolKind.ErrorType, abase.Kind);
-            var bbase = b.BaseType;
+            var bbase = b.BaseType();
             Assert.Equal(SymbolKind.ErrorType, bbase.Kind);
         }
 
@@ -1445,10 +1445,10 @@ namespace @if
             NamedTypeSymbol cfloat = (NamedTypeSymbol)nif.GetMembers("float").Single();
             Assert.Equal("float", cfloat.Name);
             Assert.Equal("@if.@float", cfloat.ToString());
-            NamedTypeSymbol cint = cfloat.BaseType;
+            NamedTypeSymbol cint = cfloat.BaseType();
             Assert.Equal("int", cint.Name);
             Assert.Equal("@if.@int<@if.@break>", cint.ToString());
-            NamedTypeSymbol ibreak = cfloat.Interfaces.Single();
+            NamedTypeSymbol ibreak = cfloat.Interfaces().Single();
             Assert.Equal("break", ibreak.Name);
             Assert.Equal("@if.@break", ibreak.ToString());
         }
@@ -1493,34 +1493,34 @@ class B : A<B.Y.Error>
     public class Y : X { }
 }
 ";
-            //B.BaseType, B.Y.BaseType
+            //B.BaseType(), B.Y.BaseType
             {
                 var comp = CreateStandardCompilation(text);
 
                 var classB = (NamedTypeSymbol)comp.SourceModule.GlobalNamespace.GetMembers("B")[0];
                 var classY = (NamedTypeSymbol)classB.GetMembers("Y")[0];
 
-                var baseB = classB.BaseType;
+                var baseB = classB.BaseType();
                 Assert.Equal("A<B.Y.Error>", baseB.ToTestDisplayString());
                 Assert.False(baseB.IsErrorType());
 
-                var baseY = classY.BaseType;
+                var baseY = classY.BaseType();
                 Assert.Equal("X", baseY.ToTestDisplayString());
                 Assert.True(baseY.IsErrorType());
             }
 
-            //B.Y.BaseType, B.BaseType
+            //B.Y.BaseType(), B.BaseType
             {
                 var comp = CreateStandardCompilation(text);
 
                 var classB = (NamedTypeSymbol)comp.SourceModule.GlobalNamespace.GetMembers("B")[0];
                 var classY = (NamedTypeSymbol)classB.GetMembers("Y")[0];
 
-                var baseY = classY.BaseType;
+                var baseY = classY.BaseType();
                 Assert.Equal("X", baseY.ToTestDisplayString());
                 Assert.True(baseY.IsErrorType());
 
-                var baseB = classB.BaseType;
+                var baseB = classB.BaseType();
                 Assert.Equal("A<B.Y.Error>", baseB.ToTestDisplayString());
                 Assert.False(baseB.IsErrorType());
             }
@@ -1543,9 +1543,9 @@ class C : I2 { }
 
             var bothInterfaces = ImmutableArray.Create(baseInterface, derivedInterface);
 
-            Assert.Equal(baseInterface, derivedInterface.AllInterfaces.Single());
-            Assert.Equal(derivedInterface, @class.Interfaces.Single());
-            Assert.True(@class.AllInterfaces.SetEquals(bothInterfaces, EqualityComparer<NamedTypeSymbol>.Default));
+            Assert.Equal(baseInterface, derivedInterface.AllInterfaces().Single());
+            Assert.Equal(derivedInterface, @class.Interfaces().Single());
+            Assert.True(@class.AllInterfaces().SetEquals(bothInterfaces, EqualityComparer<NamedTypeSymbol>.Default));
 
             var typeDef = (Cci.ITypeDefinition)@class;
             var module = new PEAssemblyBuilder((SourceAssemblySymbol)@class.ContainingAssembly, EmitOptions.Default, OutputKind.DynamicallyLinkedLibrary,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -131,7 +131,7 @@ class A {
             Assert.Equal(0, v.Arity); // number of type parameters
             Assert.Equal(1, v.DelegateInvokeMethod.Parameters.Length);
             Assert.Equal(Accessibility.Internal, v.DeclaredAccessibility);
-            Assert.Equal("System.MulticastDelegate", v.BaseType.ToTestDisplayString());
+            Assert.Equal("System.MulticastDelegate", v.BaseType().ToTestDisplayString());
         }
 
         [WorkItem(537188, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537188")]
@@ -210,7 +210,7 @@ namespace System
             Assert.Equal(d.DelegateInvokeMethod.Parameters[0].Type, q);
 
             // same as type parameter
-            Assert.Equal(1, d.TypeArguments.Length);
+            Assert.Equal(1, d.TypeArguments().Length);
         }
 
         [WorkItem(537401, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537401")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/LocationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/LocationTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             AssertPos(s, 12, 1);
             var c = s.GetTypeMembers("C", 0).Single() as NamedTypeSymbol;
             AssertPos(c, 20, 1);
-            var obj = c.BaseType;
+            var obj = c.BaseType();
             Assert.Equal("MetadataFile(CommonLanguageRuntimeLibrary)", obj.Locations[0].ToString());
             var f = c.GetMembers("F").Single() as FieldSymbol;
             AssertPos(f, 26, 1);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -358,7 +358,7 @@ public interface A {
             Assert.Equal(TypeKind.Class, refP.TypeKind);
             Assert.True(refP.IsReferenceType);
             Assert.False(refP.IsValueType);
-            Assert.Equal("Object", refP.BaseType.Name);
+            Assert.Equal("Object", refP.BaseType().Name);
             Assert.Equal(2, refP.GetMembers().Length); // M + generated constructor.
             Assert.Equal(1, refP.GetMembers("M").Length);
 
@@ -370,7 +370,7 @@ public interface A {
             Assert.False(outP.IsAbstract);
             Assert.True(outP.IsSealed);
             Assert.Equal(Accessibility.Public, outP.DeclaredAccessibility);
-            Assert.Equal(5, outP.Interfaces.Length);
+            Assert.Equal(5, outP.Interfaces().Length);
             Assert.Equal(0, outP.GetTypeMembers().Length); // Enumerable.Empty<NamedTypeSymbol>()
             Assert.Equal(0, outP.GetTypeMembers(String.Empty).Length);
             Assert.Equal(0, outP.GetTypeMembers(String.Empty, 0).Length);
@@ -502,11 +502,11 @@ namespace NS.NS1
             var ns1 = ns.GetMembers("NS1").Single() as NamespaceSymbol;
 
             var classImpl = ns1.GetTypeMembers("Impl", 0).Single() as NamedTypeSymbol;
-            Assert.Equal(3, classImpl.Interfaces.Length);
+            Assert.Equal(3, classImpl.Interfaces().Length);
             // 
-            var itfc = classImpl.Interfaces.First() as NamedTypeSymbol;
-            Assert.Equal(1, itfc.Interfaces.Length);
-            itfc = itfc.Interfaces.First() as NamedTypeSymbol;
+            var itfc = classImpl.Interfaces().First() as NamedTypeSymbol;
+            Assert.Equal(1, itfc.Interfaces().Length);
+            itfc = itfc.Interfaces().First() as NamedTypeSymbol;
             Assert.Equal("I1", itfc.Name);
 
             // explicit interface member names include the explicit interface
@@ -525,8 +525,8 @@ namespace NS.NS1
             Assert.Equal("ref NS.Abc p", param.ToTestDisplayString());
 
             var structImpl = ns1.GetTypeMembers("S").Single() as NamedTypeSymbol;
-            Assert.Equal(1, structImpl.Interfaces.Length);
-            itfc = structImpl.Interfaces.First() as NamedTypeSymbol;
+            Assert.Equal(1, structImpl.Interfaces().Length);
+            itfc = structImpl.Interfaces().First() as NamedTypeSymbol;
             Assert.Equal("NS.IGoo<T>", itfc.ToTestDisplayString());
             //var mem2 = structImpl.GetMembers("M").Single() as MethodSymbol;
             // not impl
@@ -638,7 +638,7 @@ namespace N1.N2  {
             #endregion
 
             #region "Abc"
-            var type2 = type1.BaseType;
+            var type2 = type1.BaseType();
             Assert.Equal("Abc", type2.Name);
             mems = type2.GetMembers();
 
@@ -831,7 +831,7 @@ namespace N1.N2  {
             #endregion
 
             #region "Abc"
-            var type2 = type1.BaseType;
+            var type2 = type1.BaseType();
             Assert.Equal("Abc", type2.Name);
             mems = type2.GetMembers();
             Assert.Equal(8, mems.Length);
@@ -954,10 +954,10 @@ namespace NS  {
             var mems = type1.GetMembers();
             Assert.Equal(2, mems.Length);
 
-            var mems1 = type1.BaseType.GetMembers();
+            var mems1 = type1.BaseType().GetMembers();
             Assert.Equal(4, mems1.Length);
 
-            var mems2 = type1.BaseType.BaseType.GetMembers();
+            var mems2 = type1.BaseType().BaseType().GetMembers();
             Assert.Equal(3, mems2.Length);
 
             var list = new List<Symbol>();
@@ -1063,10 +1063,10 @@ namespace NS  {
             var mems = type1.GetMembers();
             Assert.Equal(2, mems.Length);
 
-            var mems1 = type1.BaseType.GetMembers();
+            var mems1 = type1.BaseType().GetMembers();
             Assert.Equal(4, mems1.Length);
 
-            var mems2 = type1.BaseType.BaseType.GetMembers();
+            var mems2 = type1.BaseType().BaseType().GetMembers();
             Assert.Equal(3, mems2.Length);
 
             var list = new List<Symbol>();
@@ -1344,7 +1344,7 @@ public class C : B<int, long>
 
             var classB = (NamedTypeSymbol)comp.GlobalNamespace.GetMembers("B").Single();
 
-            var classBTypeArguments = classB.TypeArguments;
+            var classBTypeArguments = classB.TypeArguments();
             Assert.Equal(2, classBTypeArguments.Length);
             Assert.Equal("Q", classBTypeArguments[0].Name);
             Assert.Equal("R", classBTypeArguments[1].Name);
@@ -1362,10 +1362,10 @@ public class C : B<int, long>
 
             var classC = (NamedTypeSymbol)comp.GlobalNamespace.GetMembers("C").Single();
 
-            var classCBase = classC.BaseType;
+            var classCBase = classC.BaseType();
             Assert.Equal(classB, classCBase.ConstructedFrom);
 
-            var classCBaseTypeArguments = classCBase.TypeArguments;
+            var classCBaseTypeArguments = classCBase.TypeArguments();
             Assert.Equal(2, classCBaseTypeArguments.Length);
             Assert.Equal(SpecialType.System_Int32, classCBaseTypeArguments[0].SpecialType);
             Assert.Equal(SpecialType.System_Int64, classCBaseTypeArguments[1].SpecialType);
@@ -1492,7 +1492,7 @@ namespace N2
 
             var n2 = comp.GlobalNamespace.GetMembers("N2").Single() as NamespaceSymbol;
             var test = n2.GetTypeMembers("Test").Single() as NamedTypeSymbol;
-            var bt = test.Interfaces.Single() as NamedTypeSymbol;
+            var bt = test.Interfaces().Single() as NamedTypeSymbol;
             Assert.Equal("N1.I1", bt.ToTestDisplayString());
         }
 
@@ -1661,7 +1661,7 @@ class C : I
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("C").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("I.Method").Single();
             Assert.Equal(MethodKind.ExplicitInterfaceImplementation, classMethod.MethodKind);
@@ -1705,7 +1705,7 @@ class F : System.IFormattable
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("F").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("System.IFormattable.ToString").Single();
             Assert.Equal(MethodKind.ExplicitInterfaceImplementation, classMethod.MethodKind);
@@ -1751,7 +1751,7 @@ class C : I
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("C").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classMethod = (MethodSymbol)@class.GetMembers("I.Method").Single();
             Assert.Equal(MethodKind.ExplicitInterfaceImplementation, classMethod.MethodKind);
@@ -1802,7 +1802,7 @@ class IC : Namespace.I<int>
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("IC").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceMethod = (MethodSymbol)substitutedInterface.GetMembers("Method").Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -573,7 +573,7 @@ class C : B<string>
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("Q"));
 
                 // Generic type with parameter substitution.
-                type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C").BaseType;
+                type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C").BaseType();
                 Assert.Equal(type.TypeParameters.Length, 1);
                 Assert.NotSame(type, type.ConstructedFrom);
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("P"));
@@ -1736,7 +1736,7 @@ class C : I
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("C").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classProperty = (PropertySymbol)@class.GetMembers("I.P").Single();
 
@@ -1770,7 +1770,7 @@ class C : I
 
             var @class = (NamedTypeSymbol)globalNamespace.GetTypeMembers("C").Single();
             Assert.Equal(TypeKind.Class, @class.TypeKind);
-            Assert.True(@class.Interfaces.Contains(@interface));
+            Assert.True(@class.Interfaces().Contains(@interface));
 
             var classProperty = (PropertySymbol)@class.GetMembers("I.P").Single();
             Assert.Equal(RefKind.Ref, classProperty.RefKind);
@@ -1811,7 +1811,7 @@ class C : N.I<int>
 
             var classProperty = (PropertySymbol)@class.GetMembers("N.I<System.Int32>.P").Single();
 
-            var substitutedInterface = @class.Interfaces.Single();
+            var substitutedInterface = @class.Interfaces().Single();
             Assert.Equal(@interface, substitutedInterface.ConstructedFrom);
 
             var substitutedInterfaceProperty = (PropertySymbol)substitutedInterface.GetMembers("P").Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/SourcePlusMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/SourcePlusMetadataTests.cs
@@ -22,11 +22,11 @@ class Y {}
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, x.BaseType.Kind);
+            Assert.Equal(SymbolKind.NamedType, x.BaseType().Kind);
             var y = global.GetTypeMembers("Y", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, y.BaseType.Kind);
-            Assert.Equal(x.BaseType, y.BaseType);
-            Assert.Equal("Object", y.BaseType.Name);
+            Assert.Equal(SymbolKind.NamedType, y.BaseType().Kind);
+            Assert.Equal(x.BaseType(), y.BaseType());
+            Assert.Equal("Object", y.BaseType().Name);
         }
 
         [Fact]
@@ -39,8 +39,8 @@ struct X {}
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, x.BaseType.Kind);
-            Assert.Equal("ValueType", x.BaseType.Name);
+            Assert.Equal(SymbolKind.NamedType, x.BaseType().Kind);
+            Assert.Equal("ValueType", x.BaseType().Name);
         }
 
         [Fact]
@@ -55,13 +55,13 @@ class Z {}
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
             var x = global.GetTypeMembers("X", 0).Single();
-            Assert.Null(x.BaseType);
+            Assert.Null(x.BaseType());
             var y = global.GetTypeMembers("Y", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, y.BaseType.Kind);
+            Assert.Equal(SymbolKind.NamedType, y.BaseType().Kind);
             var z = global.GetTypeMembers("Z", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, z.BaseType.Kind);
-            Assert.Equal(z.BaseType, y.BaseType);
-            Assert.Equal("Object", y.BaseType.Name);
+            Assert.Equal(SymbolKind.NamedType, z.BaseType().Kind);
+            Assert.Equal(z.BaseType(), y.BaseType());
+            Assert.Equal("Object", y.BaseType().Name);
         }
 
         [Fact]
@@ -77,8 +77,8 @@ namespace System {
             var global = comp.GlobalNamespace;
             var system = global.GetMembers("System").Single() as NamespaceSymbol;
             var a = system.GetTypeMembers("A", 0).Single();
-            Assert.Equal(SymbolKind.NamedType, a.BaseType.Kind);
-            Assert.Equal("Object", a.BaseType.Name);
+            Assert.Equal(SymbolKind.NamedType, a.BaseType().Kind);
+            Assert.Equal("Object", a.BaseType().Name);
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace NS
             var ref2 = TestReferences.SymbolsTests.InheritIComparable;
             var comp2 = CSharpCompilation.Create("Compilation2", references: new MetadataReference[] { ref2, MscorlibRef });
             var metaSym = comp2.GlobalNamespace.GetTypeMembers("BaseTypeSpecifierClass").First();
-            Assert.Equal(srcSym.Interfaces[0], metaSym.Interfaces[0]);
+            Assert.Equal(srcSym.Interfaces()[0], metaSym.Interfaces()[0]);
         }
 
         [WorkItem(527532, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527532")]
@@ -202,7 +202,7 @@ namespace NS
             var ref2 = TestReferences.SymbolsTests.InheritIComparable;
             var comp2 = CSharpCompilation.Create("Compilation2", references: new MetadataReference[] { ref2, MscorlibRef });
             var metaSym = comp2.GlobalNamespace.GetTypeMembers("FooAttribute").First();
-            Assert.Equal(srcSym.BaseType, metaSym.BaseType);
+            Assert.Equal(srcSym.BaseType(), metaSym.BaseType());
         }
 
         [WorkItem(4084, "DevDiv_Projects/Roslyn")]
@@ -246,8 +246,8 @@ class B : Box<System." + systemTypeName + @"> {}
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var b = global.GetTypeMembers("B", 0).Single();
-            var key = a.BaseType.TypeArguments[0] as NamedTypeSymbol;
-            var nam = b.BaseType.TypeArguments[0] as NamedTypeSymbol;
+            var key = a.BaseType().TypeArguments()[0] as NamedTypeSymbol;
+            var nam = b.BaseType().TypeArguments()[0] as NamedTypeSymbol;
             Assert.Equal(SymbolKind.NamedType, key.Kind);
             Assert.Equal(SymbolKind.NamedType, nam.Kind);
             Assert.Equal(nam, key);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var nts = t as NamedTypeSymbol;
             Assert.NotEqual(null, nts);
             Assert.Equal(1, nts.Arity);
-            return nts.TypeArguments[0];
+            return nts.TypeArguments()[0];
         }
 
         [Fact]
@@ -50,7 +50,7 @@ public class Top : A<E> { // base is A<E>
             var global = comp.GlobalNamespace;
             var at = global.GetTypeMembers("A", 1).Single(); // A<T>
             var t = at.TypeParameters[0];
-            Assert.Equal(t, TypeArg(at.GetTypeMembers("TBox", 0).Single().BaseType));
+            Assert.Equal(t, TypeArg(at.GetTypeMembers("TBox", 0).Single().BaseType()));
             var atbu = at.GetTypeMembers("B", 1).Single(); // A<T>.B<U>
             var u = atbu.TypeParameters[0];
             var c = atbu.GetTypeMembers("C", 0).Single(); // A<T>.B<U>.C
@@ -61,13 +61,13 @@ public class Top : A<E> { // base is A<E>
             var e = global.GetTypeMembers("E", 0).Single(); // E
             var f = global.GetTypeMembers("F", 0).Single(); // F
             var top = global.GetTypeMembers("Top", 0).Single(); // Top
-            var ae = top.BaseType; // A<E>
+            var ae = top.BaseType(); // A<E>
             Assert.Equal(at, ae.OriginalDefinition);
             Assert.Equal(at, at.ConstructedFrom);
             Assert.Equal(e, TypeArg(ae));
             var bf = top.GetTypeMembers("BF", 0).Single(); // Top.BF
             Assert.Equal(top, bf.ContainingType);
-            var aebf = bf.BaseType;
+            var aebf = bf.BaseType();
             Assert.Equal(f, TypeArg(aebf));
             Assert.Equal(ae, aebf.ContainingType);
             var aebfc = aebf.GetTypeMembers("C", 0).Single(); // A<E>.B<F>.C
@@ -75,8 +75,8 @@ public class Top : A<E> { // base is A<E>
             Assert.NotEqual(c, aebfc.ConstructedFrom);
             Assert.Equal(f, TypeArg(aebfc.ContainingType));
             Assert.Equal(e, TypeArg(aebfc.ContainingType.ContainingType));
-            Assert.Equal(e, TypeArg(aebfc.GetTypeMembers("TBox", 0).Single().BaseType));
-            Assert.Equal(f, TypeArg(aebfc.GetTypeMembers("UBox", 0).Single().BaseType)); // exercises alpha-renaming.
+            Assert.Equal(e, TypeArg(aebfc.GetTypeMembers("TBox", 0).Single().BaseType()));
+            Assert.Equal(f, TypeArg(aebfc.GetTypeMembers("UBox", 0).Single().BaseType())); // exercises alpha-renaming.
             Assert.Equal(aebfc, DeepConstruct(c, ImmutableArray.Create<TypeSymbol>(e, f))); // exercise DeepConstruct
         }
 
@@ -110,7 +110,7 @@ class C
             var c = global.GetTypeMembers("C", 0).Single() as NamedTypeSymbol;
             var field = c.GetMembers("field").Single() as FieldSymbol;
             var neti = field.Type as NamedTypeSymbol;
-            Assert.Equal(SpecialType.System_Int32, neti.TypeArguments[0].SpecialType);
+            Assert.Equal(SpecialType.System_Int32, neti.TypeArguments()[0].SpecialType);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1609,7 +1609,7 @@ namespace n3
 
             var ns3 = comp.SourceModule.GlobalNamespace.GetMember<NamespaceSymbol>("n3");
             var classC = ns3.GetMember<NamedTypeSymbol>("C");
-            var classCInterface = classC.Interfaces.Single();
+            var classCInterface = classC.Interfaces().Single();
             Assert.Equal("IGoo", classCInterface.Name);
             Assert.Equal(TypeKind.Error, classCInterface.TypeKind);
 
@@ -2158,10 +2158,10 @@ class B : A
                 );
 
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
-            var baseType = ns.GetTypeMembers("A").Single().BaseType;
+            var baseType = ns.GetTypeMembers("A").Single().BaseType();
             Assert.Equal("Goo", baseType.Name);
             Assert.Equal(TypeKind.Error, baseType.TypeKind);
-            Assert.Null(baseType.BaseType);
+            Assert.Null(baseType.BaseType());
 
             var type2 = ns.GetTypeMembers("Bar").Single() as NamedTypeSymbol;
             var mem1 = type2.GetMembers("foundNamespaceInsteadOfType").Single() as FieldSymbol;
@@ -2399,18 +2399,18 @@ namespace NS
                 new ErrorDescription { Code = (int)ErrorCode.ERR_CircularBase, Line = 9, Column = 18 });
 
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
-            var baseType = (NamedTypeSymbol)ns.GetTypeMembers("A").Single().BaseType;
-            Assert.Null(baseType.BaseType);
+            var baseType = (NamedTypeSymbol)ns.GetTypeMembers("A").Single().BaseType();
+            Assert.Null(baseType.BaseType());
             Assert.Equal("B", baseType.Name);
             Assert.Equal(TypeKind.Error, baseType.TypeKind);
 
-            baseType = (NamedTypeSymbol)ns.GetTypeMembers("DD").Single().BaseType;
-            Assert.Null(baseType.BaseType);
+            baseType = (NamedTypeSymbol)ns.GetTypeMembers("DD").Single().BaseType();
+            Assert.Null(baseType.BaseType());
             Assert.Equal("BB", baseType.Name);
             Assert.Equal(TypeKind.Error, baseType.TypeKind);
 
-            baseType = (NamedTypeSymbol)ns.GetTypeMembers("BB").Single().BaseType;
-            Assert.Null(baseType.BaseType);
+            baseType = (NamedTypeSymbol)ns.GetTypeMembers("BB").Single().BaseType();
+            Assert.Null(baseType.BaseType());
             Assert.Equal("CC", baseType.Name);
             Assert.Equal(TypeKind.Error, baseType.TypeKind);
         }
@@ -3169,7 +3169,7 @@ public class MyClass2 : MyClass
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
             var type1 = ns.GetTypeMembers("IGoo").Single() as NamedTypeSymbol;
             // bug: expected 1 but error symbol
-            // Assert.Equal(1, type1.Interfaces.Count());
+            // Assert.Equal(1, type1.Interfaces().Count());
 
             var type2 = ns.GetTypeMembers("IBar").Single() as NamedTypeSymbol;
             var mem1 = type2.GetMembers().First() as MethodSymbol;
@@ -3182,8 +3182,8 @@ public class MyClass2 : MyClass
             Assert.Equal("NoType", ptype.Name);
 
             var type3 = ns.GetTypeMembers("A").Single() as NamedTypeSymbol;
-            var base1 = type3.BaseType;
-            Assert.Null(base1.BaseType);
+            var base1 = type3.BaseType();
+            Assert.Null(base1.BaseType());
             Assert.Equal(TypeKind.Error, base1.TypeKind);
             Assert.Equal("CNotExist", base1.Name);
 
@@ -3416,8 +3416,8 @@ class BAttribute : System.Attribute { }
 
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
             var type1 = ns.GetTypeMembers("C").Single() as NamedTypeSymbol;
-            var base1 = type1.BaseType;
-            Assert.Null(base1.BaseType);
+            var base1 = type1.BaseType();
+            Assert.Null(base1.BaseType());
             Assert.Equal(TypeKind.Error, base1.TypeKind);
             Assert.Equal("B1", base1.Name);
         }
@@ -14367,7 +14367,7 @@ namespace NS
 
             var ns = comp.SourceModule.GlobalNamespace.GetMembers("NS").Single() as NamespaceSymbol;
             var type1 = ns.GetMembers("C").Single() as NamedTypeSymbol;
-            var b = type1.BaseType;
+            var b = type1.BaseType();
         }
 
         [Fact]
@@ -18389,7 +18389,7 @@ class Derived : Base<NotFound>{}";
 
             var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text, new ErrorDescription { Code = (int)ErrorCode.ERR_SingleTypeNameNotFound, Line = 3, Column = 22 });
             var derived = comp.SourceModule.GlobalNamespace.GetTypeMembers("Derived").Single();
-            var Base = derived.BaseType;
+            var Base = derived.BaseType();
             Assert.Equal(TypeKind.Class, Base.TypeKind);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -50,8 +50,8 @@ class A<T> {
 }
 ";
             var compilation = CreateStandardCompilation(code);
-            var aint1 = compilation.GlobalNamespace.GetTypeMembers("A1")[0].BaseType;  // A<int>
-            var aint2 = compilation.GlobalNamespace.GetTypeMembers("A2")[0].BaseType;  // A<int>
+            var aint1 = compilation.GlobalNamespace.GetTypeMembers("A1")[0].BaseType();  // A<int>
+            var aint2 = compilation.GlobalNamespace.GetTypeMembers("A2")[0].BaseType();  // A<int>
             var b1 = aint1.GetTypeMembers("B", 1).Single();                            // A<int>.B<U>
             var b2 = aint2.GetTypeMembers("B", 1).Single();                            // A<int>.B<U>
             Assert.NotSame(b1.TypeParameters[0], b2.TypeParameters[0]);                // they've been alpha renamed independently
@@ -117,9 +117,9 @@ interface B {
             var ns = global.GetMembers("NS").Single() as NamespaceSymbol;
 
             var type1 = ns.GetTypeMembers("C", 0).SingleOrDefault() as NamedTypeSymbol;
-            Assert.Equal(0, type1.Interfaces.Length);
-            Assert.Equal(3, type1.AllInterfaces.Length);
-            var sorted = (from i in type1.AllInterfaces
+            Assert.Equal(0, type1.Interfaces().Length);
+            Assert.Equal(3, type1.AllInterfaces().Length);
+            var sorted = (from i in type1.AllInterfaces()
                           orderby i.Name
                           select i).ToArray();
             var i1 = sorted[0] as NamedTypeSymbol;
@@ -132,21 +132,21 @@ interface B {
             Assert.Equal("MT.IGoo", i3.ToTestDisplayString());
             Assert.Equal(0, i3.Arity);
 
-            Assert.Equal("B", type1.BaseType.Name);
+            Assert.Equal("B", type1.BaseType().Name);
             // B
-            var type2 = type1.BaseType as NamedTypeSymbol;
-            Assert.Equal(3, type2.AllInterfaces.Length);
-            Assert.NotNull(type2.BaseType);
+            var type2 = type1.BaseType() as NamedTypeSymbol;
+            Assert.Equal(3, type2.AllInterfaces().Length);
+            Assert.NotNull(type2.BaseType());
             // A<int>
-            var type3 = type2.BaseType as NamedTypeSymbol;
+            var type3 = type2.BaseType() as NamedTypeSymbol;
             Assert.Equal("NS.A<System.Int32>", type3.ToTestDisplayString());
-            Assert.Equal(2, type3.Interfaces.Length);
-            Assert.Equal(3, type3.AllInterfaces.Length);
+            Assert.Equal(2, type3.Interfaces().Length);
+            Assert.Equal(3, type3.AllInterfaces().Length);
 
             var type33 = ns.GetTypeMembers("A", 1).SingleOrDefault() as NamedTypeSymbol;
             Assert.Equal("NS.A<T>", type33.ToTestDisplayString());
-            Assert.Equal(2, type33.Interfaces.Length);
-            Assert.Equal(3, type33.AllInterfaces.Length);
+            Assert.Equal(2, type33.Interfaces().Length);
+            Assert.Equal(3, type33.AllInterfaces().Length);
         }
 
         [WorkItem(537752, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537752")]
@@ -196,10 +196,10 @@ interface B {
             var ns = global.GetMembers("NS").Single() as NamespaceSymbol;
 
             var type1 = ns.GetTypeMembers("C", 0).SingleOrDefault() as NamedTypeSymbol;
-            Assert.Equal(0, type1.Interfaces.Length);
+            Assert.Equal(0, type1.Interfaces().Length);
             //
-            Assert.Equal(4, type1.AllInterfaces.Length);
-            var sorted = (from i in type1.AllInterfaces
+            Assert.Equal(4, type1.AllInterfaces().Length);
+            var sorted = (from i in type1.AllInterfaces()
                           orderby i.Name
                           select i).ToArray();
             var i1 = sorted[0] as NamedTypeSymbol;
@@ -215,23 +215,23 @@ interface B {
             Assert.Equal("MT.IGoo", i4.ToTestDisplayString());
             Assert.Equal(0, i4.Arity);
 
-            Assert.Equal("B", type1.BaseType.Name);
+            Assert.Equal("B", type1.BaseType().Name);
             // B
-            var type2 = type1.BaseType as NamedTypeSymbol;
+            var type2 = type1.BaseType() as NamedTypeSymbol;
             //
-            Assert.Equal(4, type2.AllInterfaces.Length);
-            Assert.NotNull(type2.BaseType);
+            Assert.Equal(4, type2.AllInterfaces().Length);
+            Assert.NotNull(type2.BaseType());
             // A<ulong>
-            var type3 = type2.BaseType as NamedTypeSymbol;
+            var type3 = type2.BaseType() as NamedTypeSymbol;
             // T1?
             Assert.Equal("NS.A<System.UInt64>", type3.ToTestDisplayString());
-            Assert.Equal(3, type3.Interfaces.Length);
-            Assert.Equal(4, type3.AllInterfaces.Length);
+            Assert.Equal(3, type3.Interfaces().Length);
+            Assert.Equal(4, type3.AllInterfaces().Length);
 
             var type33 = ns.GetTypeMembers("A", 1).SingleOrDefault() as NamedTypeSymbol;
             Assert.Equal("NS.A<T>", type33.ToTestDisplayString());
-            Assert.Equal(3, type33.Interfaces.Length);
-            Assert.Equal(4, type33.AllInterfaces.Length);
+            Assert.Equal(3, type33.Interfaces().Length);
+            Assert.Equal(4, type33.AllInterfaces().Length);
         }
 
         [WorkItem(537746, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537746")]
@@ -341,10 +341,10 @@ namespace NS {
             var type1 = ns.GetTypeMembers("A", 1).SingleOrDefault() as NamedTypeSymbol;
             // 2 Methods + Ctor
             Assert.Equal(3, type1.GetMembers().Length);
-            Assert.Equal(1, type1.Interfaces.Length);
+            Assert.Equal(1, type1.Interfaces().Length);
             Assert.Equal(2, type1.Locations.Length);
 
-            var i1 = type1.Interfaces[0] as NamedTypeSymbol;
+            var i1 = type1.Interfaces()[0] as NamedTypeSymbol;
             Assert.Equal("MT.IGoo<T>", i1.ToTestDisplayString());
             Assert.Equal(2, i1.GetMembers().Length);
             Assert.Equal(2, i1.Locations.Length);
@@ -479,7 +479,7 @@ public partial class A { }
             Assert.Equal(TypeKind.Array, elemType2.TypeKind);
             // bug 2034
             Assert.Equal("System.UInt64[][,]", elemType2.ToTestDisplayString());
-            Assert.Equal("Array", elemType2.BaseType.Name);
+            Assert.Equal("Array", elemType2.BaseType().Name);
 
             var method = classTest.GetMembers("MethodWithArray").Single() as MethodSymbol;
             Assert.Equal(classTest, method.ContainingSymbol);
@@ -534,12 +534,12 @@ public class A {
             var sym1 = (classTest.GetMembers("AryField").First() as FieldSymbol).Type;
             Assert.Equal(SymbolKind.ArrayType, sym1.Kind);
             //
-            Assert.Equal(1, sym1.Interfaces.Length);
-            Assert.Equal("IList", sym1.Interfaces.First().Name);
+            Assert.Equal(1, sym1.Interfaces().Length);
+            Assert.Equal("IList", sym1.Interfaces().First().Name);
 
-            Assert.Equal(9, sym1.AllInterfaces.Length);
+            Assert.Equal(9, sym1.AllInterfaces().Length);
             // ? Don't seem sort right
-            var sorted = sym1.AllInterfaces.OrderBy(i => i.Name).ToArray();
+            var sorted = sym1.AllInterfaces().OrderBy(i => i.Name).ToArray();
 
             var i1 = sorted[0] as NamedTypeSymbol;
             var i2 = sorted[1] as NamedTypeSymbol;
@@ -562,7 +562,7 @@ public class A {
 
             var sym2 = (classTest.GetMembers("AryField2").First() as FieldSymbol).Type;
             Assert.Equal(SymbolKind.ArrayType, sym2.Kind);
-            Assert.Equal(0, sym2.Interfaces.Length);
+            Assert.Equal(0, sym2.Interfaces().Length);
         }
 
         [Fact]
@@ -848,7 +848,7 @@ Goo();
             Assert.Equal(Accessibility.Public, igoo.DeclaredAccessibility);
             Assert.Equal(1, igoo.TypeParameters.Length);
             Assert.Equal("T", igoo.TypeParameters[0].Name);
-            Assert.Equal(1, igoo.TypeArguments.Length);
+            Assert.Equal(1, igoo.TypeArguments().Length);
 
             // Bug#932083 - Not impl
             // Assert.False(igoo.TypeParameters[0].IsReferenceType);
@@ -864,7 +864,7 @@ Goo();
             Assert.Equal("U", classA.TypeParameters[1].Name);
 
             // same as type parameter
-            Assert.Equal(2, classA.TypeArguments.Length);
+            Assert.Equal(2, classA.TypeArguments().Length);
 
             var structS = namespaceNS.GetTypeMembers("S").First();
             Assert.Equal(namespaceNS, structS.ContainingSymbol);
@@ -875,7 +875,7 @@ Goo();
             Assert.Equal("X", structS.TypeParameters[0].Name);
             Assert.Equal("Y", structS.TypeParameters[1].Name);
             Assert.Equal("Z", structS.TypeParameters[2].Name);
-            Assert.Equal(3, structS.TypeArguments.Length);
+            Assert.Equal(3, structS.TypeArguments().Length);
         }
 
         [WorkItem(537199, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537199")]
@@ -970,7 +970,7 @@ public class MyClass : T1
 }";
             var comp = CreateCompilation(code);
             NamedTypeSymbol testTypeSymbol = comp.Assembly.GlobalNamespace.GetTypeMembers("MyClass").Single() as NamedTypeSymbol;
-            Assert.Equal("T1", testTypeSymbol.BaseType.ToTestDisplayString());
+            Assert.Equal("T1", testTypeSymbol.BaseType().ToTestDisplayString());
         }
 
         [WorkItem(537447, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537447")]
@@ -983,7 +983,7 @@ public class X : GC1<BOGUS> {}
 ";
             var comp = CreateCompilation(code);
             NamedTypeSymbol testTypeSymbol = comp.Assembly.GlobalNamespace.GetTypeMembers("X").Single() as NamedTypeSymbol;
-            Assert.Equal("GC1<BOGUS>", testTypeSymbol.BaseType.ToTestDisplayString());
+            Assert.Equal("GC1<BOGUS>", testTypeSymbol.BaseType().ToTestDisplayString());
         }
 
         [WorkItem(537449, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537449")]
@@ -1025,7 +1025,7 @@ interface I5 : I3, I4 {}
 ";
             var comp = CreateStandardCompilation(text);
             var global = comp.GlobalNamespace;
-            var interfaces = global.GetTypeMembers("I5", 0).Single().AllInterfaces;
+            var interfaces = global.GetTypeMembers("I5", 0).Single().AllInterfaces();
             Assert.Equal(4, interfaces.Length);
             Assert.Equal(global.GetTypeMembers("I4", 0).Single(), interfaces[0]);
             Assert.Equal(global.GetTypeMembers("I3", 0).Single(), interfaces[1]);
@@ -1110,7 +1110,7 @@ namespace NS
             var global = comp.GlobalNamespace;
             var ns1 = global.GetMembers("NS").Single() as NamespaceSymbol;
             var syma = ns1.GetMembers("A").Single() as NamedTypeSymbol;
-            var bt = (ns1.GetMembers("B").FirstOrDefault() as NamedTypeSymbol).BaseType;
+            var bt = (ns1.GetMembers("B").FirstOrDefault() as NamedTypeSymbol).BaseType();
             Assert.Equal("Object", bt.Name);
         }
 
@@ -1190,7 +1190,7 @@ namespace System
             var global = comp.GlobalNamespace;
             var system = global.GetMembers("System").Single() as NamespaceSymbol;
             var mystring = system.GetMembers("MyString").Single() as NamedTypeSymbol;
-            var sourceString = mystring.BaseType;
+            var sourceString = mystring.BaseType();
             Assert.Equal(0,
                 sourceString.GetMembers()
                 .Count(m => !(m is MethodSymbol) || (m as MethodSymbol).MethodKind != MethodKind.Constructor));
@@ -1230,29 +1230,29 @@ namespace N
             var ns = global.GetMember<NamespaceSymbol>("N");
 
             var typeA = ns.GetMember<NamedTypeSymbol>("A");
-            var typeAb = typeA.BaseType;
+            var typeAb = typeA.BaseType();
             Assert.Equal(SymbolKind.ErrorType, typeAb.Kind);
             Assert.Equal(2, typeAb.Arity);
 
             var typeB = typeA.GetMember<NamedTypeSymbol>("B");
-            Assert.Equal("BB", typeB.BaseType.Name);
-            var typeBi = typeB.Interfaces.Single();
+            Assert.Equal("BB", typeB.BaseType().Name);
+            var typeBi = typeB.Interfaces().Single();
             Assert.Equal("IGoo", typeBi.Name);
             Assert.Equal(SymbolKind.ErrorType, typeBi.Kind);
             Assert.Equal(2, typeBi.Arity); //matches arity in source, not arity of desired symbol
 
             var typeC = ns.GetMember<NamedTypeSymbol>("C");
-            Assert.Equal(SpecialType.System_Object, typeC.BaseType.SpecialType);
-            var typeCi = typeC.Interfaces.Single();
+            Assert.Equal(SpecialType.System_Object, typeC.BaseType().SpecialType);
+            var typeCi = typeC.Interfaces().Single();
             Assert.Equal("IBar", typeCi.Name);
             Assert.Equal(SymbolKind.ErrorType, typeCi.Kind);
             Assert.Equal(2, typeCi.Arity); //matches arity in source, not arity of desired symbol
 
             var typeD = typeC.GetMember<NamedTypeSymbol>("D");
-            var typeDi = typeD.Interfaces.Single();
+            var typeDi = typeD.Interfaces().Single();
             Assert.Equal("IGoo", typeDi.Name);
             Assert.Equal(3, typeDi.TypeParameters.Length);
-            Assert.Equal(SymbolKind.ErrorType, typeDi.TypeArguments[2].Kind);
+            Assert.Equal(SymbolKind.ErrorType, typeDi.TypeArguments()[2].Kind);
         }
 
         [Fact]
@@ -1317,41 +1317,41 @@ partial class Derived6 : Base<int, int>, Interface1<int, int> { }
 
             foreach (var derived in derivedTypes)
             {
-                if (derived.BaseType.SpecialType != SpecialType.System_Object)
+                if (derived.BaseType().SpecialType != SpecialType.System_Object)
                 {
-                    Assert.Equal(TypeKind.Error, derived.BaseType.TypeKind);
+                    Assert.Equal(TypeKind.Error, derived.BaseType().TypeKind);
                 }
-                foreach (var i in derived.Interfaces)
+                foreach (var i in derived.Interfaces())
                 {
                     Assert.Equal(TypeKind.Error, i.TypeKind);
                 }
             }
 
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[0].BaseType));
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[0].Interfaces.Single()));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[0].BaseType()));
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[0].Interfaces().Single()));
 
             //everything after the first interface is an interface
-            Assert.Equal(SpecialType.System_Object, derivedTypes[1].BaseType.SpecialType);
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[1].Interfaces[0]));
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[1].Interfaces[1]));
+            Assert.Equal(SpecialType.System_Object, derivedTypes[1].BaseType().SpecialType);
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[1].Interfaces()[0]));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[1].Interfaces()[1]));
 
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[2].BaseType));
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[2].Interfaces.Single()));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[2].BaseType()));
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[2].Interfaces().Single()));
 
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[3].BaseType));
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[3].Interfaces.Single()));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[3].BaseType()));
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[3].Interfaces().Single()));
 
-            Assert.Equal(SpecialType.System_Object, derivedTypes[4].BaseType.SpecialType);
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[4].Interfaces[0]));
-            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[4].Interfaces[1]));
+            Assert.Equal(SpecialType.System_Object, derivedTypes[4].BaseType().SpecialType);
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[4].Interfaces()[0]));
+            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[4].Interfaces()[1]));
 
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[5].BaseType));
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[5].Interfaces[0]));
-            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[5].Interfaces[1]));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[5].BaseType()));
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[5].Interfaces()[0]));
+            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[5].Interfaces()[1]));
 
-            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[6].BaseType));
-            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[6].Interfaces[1]));
-            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[6].Interfaces[0]));
+            Assert.Same(baseType, ExtractErrorGuess(derivedTypes[6].BaseType()));
+            Assert.Same(interface1, ExtractErrorGuess(derivedTypes[6].Interfaces()[1]));
+            Assert.Same(interface2, ExtractErrorGuess(derivedTypes[6].Interfaces()[0]));
         }
 
         private static TypeSymbol ExtractErrorGuess(NamedTypeSymbol typeSymbol)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeUnificationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeUnificationTests.cs
@@ -409,7 +409,7 @@ interface IB<T, U> : IA<U, object>, IA<T, U>
 }";
             var comp = CreateStandardCompilation(text);
             var type = comp.GetMember<NamedTypeSymbol>("IB");
-            AssertCanUnify(type.Interfaces[0], type.Interfaces[1]);
+            AssertCanUnify(type.Interfaces()[0], type.Interfaces()[1]);
             DiagnosticsUtils.VerifyErrorCodes(comp.GetDiagnostics(),
                 new ErrorDescription { Code = (int)ErrorCode.ERR_UnifyingInterfaceInstantiations, Line = 4, Column = 11 });
         }

--- a/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
@@ -1044,13 +1044,13 @@ class Query
 
             //  test
             Assert.Equal(typeViewName, type.ToDisplayString());
-            Assert.Equal("object", type.BaseType.ToDisplayString());
+            Assert.Equal("object", type.BaseType().ToDisplayString());
             Assert.True(fieldsCount == 0 ? !type.IsGenericType : type.IsGenericType);
             Assert.Equal(fieldsCount, type.Arity);
             Assert.Equal(Accessibility.Internal, type.DeclaredAccessibility);
             Assert.True(type.IsSealed);
             Assert.False(type.IsStatic);
-            Assert.Equal(0, type.Interfaces.Length);
+            Assert.Equal(0, type.Interfaces().Length);
 
             //  test non-existing members
             Assert.Equal(0, type.GetMembers("doesnotexist").Length);

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
@@ -59,20 +59,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata
                         result.Append(" ");
                         result.Append(member);
 
-                        if (namedType.BaseType != null)
+                        if (namedType.BaseType() != null)
                         {
                             result.AppendLine();
                             result.Append(memberIndent);
                             result.Append("       extends ");
-                            result.Append(namedType.BaseType);
+                            result.Append(namedType.BaseType());
                         }
 
-                        if (namedType.Interfaces.Length > 0)
+                        if (namedType.Interfaces().Length > 0)
                         {
                             result.AppendLine();
                             result.Append(memberIndent);
                             result.Append("       implements ");
-                            result.Append(string.Join(", ", namedType.Interfaces));
+                            result.Append(string.Join(", ", namedType.Interfaces()));
                         }
 
                         result.AppendLine();

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -3257,7 +3257,7 @@ class C
             var fieldType = (NamedTypeSymbol)field.Type;
             Assert.Equal(TypeKind.Error, fieldType.TypeKind);
             Assert.Equal("EventRegistrationTokenTable", fieldType.Name);
-            Assert.Equal(@event.Type, fieldType.TypeArguments.Single());
+            Assert.Equal(@event.Type, fieldType.TypeArguments().Single());
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     return false;
                 }
                 var expArgs = expType.GetGenericArguments();
-                var actArgs = namedType.TypeArguments;
+                var actArgs = namedType.TypeArguments();
                 if (!(expArgs.Count() == actArgs.Length))
                 {
                     return false;
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     return false;
                 }
-                if (!IsEqual(arySym.BaseType, expType.GetTypeInfo().BaseType))
+                if (!IsEqual(arySym.BaseType(), expType.GetTypeInfo().BaseType))
                 {
                     return false;
                 }
@@ -553,5 +553,30 @@ internal static class Extensions
         }
 
         return (Symbol)model.GetDeclaredSymbol(declaration, cancellationToken);
+    }
+
+    public static NamedTypeSymbol BaseType(this TypeSymbol symbol)
+    {
+        return symbol.BaseTypeNoUseSiteDiagnostics;
+    }
+
+    public static ImmutableArray<NamedTypeSymbol> Interfaces(this TypeSymbol symbol)
+    {
+        return symbol.InterfacesNoUseSiteDiagnostics();
+    }
+
+    public static ImmutableArray<NamedTypeSymbol> AllInterfaces(this TypeSymbol symbol)
+    {
+        return symbol.AllInterfacesNoUseSiteDiagnostics;
+    }
+
+    public static ImmutableArray<TypeSymbol> TypeArguments(this NamedTypeSymbol symbol)
+    {
+        return symbol.TypeArgumentsNoUseSiteDiagnostics;
+    }
+
+    public static ImmutableArray<TypeSymbol> ConstraintTypes(this TypeParameterSymbol symbol)
+    {
+        return symbol.ConstraintTypesNoUseSiteDiagnostics;
     }
 }

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -298,4 +298,28 @@ Friend Module Extensions
         Return ret
     End Function
 
+    <Extension>
+    Public Function BaseType(symbol As TypeSymbol) As NamedTypeSymbol
+        Return symbol.BaseTypeNoUseSiteDiagnostics
+    End Function
+
+    <Extension>
+    Public Function Interfaces(symbol As TypeSymbol) As ImmutableArray(Of NamedTypeSymbol)
+        Return symbol.InterfacesNoUseSiteDiagnostics
+    End Function
+
+    <Extension>
+    Public Function AllInterfaces(symbol As TypeSymbol) As ImmutableArray(Of NamedTypeSymbol)
+        Return symbol.AllInterfacesNoUseSiteDiagnostics
+    End Function
+
+    <Extension>
+    Public Function TypeArguments(symbol As NamedTypeSymbol) As ImmutableArray(Of TypeSymbol)
+        Return symbol.TypeArgumentsNoUseSiteDiagnostics
+    End Function
+
+    <Extension>
+    Public Function ConstraintTypes(symbol As TypeParameterSymbol) As ImmutableArray(Of TypeSymbol)
+        Return symbol.ConstraintTypes
+    End Function
 End Module

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -320,6 +320,6 @@ Friend Module Extensions
 
     <Extension>
     Public Function ConstraintTypes(symbol As TypeParameterSymbol) As ImmutableArray(Of TypeSymbol)
-        Return symbol.ConstraintTypes
+        Return symbol.ConstraintTypesNoUseSiteDiagnostics
     End Function
 End Module

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -39,17 +39,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public MustOverride ReadOnly Property TypeParameters As ImmutableArray(Of TypeParameterSymbol)
 
         ''' <summary>
-        ''' Returns the type arguments that have been substituted for the type parameters. 
-        ''' If nothing has been substituted for a give type parameters,
-        ''' then the type parameter itself is consider the type argument.
-        ''' </summary>
-        Public ReadOnly Property TypeArguments As ImmutableArray(Of TypeSymbol)
-            Get
-                Return TypeArgumentsNoUseSiteDiagnostics
-            End Get
-        End Property
-
-        ''' <summary>
         ''' Returns custom modifiers for the type argument that has been substituted for the type parameter. 
         ''' The modifiers correspond to the type argument at the same ordinal within the <see cref="TypeArgumentsNoUseSiteDiagnostics"/>
         ''' array.
@@ -66,6 +55,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend MustOverride ReadOnly Property HasTypeArgumentsCustomModifiers As Boolean
 
+        ''' <summary>
+        ''' Returns the type arguments that have been substituted for the type parameters. 
+        ''' If nothing has been substituted for a give type parameters,
+        ''' then the type parameter itself is consider the type argument.
+        ''' </summary>
         Friend MustOverride ReadOnly Property TypeArgumentsNoUseSiteDiagnostics As ImmutableArray(Of TypeSymbol)
 
         Friend Function TypeArgumentsWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of TypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
@@ -56,12 +56,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Duplicates and cycles are removed, although the collection may include redundant
         ''' constraints where one constraint is a base type of another.
         ''' </summary>
-        Public ReadOnly Property ConstraintTypes As ImmutableArray(Of TypeSymbol)
-            Get
-                Return ConstraintTypesNoUseSiteDiagnostics
-            End Get
-        End Property
-
         Friend MustOverride ReadOnly Property ConstraintTypesNoUseSiteDiagnostics As ImmutableArray(Of TypeSymbol)
 
         Friend Function ConstraintTypesWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of TypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -80,12 +80,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' (for example, interfaces), Nothing is returned. Also the special class System.Object
         ''' always has a BaseType of Nothing.
         ''' </summary>
-        Public ReadOnly Property BaseType As NamedTypeSymbol
-            Get
-                Return BaseTypeNoUseSiteDiagnostics
-            End Get
-        End Property
-
         Friend MustOverride ReadOnly Property BaseTypeNoUseSiteDiagnostics As NamedTypeSymbol
 
         Friend Function BaseTypeWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As NamedTypeSymbol
@@ -113,12 +107,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Gets the set of interfaces that this type directly implements. This set does not
         ''' include interfaces that are base interfaces of directly implemented interfaces.
         ''' </summary>
-        Public ReadOnly Property Interfaces As ImmutableArray(Of NamedTypeSymbol)
-            Get
-                Return InterfacesNoUseSiteDiagnostics
-            End Get
-        End Property
-
         Friend MustOverride ReadOnly Property InterfacesNoUseSiteDiagnostics As ImmutableArray(Of NamedTypeSymbol)
 
         ''' <summary>
@@ -134,12 +122,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Note: When interfaces specified on the same inheritance level differ by tuple names only,
         ''' only the last one will be listed here.
         ''' </summary>
-        Public ReadOnly Property AllInterfaces As ImmutableArray(Of NamedTypeSymbol)
-            Get
-                Return AllInterfacesNoUseSiteDiagnostics
-            End Get
-        End Property
-
         Friend ReadOnly Property AllInterfacesNoUseSiteDiagnostics As ImmutableArray(Of NamedTypeSymbol)
             Get
                 If (_lazyAllInterfaces.IsDefault) Then

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
@@ -70,7 +70,7 @@ public class App : C
             var member02 = (typesym.GetMembers("Prop").Single() as PropertySymbol).Type;
 
             // 'C'
-            var member03 = typesym.BaseType;
+            var member03 = typesym.BaseType();
 
             // 'S'
             var member04 = (typesym.GetMembers("M").Single() as MethodSymbol).Parameters[0].Type;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 binder = new InContainerBinder(substitutedSourceType, binder);
                 if (substitutedSourceType.Arity > 0)
                 {
-                    binder = new WithTypeArgumentsBinder(substitutedSourceType.TypeArguments, binder);
+                    binder = new WithTypeArgumentsBinder(substitutedSourceType.TypeArgumentsNoUseSiteDiagnostics, binder);
                 }
             }
 
@@ -1645,7 +1645,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     {
                         return desiredTypeParameters.Length == 0
                             ? candidateMethod
-                            : candidateMethod.Construct(candidateSubstitutedSourceType.TypeArguments);
+                            : candidateMethod.Construct(candidateSubstitutedSourceType.TypeArgumentsNoUseSiteDiagnostics);
                     }
                 }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress)
         {
             var interfaces = _sourceTypeParameter.GetInterfaces(inProgress);
-            return this.TypeMap.SubstituteNamedTypes(Interfaces);
+            return this.TypeMap.SubstituteNamedTypes(InterfacesNoUseSiteDiagnostics()); // It looks like there is a bug on this line https://github.com/dotnet/roslyn/issues/23886
         }
 
         private TypeMap TypeMap

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
                 CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
-                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments().Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{
@@ -258,7 +258,7 @@ class Generic<T>
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
                 CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
-                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments().Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt: @"
 {
@@ -731,7 +731,7 @@ class Generic<T>
                 Assert.Equal(1, locals.Count);
                 var method = testData.Methods.Single().Value.Method;
                 CheckAttribute(assembly, method, AttributeDescription.DynamicAttribute, expected: true);
-                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments.Single().TypeKind);
+                Assert.Equal(TypeKind.Dynamic, ((NamedTypeSymbol)method.ReturnType).TypeArguments().Single().TypeKind);
                 VerifyCustomTypeInfo(locals[0], "d", 0x02);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d", expectedILOpt:
 @"{

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
         internal static void VerifyTypeParameters(NamedTypeSymbol type)
         {
             AssertEx.All(type.TypeParameters, typeParameter => type.IsContainingSymbolOfAllTypeParameters(typeParameter));
-            AssertEx.All(type.TypeArguments, typeArgument => type.IsContainingSymbolOfAllTypeParameters(typeArgument));
+            AssertEx.All(type.TypeArguments(), typeArgument => type.IsContainingSymbolOfAllTypeParameters(typeArgument));
             var container = type.ContainingType;
             if ((object)container != null)
             {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2011,14 +2011,14 @@ class C<T>
                 var containingType = method.ContainingType;
                 var returnType = (NamedTypeSymbol)method.ReturnType;
                 // Return type E<T> with type argument T from <>c<T>.
-                Assert.Equal(returnType.TypeArguments[0].ContainingSymbol, containingType.ContainingType);
+                Assert.Equal(returnType.TypeArguments()[0].ContainingSymbol, containingType.ContainingType);
                 var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
                 Assert.Equal(1, locals.Length);
                 // All locals of type E<T> with type argument T from <>c<T>.
                 foreach (var local in locals)
                 {
                     var localType = (NamedTypeSymbol)local.Type;
-                    var typeArg = localType.TypeArguments[0];
+                    var typeArg = localType.TypeArguments()[0];
                     Assert.Equal(typeArg.ContainingSymbol, containingType.ContainingType);
                 }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1783,10 +1783,10 @@ class C
                 var method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m0<W>").Method;
                 var containingType = method.ContainingType;
                 var returnType = (NamedTypeSymbol)method.ReturnType;
-                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
-                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[1]);
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments()[0]);
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments()[1]);
                 returnType = returnType.ContainingType;
-                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
+                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments()[0]);
 
                 VerifyLocal(testData, "<>x<T, U, V>", locals[1], "<>m1<W>", "o", expectedILOpt:
 @"{
@@ -1802,9 +1802,9 @@ class C
                 method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m1<W>").Method;
                 // method.ReturnType: A<U>.B<V, object>[]
                 returnType = (NamedTypeSymbol)((ArrayTypeSymbol)method.ReturnType).ElementType;
-                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[0]);
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments()[0]);
                 returnType = returnType.ContainingType;
-                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[0]);
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments()[0]);
 
                 VerifyLocal(testData, "<>x<T, U, V>", locals[2], "<>m2<W>", "t", expectedILOpt:
 @"{
@@ -1863,10 +1863,10 @@ class C
                     expectedGeneric: true);
                 method = (MethodSymbol)testData.GetMethodData("<>x<T, U, V>.<>m5<W>").Method;
                 returnType = (NamedTypeSymbol)method.ReturnType;
-                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments[0]);
-                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments[1]);
-                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments[2]);
-                Assert.Equal(method.TypeParameters[0], returnType.TypeArguments[3]);
+                Assert.Equal(containingType.TypeParameters[0], returnType.TypeArguments()[0]);
+                Assert.Equal(containingType.TypeParameters[1], returnType.TypeArguments()[1]);
+                Assert.Equal(containingType.TypeParameters[2], returnType.TypeArguments()[2]);
+                Assert.Equal(method.TypeParameters[0], returnType.TypeArguments()[3]);
 
                 // Verify <>c__TypeVariables type was emitted (#976772).
                 using (var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(assembly)))

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -749,7 +749,7 @@ namespace System
             var compCorLib = CreateCompilation(sourceCorLib, assemblyName: CorLibAssemblyName, references: new[] { MscorlibRef, refLib });
             compCorLib.VerifyDiagnostics();
             var objectType = compCorLib.SourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Object");
-            Assert.NotNull(objectType.BaseType);
+            Assert.NotNull(objectType.BaseType());
 
             ImmutableArray<byte> peBytes;
             ImmutableArray<byte> pdbBytes;
@@ -867,7 +867,7 @@ namespace System
             var compCorLib = CreateCompilation(sourceCorLib, assemblyName: CorLibAssemblyName, references: new[] { MscorlibRef, refLib });
             compCorLib.VerifyDiagnostics();
             var objectType = compCorLib.SourceAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Object");
-            Assert.NotNull(objectType.BaseType);
+            Assert.NotNull(objectType.BaseType());
 
             var pdbPath = Temp.CreateDirectory().Path;
             ImmutableArray<byte> peBytes;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     If symbol.Kind = SymbolKind.TypeParameter Then
                         Debug.Assert(symbol.OriginalDefinition.ContainingSymbol = substitutedSourceType.OriginalDefinition)
                         Dim ordinal = DirectCast(symbol, TypeParameterSymbol).Ordinal
-                        symbols(i) = substitutedSourceType.TypeArguments(ordinal)
+                        symbols(i) = substitutedSourceType.TypeArgumentsNoUseSiteDiagnostics(ordinal)
                         Debug.Assert(symbols(i).Kind = SymbolKind.TypeParameter)
                     End If
                 Next

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -1394,7 +1394,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     If IsViableSourceMethod(candidateMethod, desiredMethodName, desiredTypeParameters, sourceMethodMustBeInstance) Then
                         Return If(desiredTypeParameters.Length = 0,
                             candidateMethod,
-                            candidateMethod.Construct(candidateSubstitutedSourceType.TypeArguments))
+                            candidateMethod.Construct(candidateSubstitutedSourceType.TypeArgumentsNoUseSiteDiagnostics))
                     End If
                 Next
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.vb
@@ -147,7 +147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
 
             Dim result = variable.ToBoundExpression(syntax, node.IsLValue, node.SuppressVirtualCalls)
-            Debug.Assert(result.Type = node.Type OrElse result.Type.BaseType = node.Type)
+            Debug.Assert(result.Type = node.Type OrElse result.Type.BaseTypeNoUseSiteDiagnostics = node.Type)
             Return result
         End Function
 


### PR DESCRIPTION
This change removes the following APIs:
- TypeSymbol.BaseType
- TypeSymbol.Interfaces
- TypeSymbol.AllInterfaces
- NamedTypeSymbol.TypeArguments
- TypeParameterSymbol.ConstraintTypes

These APIs simply delegate the work to APIs with "NoUseSiteDiagnostics" suffix and are not supposed to be used inside compilers. They were left in the code-base because they used to be part of the public surface and the names were nicer, but they are no longer part of the public surface.
 