### PR TITLE
Remove workaround that's already included in MSBuild 15.5

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -82,10 +82,6 @@
 
     <MSBuildAssemblyNameFragment>Core</MSBuildAssemblyNameFragment>
 
-    <!-- To copy .dll.config and .exe.config files of the referenced projects to the output dir
-         (see https://github.com/Microsoft/msbuild/issues/1307) -->
-    <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.dll.config;.exe.config</AllowedReferenceRelatedFileExtensions>
-
     <!-- This controls the places MSBuild will consult to resolve assembly references.  This is 
          kept as minimal as possible to make our build reliable from machine to machine.  Global
          locations such as GAC, AssemblyFoldersEx, etc ... are deliberately removed from this 


### PR DESCRIPTION
See https://github.com/Microsoft/msbuild/commit/052ad30f8f706a87e9fa9431fda1ec9c0b73893b

I suppose this would need to wait until all CI systems use 15.5+ though? But since it's already RTM, maybe all checks will pass? We'll see ;)