### PR TITLE
Offer 'in' as completion in operator

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/InKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/InKeywordRecommenderTests.cs
@@ -489,6 +489,30 @@ class C {
         }
 
         [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.ReadOnlyReferences)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(24079, "https://github.com/dotnet/roslyn/issues/24079")]
+        public async Task TestInAsParameterModifierInConversionOperators()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    public static explicit operator double($$) { }
+}");
+        }
+
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.ReadOnlyReferences)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(24079, "https://github.com/dotnet/roslyn/issues/24079")]
+        public async Task TestInAsParameterModifierInBinaryOperators()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    public static Program operator +($$) { }
+}");
+        }
+
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.ReadOnlyReferences)]
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInConstructorCallFirstArgumentModifier()
         {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/OutKeywordRecommenderTests.cs
@@ -239,6 +239,7 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(24079, "https://github.com/dotnet/roslyn/issues/24079")]
         public async Task TestNotAfterOperator()
         {
             await VerifyAbsenceAsync(

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/InKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/InKeywordRecommender.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 IsValidContextInForEachClause(context) ||
                 IsValidContextInFromClause(context, cancellationToken) ||
                 IsValidContextInJoinClause(context, cancellationToken) ||
-                syntaxTree.IsParameterModifierContext(position, context.LeftToken, cancellationToken) ||
+                syntaxTree.IsParameterModifierContext(position, context.LeftToken, cancellationToken, includeOperators: true) ||
                 syntaxTree.IsAnonymousMethodParameterModifierContext(position, context.LeftToken, cancellationToken) ||
                 syntaxTree.IsPossibleLambdaParameterModifierContext(position, context.LeftToken, cancellationToken) ||
                 context.TargetToken.IsConstructorOrMethodParameterArgumentContext() ||

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxNodeExtensions.cs
@@ -1,26 +1,32 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 {
     internal static class SyntaxNodeExtensions
     {
-        public static bool IsDelegateOrConstructorOrLocalFunctionOrMethodParameterList(this SyntaxNode node)
+        public static bool IsDelegateOrConstructorOrLocalFunctionOrMethodOrOperatorParameterList(this SyntaxNode node, bool includeOperators)
         {
             if (!node.IsKind(SyntaxKind.ParameterList))
             {
                 return false;
             }
 
-            return
-                node.IsParentKind(SyntaxKind.MethodDeclaration) ||
+            if (node.IsParentKind(SyntaxKind.MethodDeclaration) ||
                 node.IsParentKind(SyntaxKind.LocalFunctionStatement) ||
                 node.IsParentKind(SyntaxKind.ConstructorDeclaration) ||
-                node.IsParentKind(SyntaxKind.DelegateDeclaration);
+                node.IsParentKind(SyntaxKind.DelegateDeclaration))
+            {
+                return true;
+            }
+
+            if (includeOperators)
+            {
+                return
+                    node.IsParentKind(SyntaxKind.OperatorDeclaration) ||
+                    node.IsParentKind(SyntaxKind.ConversionOperatorDeclaration);
+            }
+
+            return false;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -978,6 +978,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             int position,
             SyntaxToken tokenOnLeftOfPosition,
             CancellationToken cancellationToken,
+            bool includeOperators = false,
             bool isThisKeyword = false)
         {
             // cases:
@@ -988,13 +989,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             token = token.GetPreviousTokenIfTouchingWord(position);
 
             if (token.IsKind(SyntaxKind.OpenParenToken) &&
-                token.Parent.IsDelegateOrConstructorOrLocalFunctionOrMethodParameterList())
+                token.Parent.IsDelegateOrConstructorOrLocalFunctionOrMethodOrOperatorParameterList(includeOperators))
             {
                 return true;
             }
 
             if (token.IsKind(SyntaxKind.CommaToken) &&
-                token.Parent.IsDelegateOrConstructorOrLocalFunctionOrMethodParameterList())
+                token.Parent.IsDelegateOrConstructorOrLocalFunctionOrMethodOrOperatorParameterList(includeOperators))
             {
                 if (isThisKeyword)
                 {
@@ -1010,7 +1011,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             if (token.IsKind(SyntaxKind.CloseBracketToken) &&
                 token.Parent.IsKind(SyntaxKind.AttributeList) &&
                 token.Parent.IsParentKind(SyntaxKind.Parameter) &&
-                token.Parent.GetParent().GetParent().IsDelegateOrConstructorOrLocalFunctionOrMethodParameterList())
+                token.Parent.GetParent().GetParent().IsDelegateOrConstructorOrLocalFunctionOrMethodOrOperatorParameterList(includeOperators))
             {
                 if (isThisKeyword)
                 {
@@ -1026,7 +1027,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             if (isThisKeyword &&
                 (token.IsKind(SyntaxKind.RefKeyword) || token.IsKind(SyntaxKind.InKeyword)) &&
-                token.Parent.GetParent().IsDelegateOrConstructorOrLocalFunctionOrMethodParameterList())
+                token.Parent.GetParent().IsDelegateOrConstructorOrLocalFunctionOrMethodOrOperatorParameterList(includeOperators))
             {
                 var parameter = token.GetAncestor<ParameterSyntax>();
                 var parameterList = parameter.GetAncestorOrThis<ParameterListSyntax>();


### PR DESCRIPTION
### Customer scenario
Type a custom operator. When you reach the parameters, `in` should be offered as a completion.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24079

### Workarounds, if any
Type `in` despite lack of completion.

### Risk
### Performance impact
Low. Adding a syntax kind check to a method that is used for recommending `in`. That method is only used by similar recommenders (`out` and such) and those skip the new logic.

### Is this a regression from a previous update?
No.

### How was the bug found?
Reported by customer.