### PR TITLE
Migrate to the editor 15.6.241

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -211,7 +211,7 @@
     <SystemTextRegularExpressionsVersion>4.3.0</SystemTextRegularExpressionsVersion>
     <SystemThreadingVersion>4.3.0</SystemThreadingVersion>
     <SystemThreadingTasksVersion>4.3.0</SystemThreadingTasksVersion>
-    <SystemThreadingTasksDataflowVersion>4.7.0</SystemThreadingTasksDataflowVersion>
+    <SystemThreadingTasksDataflowVersion>4.5.24</SystemThreadingTasksDataflowVersion>
     <SystemThreadingTasksParallelVersion>4.3.0</SystemThreadingTasksParallelVersion>
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemValueTupleVersion>4.3.0</SystemValueTupleVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -71,25 +71,25 @@
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26730-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26730-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26730-alpha</MicrosoftVisualStudioComponentModelHostVersion>
-    <MicrosoftVisualStudioCompositionVersion>15.0.71</MicrosoftVisualStudioCompositionVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>15.6.161-preview</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVisualStudioCompositionVersion>15.5.23</MicrosoftVisualStudioCompositionVersion>
+    <MicrosoftVisualStudioCoreUtilityVersion>15.6.241-preview</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerEngineVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerEngineVersion>
     <MicrosoftVisualStudioDebuggerMetadataVersion>15.0.26811-vsucorediag</MicrosoftVisualStudioDebuggerMetadataVersion>
     <MicrosoftVisualStudioDebuggerInterop100Version>10.0.30319</MicrosoftVisualStudioDebuggerInterop100Version>
     <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.0.26730-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
-    <MicrosoftVisualStudioEditorVersion>15.6.161-preview</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioEditorVersion>15.6.241-preview</MicrosoftVisualStudioEditorVersion>
     <MicrosoftVisualStudioGraphModelVersion>15.0.26730-alpha</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>15.0.26730-alpha</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>15.0.26730-alpha</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>15.0.25726-Preview5</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.3.1710.203</MicrosoftVisualStudioLanguageCallHierarchyVersion>
-    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.6.161-preview</MicrosoftVisualStudioLanguageIntellisenseVersion>
-    <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.6.161-preview</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
-    <MicrosoftVisualStudioLanguageStandardClassificationVersion>15.6.161-preview</MicrosoftVisualStudioLanguageStandardClassificationVersion>
+    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.6.241-preview</MicrosoftVisualStudioLanguageIntellisenseVersion>
+    <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.6.241-preview</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
+    <MicrosoftVisualStudioLanguageStandardClassificationVersion>15.6.241-preview</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6070</MicrosoftVisualStudioOLEInteropVersion>
-    <MicrosoftVisualStudioPlatformVSEditorVersion>15.6.161-preview</MicrosoftVisualStudioPlatformVSEditorVersion>
+    <MicrosoftVisualStudioPlatformVSEditorVersion>15.6.241-preview</MicrosoftVisualStudioPlatformVSEditorVersion>
     <MicrosoftVisualStudioProgressionCodeSchemaVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionCodeSchemaVersion>
     <MicrosoftVisualStudioProgressionCommonVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionCommonVersion>
     <MicrosoftVisualStudioProgressionInterfacesVersion>15.0.26730-alpha</MicrosoftVisualStudioProgressionInterfacesVersion>
@@ -115,11 +115,11 @@
     <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
     <MicrosoftVisualStudioTelemetryVersion>15.0.26730-alpha</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
