### PR TITLE
Extend eligible params types to array generic interfaces and span

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2572,11 +2572,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static TypeSymbol GetCorrespondingParameterType(ref MemberAnalysisResult result, ImmutableArray<ParameterSymbol> parameters, int arg)
         {
             int paramNum = result.ParameterFromArgument(arg);
-            var type =
-                (paramNum == parameters.Length - 1 && result.Kind == MemberResolutionKind.ApplicableInExpandedForm) ?
-                ((ArrayTypeSymbol)parameters[paramNum].Type).ElementType :
-                parameters[paramNum].Type;
-            return type;
+            return (paramNum == parameters.Length - 1 && result.Kind == MemberResolutionKind.ApplicableInExpandedForm)
+                ? parameters[paramNum].Type.GetElementTypeOfParamsType()
+                : parameters[paramNum].Type;
         }
 
         private BoundExpression BindArrayCreationExpression(ArrayCreationExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -815,7 +815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Note: we need to confirm the "arrayness" on the original definition because
             // it's possible that the type becomes an array as a result of substitution.
             ParameterSymbol final = member.GetParameters().Last();
-            return final.IsParams && ((ParameterSymbol)final.OriginalDefinition).Type.IsSZArray();
+            return final.IsParams && final.OriginalDefinition.Type.IsPossibleParamsType();
         }
 
         private static bool IsOverride(Symbol overridden, Symbol overrider)
@@ -2874,7 +2874,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var refs = ArrayBuilder<RefKind>.GetInstance();
             bool anyRef = false;
             var parameters = member.GetParameters();
-            var elementType = ((ArrayTypeSymbol)parameters[parameters.Length - 1].Type).ElementType;
+            var paramsType = parameters[parameters.Length - 1].Type;
+            var elementType = paramsType.GetElementTypeOfParamsType();
             bool hasAnyRefArg = argumentRefKinds.Any();
             hasAnyRefOmittedArgument = false;
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -162,6 +162,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureIndexingMovableFixedBuffers = MessageBase + 12744,
         IDS_FeatureRecursivePatterns = MessageBase + 12745,
         IDS_FeatureNestedStackalloc = MessageBase + 12746,
+
+        IDS_FeatureParamsArrayInterfaceAndSpan = MessageBase + 12747,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -221,6 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // C# 8.0 features.
                 case MessageID.IDS_FeatureRecursivePatterns:
                 case MessageID.IDS_FeatureNestedStackalloc:
+                case MessageID.IDS_FeatureParamsArrayInterfaceAndSpan: // semantic check
                     return LanguageVersion.CSharp8;
 
                 // C# 7.3 features.

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -360,5 +360,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return self >= MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion();
         }
