### PR TITLE
Avoid using a ref local for array element l-value

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -606,7 +606,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsInvariantArray(TypeSymbol type)
         {
-            return (type as ArrayTypeSymbol)?.ElementType?.IsSealed == true;
+            return (type as ArrayTypeSymbol)?.ElementType.IsSealed == true;
         }
 
         private BoundExpression BoxReceiver(BoundExpression rewrittenReceiver, NamedTypeSymbol memberContainingType)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -520,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // and the runtime type of the array is not object[] (but e.g. string[]) the pointer approach is broken.
                             // T is Object in such case and we can't take a read-write pointer of type Object& to an array element of non-object type.
                             //
-                            // In this case we rewrite the assignment as follows:
+                            // In the dynamic case, or when the array may be co-variant, we rewrite the assignment as follows:
                             //
                             //   E t_array = array;
                             //   I t_index = index; (possibly more indices)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -507,17 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.ArrayAccess:
-                    if (isDynamicAssignment)
                     {
-                        // In non-dynamic array[index] op= R we emit:
-                        //   T& tmp = &array[index];
-                        //   *tmp = *L op R;
-                        // where T is the type of L.
-                        // 
-                        // If L is an array access, the assignment is dynamic, the compile-time of the array is dynamic[] 
-                        // and the runtime type of the array is not object[] (but e.g. string[]) the pointer approach is broken.
-                        // T is Object in such case and we can't take a read-write pointer of type Object& to an array element of non-object type.
-                        //
                         // In this case we rewrite the assignment as follows:
                         //
                         //   E t_array = array;
@@ -531,7 +521,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         return SpillArrayElementAccess(loweredArray, loweredIndices, stores, temps);
                     }
-                    break;
 
                 case BoundKind.DynamicMemberAccess:
                     return TransformDynamicMemberAccess((BoundDynamicMemberAccess)originalLHS, stores, temps);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.ArrayAccess:
                     {
                         var arrayAccess = (BoundArrayAccess)originalLHS;
-                        if (isDynamicAssignment || !IsInvariantArrayAccess(arrayAccess))
+                        if (isDynamicAssignment || !IsInvariantArray(arrayAccess.Expression.Type))
                         {
                             // In non-dynamic, invariant array[index] op= R we emit:
                             //   T& tmp = &array[index];
@@ -604,10 +604,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return variableTemp;
         }
 
-        private static bool IsInvariantArrayAccess(BoundArrayAccess arrayAccess)
+        private static bool IsInvariantArray(TypeSymbol type)
         {
-            var elementType = (arrayAccess.Expression.Type as ArrayTypeSymbol)?.ElementType;
-            return elementType?.IsSealed == true;
+            return (type as ArrayTypeSymbol)?.ElementType?.IsSealed == true;
         }
 
         private BoundExpression BoxReceiver(BoundExpression rewrittenReceiver, NamedTypeSymbol memberContainingType)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -4860,7 +4860,7 @@ class Program
         }
 
         [Fact]
-        public void TestCompoundOnAfieldOfGeneric()
+        public void TestCompoundOnAFieldOfGeneric()
         {
             var source = @"
 class Program

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -16189,5 +16189,42 @@ unsafe class Test
   IL_000c:  ret
 }");
         }