-    <MicrosoftVisualStudioTextDataVersion>15.6.161-preview</MicrosoftVisualStudioTextDataVersion>
-    <MicrosoftVisualStudioTextInternalVersion>15.6.161-preview</MicrosoftVisualStudioTextInternalVersion>
-    <MicrosoftVisualStudioTextLogicVersion>15.6.161-preview</MicrosoftVisualStudioTextLogicVersion>
-    <MicrosoftVisualStudioTextUIVersion>15.6.161-preview</MicrosoftVisualStudioTextUIVersion>
-    <MicrosoftVisualStudioTextUIWpfVersion>15.6.161-preview</MicrosoftVisualStudioTextUIWpfVersion>
+    <MicrosoftVisualStudioTextDataVersion>15.6.241-preview</MicrosoftVisualStudioTextDataVersion>
+    <MicrosoftVisualStudioTextInternalVersion>15.6.241-preview</MicrosoftVisualStudioTextInternalVersion>
+    <MicrosoftVisualStudioTextLogicVersion>15.6.241-preview</MicrosoftVisualStudioTextLogicVersion>
+    <MicrosoftVisualStudioTextUIVersion>15.6.241-preview</MicrosoftVisualStudioTextUIVersion>
+    <MicrosoftVisualStudioTextUIWpfVersion>15.6.241-preview</MicrosoftVisualStudioTextUIWpfVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>7.10.6070</MicrosoftVisualStudioTextManagerInteropVersion>
     <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop100Version>
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -66,7 +66,6 @@
     <MicrosoftNuGetBuildTasksVersion>0.1.0</MicrosoftNuGetBuildTasksVersion>
     <MicrosoftPortableTargetsVersion>0.1.2-dev</MicrosoftPortableTargetsVersion>
     <MicrosoftServiceHubClientVersion>1.1.122-rc</MicrosoftServiceHubClientVersion>
-    <MicrosoftTplDataflowVersion>4.5.24</MicrosoftTplDataflowVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26730-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26730-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -211,6 +211,7 @@
     <SystemTextRegularExpressionsVersion>4.3.0</SystemTextRegularExpressionsVersion>
     <SystemThreadingVersion>4.3.0</SystemThreadingVersion>
     <SystemThreadingTasksVersion>4.3.0</SystemThreadingTasksVersion>
+    <SystemThreadingTasksDataflowVersion>4.8.0</SystemThreadingTasksDataflowVersion>
     <SystemThreadingTasksParallelVersion>4.3.0</SystemThreadingTasksParallelVersion>
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemValueTupleVersion>4.3.0</SystemValueTupleVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -211,7 +211,7 @@
     <SystemTextRegularExpressionsVersion>4.3.0</SystemTextRegularExpressionsVersion>
     <SystemThreadingVersion>4.3.0</SystemThreadingVersion>
     <SystemThreadingTasksVersion>4.3.0</SystemThreadingTasksVersion>
-    <SystemThreadingTasksDataflowVersion>4.8.0</SystemThreadingTasksDataflowVersion>
+    <SystemThreadingTasksDataflowVersion>4.7.0</SystemThreadingTasksDataflowVersion>
     <SystemThreadingTasksParallelVersion>4.3.0</SystemThreadingTasksParallelVersion>
     <SystemThreadingThreadVersion>4.3.0</SystemThreadingThreadVersion>
     <SystemValueTupleVersion>4.3.0</SystemValueTupleVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -66,6 +66,7 @@
     <MicrosoftNuGetBuildTasksVersion>0.1.0</MicrosoftNuGetBuildTasksVersion>
     <MicrosoftPortableTargetsVersion>0.1.2-dev</MicrosoftPortableTargetsVersion>
     <MicrosoftServiceHubClientVersion>1.1.122-rc</MicrosoftServiceHubClientVersion>
+    <MicrosoftTplDataflowVersion>4.5.24</MicrosoftTplDataflowVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26730-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26730-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -18,6 +18,7 @@ using Roslyn.Test.EditorUtilities.NavigateTo;
 using Roslyn.Test.Utilities;
 using Xunit;
 
+#pragma warning disable CS0618 // MatchKind is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
 {
     public class InteractiveNavigateToTests : AbstractNavigateToTests
@@ -646,3 +647,4 @@ class C2
         }
     }
 }
+#pragma warning restore CS0618 // MatchKind is obsolete

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -15,6 +15,7 @@ using Roslyn.Test.EditorUtilities.NavigateTo;
 using Roslyn.Test.Utilities;
 using Xunit;
 
+#pragma warning disable CS0618 // MatchKind is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
 {
     public class NavigateToTests : AbstractNavigateToTests
@@ -1072,3 +1073,4 @@ class D
         }
     }
 }
