### PR TITLE
Honor type style preferences on tuple literals

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1539,6 +1539,18 @@ namespace System
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(11094, "https://github.com/dotnet/roslyn/issues/11094")]
+        public async Task SuggestVarOnLocalWithNonApparentTupleType()
+        {
+            var before = @"class C { static void M(C c) { [|(int a, C b)|] s = (a: 1, b: c); } }";
+            var after = @"class C { static void M(C c) { var s = (a: 1, b: c); } }";
+
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparentAndForIntrinsics()));
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparent()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [WorkItem(11154, "https://github.com/dotnet/roslyn/issues/11154")]
         public async Task ValueTupleCreate()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1534,8 +1534,7 @@ namespace System
             var after = @"class C { static void M() { var s = (a: 1, ""hello""); } }";
 
             await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
-
-            // We would rather this refactoring also worked. See https://github.com/dotnet/roslyn/issues/11094
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparentAndForIntrinsics());
             await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparent()));
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -79,8 +79,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
             if (initializerExpression.IsKind(SyntaxKind.TupleExpression))
             {
                 var tuple = (TupleExpressionSyntax)initializerExpression;
-                return tuple.Arguments.All(a => IsTypeApparentInAssignmentExpression(stylePreferences, a.Expression,
-                    semanticModel, cancellationToken, typeInDeclaration));
+                foreach (var argument in tuple.Arguments)
+                {
+                    if (!IsTypeApparentInAssignmentExpression(stylePreferences, argument.Expression, semanticModel, cancellationToken, typeInDeclaration))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
 
             // default(type)

--- a/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -75,6 +75,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
             CancellationToken cancellationToken,
             ITypeSymbol typeInDeclaration = null)
         {
+            // tuple literals
+            if (initializerExpression.IsKind(SyntaxKind.TupleExpression))
+            {
+                var tuple = (TupleExpressionSyntax)initializerExpression;
+                return tuple.Arguments.All(a => IsTypeApparentInAssignmentExpression(stylePreferences, a.Expression,
+                    semanticModel, cancellationToken, typeInDeclaration));
+            }
+
             // default(type)
             if (initializerExpression.IsKind(SyntaxKind.DefaultExpression))
             {


### PR DESCRIPTION
### Customer scenario
`UseImplicitType` on tuple literals should apply when the user preference applies recursively on all the tuple elements.
For example, on `(int a, string) s = (a: 1, "hello");` we'll offer `var` if we would have offered `var` on `int a = 1;` and `string b = "hello";`.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/11094

### Risk
### Performance impact
Low. The change is limited to the `IsTypeApparentInAssignmentExpression` method, so that it handles tuples by checking the tuple elements.

### Is this a regression from a previous update?
No.

### How was the bug found?
Found during the development of the tuples language feature.