### PR TITLE
Command-line options starting with dash are not file paths

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -288,11 +288,10 @@ d.cs
 
         [Fact]
         [WorkItem(21508, "https://github.com/dotnet/roslyn/issues/21508")]
-        public void ArgumentStartwithDashAndContainingSlash()
+        public void ArgumentStartWithDashAndContainingSlash()
         {
             CSharpCommandLineArguments args;
             var folder = Temp.CreateDirectory();
-            CreateFile(folder, "a.cs");
 
             args = DefaultParse(new[] { "-debug+/debug:portable" }, folder.Path);
             args.Errors.Verify(

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -286,6 +286,25 @@ d.cs
             Assert.Equal("решения.Class1", args.CompilationOptions.MainTypeName);
         }
 
+        [Fact]
+        [WorkItem(21508, "https://github.com/dotnet/roslyn/issues/21508")]
+        public void ArgumentStartwithDashAndContainingSlash()
+        {
+            CSharpCommandLineArguments args;
+            var folder = Temp.CreateDirectory();
+            CreateFile(folder, "a.cs");
+
+            args = DefaultParse(new[] { "-debug+/debug:portable" }, folder.Path);
+            args.Errors.Verify(
+                // error CS2007: Unrecognized option: '-debug+/debug:portable'
+                Diagnostic(ErrorCode.ERR_BadSwitch).WithArguments("-debug+/debug:portable").WithLocation(1, 1),
+                // warning CS2008: No source files specified.
+                Diagnostic(ErrorCode.WRN_NoSources).WithLocation(1, 1),
+                // error CS1562: Outputs without source must have the /out option specified
+                Diagnostic(ErrorCode.ERR_OutputNeedsName).WithLocation(1, 1)
+                );
+        }
+
         [WorkItem(546009, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546009")]
         [WorkItem(545991, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545991")]
         [ConditionalFact(typeof(WindowsOnly))]

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -91,10 +91,10 @@ namespace Microsoft.CodeAnalysis
             // pattern /goo/*  or  //* will not be treated as a compiler option
             //
             // TODO: consider introducing "/s:path" to disambiguate paths starting with /
-            if (arg.Length > 1)
+            if (arg.Length > 1 && arg[0] != '-')
             {
                 int separator = arg.IndexOf('/', 1);
-                if (separator > 0 && (colon < 0 || separator < colon) && arg[0] != '-')
+                if (separator > 0 && (colon < 0 || separator < colon))
                 {
                     //   "/goo/
                     //   "//

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis
             if (arg.Length > 1)
             {
                 int separator = arg.IndexOf('/', 1);
-                if (separator > 0 && (colon < 0 || separator < colon))
+                if (separator > 0 && (colon < 0 || separator < colon) && arg[0] != '-')
                 {
                     //   "/goo/
                     //   "//

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -86,6 +86,19 @@ End Class
             CleanupAllGeneratedFiles(src)
         End Sub
 
+        <Fact>
+        <WorkItem(21508, "https://github.com/dotnet/roslyn/issues/21508")>
+        Public Sub ArgumentStartWithDashAndContainingSlash()
+            Dim args As VisualBasicCommandLineArguments
+            Dim folder = Temp.CreateDirectory()
+
+            args = DefaultParse({"-debug+/debug:portable"}, folder.Path)
+            args.Errors.AssertTheseDiagnostics(<errors>
+BC2007: unrecognized option '-debug+/debug:portable'; ignored
+BC2008: no input sources specified
+                                               </errors>)
+        End Sub
+
         <WorkItem(545247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545247")>
         <Fact()>
         Public Sub CommandLineCompilationWithQuotedMainArgument()


### PR DESCRIPTION
### Customer scenario
Invoke the compiler with invalid command-line argument which starts with a `-` but also contains a `/`. The compiler throws an assertion.
For example, `-debug+/debug:portable`.
The assertion is that options can start with `-`, but paths shouldn't. The reason we're treating this argument as a possible path is because it contains a `/` (which is recognized by a heuristic for Linux paths).

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/21508

### Workarounds, if any
Specify valid command-line arguments.

### Risk
### Performance impact
Low. Adding a character check during command-line parsing.

### Is this a regression from a previous update?
No

### How was the bug found?
Reported by team-member.