### PR TITLE
unregister onExit event handler on disposing interactive host

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -115,10 +115,9 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 // set _disposing so that we don't attempt restart the host anymore:
                 _disposing = true;
-                if (_currentLocalHandler != null)
+                if (Interlocked.Exchange(ref _processExitHandling, ProcessExitHandled) == ProcessExitHooked)
                 {
-                    Process.Exited -=  _currentLocalHandler;
-                    _currentLocalHandler = null;
+                    Process.Exited -= ProcessExitedHandler;
                 }
 
                 InitiateTermination(Process, _processId);

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             private Thread _readOutputThread;           // nulled on dispose
             private Thread _readErrorOutputThread;      // nulled on dispose
             private InteractiveHost _host;              // nulled on dispose
-            private int _processExitHandling;           // set to ProcessExitHandled on dispose
+            private volatile int _processExitHandling;           // set to ProcessExitHandled on dispose
 
             internal RemoteService(InteractiveHost host, Process process, int processId, Service service)
             {

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         if (_processExitHandling == ProcessExitHooked)
                         {
                             Process.Exited -= ProcessExitedHandler;
-                        //    await _host.OnProcessExited(Process).ConfigureAwait(false);
+                            await _host.OnProcessExited(Process).ConfigureAwait(false);
                             _processExitHandling = ProcessExitHandled;
                         }
                     }
@@ -130,31 +130,23 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 if (joinThreads)
                 {
-                    var readOutputThreadJoinTask = Task.Run(() =>
+                    try
                     {
-                        try
-                        {
-                            _readOutputThread?.Join();
-                        }
-                        catch (ThreadStateException)
-                        {
-                            // thread hasn't started
-                        }
-                    });
-
-                    var readErrorOutputThreadJoinTask = Task.Run(() =>
+                        _readOutputThread?.Join();
+                    }
+                    catch (ThreadStateException)
                     {
-                        try
-                        {
-                            _readErrorOutputThread?.Join();
-                        }
-                        catch (ThreadStateException)
-                        {
-                            // thread hasn't started
-                        }
-                    });
+                        // thread hasn't started
+                    }
 
-                    Task.WaitAll(readOutputThreadJoinTask, readErrorOutputThreadJoinTask);
+                    try
+                    {
+                        _readErrorOutputThread?.Join();
+                    }
+                    catch (ThreadStateException)
+                    {
+                        // thread hasn't started
+                    }
                 }
 
                 // null the host so that we don't attempt to write to the buffer anymore:

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         {
                             Process.Exited -= ProcessExitedHandler;
                             _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
-                            // Should set _processExitHandling before calling OnProcessExited to avoid deadlocks.
+                            // Should set _processExitHandlerStatus before calling OnProcessExited to avoid deadlocks.
                             await _host.OnProcessExited(Process).ConfigureAwait(false);
                         }
                     }

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -73,6 +73,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                             Process.Exited -= ProcessExitedHandler;
                             _processExitHandlerStatus = ProcessExitHandlerStatus.Handled;
                             // Should set _processExitHandlerStatus before calling OnProcessExited to avoid deadlocks.
