### PR TITLE
Fix ArgumentException when creating diagnostic with effective severit…

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticCreationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/DiagnosticCreationTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
+{
+    public partial class DiagnosticCreationTests
+    {
+        [Fact, WorkItem(547049, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547049")]
+        public void TestDiagnosticCreationWithOverriddenSeverity()
+        {
+            var defaultSeverity = DiagnosticSeverity.Info;
+            var effectiveSeverity = DiagnosticSeverity.Error;
+            var descriptor = new DiagnosticDescriptor("ID", "Title", "MessageFormat", "Category", defaultSeverity, isEnabledByDefault: true);
+            var diagnostic = Diagnostic.Create(descriptor, Location.None, effectiveSeverity, additionalLocations: null, properties: null);
+            Assert.Equal(effectiveSeverity, diagnostic.Severity);
+            Assert.Equal(0, diagnostic.WarningLevel);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var warningLevel = GetDefaultWarningLevel(descriptor.DefaultSeverity);
+            var warningLevel = GetDefaultWarningLevel(effectiveSeverity);
             return SimpleDiagnostic.Create(
                 descriptor,
                 severity: effectiveSeverity,


### PR DESCRIPTION
…y error

Fixes VSO 547049

<details><summary>Ask Mode template</summary>

### Customer scenario

VS crashes when user opens a solution with custom ruleset that escalates the effective severity of certain IDE diagnostics to be Error (such as analyzer dependency conflict diagnostics).

### Bugs this fixes

[VSO 547049](https://devdiv.visualstudio.com/DevDiv/_workitems?id=547049&_a=edit): IDE crash while opening solution from Team Explorer

### Workarounds, if any

Do not change default severity of host IDE diagnostics.

### Risk

Low risk, we are correctly computing the warning level for effective severity, instead of default severity.

### Performance impact

None

### Is this a regression from a previous update?

This is a regression introduced by a very recent post 15.5 change: https://github.com/dotnet/roslyn/pull/23794

### Root cause analysis

We did not test the scenario where effective severity of IDE diagnostics is escalated to Error

### How was the bug found?

Dogfooding

### Test documentation updated?

N/A

</details>