+
+        [Fact]
+        public void ArrayElementIncrement_ValueType()
+        {
+            string source =
+@"class C
+{
+    static void Main()
+    {
+        F(new int[] { 1 });
+    }
+    static void F(int[] a)
+    {
+        G(a);
+        System.Console.Write(a[0]);
+    }
+    static void G(int[] a)
+    {
+        a[0]++;
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "2");
+            verifier.VerifyIL("C.G",
+@"{
+  // Code size       13 (0xd)
+  .maxstack  3
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    ""int""
+  IL_0007:  dup
+  IL_0008:  ldind.i4
+  IL_0009:  ldc.i4.1
+  IL_000a:  add
+  IL_000b:  stind.i4
+  IL_000c:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -16073,5 +16073,47 @@ unsafe class Test
 
             CompileAndVerify(comp, expectedOutput: "SpanOpCalled", verify: Verification.Fails);
         }
+
+        [WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")]
+        [Fact]
+        public void CovariantArrayElementCompoundAssignment()
+        {
+            string source =
+@"class C
+{
+    static void Main()
+    {
+        F(new object[] { """" }, ""A"");
+        F(new string[] { """" }, ""B"");
+    }
+    static void F(object[] o, string s)
+    {
+        G(o, s);
+        System.Console.Write(o[0]);
+    }
+    static void G(object[] o, string s)
+    {
+        o[0] += s;
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "AB");
+            verifier.VerifyIL("C.G",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  4
+  .locals init (object[] V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  ldloc.0
+  IL_0005:  ldc.i4.0
+  IL_0006:  ldelem.ref
+  IL_0007:  ldarg.1
+  IL_0008:  call       ""string string.Concat(object, object)""
+  IL_000d:  stelem.ref
+  IL_000e:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
@@ -1,5 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#Const DONT_USE_BYREF_LOCALS_FOR_USE_TWICE = True
+
 Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Collections
@@ -274,8 +276,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' easier to implement.
 
                 Dim receiver As Result = UseTwiceReceiver(containingMember, node.ReceiverOpt, arg)
-                Dim first = node.Update(receiver.First, fieldSymbol, node.IsLValue, node.ConstantsInProgressOpt, node.Type)
-                Dim second = node.Update(receiver.Second, fieldSymbol, node.IsLValue, node.ConstantsInProgressOpt, node.Type)
+                Dim first = node.Update(receiver.First, fieldSymbol, node.IsLValue, suppressVirtualCalls:=False, node.ConstantsInProgressOpt, node.Type)
+                Dim second = node.Update(receiver.Second, fieldSymbol, node.IsLValue, suppressVirtualCalls:=False, node.ConstantsInProgressOpt, node.Type)
 
                 Debug.Assert(first.IsLValue AndAlso second.IsLValue)
                 Return New Result(first, second)
@@ -496,7 +498,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
 #If DONT_USE_BYREF_LOCALS_FOR_USE_TWICE Then
-        Private Shared Function UseTwiceReceiver(containingMember As Symbol, receiverOpt As BoundExpression, arg As ArrayBuilder(Of TempLocalSymbol)) As Result
+        Private Shared Function UseTwiceReceiver(containingMember As Symbol, receiverOpt As BoundExpression, arg As ArrayBuilder(Of SynthesizedLocal)) As Result
             If receiverOpt Is Nothing Then
                 Return New Result(Nothing, Nothing)
             ElseIf receiverOpt.IsLValue AndAlso receiverOpt.Type.IsReferenceType Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
@@ -1,6 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#Const DONT_USE_BYREF_LOCALS_FOR_USE_TWICE = True
+#Const DONT_USE_BYREF_LOCALS_FOR_ARRAY_ACCESS = True
 
 Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(node.IsLValue)
 
-#If DONT_USE_BYREF_LOCALS_FOR_USE_TWICE Then
+#If DONT_USE_BYREF_LOCALS_FOR_ARRAY_ACCESS Then
             ' Note, as an alternative we could capture reference to the array element in a ByRef temp.
             ' However, without an introduction of an indirect assignment node, IL-gen is unable to distinguish 
             ' when it should assign indirect or should assign a reference. For now, decided to not introduce 
@@ -268,7 +268,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return New Result(node, node)
 
             Else
-#If DONT_USE_BYREF_LOCALS_FOR_USE_TWICE Then
+#If DONT_USE_BYREF_LOCALS_FOR_FIELD_ACCESS Then
                 ' Note, as an alternative we could capture reference to the field in a ByRef temp.
                 ' However, without an introduction of an indirect assignment node, IL-gen is unable to distinguish 
                 ' when it should assign indirect or should assign a reference. For now, decided to not introduce 
@@ -497,7 +497,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        initializer.Update(secondArgsArray.AsImmutableOrNull(), initializer.Type), Nothing, Nothing, boundArray.Type)
         End Sub
 
-#If DONT_USE_BYREF_LOCALS_FOR_USE_TWICE Then
+#If DONT_USE_BYREF_LOCALS_FOR_FIELD_ACCESS Then
         Private Shared Function UseTwiceReceiver(containingMember As Symbol, receiverOpt As BoundExpression, arg As ArrayBuilder(Of SynthesizedLocal)) As Result
             If receiverOpt Is Nothing Then
                 Return New Result(Nothing, Nothing)

--- a/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/UseTwiceRewriter.vb
@@ -208,9 +208,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(node.IsLValue)
 
+#If DONT_USE_BYREF_LOCALS_FOR_USE_TWICE Then
+#Else
             If IsInvariantArray(node.Expression.Type) Then
                 Return UseTwiceLValue(containingMember, node, arg)
             End If
+#End If
 
             ' Note, as an alternative we could capture reference to the array element in a ByRef temp.
             ' However, without an introduction of an indirect assignment node, IL-gen is unable to distinguish 
@@ -239,8 +242,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function IsInvariantArray(type As TypeSymbol) As Boolean
-            Dim value = TryCast(type, ArrayTypeSymbol)?.ElementType?.IsNotInheritable
-            Return value.HasValue AndAlso value.GetValueOrDefault()
+            Dim value = TryCast(type, ArrayTypeSymbol)?.ElementType.IsNotInheritable
+            Return value.GetValueOrDefault()
         End Function
 
         Private Shared Function UseTwiceLValue(containingMember As Symbol, lvalue As BoundExpression, temporaries As ArrayBuilder(Of SynthesizedLocal)) As Result

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -14314,23 +14314,29 @@ Module M
     End Sub
     Function G(a() As String) As String
         With a(0)
-            Return .ToString()
+            Return .ToString() + .ToLower()
         End With
     End Function
 End Module
     </file>
 </compilation>
-            CompileAndVerify(comp, expectedOutput:="B").
+            CompileAndVerify(comp, expectedOutput:="Bb").
             VerifyIL("M.G",
             <![CDATA[
 {
-  // Code size        9 (0x9)
+  // Code size       22 (0x16)
   .maxstack  2
+  .locals init (String V_0) //$W0
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
   IL_0002:  ldelem.ref
-  IL_0003:  callvirt   "Function String.ToString() As String"
-  IL_0008:  ret
+  IL_0003:  stloc.0
+  IL_0004:  ldloc.0
+  IL_0005:  callvirt   "Function String.ToString() As String"
+  IL_000a:  ldloc.0
+  IL_000b:  callvirt   "Function String.ToLower() As String"
+  IL_0010:  call       "Function String.Concat(String, String) As String"
+  IL_0015:  ret
 }
 ]]>)
         End Sub
@@ -14351,23 +14357,37 @@ Module M
     End Sub
     Function G(a() As Object) As String
         With a(0)
-            Return .ToString()
+            Return .ToString() + .ToLower()
         End With
     End Function
 End Module
     </file>
 </compilation>
-            CompileAndVerify(comp, expectedOutput:="AB").
+            CompileAndVerify(comp, expectedOutput:="AaBb").
             VerifyIL("M.G",
             <![CDATA[
 {
-  // Code size        9 (0x9)
-  .maxstack  2
+  // Code size       42 (0x2a)
+  .maxstack  8
+  .locals init (Object V_0) //$W0
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
   IL_0002:  ldelem.ref
-  IL_0003:  callvirt   "Function Object.ToString() As String"
-  IL_0008:  ret
+  IL_0003:  stloc.0
+  IL_0004:  ldloc.0
+  IL_0005:  callvirt   "Function Object.ToString() As String"
+  IL_000a:  ldloc.0
+  IL_000b:  ldnull
+  IL_000c:  ldstr      "ToLower"
+  IL_0011:  ldc.i4.0
+  IL_0012:  newarr     "Object"
+  IL_0017:  ldnull
+  IL_0018:  ldnull
+  IL_0019:  ldnull
+  IL_001a:  call       "Function Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateGet(Object, System.Type, String, Object(), String(), System.Type(), Boolean()) As Object"
+  IL_001f:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object"
+  IL_0024:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Object) As String"
+  IL_0029:  ret
 }
 ]]>)
         End Sub
@@ -14387,23 +14407,29 @@ Module M
     End Sub
     Function G(a() As Integer) As String
         With a(0)
-            Return .ToString()
+            Return .ToString() + .ToString()
         End With
     End Function
 End Module
     </file>
 </compilation>
-            CompileAndVerify(comp, expectedOutput:="1").
+            CompileAndVerify(comp, expectedOutput:="11").
             VerifyIL("M.G",
             <![CDATA[
 {
-  // Code size       13 (0xd)
+  // Code size       26 (0x1a)
   .maxstack  2
+  .locals init (Integer& V_0) //$W0
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
   IL_0002:  ldelema    "Integer"
-  IL_0007:  call       "Function Integer.ToString() As String"
-  IL_000c:  ret
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  call       "Function Integer.ToString() As String"
+  IL_000e:  ldloc.0
+  IL_000f:  call       "Function Integer.ToString() As String"
+  IL_0014:  call       "Function String.Concat(String, String) As String"
+  IL_0019:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -13850,10 +13850,13 @@ Module M
         F(New String() {"b"})
     End Sub
     Sub F(a() As Object)
-        G(a(0))
+        G(a)
         System.Console.Write(a(0))
     End Sub
-    Sub G(ByRef s As String)
+    Sub G(a() As Object)
+        H(a(0))
+    End Sub
+    Sub H(ByRef s As String)
         s = s.ToUpper()
     End Sub
 End Module
@@ -13863,14 +13866,21 @@ End Module
             VerifyIL("M.G",
             <![CDATA[
 {
-  // Code size       10 (0xa)
-  .maxstack  2
+  // Code size       21 (0x15)
+  .maxstack  3
+  .locals init (String V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldarg.0
-  IL_0002:  ldind.ref
-  IL_0003:  callvirt   "Function String.ToUpper() As String"
-  IL_0008:  stind.ref
-  IL_0009:  ret
+  IL_0001:  dup
+  IL_0002:  ldc.i4.0
+  IL_0003:  ldelem.ref
+  IL_0004:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Object) As String"
+  IL_0009:  stloc.0
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  call       "Sub M.H(ByRef String)"
+  IL_0011:  ldc.i4.0
+  IL_0012:  ldloc.0
+  IL_0013:  stelem.ref
+  IL_0014:  ret
 }
 ]]>)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -13838,8 +13838,46 @@ End Module
 
         End Sub
 
+        <Fact>
+        Public Sub ArrayElementByReferenceDerived_Invariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New String() {"b"})
+    End Sub
+    Sub F(a() As String)
+        G(a)
+        System.Console.Write(a(0))
+    End Sub
+    Sub G(a() As String)
+        H(a(0))
+    End Sub
+    Sub H(ByRef s As String)
+        s = s.ToUpper()
+    End Sub
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="B").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "String"
+  IL_0007:  call       "Sub M.H(ByRef String)"
+  IL_000c:  ret
+}
+]]>)
+        End Sub
+
         <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
-        Public Sub CovariantArrayElementByReference()
+        Public Sub ArrayElementByReferenceDerived_Covariant()
             Dim comp =
 <compilation>
     <file>
@@ -13885,11 +13923,137 @@ End Module
 ]]>)
         End Sub
 
-        <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
-        Public Sub CovariantArrayElementCompoundAssignment()
+        <Fact>
+        Public Sub ArrayElementByReferenceDerived_ValueType()
             Dim comp =
 <compilation>
     <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Integer() {1})
+    End Sub
+    Sub F(a() As Integer)
+        G(a)
+        System.Console.Write(a(0))
+    End Sub
+    Sub G(a() As Integer)
+        H(a(0))
+    End Sub
+    Sub H(ByRef i As Integer)
+        i = 2
+    End Sub
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="2").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "Integer"
+  IL_0007:  call       "Sub M.H(ByRef Integer)"
+  IL_000c:  ret
+}
+]]>)
+        End Sub
+
+        ' Generated code results in ArrayTypeMismatchException,
+        ' matching native compiler.
+        <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
+        Public Sub ArrayElementByReferenceBase_Covariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Object() {"a"})
+        F(New String() {"b"})
+    End Sub
+    Sub F(a() As Object)
+        Try
+            G(a)
+            System.Console.Write(a(0))
+        Catch e As System.Exception
+            System.Console.Write(e.GetType().Name)
+        End Try
+    End Sub
+    Sub G(a() As Object)
+        H(a(0))
+    End Sub
+    Sub H(ByRef s As Object)
+        s = s.ToString().ToUpper()
+    End Sub
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="AArrayTypeMismatchException").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "Object"
+  IL_0007:  call       "Sub M.H(ByRef Object)"
+  IL_000c:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub ArrayElementCompoundAssignment_Invariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New String() {""}, "B")
+    End Sub
+    Sub F(a() As String, s As String)
+        G(a, s)
+        System.Console.Write(a(0))
+    End Sub
+    Sub G(a() As String, s As String)
+        a(0) += s
+    End Sub
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="B").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       19 (0x13)
+  .maxstack  3
+  .locals init (String& V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "String"
+  IL_0007:  dup
+  IL_0008:  stloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  ldind.ref
+  IL_000b:  ldarg.1
+  IL_000c:  call       "Function String.Concat(String, String) As String"
+  IL_0011:  stind.ref
+  IL_0012:  ret
+}
+]]>)
+        End Sub
+
+        <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
+        Public Sub ArrayElementCompoundAssignment_Covariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
 Module M
     Sub Main()
         F(New Object() {""}, "A")