+#pragma warning restore CS0618 // MatchKind is obsolete

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -121,6 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 }
             }
 
+#pragma warning disable CS0618 // MatchKind is obsolete
             private void ReportMatchResult(Project project, INavigateToSearchResult result)
             {
                 var navigateToItem = new NavigateToItem(
@@ -146,6 +147,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                     default: return MatchKind.None;
                 }
             }
+#pragma warning restore CS0618 // MatchKind is obsolete
 
             /// <summary>
             /// Returns the name for the language used by the old Navigate To providers.

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     internal partial class QuickInfoPresenter
@@ -109,3 +110,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoSource.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     internal partial class QuickInfoPresenter
@@ -30,3 +31,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.cs
+++ b/src/EditorFeatures/Core.Wpf/QuickInfo/Presentation/QuickInfoPresenter.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Presentation
 {
     [Export(typeof(IQuickInfoSourceProvider))]
@@ -42,3 +43,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     internal partial class QuickInfoCommandHandlerAndSourceProvider
@@ -50,3 +51,4 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     [Export]
@@ -96,3 +97,4 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     internal partial class Controller :
@@ -168,3 +169,4 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller_InvokeQuickInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller_InvokeQuickInfo.cs
@@ -25,11 +25,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
         }
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
         public void InvokeQuickInfo(int position, bool trackMouse, IQuickInfoSession augmentSession)
         {
             AssertIsForeground();
             DismissSessionIfActive();
             StartSession(position, trackMouse, augmentSession);
         }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete
     }
 }

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -66,6 +66,7 @@
          does depend on internal APIs, so we need to a force a reference here. -->
     <Reference Include="$(NuGetPackageRoot)\microsoft.visualstudio.text.internal\$(MicrosoftVisualStudioTextInternalVersion)\lib\net46\Microsoft.VisualStudio.Text.Internal.dll" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="BasicUndo" Version="$(BasicUndoVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimeVersion)" />

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -65,7 +65,6 @@
          but includes the lib folder so it's copied as a dependency of Microsoft.VisualStudio.Platform.VSEditor. Unfortunately we still have test code that
          does depend on internal APIs, so we need to a force a reference here. -->
     <Reference Include="$(NuGetPackageRoot)\microsoft.visualstudio.text.internal\$(MicrosoftVisualStudioTextInternalVersion)\lib\net46\Microsoft.VisualStudio.Text.Internal.dll" />
-    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="BasicUndo" Version="$(BasicUndoVersion)" />

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -79,6 +79,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Services.UnitTests" />

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -66,7 +66,6 @@
          does depend on internal APIs, so we need to a force a reference here. -->
     <Reference Include="$(NuGetPackageRoot)\microsoft.visualstudio.text.internal\$(MicrosoftVisualStudioTextInternalVersion)\lib\net46\Microsoft.VisualStudio.Text.Internal.dll" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="BasicUndo" Version="$(BasicUndoVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimeVersion)" />

--- a/src/EditorFeatures/Test2/IntelliSense/QuickInfoControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/QuickInfoControllerTests.vb
@@ -14,6 +14,8 @@ Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Utilities
 Imports Moq
+
+#Disable Warning BC40000 ' IQuickInfo* is obsolete
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
     Public Class QuickInfoControllerTests
@@ -241,3 +243,4 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Class
     End Class
 End Namespace
+#Enable Warning BC40000 ' IQuickInfo* is obsolete

--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(TestWaitIndicator),
                 typeof(TestExtensionErrorHandler),
                 typeof(TestExportJoinableTaskContext), // Needed by editor components, but not actually exported anywhere else
-                typeof(TestObscuringTipManager) // Needed by editor components, but only exported in editor VS layer. Tracked by the editor bug #544569.
+                typeof(TestObscuringTipManager) // Needed by editor components, but only exported in editor VS layer. Tracked by https://devdiv.visualstudio.com/DevDiv/_workitems?id=544569.
             };
 
             return types//.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(InternalSolutionCrawlerOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))

