### PR TITLE
UseExplicitType: Arrays/pointers/nullables of intrinsic types are intrinsic. …

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -299,6 +299,32 @@ class Program
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InArrayOfNullableIntrinsicType()
+        {
+            var before = @"
+class Program
+{
+    void Method(int?[] x)
+    {
+        [|var|] y = x;
+    }
+}";
+            var after = @"
+class Program
+{
+    void Method(int?[] x)
+    {
+        int?[] y = x;
+    }
+}";
+            // The type is intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
         public async Task InNullableCustomType()
         {
             var before = @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -221,6 +221,186 @@ class Program
         #endregion
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InArrayType()
+        {
+            var before = @"
+class Program
+{
+    void Method()
+    {
+        [|var|] x = new Program[0];
+    }
+}";
+            var after = @"
+class Program
+{
+    void Method()
+    {
+        Program[] x = new Program[0];
+    }
+}";
+            // The type is apparent and not intrinsic
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ExplicitTypeForBuiltInTypesOnly()));
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ExplicitTypeExceptWhereApparent()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InArrayTypeWithIntrinsicType()
+        {
+            var before = @"
+class Program
+{
+    void Method()
+    {
+        [|var|] x = new int[0];
+    }
+}";
+            var after = @"
+class Program
+{
+    void Method()
+    {
+        int[] x = new int[0];
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent()); // preference for builtin types dominates
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InNullableIntrinsicType()
+        {
+            var before = @"
+class Program
+{
+    void Method(int? x)
+    {
+        [|var|] y = x;
+    }
+}";
+            var after = @"
+class Program
+{
+    void Method(int? x)
+    {
+        int? y = x;
+    }
+}";
+            // The type is intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InNullableCustomType()
+        {
+            var before = @"
+struct Program
+{
+    void Method(Program? x)
+    {
+        [|var|] y = x;
+    }
+}";
+            var after = @"
+struct Program
+{
+    void Method(Program? x)
+    {
+        Program? y = x;
+    }
+}";
+            // The type is not intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ExplicitTypeForBuiltInTypesOnly()));
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InPointerTypeWithIntrinsicType()
+        {
+            var before = @"
+unsafe class Program
+{
+    void Method(int* y)
+    {
+        [|var|] x = y;
+    }
+}";
+            var after = @"
+unsafe class Program
+{
+    void Method(int* y)
+    {
+        int* x = y;
+    }
+}";
+            // The type is intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent()); // preference for builtin types dominates
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
+        public async Task InPointerTypeWithCustomType()
+        {
+            var before = @"
+unsafe class Program
+{
+    void Method(Program* y)
+    {
+        [|var|] x = y;
+    }
+}";
+            var after = @"
+unsafe class Program
+{
+    void Method(Program* y)
+    {
+        Program* x = y;
+    }
+}";
+            // The type is not intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ExplicitTypeForBuiltInTypesOnly()));
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
+        public async Task InOutParameter()
+        {
+            var before = @"
+class Program
+{
+    void Method(out int x)
+    {
+        Method(out [|var|] x);
+    }
+}";
+            var after = @"
+class Program
+{
+    void Method(out int x)
+    {
+        Method(out int x);
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeForBuiltInTypesOnly());
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeExceptWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnDynamic()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1086,6 +1266,7 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(23907, "https://github.com/dotnet/roslyn/issues/23907")]
         public async Task SuggestExplicitTypeNotificationLevelWarning()
         {
             var source =
@@ -1094,7 +1275,7 @@ class C
 {
     static void M()
     {
-        [|var|] n1 = new[] {2, 4, 6, 8};
+        [|var|] n1 = new[] { new C() }; // type not apparent and not intrinsic
     }
 }";
             await TestDiagnosticInfoAsync(source,

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1771,7 +1771,7 @@ options: ImplicitTypeEverywhere());
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
-        public async Task SuggestVarOnDeclarationExpressionSyntaxWithIntrinsicType()
+        public async Task DoNotSuggestVarOnDeclarationExpressionSyntaxWithIntrinsicType()
         {
             var before =
 @"class C

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1482,7 +1482,7 @@ class C
 {
     static void M()
     {
-        [|int[]|] n1 = new[] {2, 4, 6, 8};
+        [|C[]|] n1 = new[] { new C() }; // type not apparent and not intrinsic
     }
 }";
             await TestDiagnosticInfoAsync(source,
@@ -1507,6 +1507,45 @@ class C
                 options: ImplicitTypeEnforcements(),
                 diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Error);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
+        public async Task SuggestVarOnLocalWithIntrinsicArrayType()
+        {
+            var before = @"class C { static void M() { [|int[]|] s = new int[0]; } }";
+            var after = @"class C { static void M() { var s = new int[0]; } }";
+
+            //The type is intrinsic and apparent
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeButKeepIntrinsics()));
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparent())); // Preference of intrinsic types dominates
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
+        public async Task SuggestVarOnLocalWithCustomArrayType()
+        {
+            var before = @"class C { static void M() { [|C[]|] s = new C[0]; } }";
+            var after = @"class C { static void M() { var s = new C[0]; } }";
+
+            //The type is not intrinsic but apparent
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeButKeepIntrinsics());
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
+        public async Task SuggestVarOnLocalWithNonApparentCustomArrayType()
+        {
+            var before = @"class C { static void M() { [|C[]|] s = new[] { new C() }; } }";
+            var after = @"class C { static void M() { var s = new[] { new C() }; } }";
+
+            //The type is not intrinsic and not apparent
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeButKeepIntrinsics());
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparent()));
         }
 
         private static string trivial2uple =
@@ -1728,6 +1767,21 @@ class C
     }
 }",
 options: ImplicitTypeEverywhere());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(23893, "https://github.com/dotnet/roslyn/issues/23893")]