@@ -13923,6 +14087,157 @@ End Module
   IL_0008:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object"
   IL_000d:  stelem.ref
   IL_000e:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub ArrayElementCompoundAssignment_ValueType()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Integer() {1}, 2)
+    End Sub
+    Sub F(a() As Integer, i As Integer)
+        G(a, i)
+        System.Console.Write(a(0))
+    End Sub
+    Sub G(a() As Integer, i As Integer)
+        a(0) += i
+    End Sub
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="3").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       15 (0xf)
+  .maxstack  3
+  .locals init (Integer& V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "Integer"
+  IL_0007:  dup
+  IL_0008:  stloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  ldind.i4
+  IL_000b:  ldarg.1
+  IL_000c:  add.ovf
+  IL_000d:  stind.i4
+  IL_000e:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub ArrayElementWithBlock_Invariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New String() {"B"})
+    End Sub
+    Sub F(a() As String)
+        System.Console.Write(G(a))
+    End Sub
+    Function G(a() As String) As String
+        With a(0)
+            Return .ToString()
+        End With
+    End Function
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="B").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelem.ref
+  IL_0003:  callvirt   "Function String.ToString() As String"
+  IL_0008:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub ArrayElementWithBlock_Covariant()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Object() {"A"})
+        F(New String() {"B"})
+    End Sub
+    Sub F(a() As Object)
+        System.Console.Write(G(a))
+    End Sub
+    Function G(a() As Object) As String
+        With a(0)
+            Return .ToString()
+        End With
+    End Function
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="AB").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelem.ref
+  IL_0003:  callvirt   "Function Object.ToString() As String"
+  IL_0008:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub ArrayElementWithBlock_ValueType()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Integer() {1})
+    End Sub
+    Sub F(a() As Integer)
+        System.Console.Write(G(a))
+    End Sub
+    Function G(a() As Integer) As String
+        With a(0)
+            Return .ToString()
+        End With
+    End Function
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="1").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  ldelema    "Integer"
+  IL_0007:  call       "Function Integer.ToString() As String"
+  IL_000c:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -14133,6 +14133,57 @@ End Module
 ]]>)
         End Sub
 