--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -40,7 +40,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(DefaultSymbolMappingService),
                 typeof(TestWaitIndicator),
                 typeof(TestExtensionErrorHandler),
-                typeof(TestExportJoinableTaskContext) // Needed by editor components, but not actually exported anywhere else
+                typeof(TestExportJoinableTaskContext), // Needed by editor components, but not actually exported anywhere else
+                typeof(TestObscuringTipManager) // Needed by editor components, but only exported in editor VS layer. Tracked by the editor bug #544569.
             };
 
             return types//.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(InternalSolutionCrawlerOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))

--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         public static ExportProvider CreateExportProvider(ComposableCatalog catalog)
         {
-            var configuration = CompositionConfiguration.Create(catalog.WithDesktopSupport().WithCompositionService());
+            var configuration = CompositionConfiguration.Create(catalog.WithCompositionService());
             var runtimeComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
             return runtimeComposition.CreateExportProviderFactory().CreateExportProvider();
         }

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             _aggregator = new NavigateToTestAggregator(_provider);
         }
 
+#pragma warning disable CS0618 // MatchKind is obsolete
         protected void VerifyNavigateToResultItems(
             List<NavigateToItem> expecteditems, IEnumerable<NavigateToItem> items)
         {
@@ -163,5 +164,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             result = a.SecondarySort.CompareTo(b.SecondarySort);
             return result;
         }
