### PR TITLE
Update Pdb2Pdb to 1.1.0-beta1-62506-02

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -141,7 +141,7 @@
     <NuGetVisualStudioVersion>4.0.0-rc-2048</NuGetVisualStudioVersion>
     <NuSpecReferenceGeneratorVersion>1.4.2</NuSpecReferenceGeneratorVersion>
     <OctokitVersion>0.23.0</OctokitVersion>
-    <Pdb2PdbVersion>1.1.0-beta1-62301-01</Pdb2PdbVersion>
+    <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>
     <RestSharpVersion>105.2.3</RestSharpVersion>
     <RoslynBuildUtilVersion>0.9.8-beta</RoslynBuildUtilVersion>
     <RoslynDependenciesOptimizationDataVersion>2.6.0-beta1-62205-01</RoslynDependenciesOptimizationDataVersion>

--- a/build/Targets/RepoToolset/SymStore.targets
+++ b/build/Targets/RepoToolset/SymStore.targets
@@ -59,7 +59,7 @@ Update this file only if the change to RepoToolset gets approved and merged.
           Condition="'$(PublishOutputToSymStore)' == 'true' and ('$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded')">
 
     <PropertyGroup>
-      <_PdbConverterPath>$(NuGetPackageRoot)pdb2pdb\$(Pdb2PdbVersion)\tools\Pdb2Pdb.exe</_PdbConverterPath>
+      <_PdbConverterPath>$(NuGetPackageRoot)microsoft.diasymreader.pdb2pdb\$(MicrosoftDiaSymReaderPdb2PdbVersion)\tools\Pdb2Pdb.exe</_PdbConverterPath>
       <_PdbConverterCommandLineArgs>"$(TargetPath)" /out "$(_SymStorePdbPath)" /verbose</_PdbConverterCommandLineArgs>
     </PropertyGroup>
 

--- a/build/ToolsetPackages/RoslynToolset.csproj
+++ b/build/ToolsetPackages/RoslynToolset.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="xunit.analyzers" Version="$(xunitanalyzersVersion)" ExcludeAssets="all" />
     <PackageReference Include="xunit.runner.console" Version="$(xunitrunnerconsoleVersion)" ExcludeAssets="all" />
     <PackageReference Include="RoslynTools.ReferenceAssemblies" Version="$(RoslynToolsReferenceAssembliesVersion)" ExcludeAssets="all" />
-    <PackageReference Include="pdb2pdb" Version="$(Pdb2PdbVersion)" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="FakeSign" Version="$(FakeSignVersion)" ExcludeAssets="all" />


### PR DESCRIPTION
### Customer scenario

Updates PDB converter to the latest version. This new version includes SourceLink in the converted Windows PDBs along with legacy srcsvr info. The former is picked up by VS Debugger the latter by WinDBG (which ignores SourceLink). This change will allow to debug Roslyn with Windows PDBs without enabling legacy srcsvr in VS debugger options.

### Bugs this fixes

### Workarounds, if any

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?

  