+        <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
+        Public Sub ArrayElementCompoundAssignment_Covariant_NonConstantIndex()
+            Dim comp =
+<compilation>
+    <file>
+Option Strict Off
+Module M
+    Sub Main()
+        F(New Object() {""}, "A")
+        F(New String() {""}, "B")
+    End Sub
+    Sub F(a() As Object, s As String)
+        G(a, s)
+        System.Console.Write(a(0))
+    End Sub
+    Sub G(a() As Object, s As String)
+        a(Index(a)) += s
+    End Sub
+    Function Index(arg As Object) As Integer
+        System.Console.Write(arg.GetType().Name)
+        Return 0
+    End Function
+End Module
+    </file>
+</compilation>
+            CompileAndVerify(comp, expectedOutput:="Object[]AString[]B").
+            VerifyIL("M.G",
+            <![CDATA[
+{
+  // Code size       22 (0x16)
+  .maxstack  4
+  .locals init (Object() V_0,
+                Integer V_1)
+  IL_0000:  ldarg.0
+  IL_0001:  dup
+  IL_0002:  stloc.0
+  IL_0003:  ldarg.0
+  IL_0004:  call       "Function M.Index(Object) As Integer"
+  IL_0009:  dup
+  IL_000a:  stloc.1
+  IL_000b:  ldloc.0
+  IL_000c:  ldloc.1
+  IL_000d:  ldelem.ref
+  IL_000e:  ldarg.1
+  IL_000f:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object"
+  IL_0014:  stelem.ref
+  IL_0015:  ret
+}
+]]>)
+        End Sub
+
         <Fact>
         Public Sub ArrayElementWithBlock_Invariant()
             Dim comp =

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -12487,7 +12487,7 @@ End Class
 
         <WorkItem(745103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/745103")>
         <Fact()>
-        Public Sub TestCompoundOnAfieldOfGeneric()
+        Public Sub TestCompoundOnAFieldOfGeneric()
             CompileAndVerify(
 <compilation>
     <file name="a.vb">
@@ -13883,7 +13883,6 @@ End Module
   IL_0014:  ret
 }
 ]]>)
