### PR TITLE
added Microsoft.VisualStudio.IntegrationTest.Setup.vsix to signing

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -106,7 +106,6 @@
         "Dlls\\ServicesTestUtilities\\Roslyn.Services.Test.Utilities.dll",
         "Dlls\\TestUtilities\\net461\\Roslyn.Test.Utilities.dll",
         "Dlls\\VisualStudioIntegrationTestUtilities\\Microsoft.VisualStudio.IntegrationTest.Utilities.dll",
-        "Dlls\\Diagnostics\\Roslyn.Hosting.Diagnostics.dll",
         "Vsix\\VisualStudioIntegrationTestSetup\\Microsoft.VisualStudio.IntegrationTest.Setup.dll"
       ]
     },

--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -105,7 +105,9 @@
       "values": [
         "Dlls\\ServicesTestUtilities\\Roslyn.Services.Test.Utilities.dll",
         "Dlls\\TestUtilities\\net461\\Roslyn.Test.Utilities.dll",
-        "Dlls\\VisualStudioIntegrationTestUtilities\\Microsoft.VisualStudio.IntegrationTest.Utilities.dll"
+        "Dlls\\VisualStudioIntegrationTestUtilities\\Microsoft.VisualStudio.IntegrationTest.Utilities.dll",
+        "Dlls\\Diagnostics\\Roslyn.Hosting.Diagnostics.dll",
+        "Vsix\\VisualStudioIntegrationTestSetup\\Microsoft.VisualStudio.IntegrationTest.Setup.dll"
       ]
     },
     {
@@ -141,6 +143,7 @@
         "Vsix\\VisualStudioSetup.Next\\Roslyn.VisualStudio.Setup.Next.vsix",
         "Vsix\\VisualStudioSetup\\Roslyn.VisualStudio.Setup.vsix",
         "Vsix\\Roslyn\\RoslynDeployment.vsix",
+        "Vsix\\VisualStudioIntegrationTestSetup\\Microsoft.VisualStudio.IntegrationTest.Setup.vsix"
       ]
     },
     {
@@ -173,6 +176,7 @@
     "Microsoft.CodeAnalysis.VisualBasic.1.0.1.nupkg",
     "Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.1.nupkg",
     "Microsoft.CodeAnalysis.Workspaces.Common.1.0.1.nupkg",
+    "Microsoft.Diagnostics.Runtime.dll",
     "Microsoft.DiaSymReader.Native.amd64.dll",
     "Microsoft.DiaSymReader.Native.arm.dll",
     "Microsoft.DiaSymReader.Native.x86.dll",

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -754,6 +754,10 @@ Public Class BuildDevDivInsertionFiles
                           Throw New Exception($"Mapped VSIX path does not exist: {filePath}")
                       End If
                       Dim name = Path.GetFileName(filePath)
+                      If map.ContainsKey(name) Then
+                          Throw New Exception($"{name} already exist!")
+                      End If
+
                       map.Add(name, filePath)
                   End Sub
 
@@ -837,7 +841,6 @@ Public Class BuildDevDivInsertionFiles
         add("UnitTests\EditorServicesTest\Microsoft.VisualStudio.Platform.VSEditor.Interop.dll")
         add("Vsix\ExpressionEvaluatorPackage\Microsoft.VisualStudio.Debugger.Engine.dll")
         add("Vsix\VisualStudioIntegrationTestSetup\Microsoft.Diagnostics.Runtime.dll")
-        add("Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix")
         add("Exes\Toolset\System.AppContext.dll")
         add("Exes\Toolset\System.Console.dll")
         add("Exes\Toolset\System.Collections.Immutable.dll")


### PR DESCRIPTION
some tests are failing due to missing waiter. we want to deploy our test setup vsix so that we can deploy our waiter to test machine, but that vsix is currently not signed.

this puts dlls and vsix as files we need to sign.