### PR TITLE
Add MEF metadata to IDeferredQuickInfoContentToFrameworkElementConverter

### DIFF
--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/ClassifiableDeferredContentConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/ClassifiableDeferredContentConverter.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Text.Classification;
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
     [Export(typeof(IDeferredQuickInfoContentToFrameworkElementConverter))]
+    [QuickInfoConverterMetadata(typeof(ClassifiableDeferredContent))]
     class ClassifiableDeferredContentConverter : IDeferredQuickInfoContentToFrameworkElementConverter
     {
         private readonly ClassificationTypeMap _typeMap;

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/DocumentationCommentDeferredContentConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/DocumentationCommentDeferredContentConverter.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Text.Classification;
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo.Converters
 {
     [Export(typeof(IDeferredQuickInfoContentToFrameworkElementConverter))]
+    [QuickInfoConverterMetadata(typeof(DocumentationCommentDeferredContent))]
     internal sealed class DocumentationCommentDeferredContentConverter : IDeferredQuickInfoContentToFrameworkElementConverter
     {
         private readonly ClassificationTypeMap _typeMap;

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/ProjectionBufferDeferredContentConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/ProjectionBufferDeferredContentConverter.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
     [Export(typeof(IDeferredQuickInfoContentToFrameworkElementConverter))]
+    [QuickInfoConverterMetadata(typeof(ProjectionBufferDeferredContent))]
     class ProjectionBufferDeferredContentConverter : IDeferredQuickInfoContentToFrameworkElementConverter
     {
         private readonly IProjectionBufferFactoryService _projectionBufferFactoryService;

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/QuickInfoConverterMetadataAttribute.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/QuickInfoConverterMetadataAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.CodeAnalysis.Editor.QuickInfo
+{
+    [MetadataAttribute]
+    internal sealed class QuickInfoConverterMetadataAttribute : Attribute
+    {
+        public QuickInfoConverterMetadataAttribute(Type deferredType)
+        {
+            DeferredTypeFullName = deferredType.FullName;
+        }
+
+        public string DeferredTypeFullName { get; }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/QuickInfoDisplayDeferredContentConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/QuickInfoDisplayDeferredContentConverter.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
     [Export(typeof(IDeferredQuickInfoContentToFrameworkElementConverter))]
+    [QuickInfoConverterMetadata(typeof(QuickInfoDisplayDeferredContent))]
     class QuickInfoDisplayDeferredContentConverter : IDeferredQuickInfoContentToFrameworkElementConverter
     {
         public FrameworkElement CreateFrameworkElement(IDeferredQuickInfoContent deferredContent, DeferredContentFrameworkElementFactory factory)

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/SymbolGlyphDeferredContentConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Converters/SymbolGlyphDeferredContentConverter.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.PlatformUI;
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
     [Export(typeof(IDeferredQuickInfoContentToFrameworkElementConverter))]
+    [QuickInfoConverterMetadata(typeof(SymbolGlyphDeferredContent))]
     class SymbolGlyphDeferredContentConverter : IDeferredQuickInfoContentToFrameworkElementConverter
     {
         public FrameworkElement CreateFrameworkElement(IDeferredQuickInfoContent deferredContent, DeferredContentFrameworkElementFactory factory)

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/DeferredContentFrameworkElementFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/DeferredContentFrameworkElementFactory.cs
@@ -3,24 +3,53 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows;
-using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.QuickInfo
 {
     [Export]
     internal class DeferredContentFrameworkElementFactory
     {
-        private readonly Dictionary<Type, IDeferredQuickInfoContentToFrameworkElementConverter> _convertersByType;
+        private readonly Dictionary<string, Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>> _convertersByTypeFullName
+            = new Dictionary<string, Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>>();
+        private readonly IEnumerable<Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>> _convertersWithoutMetadata;
 
         [ImportingConstructor]
-        public DeferredContentFrameworkElementFactory([ImportMany] IEnumerable<IDeferredQuickInfoContentToFrameworkElementConverter> converters)
+        public DeferredContentFrameworkElementFactory(
+            [ImportMany] IEnumerable<Lazy<IDeferredQuickInfoContentToFrameworkElementConverter, IQuickInfoConverterMetadata>> converters,
+            [ImportMany] IEnumerable<Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>> convertersWithoutMetadata)
         {
-            _convertersByType = converters.ToDictionary(c => c.GetApplicableType());
+            _convertersByTypeFullName = converters.ToDictionary(
+                lazy => lazy.Metadata.DeferredTypeFullName,
+                lazy => (Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>)lazy);
+
+            _convertersWithoutMetadata = convertersWithoutMetadata;
         }
 
         internal FrameworkElement CreateElement(IDeferredQuickInfoContent deferredContent)
         {
-            return _convertersByType[deferredContent.GetType()].CreateFrameworkElement(deferredContent, this);
+            var deferredContentFullName = deferredContent.GetType().FullName;
+            Lazy<IDeferredQuickInfoContentToFrameworkElementConverter> converter;
+
+            if (!_convertersByTypeFullName.TryGetValue(deferredContentFullName, out converter))
+            {
+                // The content must be of a type we didn't have MEF deferred metadata for. Realize the
+                // ones without MEF metadata, forcing everything to load.
+                foreach (var converterWithoutMetadata in _convertersWithoutMetadata)
+                {
+                    _convertersByTypeFullName[converterWithoutMetadata.Value.GetApplicableType().FullName] =
+                        new Lazy<IDeferredQuickInfoContentToFrameworkElementConverter>(() => converterWithoutMetadata.Value);
+                }
+
+                Contract.ThrowIfFalse(_convertersByTypeFullName.TryGetValue(deferredContentFullName, out converter));
+            }
+
+            return converter.Value.CreateFrameworkElement(deferredContent, this);
+        }
+
+        internal interface IQuickInfoConverterMetadata
+        {
+            string DeferredTypeFullName { get; }
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/QuickInfoControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/QuickInfoControllerTests.vb
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfFact(), WorkItem(1106729, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1106729")>
         Public Sub PresenterUpdatesExistingSessionIfNotDismissed()
             Dim broker = New Mock(Of IQuickInfoBroker)()
-            Dim frameworkElementFactory = New DeferredContentFrameworkElementFactory({})
+            Dim frameworkElementFactory = New DeferredContentFrameworkElementFactory({}, {})
             Dim presenter As IIntelliSensePresenter(Of IQuickInfoPresenterSession, IQuickInfoSession) = New QuickInfoPresenter(broker.Object, frameworkElementFactory)
             Dim mockEditorSession = New Mock(Of IQuickInfoSession)
             mockEditorSession.Setup(Function(m) m.IsDismissed).Returns(False)
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             brokerSession.Setup(Function(m) m.Properties).Returns(New PropertyCollection())
             broker.Setup(Function(m) m.CreateQuickInfoSession(It.IsAny(Of ITextView), It.IsAny(Of ITrackingPoint), It.IsAny(Of Boolean))).Returns(brokerSession.Object)
 
-            Dim frameworkElementFactory = New DeferredContentFrameworkElementFactory({})
+            Dim frameworkElementFactory = New DeferredContentFrameworkElementFactory({}, {})
             Dim presenter As IIntelliSensePresenter(Of IQuickInfoPresenterSession, IQuickInfoSession) = New QuickInfoPresenter(broker.Object, frameworkElementFactory)
             Dim mockEditorSession = New Mock(Of IQuickInfoSession)
             mockEditorSession.Setup(Function(m) m.IsDismissed).Returns(True)


### PR DESCRIPTION
When I added this interface, I had the implementations expose their applicable type not by metadata, but by simply calling a method on the instance. This is problematic if the implementation is in a
different assembly as we'll load it too early. This is causing F# to load when they shouldn't.

This is intended as a temporary shim that fixes the perf load for the F# case (the only current exporter of these outside the Roslyn repo itself) without forcing an interface change. This will get deleted soon enough once we migrate to newer Quick Info APIs.

<details><summary>Ask Mode template</summary>

### Customer scenario

Invoke Quick Info in C# or VB. An F# assembly is loaded by accident.

### Bugs this fixes

No bug yet (but we'll get one eventually.)

### Workarounds, if any

None.

### Risk

Low, easy to test.

### Performance impact

Fixes assembly load.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

This was an oversight caught during RPS runs during the first attempted insertion of the code. The regression is below the degrade bar so it's easy to miss.

### How was the bug found?

RPS.

</details>
