### PR TITLE
Reject ref as an invalid modifier for accessors

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -30,7 +30,8 @@ This document provides guidance for thinking about language interactions and tes
 - Performance and stress testing
  
 # Type and members
-- Access modifiers (public, protected, internal, protected internal, private protected, private), static modifier
+- Access modifiers (public, protected, internal, protected internal, private protected, private), static, ref
+    - If adding a new modifier, check modifiers for accessors as well.
 - Parameter modifiers (ref, out, params)
 - Attributes (including security attribute)
 - Generics (type arguments, constraints, variance)

--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -31,7 +31,11 @@ This document provides guidance for thinking about language interactions and tes
  
 # Type and members
 - Access modifiers (public, protected, internal, protected internal, private protected, private), static, ref
-    - If adding a new modifier, check modifiers for accessors as well.
+    - types
+    - methods
+    - fields
+    - properties (including get/set accessors)
+    - events (including add/remove accessors)
 - Parameter modifiers (ref, out, params)
 - Attributes (including security attribute)
 - Generics (type arguments, constraints, variance)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -3185,6 +3185,12 @@ parse_member_name:;
             // to the user that this is not allowed.
             if (IsPossibleModifier())
             {
+                if (this.CurrentToken.Kind == SyntaxKind.RefKeyword)
+                {
+                    // Although a legal modifier, it is never parsed unless before a struct definition
+                    return false;
+                }
+
                 var peekIndex = 1;
                 while (IsPossibleModifier(this.PeekToken(peekIndex)))
                 {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1158,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
         
-        private void ParseModifiers(SyntaxListBuilder tokens)
+        private void ParseModifiers(SyntaxListBuilder tokens, bool forAccessors)
         {
             while (true)
             {
@@ -1218,7 +1218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 modTok = this.EatToken();
                                 modTok = CheckFeatureAvailability(modTok, MessageID.IDS_FeatureRefStructs);
                             }
-                            else if (this.IsPossibleAccessorModifier())
+                            else if (forAccessors && this.IsPossibleAccessorModifier())
                             {
                                 // Accept ref as a modifier for properties and event accessors, to produce an error later during binding.
                                 modTok = this.EatToken();
@@ -2097,7 +2097,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 }
 
                 // All modifiers that might start an expression are processed above.
-                this.ParseModifiers(modifiers);
+                this.ParseModifiers(modifiers, forAccessors: false);
                 if (modifiers.Count > 0)
                 {
                     acceptStatement = false;
@@ -3384,7 +3384,7 @@ parse_member_name:;
             try
             {
                 this.ParseAttributeDeclarations(accAttrs);
-                this.ParseModifiers(accMods);
+                this.ParseModifiers(accMods, forAccessors: true);
 
                 if (!isEvent)
                 {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1218,6 +1218,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 modTok = this.EatToken();
                                 modTok = CheckFeatureAvailability(modTok, MessageID.IDS_FeatureRefStructs);
                             }
+                            else if (this.IsPossibleAccessorModifier())
+                            {
+                                // Accept ref as a modifier for properties and event accessors, to produce an error later during binding.
+                                modTok = this.EatToken();
+                            }
                             else
                             {
                                 return;
@@ -3172,11 +3177,9 @@ parse_member_name:;
             // 
             // Note: we allow all modifiers here.  That's because we want to parse things like
             // "abstract get" as an accessor.  This way we can provide a good error message
-            // to the user that this is not allowed. However, we don't allow "ref", as it might
-            // be a type modifier. We prefer to parse that as part of a member declaration.
+            // to the user that this is not allowed.
 
-            var firstModifier = GetModifier(this.CurrentToken);
-            if (firstModifier == DeclarationModifiers.None || firstModifier == DeclarationModifiers.Ref)
+            if (GetModifier(this.CurrentToken) == DeclarationModifiers.None)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -6367,6 +6367,40 @@ class Program
 
         [Fact]
         [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Properties_Ref_Get_SecondModifier()
+        {
+            var code = @"
+class Program
+{
+    public int P
+    {
+        abstract ref get => throw null;
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (6,18): error CS1014: A get or set accessor expected
+                //         abstract ref get => throw null;
+                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "ref").WithLocation(6, 18),
+                // (6,18): error CS1513: } expected
+                //         abstract ref get => throw null;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref get => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref get => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
+                //     public int P
+                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
         public void ProduceErrorsOnRef_Properties_Ref_Set()
         {
             var code = @"
@@ -6388,6 +6422,40 @@ class Program
                 // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
                 //         ref set => throw null;
                 Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
+                //     public int P
+                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Properties_Ref_Set_SecondModifier()
+        {
+            var code = @"
+class Program
+{
+    public int P
+    {
+        abstract ref set => throw null;
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (6,18): error CS1014: A get or set accessor expected
+                //         abstract ref set => throw null;
+                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "ref").WithLocation(6, 18),
+                // (6,18): error CS1513: } expected
+                //         abstract ref set => throw null;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref set => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref set => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
                 // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
                 // }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
@@ -6429,6 +6497,40 @@ public class Program
 
         [Fact]
         [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Events_Ref_Add_SecondModifier()
+        {
+            var code = @"
+public class Program
+{
+    event System.EventHandler E
+    {
+        abstract ref add => throw null; 
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (6,18): error CS1055: An add or remove accessor expected
+                //         abstract ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "ref").WithLocation(6, 18),
+                // (6,18): error CS1513: } expected
+                //         abstract ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
+                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
+                //     event System.EventHandler E
+                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
         public void ProduceErrorsOnRef_Events_Ref_Remove()
         {
             var code = @"
@@ -6450,6 +6552,40 @@ public class Program
                 // (6,20): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
                 //         ref remove => throw null; 
                 Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 20),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
+                //     event System.EventHandler E
+                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Events_Ref_Remove_SecondModifier()
+        {
+            var code = @"
+public class Program
+{
+    event System.EventHandler E
+    {
+        abstract ref remove => throw null; 
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (6,18): error CS1055: An add or remove accessor expected
+                //         abstract ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "ref").WithLocation(6, 18),
+                // (6,18): error CS1513: } expected
+                //         abstract ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
+                // (6,29): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 29),
+                // (6,29): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         abstract ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 29),
                 // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
                 // }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -6348,21 +6348,9 @@ class Program
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                // (6,13): error CS0106: The modifier 'ref' is not valid for this item
                 //         ref get => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         ref get => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
-                //     public int P
-                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(6, 13));
         }
 
         [Fact]
@@ -6379,24 +6367,12 @@ class Program
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (6,18): error CS1014: A get or set accessor expected
+                // (6,22): error CS0106: The modifier 'abstract' is not valid for this item
                 //         abstract ref get => throw null;
-                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "ref").WithLocation(6, 18),
-                // (6,18): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("abstract").WithLocation(6, 22),
+                // (6,22): error CS0106: The modifier 'ref' is not valid for this item
                 //         abstract ref get => throw null;
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref get => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref get => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
-                //     public int P
-                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(6, 22));
         }
 
         [Fact]
@@ -6413,21 +6389,9 @@ class Program
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                // (6,13): error CS0106: The modifier 'ref' is not valid for this item
                 //         ref set => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         ref set => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
-                //     public int P
-                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("ref").WithLocation(6, 13));
         }
 
         [Fact]
@@ -6444,29 +6408,17 @@ class Program
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (6,18): error CS1014: A get or set accessor expected
+                // (6,22): error CS0106: The modifier 'abstract' is not valid for this item
                 //         abstract ref set => throw null;
-                Diagnostic(ErrorCode.ERR_GetOrSetExpected, "ref").WithLocation(6, 18),
-                // (6,18): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("abstract").WithLocation(6, 22),
+                // (6,22): error CS0106: The modifier 'ref' is not valid for this item
                 //         abstract ref set => throw null;
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref set => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref set => throw null;
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
-                //     public int P
-                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("ref").WithLocation(6, 22));
         }
 
         [Fact]
         [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
-        public void ProduceErrorsOnRef_Events_Ref_Add()
+        public void ProduceErrorsOnRef_Events_Ref()
         {
             var code = @"
 public class Program
@@ -6474,30 +6426,22 @@ public class Program
     event System.EventHandler E
     {
         ref add => throw null; 
+        ref remove => throw null; 
     }
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                // (6,9): error CS1609: Modifiers cannot be placed on event accessor declarations
                 //         ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
-                //     event System.EventHandler E
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+                Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "ref").WithLocation(6, 9),
+                // (7,9): error CS1609: Modifiers cannot be placed on event accessor declarations
+                //         ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "ref").WithLocation(7, 9));
         }
 
         [Fact]
         [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
-        public void ProduceErrorsOnRef_Events_Ref_Add_SecondModifier()
+        public void ProduceErrorsOnRef_Events_Ref_SecondModifier()
         {
             var code = @"
 public class Program
@@ -6505,93 +6449,17 @@ public class Program
     event System.EventHandler E
     {
         abstract ref add => throw null; 
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyDiagnostics(
-                // (6,18): error CS1055: An add or remove accessor expected
-                //         abstract ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "ref").WithLocation(6, 18),
-                // (6,18): error CS1513: } expected
-                //         abstract ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (6,26): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref add => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 26),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
-                //     event System.EventHandler E
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
-        }
-
-        [Fact]
-        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
-        public void ProduceErrorsOnRef_Events_Ref_Remove()
-        {
-            var code = @"
-public class Program
-{
-    event System.EventHandler E
-    {
-        ref remove => throw null; 
-    }
-}";
-
-            CreateStandardCompilation(code).VerifyDiagnostics(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,20): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 20),
-                // (6,20): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 20),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
-                //     event System.EventHandler E
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
-        }
-
-        [Fact]
-        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
-        public void ProduceErrorsOnRef_Events_Ref_Remove_SecondModifier()
-        {
-            var code = @"
-public class Program
-{
-    event System.EventHandler E
-    {
         abstract ref remove => throw null; 
     }
 }";
 
             CreateStandardCompilation(code).VerifyDiagnostics(
-                // (6,18): error CS1055: An add or remove accessor expected
+                // (6,9): error CS1609: Modifiers cannot be placed on event accessor declarations
+                //         abstract ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "abstract").WithLocation(6, 9),
+                // (7,9): error CS1609: Modifiers cannot be placed on event accessor declarations
                 //         abstract ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "ref").WithLocation(6, 18),
-                // (6,18): error CS1513: } expected
-                //         abstract ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(6, 18),
-                // (6,29): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 29),
-                // (6,29): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
-                //         abstract ref remove => throw null; 
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 29),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
-                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
-                //     event System.EventHandler E
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+                Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "abstract").WithLocation(7, 9));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -6333,5 +6333,129 @@ class C<T> : where T : X
             }
             EOF();
         }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Properties_Ref_Get()
+        {
+            var code = @"
+class Program
+{
+    public int P
+    {
+        ref get => throw null;
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (5,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref get => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref get => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
+                //     public int P
+                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Properties_Ref_Set()
+        {
+            var code = @"
+class Program
+{
+    public int P
+    {
+        ref set => throw null;
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (5,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref set => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref set => throw null;
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,16): error CS0548: 'Program.P': property or indexer must have at least one accessor
+                //     public int P
+                Diagnostic(ErrorCode.ERR_PropertyWithNoAccessors, "P").WithArguments("Program.P").WithLocation(4, 16));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Events_Ref_Add()
+        {
+            var code = @"
+public class Program
+{
+    event System.EventHandler E
+    {
+        ref add => throw null; 
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (5,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (6,17): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref add => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 17),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
+                //     event System.EventHandler E
+                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+        }
+
+        [Fact]
+        [WorkItem(23833, "https://github.com/dotnet/roslyn/issues/23833")]
+        public void ProduceErrorsOnRef_Events_Ref_Remove()
+        {
+            var code = @"
+public class Program
+{
+    event System.EventHandler E
+    {
+        ref remove => throw null; 
+    }
+}";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (5,6): error CS1513: } expected
+                //     {
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
+                // (6,20): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 20),
+                // (6,20): error CS1519: Invalid token '=>' in class, struct, or interface member declaration
+                //         ref remove => throw null; 
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(6, 20),
+                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1),
+                // (4,31): error CS0065: 'Program.E': event property must have both add and remove accessors
+                //     event System.EventHandler E
+                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("Program.E").WithLocation(4, 31));
+        }
     }
 }


### PR DESCRIPTION
### Customer scenario

User typing `ref` before an accessor (like `add`, `remove`, `set`, and `get`), will cause the C# compiler to OOM. VS will hang until it eventually runs out of memory.

```csharp
public int Prop
{
    ref get {
```

### Bugs this fixes

Fixes #23833

### Workarounds, if any

None.

### Risk

Minimal. It is rejecting a certain keyword in the parser.

### Performance impact

Minimal.

### Is this a regression from a previous update?

Yes. This bug shipped with ref structs.

### Root cause analysis

With the introduction of `ref struct`s, `ref` was considered a valid modifier, but accessor modifiers were not adjusted as well.

### How was the bug found?

Customer report.

### Test documentation updated?

Yes.