### PR TITLE
Skip pseudo-variables with use-site errors

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -331,6 +331,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                     _currentFrame,
                                     sourceAssembly,
                                     alias);
+                                // Skip pseudo-variables with errors.
+                                if (local.GetUseSiteDiagnostic()?.Severity == DiagnosticSeverity.Error)
+                                {
+                                    continue;
+                                }
                                 var methodName = GetNextMethodName(methodBuilder);
                                 var syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken));
                                 var aliasMethod = this.CreateMethod(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -242,6 +242,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                                 Dim methodName = GetNextMethodName(methodBuilder)
                                 Dim syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken))
                                 Dim local = PlaceholderLocalSymbol.Create(typeNameDecoder, _currentFrame, [alias])
+                                ' Skip pseudo-variables with errors.
+                                If local.GetUseSiteErrorInfo()?.Severity = DiagnosticSeverity.Error Then
+                                    Continue For
+                                End If
                                 Dim aliasMethod = Me.CreateMethod(
                                     container,
                                     methodName,


### PR DESCRIPTION
### Customer scenario

Locals window in the debugger is empty after stepping over method with unrecognized return type.

### Bugs this fixes

535899

### Workarounds, if any

Run to next statement rather than stepping.

### Risk

Low.

### Performance impact

None.

### Is this a regression from a previous update?

No.

### How was the bug found?

Customer reported.
