### PR TITLE
Make sure 'in' is honored in cref parsers/completion lists

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -77,3 +77,5 @@ In Visual Studio 2017 version 15.6 such conversions will be explicitly disallowe
 Example: `Func<int> f = default(TypedReference).GetHashCode; // new error CS0123: No overload for 'GetHashCode' matches delegate 'Func<int>'` 
    
 - https://github.com/dotnet/roslyn/pull/23416 Before Visual Studio 2017 version 15.6 (Roslyn version 2.8) the compiler accepted `__arglist(...)` expressions with void-typed arguments. For instance, `__arglist(Console.WriteLine())`. But such program would fail at runtime. In Visual Studio 2017 version 15.6, this causes a compile-time error.
+
+- https://github.com/dotnet/roslyn/pull/24023 In Visual Studio 2017 version 15.6, Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax constructor and Update(), the parameter refOrOutKeyword was renamed to refKindKeyword (source breaking change if you're using named arguments).

--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -92,6 +92,7 @@ Interaction with IDE, Debugger, and EnC should be worked out with relevant teams
     - Typing experience and dealing with incomplete code
     - Intellisense (squiggles, dot completion)
     - "go to" and renaming
+    - cref comments
     - UpgradeProject code fixer
     - More: [IDE Test Plan](https://github.com/dotnet/roslyn/blob/master/docs/contributing/IDE%20Test%20Plan.md)
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -869,7 +869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (CrefParameterSyntax parameter in parameterListSyntax.Parameters)
             {
-                RefKind refKind = parameter.RefOrOutKeyword.Kind().GetRefKind();
+                RefKind refKind = parameter.RefKindKeyword.Kind().GetRefKind();
 
                 TypeSymbol type = BindCrefParameterOrReturnType(parameter.Type, (MemberCrefSyntax)parameterListSyntax.Parent, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -28599,59 +28599,59 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
   /// </summary>
   internal sealed partial class CrefParameterSyntax : CSharpSyntaxNode
   {
-    internal readonly SyntaxToken refOrOutKeyword;
+    internal readonly SyntaxToken refKindKeyword;
     internal readonly TypeSyntax type;
 
-    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refOrOutKeyword, TypeSyntax type, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refKindKeyword, TypeSyntax type, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
         : base(kind, diagnostics, annotations)
     {
         this.SlotCount = 2;
-        if (refOrOutKeyword != null)
+        if (refKindKeyword != null)
         {
-            this.AdjustFlagsAndWidth(refOrOutKeyword);
-            this.refOrOutKeyword = refOrOutKeyword;
+            this.AdjustFlagsAndWidth(refKindKeyword);
+            this.refKindKeyword = refKindKeyword;
         }
         this.AdjustFlagsAndWidth(type);
         this.type = type;
     }
 
 
-    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refOrOutKeyword, TypeSyntax type, SyntaxFactoryContext context)
+    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refKindKeyword, TypeSyntax type, SyntaxFactoryContext context)
         : base(kind)
     {
         this.SetFactoryContext(context);
         this.SlotCount = 2;
-        if (refOrOutKeyword != null)
+        if (refKindKeyword != null)
         {
-            this.AdjustFlagsAndWidth(refOrOutKeyword);
-            this.refOrOutKeyword = refOrOutKeyword;
+            this.AdjustFlagsAndWidth(refKindKeyword);
+            this.refKindKeyword = refKindKeyword;
         }
         this.AdjustFlagsAndWidth(type);
         this.type = type;
     }
 
 
-    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refOrOutKeyword, TypeSyntax type)
+    internal CrefParameterSyntax(SyntaxKind kind, SyntaxToken refKindKeyword, TypeSyntax type)
         : base(kind)
     {
         this.SlotCount = 2;
-        if (refOrOutKeyword != null)
+        if (refKindKeyword != null)
         {
-            this.AdjustFlagsAndWidth(refOrOutKeyword);
-            this.refOrOutKeyword = refOrOutKeyword;
+            this.AdjustFlagsAndWidth(refKindKeyword);
+            this.refKindKeyword = refKindKeyword;
         }
         this.AdjustFlagsAndWidth(type);
         this.type = type;
     }
 
-    public SyntaxToken RefOrOutKeyword { get { return this.refOrOutKeyword; } }
+    public SyntaxToken RefKindKeyword { get { return this.refKindKeyword; } }
     public TypeSyntax Type { get { return this.type; } }
 
     internal override GreenNode GetSlot(int index)
     {
         switch (index)
         {
-            case 0: return this.refOrOutKeyword;
+            case 0: return this.refKindKeyword;
             case 1: return this.type;
             default: return null;
         }
@@ -28672,11 +28672,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         visitor.VisitCrefParameter(this);
     }
 
-    public CrefParameterSyntax Update(SyntaxToken refOrOutKeyword, TypeSyntax type)
+    public CrefParameterSyntax Update(SyntaxToken refKindKeyword, TypeSyntax type)
     {
-        if (refOrOutKeyword != this.RefOrOutKeyword || type != this.Type)
+        if (refKindKeyword != this.RefKindKeyword || type != this.Type)
         {
-            var newNode = SyntaxFactory.CrefParameter(refOrOutKeyword, type);
+            var newNode = SyntaxFactory.CrefParameter(refKindKeyword, type);
             var diags = this.GetDiagnostics();
             if (diags != null && diags.Length > 0)
                newNode = newNode.WithDiagnosticsGreen(diags);
@@ -28691,23 +28691,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
     {
-         return new CrefParameterSyntax(this.Kind, this.refOrOutKeyword, this.type, diagnostics, GetAnnotations());
+         return new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.type, diagnostics, GetAnnotations());
     }
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[] annotations)
     {
-         return new CrefParameterSyntax(this.Kind, this.refOrOutKeyword, this.type, GetDiagnostics(), annotations);
+         return new CrefParameterSyntax(this.Kind, this.refKindKeyword, this.type, GetDiagnostics(), annotations);
     }
 
     internal CrefParameterSyntax(ObjectReader reader)
         : base(reader)
     {
       this.SlotCount = 2;
-      var refOrOutKeyword = (SyntaxToken)reader.ReadValue();
-      if (refOrOutKeyword != null)
+      var refKindKeyword = (SyntaxToken)reader.ReadValue();
+      if (refKindKeyword != null)
       {
-         AdjustFlagsAndWidth(refOrOutKeyword);
-         this.refOrOutKeyword = refOrOutKeyword;
+         AdjustFlagsAndWidth(refKindKeyword);
+         this.refKindKeyword = refKindKeyword;
       }
       var type = (TypeSyntax)reader.ReadValue();
       if (type != null)
@@ -28720,7 +28720,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     internal override void WriteTo(ObjectWriter writer)
     {
       base.WriteTo(writer);
-      writer.WriteValue(this.refOrOutKeyword);
+      writer.WriteValue(this.refKindKeyword);
       writer.WriteValue(this.type);
     }
 
@@ -37143,9 +37143,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     public override CSharpSyntaxNode VisitCrefParameter(CrefParameterSyntax node)
     {
-      var refOrOutKeyword = (SyntaxToken)this.Visit(node.RefOrOutKeyword);
+      var refKindKeyword = (SyntaxToken)this.Visit(node.RefKindKeyword);
       var type = (TypeSyntax)this.Visit(node.Type);
-      return node.Update(refOrOutKeyword, type);
+      return node.Update(refKindKeyword, type);
     }
 
     public override CSharpSyntaxNode VisitXmlElement(XmlElementSyntax node)
@@ -43185,19 +43185,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       return result;
     }
 
-    public CrefParameterSyntax CrefParameter(SyntaxToken refOrOutKeyword, TypeSyntax type)
+    public CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, TypeSyntax type)
     {
 #if DEBUG
-      if (refOrOutKeyword != null)
+      if (refKindKeyword != null)
       {
-      switch (refOrOutKeyword.Kind)
+      switch (refKindKeyword.Kind)
       {
         case SyntaxKind.RefKeyword:
         case SyntaxKind.OutKeyword:
+        case SyntaxKind.InKeyword:
         case SyntaxKind.None:
           break;
         default:
-          throw new ArgumentException("refOrOutKeyword");
+          throw new ArgumentException("refKindKeyword");
       }
       }
       if (type == null)
@@ -43205,10 +43206,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 #endif
 
       int hash;
-      var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refOrOutKeyword, type, this.context, out hash);
+      var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, type, this.context, out hash);
       if (cached != null) return (CrefParameterSyntax)cached;
 
-      var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refOrOutKeyword, type, this.context);
+      var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, type, this.context);
       if (hash >= 0)
       {
           SyntaxNodeCache.AddNode(result, hash);
@@ -50110,19 +50111,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
       return result;
     }
 
-    public static CrefParameterSyntax CrefParameter(SyntaxToken refOrOutKeyword, TypeSyntax type)
+    public static CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, TypeSyntax type)
     {
 #if DEBUG
-      if (refOrOutKeyword != null)
+      if (refKindKeyword != null)
       {
-      switch (refOrOutKeyword.Kind)
+      switch (refKindKeyword.Kind)
       {
         case SyntaxKind.RefKeyword:
         case SyntaxKind.OutKeyword:
+        case SyntaxKind.InKeyword:
         case SyntaxKind.None:
           break;
         default:
-          throw new ArgumentException("refOrOutKeyword");
+          throw new ArgumentException("refKindKeyword");
       }
       }
       if (type == null)
@@ -50130,10 +50132,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 #endif
 
       int hash;
-      var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refOrOutKeyword, type, out hash);
+      var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.CrefParameter, refKindKeyword, type, out hash);
       if (cached != null) return (CrefParameterSyntax)cached;
 
-      var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refOrOutKeyword, type);
+      var result = new CrefParameterSyntax(SyntaxKind.CrefParameter, refKindKeyword, type);
       if (hash >= 0)
       {
           SyntaxNodeCache.AddNode(result, hash);

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -3953,9 +3953,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     public override SyntaxNode VisitCrefParameter(CrefParameterSyntax node)
     {
-      var refOrOutKeyword = this.VisitToken(node.RefOrOutKeyword);
+      var refKindKeyword = this.VisitToken(node.RefKindKeyword);
       var type = (TypeSyntax)this.Visit(node.Type);
-      return node.Update(refOrOutKeyword, type);
+      return node.Update(refKindKeyword, type);
     }
 
     public override SyntaxNode VisitXmlElement(XmlElementSyntax node)
@@ -9753,20 +9753,21 @@ namespace Microsoft.CodeAnalysis.CSharp
     }
 
     /// <summary>Creates a new CrefParameterSyntax instance.</summary>
