### PR TITLE
Fix a crash for a codeaction with overridden PostProcessAsync in the PreviewChanges dialog

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesCodeAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesCodeAction.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
@@ -27,13 +28,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 public override string Title => EditorFeaturesResources.Preview_changes2;
 
-                protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
+                internal override async Task<ImmutableArray<CodeActionOperation>> GetOperationsCoreAsync(IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     var previewDialogService = _workspace.Services.GetService<IPreviewDialogService>();
                     if (previewDialogService == null)
                     {
-                        return null;
+                        return ImmutableArray<CodeActionOperation>.Empty;
                     }
 
                     var changedSolution = previewDialogService.PreviewChanges(
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     if (changedSolution == null)
                     {
                         // User pressed the cancel button.
-                        return null;
+                        return ImmutableArray<CodeActionOperation>.Empty;
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
PreviewCodeAction was overriding ComputeOperations but returning a post-processed operation from the original action. This results in another PostProcess being called on the codeaction. If postprocess was overriden in originalaction that'll be ignored the second time

### Customer scenario
Bring up the a lightbulb for a codeaction that has the postprocess method overridden. Click on the Preview Changes button to bring up the preview dialog and then apply the codeaction. This can lead to the codeaction crashing and being disabled.

### Bugs this fixes
[556195](https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20Productivity/_workitems/edit/556195)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.
