### PR TITLE
AddParameter should handle and bail out on omitted argument

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/AddParameter/AddParameterTests.vb
@@ -14,6 +14,25 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.AddParameter
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
+        <WorkItem(23927, "https://github.com/dotnet/roslyn/issues/23927")>
+        Public Async Function TestMissingOnOmittedArgument() As Task
+            Await TestMissingAsync(
+"Public Module Module1
+    Private Class C
+        Public Sub New(Arg1 As Integer)
+        End Sub
+
+        Public Sub New(Arg1 As Integer, Arg2 As Integer)
+        End Sub
+    End Class
+
+    Public Sub Main()
+        Dim x = New [|C|](, 0)
+    End Sub
+End Module")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameter)>
         Public Async Function TestMissingWithImplicitConstructor() As Task
             Await TestMissingAsync(
 "

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -442,10 +442,14 @@ namespace Microsoft.CodeAnalysis.AddParameter
 
                     // Now check the type of the argument versus the type of the parameter.  If they
                     // don't match, then this is the argument we should make the parameter for.
-                    var expressionOfArgumment = syntaxFacts.GetExpressionOfArgument(argument);
-                    var argumentTypeInfo = semanticModel.GetTypeInfo(expressionOfArgumment);
-                    var isNullLiteral = syntaxFacts.IsNullLiteralExpression(expressionOfArgumment);
-                    var isDefaultLiteral = syntaxFacts.IsDefaultLiteralExpression(expressionOfArgumment);
+                    var expressionOfArgument = syntaxFacts.GetExpressionOfArgument(argument);
+                    if (expressionOfArgument is null)
+                    {
+                        return null;
+                    }
+                    var argumentTypeInfo = semanticModel.GetTypeInfo(expressionOfArgument);
+                    var isNullLiteral = syntaxFacts.IsNullLiteralExpression(expressionOfArgument);
+                    var isDefaultLiteral = syntaxFacts.IsDefaultLiteralExpression(expressionOfArgument);
 
                     if (argumentTypeInfo.Type == null && argumentTypeInfo.ConvertedType == null)
                     {


### PR DESCRIPTION
### Customer scenario
In VB, invoke a constructor with an omitted argument `New C(, 0)`. The error for a missing argument triggers the GenerateConstructor/AddParameter code fixers.
That code fixer should handle this case, by bailing out (don't offer a fix).

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23927

### Risk
### Performance impact
Low. Adding null check.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer