### PR TITLE
MemberSemanticModel.GetBoundLambdaOrQuery should use GetAdjustedNodePosition helper to ensure proper handling of zero-length tokens at the beginning of a syntax node.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1469,7 +1469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (enclosingLambdaOrQuery == null)
             {
                 nodeToBind = bindingRoot;
-                lambdaRecoveryBinder = GetEnclosingBinderInternalWithinRoot(nodeToBind, nodeToBind.SpanStart);
+                lambdaRecoveryBinder = GetEnclosingBinderInternalWithinRoot(nodeToBind, GetAdjustedNodePosition(nodeToBind));
             }
             else
             {
@@ -1497,7 +1497,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return GetLowerBoundNode(nodes);
                 }
 
-                lambdaRecoveryBinder = GetEnclosingBinderInLambdaOrQuery(nodeToBind.SpanStart, nodeToBind, enclosingLambdaOrQuery, ref boundEnclosingLambdaOrQuery);
+                lambdaRecoveryBinder = GetEnclosingBinderInLambdaOrQuery(GetAdjustedNodePosition(nodeToBind), nodeToBind, enclosingLambdaOrQuery, ref boundEnclosingLambdaOrQuery);
             }
 
             Binder incrementalBinder = new IncrementalBinder(this, lambdaRecoveryBinder);
@@ -1521,11 +1521,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // situations. Let's bind the node directly.
             if (enclosingLambdaOrQuery == null)
             {
-                lambdaRecoveryBinder = GetEnclosingBinderInternalWithinRoot(lambdaOrQuery, lambdaOrQuery.SpanStart);
+                lambdaRecoveryBinder = GetEnclosingBinderInternalWithinRoot(lambdaOrQuery, GetAdjustedNodePosition(lambdaOrQuery));
             }
             else
             {
-                lambdaRecoveryBinder = GetEnclosingBinderInLambdaOrQuery(lambdaOrQuery.SpanStart, lambdaOrQuery, enclosingLambdaOrQuery, ref boundEnclosingLambdaOrQuery);
+                lambdaRecoveryBinder = GetEnclosingBinderInLambdaOrQuery(GetAdjustedNodePosition(lambdaOrQuery), lambdaOrQuery, enclosingLambdaOrQuery, ref boundEnclosingLambdaOrQuery);
             }
 
             incrementalBinder = new IncrementalBinder(this, lambdaRecoveryBinder);

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5152,5 +5152,44 @@ namespace ConsoleApplication1
 }",
             MainDescription($"void Program.Test<Bar>()"));
         }
+
+        [WorkItem(23883, "https://github.com/dotnet/roslyn/issues/23883")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task InMalformedEmbeddedStatement_01()
+        {
+            await TestAsync(
+@"
+class Program
+{
+    void method1()
+    {
+        if (method2())
+            .Any(b => b.Content$$Type, out var chars)
+        {
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(23883, "https://github.com/dotnet/roslyn/issues/23883")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task InMalformedEmbeddedStatement_02()
+        {
+            await TestAsync(
+@"
+class Program
+{
+    void method1()
+    {
+        if (method2())
+            .Any(b => b$$.ContentType, out var chars)
+        {
+        }
+    }
+}
+",
+            MainDescription("(parameter) ? b"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #23883.

### Customer scenario

Steps to Reproduce:
Insert this code
```
        void method1()
        {
            if (method2())
                .Any(b => b.ContentType, out var chars)
            {
            }
        }
```
Hover over b.ContentType

Expected Behavior:
- Quick info shows (parameter) ? b over b
- and nothing over ContentType

Actual Behavior:
Visual Studio crashes when mouse is over either b or ContentType

### Bugs this fixes

#23883

### Workarounds, if any

None, except not doing repro steps.

### Risk

Low

### Performance impact

Low perf impact because no extra allocations/no complexity changes 

### Is this a regression from a previous update?

No.

### Root cause analysis

Unit-tests added.

### How was the bug found?

Customer reported 

