### PR TITLE
Add test for obsolete Deconstruct method

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -127,6 +127,41 @@ class C
         }
 
         [Fact]
+        public void ObsoleteDeconstructMethod()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        long x;
+        string y;
+
+        (x, y) = new C();
+        foreach (var (z1, z2) in new[] { new C() }) { }
+    }
+
+    [System.Obsolete]
+    public void Deconstruct(out int a, out string b)
+    {
+        a = 1;
+        b = ""hello"";
+    }
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (9,18): warning CS0612: 'C.Deconstruct(out int, out string)' is obsolete
+                //         (x, y) = new C();
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "new C()").WithArguments("C.Deconstruct(out int, out string)").WithLocation(9, 18),
+                // (10,34): warning CS0612: 'C.Deconstruct(out int, out string)' is obsolete
+                //         foreach (var (z1, z2) in new[] { new C() }) { }
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "new[] { new C() }").WithArguments("C.Deconstruct(out int, out string)").WithLocation(10, 34)
+                );
+        }
+
+        [Fact]
         [WorkItem(13632, "https://github.com/dotnet/roslyn/issues/13632")]
         public void SimpleAssignWithoutConversion()
         {


### PR DESCRIPTION
Test-only check to verify that an obsolete Deconstruct method is properly reported when used in a deconstruction.