-
         End Sub
 
         <Fact, WorkItem(547533, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=547533")>
@@ -13926,7 +13925,6 @@ End Module
   IL_000e:  ret
 }
 ]]>)
-
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
@@ -1465,25 +1465,29 @@ Position set for item 'Goo'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       46 (0x2e)
+  // Code size       56 (0x38)
   .maxstack  4
-  .locals init (T& V_0)
+  .locals init (T() V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.0
-  IL_0002:  ldelema    "T"
-  IL_0007:  dup
-  IL_0008:  stloc.0
-  IL_0009:  ldloc.0
-  IL_000a:  constrained. "T"
-  IL_0010:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_0015:  ldarg.0
-  IL_0016:  ldc.i4.0
-  IL_0017:  ldelema    "T"
-  IL_001c:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0021:  add.ovf
-  IL_0022:  constrained. "T"
-  IL_0028:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_002d:  ret
+  IL_0001:  dup
+  IL_0002:  stloc.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  readonly.
+  IL_0006:  ldelema    "T"
+  IL_000b:  ldloc.0
+  IL_000c:  ldc.i4.0
+  IL_000d:  readonly.
+  IL_000f:  ldelema    "T"
+  IL_0014:  constrained. "T"
+  IL_001a:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_001f:  ldarg.0
+  IL_0020:  ldc.i4.0
+  IL_0021:  ldelema    "T"
+  IL_0026:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_002b:  add.ovf
+  IL_002c:  constrained. "T"
+  IL_0032:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0037:  ret
 }
 ]]>)
 