+        public async Task SuggestVarOnDeclarationExpressionSyntaxWithIntrinsicType()
+        {
+            var before =
+@"class C
+{
+    static void M(out int x)
+    {
+        M([|out int|] x);
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeButKeepIntrinsics()));
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -108,24 +108,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                     return false;
                 }
 
-                type = type.RemoveNullableIfPresent();
-
-                if (type.IsSpecialType())
+                while (true)
                 {
-                    return true;
-                }
+                    type = type.RemoveNullableIfPresent();
 
-                if (type.IsArrayType())
-                {
-                    return IsMadeOfSpecialTypes(((IArrayTypeSymbol)type).ElementType);
-                }
+                    if (type.IsArrayType())
+                    {
+                        type = ((IArrayTypeSymbol)type).ElementType;
+                        continue;
+                    }
 
-                if (type.IsPointerType())
-                {
-                    return IsMadeOfSpecialTypes(((IPointerTypeSymbol)type).PointedAtType);
-                }
+                    if (type.IsPointerType())
+                    {
+                        type = ((IPointerTypeSymbol)type).PointedAtType;
+                        continue;
+                    }
 
-                return false;
+                    return type.IsSpecialType();
+                }
             }
 
             private bool IsInferredPredefinedType(SyntaxNode declarationStatement, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -94,8 +94,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var typeSyntax = GetTypeSyntaxFromDeclaration(declarationStatement);
 
                 return typeSyntax != null
-                    ? semanticModel.GetTypeInfo(typeSyntax).Type?.IsSpecialType() == true
+                    ? IsMadeOfSpecialTypes(semanticModel.GetTypeInfo(typeSyntax).Type)
                     : false;
+            }
+
+            /// <summary>
+            /// Returns true for type that are arrays/nullable/pointer types of special types
+            /// </summary>
+            private bool IsMadeOfSpecialTypes(ITypeSymbol type)
+            {
+                if (type == null)
+                {
+                    return false;
+                }
+
+                type = type.RemoveNullableIfPresent();
+
+                if (type.IsSpecialType())
+                {
+                    return true;
+                }
+
+                if (type.IsArrayType())
+                {
+                    return IsMadeOfSpecialTypes(((IArrayTypeSymbol)type).ElementType);
+                }
+
+                if (type.IsPointerType())
+                {
+                    return IsMadeOfSpecialTypes(((IPointerTypeSymbol)type).PointedAtType);
+                }
+
+                return false;
             }
 
             private bool IsInferredPredefinedType(SyntaxNode declarationStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -109,13 +139,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             private TypeSyntax GetTypeSyntaxFromDeclaration(SyntaxNode declarationStatement)
             {
-                if (declarationStatement is VariableDeclarationSyntax varDecl)
+                switch (declarationStatement)
                 {
-                    return varDecl.Type;
-                }
-                else if (declarationStatement is ForEachStatementSyntax forEach)
-                {
-                    return forEach.Type;
+                    case VariableDeclarationSyntax varDecl:
+                        return varDecl.Type;
+                    case ForEachStatementSyntax forEach:
+                        return forEach.Type;
+                    case DeclarationExpressionSyntax declExpr:
+                        return declExpr.Type;
                 }
 
                 return null;

--- a/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
 
             // constructor invocations cases:
             //      = new type();
-            if (initializerExpression.IsKind(SyntaxKind.ObjectCreationExpression) &&
+            if (initializerExpression.IsKind(SyntaxKind.ObjectCreationExpression, SyntaxKind.ArrayCreationExpression) &&
                 !initializerExpression.IsKind(SyntaxKind.AnonymousObjectCreationExpression))
             {
                 return true;


### PR DESCRIPTION
…Type of array creations is apparent. Handle out vars.

### Customer scenario
The Use Implicit/Explicit Type fixers should:
- treat arrays/pointers/nullables of intrinsic types as intrinsic,
- treat array creations as having an apparent type,
- recognize intrinsic types in declaration expressions (out vars).

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/23893
Fixes https://github.com/dotnet/roslyn/issues/23907

### Workarounds, if any
Apply the code style preferences manually.

### Risk
~~New algorithm is recursive, and could lead to a stack overflow for deeply recursive types. However, it is my understanding that the code is not expected to be hardened against this condition, and the bound vastly exceeds the requirements of "usable types".~~ (Recursion eliminated in 54c2b2d.)

The primary risk involves the possibility of issues filed in response to an observable change in IDE behavior. However, several team members agree that the new behavior better reflects the intent of options currently available to users, and we always have the ability to add options in the future. Tests have been added to cover a wide range of configurations and edge cases surrounding this change, so deviations from the new implementation are unlikely to go unnoticed.

These code style rules are not available during builds at this time, so there is no impact to compilation results regardless of user configuration.

### Performance impact
Expected to be very low. One section of the code was previously O(1) for pointer and array types, and is now O(n) where *n* is the number of dimensions in a jagged array. The compiler already contained similar algorithms for these types, and this code would be lower overhead than the other code.

### Is this a regression from a previous update?
No

### How was the bug found?
Reported by customer and internal team member.
  
  
  