+                            // Calling the host should be within the lock to prevent its disposing during the execution.
                             await _host.OnProcessExited(Process).ConfigureAwait(false);
                         }
                     }

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -132,31 +132,25 @@ namespace Microsoft.CodeAnalysis.Interactive
                 {
                     var readOutputThreadJoinTask = Task.Run(() =>
                     {
-                        if (_readOutputThread != null)
+                        try
                         {
-                            try
-                            {
-                                _readOutputThread.Join();
-                            }
-                            catch (ThreadStateException)
-                            {
-                                // thread hasn't started
-                            }
+                            _readOutputThread?.Join();
+                        }
+                        catch (ThreadStateException)
+                        {
+                            // thread hasn't started
                         }
                     });
 
                     var readErrorOutputThreadJoinTask = Task.Run(() =>
                     {
-                        if (_readErrorOutputThread != null)
+                        try
                         {
-                            try
-                            {
-                                _readErrorOutputThread.Join();
-                            }
-                            catch (ThreadStateException)
-                            {
-                                // thread hasn't started
-                            }
+                            _readErrorOutputThread?.Join();
+                        }
+                        catch (ThreadStateException)
+                        {
+                            // thread hasn't started
                         }
                     });
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -128,26 +128,26 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 InitiateTermination(Process, _processId);
 
-                if (joinThreads)
-                {
-                    try
-                    {
-                        _readOutputThread?.Join();
-                    }
-                    catch (ThreadStateException)
-                    {
-                        // thread hasn't started
-                    }
+                //if (joinThreads)
+                //{
+                //    try
+                //    {
+                //        _readOutputThread?.Join();
+                //    }
+                //    catch (ThreadStateException)
+                //    {
+                //        // thread hasn't started
+                //    }
 
-                    try
-                    {
-                        _readErrorOutputThread?.Join();
-                    }
-                    catch (ThreadStateException)
-                    {
-                        // thread hasn't started
-                    }
-                }
+                //    try
+                //    {
+                //        _readErrorOutputThread?.Join();
+                //    }
+                //    catch (ThreadStateException)
+                //    {
+                //        // thread hasn't started
+                //    }
+                //}
 
                 // null the host so that we don't attempt to write to the buffer anymore:
                 _host = null;

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         if (_processExitHandling == ProcessExitHooked)
                         {
                             Process.Exited -= ProcessExitedHandler;
-                            await _host.OnProcessExited(Process).ConfigureAwait(false);
+                        //    await _host.OnProcessExited(Process).ConfigureAwait(false);
                             _processExitHandling = ProcessExitHandled;
                         }
                     }

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         public void Dispose()
         {
-            Dispose(joinThreads: false, disposing: true);
+            Dispose(joinThreads: true, disposing: true);
         }
 
         private void Dispose(bool joinThreads, bool disposing)

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -221,30 +221,22 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         ~InteractiveHost()
         {
-            Dispose(disposing: false);
+            DisposeRemoteService(disposing: false);
         }
 
         public void Dispose()
         {
-            Dispose(disposing: true);
+            DisposeChannel();
+            DisposeRemoteService(disposing: true);
+            GC.SuppressFinalize(this);
         }
 
-        internal void Dispose(bool disposing)
+        private void DisposeRemoteService(bool disposing)
         {
-            if (disposing)
-            {
-                DisposeChannel();
-            }
-
             if (_lazyRemoteService != null)
             {
                 _lazyRemoteService.Dispose(disposing);
                 _lazyRemoteService = null;
-            }
-
-            if (disposing)
-            {
-                GC.SuppressFinalize(this);
             }
         }
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.Interactive
         // adjustable for testing purposes
         private readonly int _millisecondsTimeout;
         private const int MaxAttemptsToCreateProcess = 2;
-        private readonly SemaphoreSlim _disposeSemaphore = new SemaphoreSlim(initialCount: 1);
 
         private LazyRemoteService _lazyRemoteService;
         private int _remoteServiceInstanceId;
@@ -189,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     return null;
                 }
 
-                return new RemoteService(this, newProcess, newProcessId, newService, _disposeSemaphore);
+                return new RemoteService(this, newProcess, newProcessId, newService);
             }
             catch (OperationCanceledException)
             {
@@ -232,13 +231,6 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         internal void Dispose(bool disposing)
         {
-            var semaphore = _disposeSemaphore;
-            if (semaphore != null && disposing)
-            {
-                semaphore.Wait();
-                semaphore.Dispose();
-            }
-
             if (disposing)
             {
                 DisposeChannel();

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
         internal static void DisposeInteractiveHostProcess(InteractiveHost process)
         {
             IpcServerChannel serverChannel = process._ServerChannel;
-            process.Dispose(joinThreads: true);
+            process.Dispose(disposing: true);
 
             var listenerThread = (Thread)s_ipcServerChannelListenerThread.GetValue(serverChannel);
             listenerThread.Join();

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
         internal static void DisposeInteractiveHostProcess(InteractiveHost process)
         {
             IpcServerChannel serverChannel = process._ServerChannel;
-            process.Dispose(disposing: true);
+            process.Dispose();
 
             var listenerThread = (Thread)s_ipcServerChannelListenerThread.GetValue(serverChannel);
             listenerThread.Join();


### PR DESCRIPTION
### Customer scenario

Customer shuts down Visual Studio. There is a race condition when closing the Interactive Window and the corresponding process.

When the process is closed before the window (within this or another scenario), it sends a message to display it in the interactive window. If the window was closed somewhere between checks the it is open and executing a command to output the message, an failure happens.

### Bugs this fixes
VSO 514822 and corresponding: https://github.com/dotnet/roslyn/issues/24006 

### Workarounds, if any

None

### Risk

Low

### Performance impact

None

### Is this a regression from a previous update?
No

### How was the bug found?
Watson hits