-    public static CrefParameterSyntax CrefParameter(SyntaxToken refOrOutKeyword, TypeSyntax type)
+    public static CrefParameterSyntax CrefParameter(SyntaxToken refKindKeyword, TypeSyntax type)
     {
-      switch (refOrOutKeyword.Kind())
+      switch (refKindKeyword.Kind())
       {
         case SyntaxKind.RefKeyword:
         case SyntaxKind.OutKeyword:
+        case SyntaxKind.InKeyword:
         case SyntaxKind.None:
           break;
         default:
-          throw new ArgumentException("refOrOutKeyword");
+          throw new ArgumentException("refKindKeyword");
       }
       if (type == null)
         throw new ArgumentNullException(nameof(type));
-      return (CrefParameterSyntax)Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.CrefParameter((Syntax.InternalSyntax.SyntaxToken)refOrOutKeyword.Node, type == null ? null : (Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.TypeSyntax)type.Green).CreateRed();
+      return (CrefParameterSyntax)Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxFactory.CrefParameter((Syntax.InternalSyntax.SyntaxToken)refKindKeyword.Node, type == null ? null : (Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.TypeSyntax)type.Green).CreateRed();
     }
 
 

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -18267,11 +18267,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
     }
 
-    public SyntaxToken RefOrOutKeyword 
+    public SyntaxToken RefKindKeyword 
     {
         get
         {
-            var slot = ((Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CrefParameterSyntax)this.Green).refOrOutKeyword;
+            var slot = ((Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CrefParameterSyntax)this.Green).refKindKeyword;
             if (slot != null)
                 return new SyntaxToken(this, slot, this.Position, 0);
 
@@ -18314,11 +18314,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         visitor.VisitCrefParameter(this);
     }
 
-    public CrefParameterSyntax Update(SyntaxToken refOrOutKeyword, TypeSyntax type)
+    public CrefParameterSyntax Update(SyntaxToken refKindKeyword, TypeSyntax type)
     {
-        if (refOrOutKeyword != this.RefOrOutKeyword || type != this.Type)
+        if (refKindKeyword != this.RefKindKeyword || type != this.Type)
         {
-            var newNode = SyntaxFactory.CrefParameter(refOrOutKeyword, type);
+            var newNode = SyntaxFactory.CrefParameter(refKindKeyword, type);
             var annotations = this.GetAnnotations();
             if (annotations != null && annotations.Length > 0)
                return newNode.WithAnnotations(annotations);
@@ -18328,14 +18328,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         return this;
     }
 
-    public CrefParameterSyntax WithRefOrOutKeyword(SyntaxToken refOrOutKeyword)
+    public CrefParameterSyntax WithRefKindKeyword(SyntaxToken refKindKeyword)
     {
-        return this.Update(refOrOutKeyword, this.Type);
+        return this.Update(refKindKeyword, this.Type);
     }
 
     public CrefParameterSyntax WithType(TypeSyntax type)
     {
-        return this.Update(this.RefOrOutKeyword, type);
+        return this.Update(this.RefKindKeyword, type);
     }
   }
 

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,8 +1,6 @@
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
-*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.RefOrOutKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
-*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithRefOrOutKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 *REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CrefParameter(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,10 @@
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.RefOrOutKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithRefOrOutKeyword(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 *REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
+*REMOVED*static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CrefParameter(Microsoft.CodeAnalysis.SyntaxToken refOrOutKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool
 Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Operations.CommonConversion
 Microsoft.CodeAnalysis.CSharp.DeconstructionInfo
@@ -11,6 +15,9 @@ Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_2 = 702 -> Microsoft.CodeA
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
@@ -21,4 +28,5 @@ static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetDeconstructionInfo(this
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetInConversion(this Microsoft.CodeAnalysis.Operations.ICompoundAssignmentOperation compoundAssignment) -> Microsoft.CodeAnalysis.CSharp.Conversion
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetOutConversion(this Microsoft.CodeAnalysis.Operations.ICompoundAssignmentOperation compoundAssignment) -> Microsoft.CodeAnalysis.CSharp.Conversion
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CrefParameter(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.RefType(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax

--- a/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public sealed partial class CrefParameterSyntax
+    {
+        /// <summary>
+        /// Pre C# 7.2 back-compat overload, which simply calls the replacement property <see cref="RefKindKeyword"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SyntaxToken RefOrOutKeyword
+        {
+            get => this.RefKindKeyword;
+        }
+
+        /// <summary>
+        /// Pre C# 7.2 back-compat overload, which simply calls the replacement method <see cref="Update"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CrefParameterSyntax WithRefOrOutKeyword(SyntaxToken refOrOutKeyword)
+        {
+            return this.Update(refOrOutKeyword, this.Type);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CrefParameterSyntax.cs
@@ -10,10 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         /// Pre C# 7.2 back-compat overload, which simply calls the replacement property <see cref="RefKindKeyword"/>.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public SyntaxToken RefOrOutKeyword
-        {
-            get => this.RefKindKeyword;
-        }
+        public SyntaxToken RefOrOutKeyword => this.RefKindKeyword;
 
         /// <summary>
         /// Pre C# 7.2 back-compat overload, which simply calls the replacement method <see cref="Update"/>.

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -3845,9 +3845,10 @@
       </summary>
     </TypeComment>
     <Kind Name="CrefParameter"/>
-    <Field Name="RefOrOutKeyword" Type="SyntaxToken" Optional="true">
+    <Field Name="RefKindKeyword" Type="SyntaxToken" Optional="true">
       <Kind Name="RefKeyword"/>
       <Kind Name="OutKeyword"/>
+      <Kind Name="InKeyword"/>
     </Field>
     <Field Name="Type" Type="TypeSyntax"/>
   </Node>

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -823,13 +823,11 @@ public class C
 
             string name = GetUniqueName();
             string source1 = sourceTemplate.Replace("CHANGE", change1);
-            CSharpCompilation comp1 = CreateStandardCompilation(Parse(source1, options: TestOptions.RegularLatest),
-                options: TestOptions.DebugDll.WithDeterministic(true), assemblyName: name);
+            CSharpCompilation comp1 = CreateStandardCompilation(Parse(source1), options: TestOptions.DebugDll.WithDeterministic(true), assemblyName: name);
             ImmutableArray<byte> image1 = comp1.EmitToArray(EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(includePrivateMembers));
 
             var source2 = sourceTemplate.Replace("CHANGE", change2);
-            Compilation comp2 = CreateStandardCompilation(Parse(source2, options: TestOptions.RegularLatest),
-                options: TestOptions.DebugDll.WithDeterministic(true), assemblyName: name);
+            Compilation comp2 = CreateStandardCompilation(Parse(source2), options: TestOptions.DebugDll.WithDeterministic(true), assemblyName: name);
             ImmutableArray<byte> image2 = comp2.EmitToArray(EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(includePrivateMembers));
 
             if (expectMatch)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -350,7 +350,7 @@ class C
         M(1, first: 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (10,14): error CS1744: Named argument 'first' specifies a parameter for which a positional argument has already been given
                 //         M(1, first: 2);
@@ -406,7 +406,7 @@ class C
         M(c: 1, 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (10,11): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
                 //         M(c: 1, 2);
@@ -438,7 +438,7 @@ class C
         M(x: 1, 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,9): error CS1501: No overload for method 'M' takes 2 arguments
                 //         M(x: 1, 2);
@@ -467,7 +467,7 @@ class C
         M(1, x: 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,14): error CS1744: Named argument 'x' specifies a parameter for which a positional argument has already been given
                 //         M(1, x: 2);
@@ -499,7 +499,7 @@ class C
         M(x: 3, new[] { ""4"", ""5"" });
     }
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "1 2. 2 3. 3 4,5.", parseOptions: TestOptions.RegularLatest);
+            var comp = CompileAndVerify(source, expectedOutput: "1 2. 2 3. 3 4,5.");
             comp.VerifyDiagnostics();
         }
 
@@ -517,7 +517,7 @@ class C
         M(x: 1, x: 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,17): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         M(x: 1, x: 2);
@@ -581,7 +581,7 @@ class C
         M(y: 1, 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,11): error CS8321: Named argument 'y' is used out-of-position but is followed by an unnamed argument
                 //         M(y: 1, 2);
@@ -610,7 +610,7 @@ class C
         M(x: 1, y: 2, 3);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,9): error CS1501: No overload for method 'M' takes 3 arguments
                 //         M(x: 1, y: 2, 3);
@@ -632,7 +632,7 @@ class C
         M(x: 1, 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (4,19): error CS0231: A params parameter must be the last parameter in a formal parameter list
                 //     static void M(params int[] x, int y)
@@ -665,7 +665,7 @@ class C
         M(y: 1, x: 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest, options: TestOptions.DebugExe);
+            var comp = CreateStandardCompilation(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "x=2 y[0]=1 y.Length=1");
 
@@ -693,7 +693,7 @@ class C
         M(c: valueC, valueB);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (11,11): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
                 //         M(c: valueC, valueB);
@@ -731,7 +731,7 @@ class C
         M(c: valueC, valueB);
     }
 }";
-            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.", parseOptions: TestOptions.RegularLatest);
+            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.");
             verifier.VerifyDiagnostics();
 
             var tree = verifier.Compilation.SyntaxTrees.First();
@@ -763,7 +763,7 @@ class C
         M(c: valueC, valueB);
     }
 }";
-            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.", parseOptions: TestOptions.RegularLatest);
+            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.");
             verifier.VerifyDiagnostics();
 
             var tree = verifier.Compilation.SyntaxTrees.First();
@@ -790,7 +790,7 @@ class C
         M(a: 1, 2);
     }
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "42", parseOptions: TestOptions.RegularLatest);
+            var comp = CompileAndVerify(source, expectedOutput: "42");
             comp.VerifyDiagnostics();
         }
 
@@ -866,7 +866,7 @@ class C
         c[a: 1, d] = d;
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics();
         }
 
@@ -884,7 +884,7 @@ class C
         M(b: 2, 3, 4);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (9,11): error CS8321: Named argument 'b' is used out-of-position but is followed by an unnamed argument
                 //         M(b: 2, 3, 4);
@@ -907,7 +907,7 @@ class C
         M(1, b: 2, 3, 4);
     }
 }";
-            var verifier = CompileAndVerify(source, expectedOutput: "1 2 3 4 Length:2", parseOptions: TestOptions.RegularLatest);
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2 3 4 Length:2");
             verifier.VerifyDiagnostics();
         }
 
@@ -930,7 +930,7 @@ public class MyAttribute : Attribute
 public class C
 {
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (12,38): error CS1016: Named attribute argument expected
                 // [MyAttribute(condition: true, P = 1, 42)]
@@ -1003,7 +1003,7 @@ public class MyAttribute : Attribute
 public class C
 {
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (11,14): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
                 // [MyAttribute(c:3, 2)]
@@ -1031,7 +1031,7 @@ class C
         M(x: 1, x: 2, __arglist());
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (6,17): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         M(x: 1, x: 2, __arglist());
@@ -1053,7 +1053,7 @@ class C
         M(__arglist(x: 1, x: 2, __arglist()));
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (6,27): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         M(__arglist(x: 1, x: 2, __arglist()));
@@ -1095,7 +1095,7 @@ class C
         return result;
     }
 }";
-            var comp = CompileAndVerify(source, expectedOutput: "1 2 34. 1 2 56.", parseOptions: TestOptions.RegularLatest);
+            var comp = CompileAndVerify(source, expectedOutput: "1 2 34. 1 2 56.");
             comp.VerifyDiagnostics();
         }
 
@@ -1110,7 +1110,7 @@ class C
         M(y: 1, x: 2, __arglist(3));
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (6,11): error CS8322: Named argument 'y' is used out-of-position but is followed by an unnamed argument
                 //         M(y: 1, x: 2, __arglist(3));
@@ -1126,7 +1126,7 @@ class C
 {
     C() : this(x: 1, x: 2, 3) { }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (4,22): error CS1740: Named argument 'x' cannot be specified multiple times
                 //     C() : this(x: 1, x: 2, 3) { }
@@ -1148,7 +1148,7 @@ class C
         new C(x: 1, x: 2, 3);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (6,21): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         new C(x: 1, x: 2, 3);
@@ -1172,7 +1172,7 @@ class C
         System.Console.Write(c[x: 1, x: 2, 3]);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source);
             comp.VerifyDiagnostics(
                 // (8,38): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         System.Console.Write(c[x: 1, x: 2, 3]);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableTests.cs
@@ -171,7 +171,7 @@ class C
 }";
 
             verifier = CompileAndVerify(source: source3, expectedOutput: "1", verify: Verification.Fails);
-            verifier = CompileAndVerify(source: source3, expectedOutput: "1", parseOptions: TestOptions.RegularLatest.WithPEVerifyCompatFeature());
+            verifier = CompileAndVerify(source: source3, expectedOutput: "1", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
         }
 
         [Fact, WorkItem(543954, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543954")]
@@ -230,7 +230,7 @@ class C
             foreach (string type in new[] { "int", "ushort", "byte", "long", "float", "decimal" })
             {
                 CompileAndVerify(source: source4.Replace("TYPE", type), expectedOutput: "0", verify: Verification.Fails);
-                CompileAndVerify(source: source4.Replace("TYPE", type), expectedOutput: "0", parseOptions: TestOptions.RegularLatest.WithPEVerifyCompatFeature());
+                CompileAndVerify(source: source4.Replace("TYPE", type), expectedOutput: "0", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -3209,7 +3209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCrefParameter();
             
-            Assert.Null(node.RefOrOutKeyword);
+            Assert.Null(node.RefKindKeyword);
             Assert.NotNull(node.Type);
             
             AttachAndCheckDiagnostics(node);
@@ -12128,9 +12128,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCrefParameter();
             
-            Assert.Equal(SyntaxKind.None, node.RefOrOutKeyword.Kind());
+            Assert.Equal(SyntaxKind.None, node.RefKindKeyword.Kind());
             Assert.NotNull(node.Type);
-            var newNode = node.WithRefOrOutKeyword(node.RefOrOutKeyword).WithType(node.Type);
+            var newNode = node.WithRefKindKeyword(node.RefKindKeyword).WithType(node.Type);
             Assert.Equal(node, newNode);
         }
         

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);
         public static readonly CSharpParseOptions Regular7_1 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_1);
         public static readonly CSharpParseOptions Regular7_2 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_2);
-        public static readonly CSharpParseOptions RegularLatest = Regular.WithLanguageVersion(LanguageVersion.Latest);
-        public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
+        public static readonly CSharpParseOptions RegularWithDocumentationComments = Regular.WithDocumentationMode(DocumentationMode.Diagnose);
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string> { };
         public static readonly CSharpParseOptions ExperimentalParseOptions =

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -475,5 +475,21 @@ class C
 
             await VerifyNoItemsExistAsync(text);
         }
+        
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(23957, "https://github.com/dotnet/roslyn/issues/23957")]
+        public async Task CRef_InParameter()
+        {
+            var text = @"
+using System;
+class C 
+{ 
+    /// <see cref=""C.My$$
+    public void MyMethod(in int x) { }
+}
+";
+
+            await VerifyItemExistsAsync(text, "MyMethod(in int)");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -341,13 +341,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                         var parameter = parameters[i];
 
-                        if (parameter.RefKind == RefKind.Out)
+                        switch (parameter.RefKind)
                         {
-                            builder.Append("out ");
-                        }
-                        else if (parameter.RefKind == RefKind.Ref)
-                        {
-                            builder.Append("ref ");
+                            case RefKind.Ref:
+                                builder.Append("ref ");
+                                break;
+                            case RefKind.Out:
+                                builder.Append("out ");
+                                break;
+                            case RefKind.In:
+                                builder.Append("in ");
+                                break;
                         }
 
                         builder.Append(parameter.Type.ToMinimalDisplayString(semanticModel, position));


### PR DESCRIPTION
### Customer scenario

`RefKind.In` is not honored in cref comments. This leads to:
1) methods with `in` parameters are populated as regular byval parameters.
2) compiler displays warnings when user manually writes `<see cref="M(in int x)" />`

Note: API change will follow #22472

### Bugs this fixes

Fixes #23957 

### Workarounds, if any

None.

### Risk

Minimal. It is an addition to the parser/completion lists.

### Performance impact

Minimal. No complexity changes.

### Is this a regression from a previous update?

No.

### Root cause analysis

New feature. New tests were added to guard against possible future regressions.

### How was the bug found?

Customer comment on GitHub.

### Test documentation updated?

----
  