+
+        internal static bool AllowParamsArrayInterfaceAndSpan(this LanguageVersion self)
+        {
+            return self >= MessageID.IDS_FeatureParamsArrayInterfaceAndSpan.RequiredVersion();
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1551,9 +1551,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // That takes care of the first category of conflict; we detect the
                     // second and third categories as follows:
 
-                    var conversion = symbol as SourceUserDefinedConversionSymbol;
-                    var method = symbol as SourceMemberMethodSymbol;
-                    if ((object)conversion != null)
+                    if (symbol is SourceUserDefinedConversionSymbol conversion)
                     {
                         // Does this conversion collide *as a conversion* with any previously-seen
                         // conversion?
@@ -1584,7 +1582,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // Do not add the conversion to the set of previously-seen methods; that set
                         // is only non-conversion methods.
                     }
-                    else if ((object)method != null)
+                    else if (symbol is SourceMemberMethodSymbol method)
                     {
                         // Does this method collide *as a method* with any previously-seen
                         // conversion?

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ParamsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ParamsTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using System.Threading;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
+{
+    public class ParamsTests : CSharpTestBase
+    {
+        [Fact]
+        public void Test()
+        {
+            var source = @"
+using System;
+
+unsafe class C
+{
+	static void M(params Span<C> a) {}
+
+	public static void Main()
+	{
+		var x = new C();
+		M(x, x, x);
+	}
+}";
+
+            CreateCompilationWithMscorlibAndSpan(source, options: TestOptions.DebugExe.WithAllowUnsafe(true))
+                .VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void TestGoodParams()
+        {
+            var source = @"
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+
+static class C
+{
+    static void Dump(this IEnumerable p)
+    {
+        var e = p?.Cast<object>();
+        Console.WriteLine(e == null ? ""<null>"" : !e.Any() ? ""<empty>"" : string.Join("", "", e.Select(i => i ?? ""null"")));
+    }
+
+    static void M1(params IList<string> p) => p.Dump();
+    static void M2(params ICollection<string> p) => p.Dump();
+    static void M3(params IEnumerable<string> p) => p.Dump();
+    static void M4(params IReadOnlyList<string> p) => p.Dump();
+    static void M5(params IReadOnlyCollection<string> p) => p.Dump();
+
+    static void Main()
+    {
+        M1();
+        M1(null);
+        M1(null, null);
+        M1(""1"", ""2"", ""3"");
+
+        M2();
+        M2(null);
+        M2(null, null);
+        M2(""1"", ""2"", ""3"");
+
+        M3();
+        M3(null);
+        M3(null, null);
+        M3(""1"", ""2"", ""3"");
+
+        M4();
+        M4(null);
+        M4(null, null);
+        M4(""1"", ""2"", ""3"");
+
+        M5();
+        M5(null);
+        M5(null, null);
+        M5(""1"", ""2"", ""3"");
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, references: new[] { LinqAssemblyRef }, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: @"
+<empty>
+<null>
+null, null
+1, 2, 3
+<empty>
+<null>
+null, null
+1, 2, 3
+<empty>
+<null>
+null, null
+1, 2, 3
+<empty>
+<null>
+null, null
+1, 2, 3
+<empty>
+<null>
+null, null
+1, 2, 3
+");
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -423,11 +423,13 @@ namespace Microsoft.CodeAnalysis
 
         System_ObsoleteAttribute__ctor,
 
-        System_Span_T__ctor,
+        System_Span_T__ctor, // Span(void*, int)
+        System_Span_T__ctor2, // Span(T[])
         System_Span_T__get_Item,
         System_Span_T__get_Length,
 
-        System_ReadOnlySpan_T__ctor,
+        System_ReadOnlySpan_T__ctor, // ReadOnlySpan(void*, int)
+        System_ReadOnlySpan_T__ctor2, // ReadOnlySpan(T[])
         System_ReadOnlySpan_T__get_Item,
         System_ReadOnlySpan_T__get_Length,
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2919,7 +2919,7 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
-                     
+
                  // System_Span__ctor
                  (byte)(MemberFlags.Constructor),                                                                                                               // Flags
                  (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Span_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
@@ -2928,6 +2928,14 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                      (byte)SignatureTypeCode.Pointer, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_Span__ctor2
+                 (byte)(MemberFlags.Constructor),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Span_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     1,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.GenericTypeParameter, 0,
 
                  // System_Span__get_Item
                  (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
@@ -2952,6 +2960,14 @@ namespace Microsoft.CodeAnalysis
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                      (byte)SignatureTypeCode.Pointer, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_ReadOnlySpan__ctor2
+                 (byte)(MemberFlags.Constructor),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ReadOnlySpan_T - WellKnownType.ExtSentinel),                                              // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     1,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.GenericTypeParameter, 0,
 
                  // System_ReadOnlySpan__get_Item
                  (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
@@ -3396,9 +3412,11 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_ObsoleteAttribute__ctor
                 ".ctor",                                    // System_Span__ctor
+                ".ctor",                                    // System_Span__ctor2
                 "get_Item",                                 // System_Span__get_Item
                 "get_Length",                               // System_Span__get_Length
                 ".ctor",                                    // System_ReadOnlySpan__ctor
+                ".ctor",                                    // System_ReadOnlySpan__ctor2
                 "get_Item",                                 // System_ReadOnlySpan__get_Item
                 "get_Length",                               // System_ReadOnlySpan__get_Length
                 ".ctor",                                    // System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor


### PR DESCRIPTION
Championed issues: https://github.com/dotnet/csharplang/issues/179, https://github.com/dotnet/csharplang/issues/1757


open questions:

- do we want to forbid conflicting `params` overloads with identical element types? (otherwise all overloads would be always applicable in the expanded form and therefore ambiguous; note: the compiler wouldn't give ambiguous result for that case "for free", if we permit that, the overload resolution should be adjusted accordingly) -- this is now implemented in this prototype

Note: this is based on top of `nested-stackalloc` for spilling.