@@ -2122,25 +2126,29 @@ Position set for item 'Goo'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       46 (0x2e)
+  // Code size       56 (0x38)
   .maxstack  4
-  .locals init (T& V_0)
+  .locals init (T() V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.0
-  IL_0002:  ldelema    "T"
-  IL_0007:  dup
-  IL_0008:  stloc.0
-  IL_0009:  ldloc.0
-  IL_000a:  constrained. "T"
-  IL_0010:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_0015:  ldarg.0
-  IL_0016:  ldc.i4.0
-  IL_0017:  ldelema    "T"
-  IL_001c:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0021:  add.ovf
-  IL_0022:  constrained. "T"
-  IL_0028:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_002d:  ret
+  IL_0001:  dup
+  IL_0002:  stloc.0
+  IL_0003:  ldc.i4.0
+  IL_0004:  readonly.
+  IL_0006:  ldelema    "T"
+  IL_000b:  ldloc.0
+  IL_000c:  ldc.i4.0
+  IL_000d:  readonly.
+  IL_000f:  ldelema    "T"
+  IL_0014:  constrained. "T"
+  IL_001a:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_001f:  ldarg.0
+  IL_0020:  ldc.i4.0
+  IL_0021:  ldelema    "T"
+  IL_0026:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_002b:  add.ovf
+  IL_002c:  constrained. "T"
+  IL_0032:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0037:  ret
 }
 ]]>)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/CompoundAssignment.vb
