### PR TITLE
Properly set DevEnvDir under VS2017/MSBuild 15+

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -176,6 +176,10 @@
     <VisualStudioBuildToolsVersion Condition="'$(IsDev14VsiBuild)' == 'true'">14.3.25420</VisualStudioBuildToolsVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DevEnvDir)' == '' AND '$(VsInstallRoot)' != ''">
+    <DevEnvDir>$(VsInstallRoot)\Common7\IDE</DevEnvDir>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DevEnvDir)' == ''">
     <DevEnvDir>$([System.Environment]::ExpandEnvironmentVariables("%VS$(VisualStudioReferenceMajorVersion)0COMNTOOLS%"))</DevEnvDir>
     <DevEnvDir>$(DevEnvDir)\..\IDE</DevEnvDir>


### PR DESCRIPTION
In MSBuild 15+, the environment variable for VS doesn't exist anymore, and instead 
it can be determined by inspecting `$(VsInstallRoot)`.

### Risk

I think this is zero risk :)

### How was the bug found?

Just exploring the targets to learn how the Roslyn team does builds and project configurations
