### PR TITLE
Fixed VS2017 crash with :: operator

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2325,5 +2325,27 @@ class Program
     }
 }", Keyword("var"));
         }
+
+        [WorkItem(23940, "https://github.com/dotnet/roslyn/issues/23940")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestAliasQualifiedClass()
+        {
+            await TestAsync(
+@"
+using System;
+using Col = System.Collections.Generic;
+
+namespace AliasTest
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var list1 = new Col::List
+        }
+    }
+}",
+    Keyword("var"), Class("List"));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                         break;
 
                     case CandidateReason.WrongArity:
-                        if (name.GetRightmostName().Arity == 0)
+                        if (name.GetRightmostName()?.Arity == 0)
                         {
                             // When the user writes something like "IList" we don't want to *not* classify 
                             // just because the type bound to "IList<T>".  This is also important for use

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -2578,6 +2578,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return memberBinding.Name;
             }
 
+            if (node is AliasQualifiedNameSyntax aliasQualifiedName && aliasQualifiedName.Name != null)
+            {
+                return aliasQualifiedName.Name;
+            }
+
             return null;
         }
 


### PR DESCRIPTION
### Customer scenario

A customer attempts to use the alias qualification operator `::` to refer to a namespace.

### Bugs this fixes

Fixes #23940

### Workarounds, if any

Avoid using this syntax.

### Risk

Low.

### Performance impact

Negligible. Adds a type check that is only needed in this case.

### Is this a regression from a previous update?

No.

### Root cause analysis

No one considered this syntax in testing. @sharwell wasn't even aware it was valid.

### How was the bug found?

Reported via developer community.

### Test documentation updated?

No.
