### PR TITLE
Fixing completion in async foreach/using

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AwaitKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AwaitKeywordRecommenderTests.cs
@@ -58,6 +58,58 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAsyncUsingStatement()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    void goo()
+    {
+        using $$
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAsyncUsingStatement()
+        {
+            await VerifyAbsenceAsync(@"
+class Program
+{
+    void goo()
+    {
+        using await $$
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAsyncForeachStatement()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    void goo()
+    {
+        foreach $$
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAsyncForeachStatement()
+        {
+            await VerifyAbsenceAsync(@"
+class Program
+{
+    void goo()
+    {
+        foreach await $$
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotInQuery()
         {
             await VerifyAbsenceAsync(@"

--- a/src/EditorFeatures/CSharpTest2/Recommendations/AwaitKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AwaitKeywordRecommenderTests.cs
@@ -71,6 +71,12 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestUsingDirective()
+        {
+            await VerifyAbsenceAsync("using $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterAsyncUsingStatement()
         {
             await VerifyAbsenceAsync(@"

--- a/src/EditorFeatures/CSharpTest2/Recommendations/NewKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NewKeywordRecommenderTests.cs
@@ -419,6 +419,13 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInAsyncForeachIn()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"foreach await (var v in $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInFromIn()
         {
             await VerifyKeywordAsync(AddInsideMethod(
@@ -545,6 +552,13 @@ $$");
         {
             await VerifyKeywordAsync(AddInsideMethod(
 @"using ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInAsyncUsing()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"using await ($$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]

--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -3,7 +3,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -207,6 +206,20 @@ $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInAsyncForEach()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"foreach await ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestnotInAsyncForEach()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"foreach await (var $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInUsing()
         {
             await VerifyKeywordAsync(AddInsideMethod(
@@ -218,6 +231,20 @@ $$"));
         {
             await VerifyAbsenceAsync(AddInsideMethod(
 @"using (var $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInAsyncUsing()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"using await ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInAsyncUsing()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"using await (var $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
@@ -51,6 +51,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 return true;
             }
 
+            if (context.TargetToken.IsKind(SyntaxKind.UsingKeyword, SyntaxKind.ForEachKeyword))
+            {
+                return true;
+            }
+
             return false;
         }
     }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AwaitKeywordRecommender.cs
@@ -51,7 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 return true;
             }
 
-            if (context.TargetToken.IsKind(SyntaxKind.UsingKeyword, SyntaxKind.ForEachKeyword))
+            if (context.TargetToken.IsKind(SyntaxKind.UsingKeyword, SyntaxKind.ForEachKeyword)
+                && !context.TargetToken.Parent.IsKind(SyntaxKind.UsingDirective))
             {
                 return true;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1512,7 +1512,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //  out var
             //  for (var
             //  foreach (var
+            //  foreach await (var
             //  using (var
+            //  using await (var
             //  from var
             //  join var
 
@@ -1540,6 +1542,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     previous.IsKind(SyntaxKind.UsingKeyword))
                 {
                     return true;
+                }
+
+                if (previous.IsKind(SyntaxKind.AwaitKeyword))
+                {
+                    var beforeAwait = previous.GetPreviousToken(includeSkipped: true);
+                    if (beforeAwait.IsKind(SyntaxKind.ForEachKeyword, SyntaxKind.UsingKeyword))
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -2270,6 +2281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // foreach (var v in |
+            // foreach await (var v in |
             // from a in |
             // join b in |
             if (token.IsKind(SyntaxKind.InKeyword))
@@ -2359,6 +2371,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // using ( |
             if (token.IsKind(SyntaxKind.OpenParenToken) &&
                 token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword))
+            {
+                return true;
+            }
+
+            // using await ( |
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.AwaitKeyword) &&
+                token.GetPreviousToken(includeSkipped: true).GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword))
             {
                 return true;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1534,24 +1534,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
-            if (token.IsKind(SyntaxKind.OpenParenToken))
+            if (token.IsKind(SyntaxKind.OpenParenToken) &&
+                token.Parent.IsKind(
+                    SyntaxKind.ForStatement, SyntaxKind.ForEachStatement,
+                    SyntaxKind.ForEachVariableStatement, SyntaxKind.UsingStatement))
             {
-                var previous = token.GetPreviousToken(includeSkipped: true);
-                if (previous.IsKind(SyntaxKind.ForKeyword) ||
-                    previous.IsKind(SyntaxKind.ForEachKeyword) ||
-                    previous.IsKind(SyntaxKind.UsingKeyword))
-                {
-                    return true;
-                }
-
-                if (previous.IsKind(SyntaxKind.AwaitKeyword))
-                {
-                    var beforeAwait = previous.GetPreviousToken(includeSkipped: true);
-                    if (beforeAwait.IsKind(SyntaxKind.ForEachKeyword, SyntaxKind.UsingKeyword))
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
 
             var tokenOnLeftOfStart = syntaxTree.FindTokenOnLeftOfPosition(token.SpanStart, cancellationToken);
@@ -2369,16 +2357,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // todo: handle 'for' cases.
 
             // using ( |
-            if (token.IsKind(SyntaxKind.OpenParenToken) &&
-                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword))
-            {
-                return true;
-            }
-
             // using await ( |
-            if (token.IsKind(SyntaxKind.OpenParenToken) &&
-                token.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.AwaitKeyword) &&
-                token.GetPreviousToken(includeSkipped: true).GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword))
+            if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.UsingStatement))
             {
                 return true;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -45,6 +45,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return node != null && IsKind(node.Parent, kind1, kind2, kind3);
         }
 
+        public static bool IsParentKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4)
+        {
+            return node != null && IsKind(node.Parent, kind1, kind2, kind3, kind4);
+        }
+
         public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2)
         {
             if (node == null)


### PR DESCRIPTION
The keyword `await` should be offered for completion after `using` and `foreach`.
Also, `var` and `new` should be appropriately offered in `using await ($$` and `foreach await (var i in $$`.