@@ -1503,27 +1503,31 @@ Position set for item 'Bar'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       48 (0x30)
+  // Code size       58 (0x3a)
   .maxstack  4
-  .locals init (T& V_0)
+  .locals init (T() V_0)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  ldc.i4.0
-  IL_0003:  ldelema    "T"
-  IL_0008:  dup
-  IL_0009:  stloc.0
-  IL_000a:  ldloc.0
-  IL_000b:  constrained. "T"
-  IL_0011:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_0016:  ldarg.0
-  IL_0017:  ldc.i4.0
-  IL_0018:  ldelema    "T"
-  IL_001d:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0022:  add.ovf
-  IL_0023:  constrained. "T"
-  IL_0029:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_002e:  nop
-  IL_002f:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.0
+  IL_0005:  readonly.
+  IL_0007:  ldelema    "T"
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.0
+  IL_000e:  readonly.
+  IL_0010:  ldelema    "T"
+  IL_0015:  constrained. "T"
+  IL_001b:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.0
+  IL_0022:  ldelema    "T"
+  IL_0027:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_002c:  add.ovf
+  IL_002d:  constrained. "T"
+  IL_0033:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0038:  nop
+  IL_0039:  ret
 }
 ]]>)
         End Sub
@@ -2164,27 +2168,31 @@ Position set for item 'Bar'
             verifier.VerifyIL("Program.Shift",
             <![CDATA[
 {
-  // Code size       48 (0x30)
+  // Code size       58 (0x3a)
   .maxstack  4
-  .locals init (T& V_0)
+  .locals init (T() V_0)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  ldc.i4.0
-  IL_0003:  ldelema    "T"
-  IL_0008:  dup
-  IL_0009:  stloc.0
-  IL_000a:  ldloc.0
-  IL_000b:  constrained. "T"
-  IL_0011:  callvirt   "Function IMoveable.get_Position() As Integer"
-  IL_0016:  ldarg.0
-  IL_0017:  ldc.i4.0
-  IL_0018:  ldelema    "T"
-  IL_001d:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
-  IL_0022:  add.ovf
-  IL_0023:  constrained. "T"
-  IL_0029:  callvirt   "Sub IMoveable.set_Position(Integer)"
-  IL_002e:  nop
-  IL_002f:  ret
+  IL_0002:  dup
+  IL_0003:  stloc.0
+  IL_0004:  ldc.i4.0
+  IL_0005:  readonly.
+  IL_0007:  ldelema    "T"
+  IL_000c:  ldloc.0
+  IL_000d:  ldc.i4.0
+  IL_000e:  readonly.
+  IL_0010:  ldelema    "T"
+  IL_0015:  constrained. "T"
+  IL_001b:  callvirt   "Function IMoveable.get_Position() As Integer"
+  IL_0020:  ldarg.0
+  IL_0021:  ldc.i4.0
+  IL_0022:  ldelema    "T"
+  IL_0027:  call       "Function Program.GetOffset(Of T)(ByRef T) As Integer"
+  IL_002c:  add.ovf
+  IL_002d:  constrained. "T"
+  IL_0033:  callvirt   "Sub IMoveable.set_Position(Integer)"
+  IL_0038:  nop
+  IL_0039:  ret
 }
 ]]>)
         End Sub


### PR DESCRIPTION
### Customer scenario

Using a co-variant array element as an l-value results in `ArrayTypeMismatchException`.

```
object[] a = new string[] { "" };
a[0] += "";
```

### Bugs this fixes

[547533](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=547533)

### Workarounds, if any

Copy array element.
```
var s = a[0];
s += "";
a[0] = s;
```

### Risk

Low: Removes an optimization for array element l-values for compound assignment (C# and VB) and passing by reference (VB).

### Performance impact

Low: Removes an optimization for array element l-values for compound assignment (C# and VB) and passing by reference (VB).

### Is this a regression from a previous update?

Regression from Visual Studio 2013.

### How was the bug found?

Customer reported.

  
  