### PR TITLE
Use correct type parameter binder for local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -179,7 +179,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     lazyAttributesStored = LoadAndValidateAttributes(
                         OneOrMany.Create(this.MergedAttributeDeclarationSyntaxLists),
-                        ref _lazyCustomAttributesBag);
+                        ref _lazyCustomAttributesBag,
+                        binderOpt: (ContainingSymbol as LocalFunctionSymbol)?.SignatureBinder);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -31,6 +31,71 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LocalFunctionTests : LocalFunctionsTestBase
     {
         [Fact]
+        public void LocalFunctionTypeParametersUseCorrectBinder()
+        {
+            var text = @"
+class C
+{
+    static void M()
+    {
+        void local<[X]T>() {}
+    }
+}";
+            var tree = SyntaxFactory.ParseSyntaxTree(text);
+            var comp = CreateStandardCompilation(tree);
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: true);
+
+            var newTree = SyntaxFactory.ParseSyntaxTree(text + " ");
+            var m = newTree.GetRoot()
+                .DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+
+            Assert.True(model.TryGetSpeculativeSemanticModelForMethodBody(m.Body.SpanStart, m, out model));
+
+            var x = newTree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Single();
+            // If we aren't using the right binder here, the compiler crashes going through the binder factory
+            var info = model.GetSymbolInfo(x);
+            Assert.Null(info.Symbol);
+
+            comp.VerifyDiagnostics(
+                // (6,20): error CS8205: Attributes are not allowed on local function parameters or type parameters
+                //         void local<[X]T>() {}
+                Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[X]").WithLocation(6, 20),
+                // (6,21): error CS0246: The type or namespace name 'XAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                //         void local<[X]T>() {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("XAttribute").WithLocation(6, 21),
+                // (6,21): error CS0246: The type or namespace name 'X' could not be found (are you missing a using directive or an assembly reference?)
+                //         void local<[X]T>() {}
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "X").WithArguments("X").WithLocation(6, 21),
+                // (6,14): warning CS8321: The local function 'local' is declared but never used
+                //         void local<[X]T>() {}
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "local").WithArguments("local").WithLocation(6, 14));
+        }
+
+        [Fact]
+        public void LocalFunctionAttribute()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(@"
+using System;
+class A : Attribute {}
+
+class C
+{
+    static void M()
+    {
+        void local<[A]T>() {}
+    }
+}");
+            var comp = CreateStandardCompilation(tree);
+            var model = comp.GetSemanticModel(tree);
+            var a = tree.GetRoot().DescendantNodes()
+                .OfType<IdentifierNameSyntax>().ElementAt(2);
+            var attrInfo = model.GetSymbolInfo(a);
+            Assert.Equal(
+                comp.GlobalNamespace.GetTypeMember("A").GetMember(".ctor"),
+                attrInfo.Symbol);
+        }
+
+        [Fact]
         public void UnsafeLocal()
         {
             var source = @"


### PR DESCRIPTION


### Customer scenario

Write a local function with an (incorrect) attribute reference 
on a type parameter of the local function. Then, below the
local function, hit Ctrl+Space to bring up completion. VS crashes.

### Bugs this fixes

Fixes #17814

### Workarounds, if any

Don't place attributes on type parameters of local functions, even by mistake.

### Risk

Low. We're already doing this for regular parameters, we just missed type parameters.

### Performance impact

None. An additional field access.

### Is this a regression from a previous update?

No. Present since shipping local functions in 15.0.

### Root cause analysis

This looks like simple oversight. The binder being used for type
parameters was retrieved from the binder factory since we didn't
explicitly pass one. For members this is correct since the binder
factory can be queried for top-level binders. This is not correct for
local functions because they use method body binders, which are not
accessible from the binder factory.

Mostly, this doesn't matter. The exception is when you try to
speculatively bind an attribute on a type parameter. Here, you need an
in-method binder and VS will crash if it's the wrong binder. This was
uncommon since attributes on type parameters are not permitted in local
functions, but VS should not crash.

Tests have been added for this case.

### How was the bug found?

Customer reported.
