### PR TITLE
Correct naming when 'Introduce Variable' is applied on an InvocationExpression in a ForEachStatement

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -48,7 +48,9 @@
     <AssemblyName>Roslyn.Services.Editor.CSharp.UnitTests</AssemblyName>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>D:\Documents\Projects\Roslyn\master\Binaries\Debug\UnitTests\CSharpEditorServicesTest\</OutputPath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -48,9 +48,7 @@
     <AssemblyName>Roslyn.Services.Editor.CSharp.UnitTests</AssemblyName>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <OutputPath>D:\Documents\Projects\Roslyn\master\Binaries\Debug\UnitTests\CSharpEditorServicesTest\</OutputPath>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2983,6 +2983,46 @@ class C
 ", options: ImplicitTypingEverywhere());
         }
 
+        [WorkItem(56, "https://github.com/dotnet/roslyn/issues/56")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
+        public async Task TestIntroduceLocalFromInvocationExpressionInForEachStatement()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    void M()
+    {
+        foreach (var num in [|GetNumbers()|])
+        {
+
+        }
+    }
+
+    IEnumerable<int> GetNumbers()
+    {
+        return new[] { 1, 2, 3 };
+    }
+}
+", @"
+class C
+{
+    void M()
+    {
+        IEnumerable<int> {|Rename:getNumbers|} = GetNumbers();
+        foreach (var num in getNumbers)
+        {
+
+        }
+    }
+
+    IEnumerable<int> GetNumbers()
+    {
+        return new[] { 1, 2, 3 };
+    }
+}
+", options: ImplicitTypingEverywhere());            
+        }
+
         [WorkItem(1065661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1065661")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public async Task TestIntroduceVariableTextDoesntSpanLines1()

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -2975,5 +2975,37 @@ End Class
 "
             Await TestInRegularAndScriptAsync(code, expected)
         End Function
+
+        <WorkItem(56, "https://github.com/dotnet/roslyn/issues/56")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
+        Public Async Function TestIntroduceLocalForInvocationExpressionInForEachStatement() As Task
+            Dim code = "
+Class C
+
+    Private Sub M()
+        For Each num As Integer In [|GetNumbers()|]
+        Next
+    End Sub
+
+    Private Function GetNumbers() As IEnumerable(Of Integer)
+        Return {1, 2, 3}
+    End Function
+End Class"
+            Dim expected = "
+Class C
+
+    Private Sub M()
+        Dim {|Rename:getNumbers1|} As IEnumerable = GetNumbers()
+        For Each num As Integer In getNumbers1
+        Next
+    End Sub
+
+    Private Function GetNumbers() As IEnumerable(Of Integer)
+        Return {1, 2, 3}
+    End Function
+End Class"
+            Await TestInRegularAndScriptAsync(code, expected)
+        End Function
+
     End Class
 End Namespace

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -229,6 +229,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
 
             var baseName = semanticFacts.GenerateNameForExpression(
                 semanticModel, expression, capitalize: isConstant, cancellationToken: cancellationToken);
+
             var reservedNames = semanticModel.LookupSymbols(expression.SpanStart)
                                              .Select(s => s.Name)
                                              .Concat(existingSymbols.Select(s => s.Name));

--- a/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
@@ -222,6 +222,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 {
                     current = castExpression.Expression;
                 }
+                else if (current is InvocationExpressionSyntax invocationExpression && invocationExpression.Parent is ForEachStatementSyntax) 
+                {
+                    current = invocationExpression.Expression;
+                }
                 else if (current is DeclarationExpressionSyntax decl)
                 {
                     var name = decl.Designation as SingleVariableDesignationSyntax;

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SemanticModelExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SemanticModelExtensions.vb
@@ -121,6 +121,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return (DirectCast(current, MemberAccessExpressionSyntax)).Name.Identifier.ValueText.ToCamelCase()
                 ElseIf TypeOf current Is CastExpressionSyntax Then
                     current = (DirectCast(current, CastExpressionSyntax)).Expression
+                ElseIf TypeOf current Is InvocationExpressionSyntax Then
+                    Dim invocationExpression = (DirectCast(current, InvocationExpressionSyntax))
+                    If TypeOf invocationExpression.Parent Is ForEachStatementSyntax Then
+                        current = invocationExpression.Expression
+                    End If
                 Else
                     Exit While
                 End If


### PR DESCRIPTION
<details><summary>Correct naming when 'Introduce Variable' codefix is applied on a InvocationExpression in a ForEachStatement</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Create a ForEachStatement and iterate over an InvocationExpression like:

        foreach (var num in GetNumbers())
        {
        }

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/56

Ater codefix is applied, code changes to:

        var getNumbers = GetNumbers()
        foreach (var num in getNumbers)
        {
        }

### Performance impact

Specific check whether an invocationexpression has a foreach statement as parent. Complexity for this fix is low.

### Root cause analysis

This is a specific case thats uncommon. 
Added one unit-test for C# and VB.

### How was the bug found?

@rchande opened this issue.

</details>