+#pragma warning restore CS0618 // MatchKind is obsolete
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
@@ -8,7 +9,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
     [PartCreationPolicy(CreationPolicy.NonShared)] // JTC is "main thread" affinitized so should not be shared
     internal class TestExportJoinableTaskContext
     {
+        [ThreadStatic]
+        private static JoinableTaskContext s_jtcThreadStatic;
+
         [Export]
-        private JoinableTaskContext _joinableTaskContext = new JoinableTaskContext();
+        private JoinableTaskContext _joinableTaskContext = s_jtcThreadStatic ?? (s_jtcThreadStatic = new JoinableTaskContext());
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -6,13 +6,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
     // Starting with 15.3 the editor took a dependency on JoinableTaskContext
     // in Text.Logic and Intellisense layers as an editor host provided service.
-    [PartCreationPolicy(CreationPolicy.NonShared)] // JTC is "main thread" affinitized so should not be shared
     internal class TestExportJoinableTaskContext
     {
         [ThreadStatic]
         private static JoinableTaskContext s_jtcThreadStatic;
 
         [Export]
-        private JoinableTaskContext _joinableTaskContext = s_jtcThreadStatic ?? (s_jtcThreadStatic = new JoinableTaskContext());
+        private JoinableTaskContext JoinableTaskContext
+        {
+            get
+            {
+                // Make sure each import gets JTC set up with the calling thread as the "main" thread
+                return s_jtcThreadStatic ?? (s_jtcThreadStatic = new JoinableTaskContext());
+            }
+        }
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
@@ -8,12 +6,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
     // Starting with 15.3 the editor took a dependency on JoinableTaskContext
     // in Text.Logic and Intellisense layers as an editor host provided service.
     [PartCreationPolicy(CreationPolicy.NonShared)] // JTC is "main thread" affinitized so should not be shared
-    internal class TestExportJoinableTaskContext : ForegroundThreadAffinitizedObject
+    internal class TestExportJoinableTaskContext
     {
-        [ThreadStatic]
-        private static JoinableTaskContext s_joinableTaskContext;
-
         [Export]
-        private JoinableTaskContext _joinableTaskContext = s_joinableTaskContext ?? (s_joinableTaskContext = new JoinableTaskContext());
+        private JoinableTaskContext _joinableTaskContext = new JoinableTaskContext();
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -1,30 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
-    // In 15.3 the editor took a dependency on JoinableTaskContext.
-    // JTC appears in the VS MEF composition but does not itself
-    // contain an ExportAttribute. The Editor's own unit tests
-    // export it from a field and we need to do the same in order
-    // to be able to compose in any part of the Editor.
-    [PartCreationPolicy(CreationPolicy.NonShared)]
+    // Starting with 15.3 the editor took a dependency on JoinableTaskContext
+    // in Text.Logic and Intellisense layers as an editor host provided service.
+    [PartCreationPolicy(CreationPolicy.NonShared)] // JTC is "main thread" affinitized so should not be shared
     internal class TestExportJoinableTaskContext : ForegroundThreadAffinitizedObject
     {
-        [ThreadStatic]
-        private static JoinableTaskContext s_joinableTaskContext;
+        private static readonly ConcurrentDictionary<Thread, JoinableTaskContext> s_jtcPerThread = new ConcurrentDictionary<Thread, JoinableTaskContext>();
 
         [Export]
-        private JoinableTaskContext _joinableTaskContext = s_joinableTaskContext ??
-            (s_joinableTaskContext = new JoinableTaskContext(
-                mainThread: ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Thread)
-            );
+        private JoinableTaskContext _joinableTaskContext = s_jtcPerThread.GetOrAdd(ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Thread,
+            (thread) => new JoinableTaskContext(mainThread: thread));
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -15,10 +15,16 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
     // contain an ExportAttribute. The Editor's own unit tests
     // export it from a field and we need to do the same in order
     // to be able to compose in any part of the Editor.
+    [PartCreationPolicy(CreationPolicy.NonShared)]
     internal class TestExportJoinableTaskContext : ForegroundThreadAffinitizedObject
     {
+        [ThreadStatic]
+        private static JoinableTaskContext s_joinableTaskContext;
+
         [Export]
-        private JoinableTaskContext _joinableTaskContext = new JoinableTaskContext(
-            mainThread: ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Thread);
+        private JoinableTaskContext _joinableTaskContext = s_joinableTaskContext ??
+            (s_joinableTaskContext = new JoinableTaskContext(
+                mainThread: ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Thread)
+            );
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportJoinableTaskContext.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
 using System.ComponentModel.Composition;
-using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Threading;
 
@@ -11,10 +10,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
     [PartCreationPolicy(CreationPolicy.NonShared)] // JTC is "main thread" affinitized so should not be shared
     internal class TestExportJoinableTaskContext : ForegroundThreadAffinitizedObject
     {
-        private static readonly ConcurrentDictionary<Thread, JoinableTaskContext> s_jtcPerThread = new ConcurrentDictionary<Thread, JoinableTaskContext>();
+        [ThreadStatic]
+        private static JoinableTaskContext s_joinableTaskContext;
 
         [Export]
-        private JoinableTaskContext _joinableTaskContext = s_jtcPerThread.GetOrAdd(ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Thread,
-            (thread) => new JoinableTaskContext(mainThread: thread));
+        private JoinableTaskContext _joinableTaskContext = s_joinableTaskContext ?? (s_joinableTaskContext = new JoinableTaskContext());
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestObscuringTipManager.cs
+++ b/src/EditorFeatures/TestUtilities/TestObscuringTipManager.cs
@@ -5,7 +5,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
     // In 15.6 the editor (QuickInfo in particular) took a dependency on 
     // IObscuringTipManager, which is only exported in VS editor layer.
-    // This is tracked by the editor bug #544569.
+    // This is tracked by the editor bug https://devdiv.visualstudio.com/DevDiv/_workitems?id=544569.
     // Meantime a workaround is to export dummy IObscuringTipManager.
     [Export(typeof(IObscuringTipManager))]
     internal class TestObscuringTipManager : IObscuringTipManager

--- a/src/EditorFeatures/TestUtilities/TestObscuringTipManager.cs
+++ b/src/EditorFeatures/TestUtilities/TestObscuringTipManager.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests
+{
+    // In 15.6 the editor (QuickInfo in particular) took a dependency on 
+    // IObscuringTipManager, which is only exported in VS editor layer.
+    // This is tracked by the editor bug #544569.
+    // Meantime a workaround is to export dummy IObscuringTipManager.
+    [Export(typeof(IObscuringTipManager))]
+    internal class TestObscuringTipManager : IObscuringTipManager
+    {
+        public void PushTip(ITextView view, IObscuringTip tip)
+        {
+        }
+
+        public void RemoveTip(ITextView view, IObscuringTip tip)
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -6,6 +6,7 @@ Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.Language.NavigateTo.Interfaces
 
+#Disable Warning BC40000 ' MatchKind is obsolete
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
     Public Class NavigateToTests
         Inherits AbstractNavigateToTests
@@ -758,3 +759,4 @@ End Class
         End Function
     End Class
 End Namespace
+#Enable Warning BC40000 ' MatchKind is obsolete

--- a/src/VisualStudio/CSharp/Impl/EventCompletion/HACK_EventHookupDismissalOnBufferChangePreventerService.cs
+++ b/src/VisualStudio/CSharp/Impl/EventCompletion/HACK_EventHookupDismissalOnBufferChangePreventerService.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EventHookup
             HACK_SetShimQuickInfoSessionWorker(textView, null);
         }
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
         private void HACK_SetShimQuickInfoSessionWorker(ITextView textView, IQuickInfoSession quickInfoSession)
         {
             var properties = textView.Properties.PropertyList;
@@ -53,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.EventHookup
             public event EventHandler ApplicableToSpanChanged;
             public event EventHandler PresenterChanged;
 #pragma warning restore 67
-
+#pragma warning restore CS0618 // IQuickInfo* is obsolete
             public PropertyCollection Properties
             {
                 get

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupCommandHandler.cs
@@ -50,7 +50,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         public EventHookupCommandHandler(
             IInlineRenameService inlineRenameService,
             Microsoft.CodeAnalysis.Editor.Host.IWaitIndicator waitIndicator,
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
             IQuickInfoBroker quickInfoBroker,
+#pragma warning restore CS0618 // IQuickInfo* is obsolete
             [Import(AllowDefault = true)] IHACK_EventHookupDismissalOnBufferChangePreventerService prematureDismissalPreventer,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSource.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSource.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     internal sealed class EventHookupQuickInfoSource : IQuickInfoSource
@@ -101,3 +102,4 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSourceProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupQuickInfoSourceProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
 namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
 {
     /// <summary>
@@ -38,3 +39,4 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
         }
     }
 }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete

--- a/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager.cs
+++ b/src/VisualStudio/CSharp/Impl/EventHookup/EventHookupSessionManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
     internal sealed partial class EventHookupSessionManager : ForegroundThreadAffinitizedObject
     {
         private readonly IHACK_EventHookupDismissalOnBufferChangePreventerService _prematureDismissalPreventer;
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
         private readonly IQuickInfoBroker _quickInfoBroker;
 
         internal EventHookupSession CurrentSession { get; set; }
@@ -30,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
             _prematureDismissalPreventer = prematureDismissalPreventer;
             _quickInfoBroker = quickInfoBroker;
         }
+#pragma warning restore CS0618 // IQuickInfo* is obsolete
 
         internal void EventHookupFoundInSession(EventHookupSession analyzedSession)
         {

--- a/src/VisualStudio/CSharp/Test/EventHookup/EventHookupCommandHandlerTests.cs
+++ b/src/VisualStudio/CSharp/Test/EventHookup/EventHookupCommandHandlerTests.cs
@@ -560,6 +560,7 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.EventHookup)]
         public async Task EventHookupInUnformattedPosition1()
         {
+            System.Diagnostics.Debugger.Launch();
             var markup = @"
 class C
 {

--- a/src/VisualStudio/CSharp/Test/EventHookup/EventHookupCommandHandlerTests.cs
+++ b/src/VisualStudio/CSharp/Test/EventHookup/EventHookupCommandHandlerTests.cs
@@ -560,7 +560,6 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.EventHookup)]
         public async Task EventHookupInUnformattedPosition1()
         {
-            System.Diagnostics.Debugger.Launch();
             var markup = @"
 class C
 {

--- a/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
+++ b/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
@@ -84,6 +84,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
+++ b/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
@@ -84,7 +84,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
+++ b/src/VisualStudio/Core/Test.Next/VisualStudioTest.Next.csproj
@@ -60,7 +60,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -67,6 +67,8 @@
     <!-- 
       Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
       Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+      This is tracked by CPS issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/547065.
+      Remove this reference once it's fixed.
      -->
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -64,5 +64,10 @@
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" />
+    <!-- 
+      Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
+      Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+     -->
+    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>
 </Project>

--- a/src/VisualStudio/IntegrationTest/TestSetup/VisualStudioIntegrationTestSetup.csproj
+++ b/src/VisualStudio/IntegrationTest/TestSetup/VisualStudioIntegrationTestSetup.csproj
@@ -53,6 +53,8 @@
     <!-- 
       Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
       Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+      This is tracked by CPS issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/547065.
+      Remove this reference once it's fixed.
      -->
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>

--- a/src/VisualStudio/IntegrationTest/TestSetup/VisualStudioIntegrationTestSetup.csproj
+++ b/src/VisualStudio/IntegrationTest/TestSetup/VisualStudioIntegrationTestSetup.csproj
@@ -50,6 +50,11 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Runtime.Remoting" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="$(MicrosoftDiagnosticsRuntimeVersion)" />
+    <!-- 
+      Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
+      Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+     -->
+    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Test\Diagnostics\Diagnostics.csproj">

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -209,7 +209,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public string GetQuickInfo()
             => ExecuteOnActiveView(view =>
             {
+#pragma warning disable CS0618 // IQuickInfo* is obsolete
                 var broker = GetComponentModelService<IQuickInfoBroker>();
+#pragma warning restore CS0618 // IQuickInfo* is obsolete
 
                 var sessions = broker.GetSessions(view);
                 if (sessions.Count != 1)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -56,7 +56,10 @@
     <PackageReference Include="Microsoft.VisualStudio.VsInteractiveWindow" Version="$(MicrosoftVisualStudioVsInteractiveWindowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <!-- Required to workaround double write of System.Threading.Tasks.Dataflow -->
+    <!-- 
+        Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
+        Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition depending on it.
+    -->
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -59,6 +59,8 @@
     <!-- 
       Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
       Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+      This is tracked by CPS issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/547065.
+      Remove this reference once it's fixed.
      -->
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -56,6 +56,8 @@
     <PackageReference Include="Microsoft.VisualStudio.VsInteractiveWindow" Version="$(MicrosoftVisualStudioVsInteractiveWindowVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <!-- Required to workaround double write of System.Threading.Tasks.Dataflow -->
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -57,10 +57,10 @@
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <!-- 
-        Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
-        Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition depending on it.
-    -->
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
+      Required to avoid double write of System.Threading.Tasks.Dataflow.dll caused by both 
+      Microsoft.VisualStudio.ProjectSystem and Microsoft.VisualStudio.Composition containing it.
+     -->
+    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" ExcludeAssets="all"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -40,7 +40,6 @@
     <PackageReference Include="xunit" Version="$(xunitVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" />
-    <PackageReference Include="Microsoft.Tpl.Dataflow" Version="$(MicrosoftTplDataflowVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimeVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimeVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimeVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
Migrate to the latest editor bits v15.6.241 (containing Async QuickInfo and NavigateTo PatternMatch support), also to clear up the way for migration to the new editor commanding.
1. Suppress deprecation warnings for IQuickInfo* and NavigateTo's MatchKind.
2. Bump up VS-MEF version up to the one shipping in VS 15.5 (required to support internal metadata views used by Async QuickInfo)
3. Improve TestExportJoinableTaskContext to let it use any thread as its main thread. Async QuickInfo is widely using JoinableTaskContext.IsOnMainThread to validate threading requirements and so unit tests were failing because a shared JoinableTaskContext exported by TestExportJoinableTaskContext was capturing  wrong thread as its main thread. The solution is to make TestExportJoinableTaskContext non shared and export per-thread JoinableTaskContext so that any thread running a unit test gets its own JoinableTaskContext with main thread set accordingly.
4. Compensate for unfortunate VS-only MEF dependency taken by Async QuickInfo (IObscuringTipManager component). There is a bug tracking that on the editor side.