### PR TITLE
The argument that stands for the receiver of a `ref` extension method must be always passed as `ref`

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -440,6 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal BoundObjectCreationExpression UpdateArgumentsAndInitializer(
             ImmutableArray<BoundExpression> newArguments,
+            ImmutableArray<RefKind> newRefKinds,
             BoundExpression newInitializerExpression,
             TypeSymbol changeTypeOpt = null)
         {
@@ -447,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 constructor: Constructor,
                 arguments: newArguments,
                 argumentNamesOpt: default(ImmutableArray<string>),
-                argumentRefKindsOpt: ArgumentRefKindsOpt,
+                argumentRefKindsOpt: newRefKinds,
                 expanded: false,
                 argsToParamsOpt: default(ImmutableArray<int>),
                 constantValueOpt: ConstantValueOpt,

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -6,8 +6,9 @@ using System.Diagnostics;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
+
+using static System.Linq.ImmutableArrayExtensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 {
@@ -813,32 +814,42 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private void EmitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> refKindsOpt)
+        private void EmitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<ParameterSymbol> parameters, ImmutableArray<RefKind> argRefKindsOpt)
         {
             // We might have an extra argument for the __arglist() of a varargs method.
             Debug.Assert(arguments.Length == parameters.Length || arguments.Length == parameters.Length + 1, "argument count must match parameter count");
+            Debug.Assert(parameters.All(p => p.RefKind == RefKind.None) || !argRefKindsOpt.IsDefault, "there are nontrivial parameters, so we must have argRefKinds");
+            Debug.Assert(argRefKindsOpt.IsDefault || argRefKindsOpt.Length == arguments.Length, "if we have argRefKinds, we should have one for each argument");
+
             for (int i = 0; i < arguments.Length; i++)
             {
-                RefKind refKind;
+                RefKind argRefKind;
 
-                if (!refKindsOpt.IsDefault && i < refKindsOpt.Length)
+                if (i < parameters.Length)
                 {
-                    // if we have an explicit refKind for the given argument, use that
-                    refKind = refKindsOpt[i];
-                }
-                else if (i < parameters.Length)
-                {
-                    // otherwise check the parameter
-                    refKind = parameters[i].RefKind;
+                    if (!argRefKindsOpt.IsDefault && i < argRefKindsOpt.Length)
+                    {
+                        // if we have an explicit refKind for the given argument, use that
+                        argRefKind = argRefKindsOpt[i];
+
+                        Debug.Assert(argRefKind == parameters[i].RefKind ||
+                                argRefKind == RefKindExtensions.StrictIn && parameters[i].RefKind == RefKind.In,
+                                "in Emit the argument RefKind must be compatible with the corresponding parameter");
+                    }
+                    else
+                    {
+                        // otherwise fallback to the refKind of the parameter
+                        argRefKind = parameters[i].RefKind;
+                    }
                 }
                 else
                 {
                     // vararg case
                     Debug.Assert(arguments[i].Kind == BoundKind.ArgListOperator);
-                    refKind = RefKind.None;
+                    argRefKind = RefKind.None;
                 }
 
-                EmitArgument(arguments[i], refKind);
+                EmitArgument(arguments[i], argRefKind);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -811,7 +811,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol localFunc,
             out BoundExpression receiver,
             out MethodSymbol method,
-            ref ImmutableArray<BoundExpression> parameters)
+            ref ImmutableArray<BoundExpression> arguments,
+            ref ImmutableArray<RefKind> argRefKinds)
         {
             Debug.Assert(localFunc.MethodKind == MethodKind.LocalFunction);
 
@@ -823,12 +824,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var frameCount = loweredSymbol.ExtraSynthesizedParameterCount;
             if (frameCount != 0)
             {
-                Debug.Assert(!parameters.IsDefault);
+                Debug.Assert(!arguments.IsDefault);
 
-                // Build a new list of parameters to pass to the local function
+                // Build a new list of arguments to pass to the local function
                 // call that includes any necessary capture frames
-                var parametersBuilder = ArrayBuilder<BoundExpression>.GetInstance();
-                parametersBuilder.AddRange(parameters);
+                var argumetsBuilder = ArrayBuilder<BoundExpression>.GetInstance(loweredSymbol.ParameterCount);
+                argumetsBuilder.AddRange(arguments);
 
                 var start = loweredSymbol.ParameterCount - frameCount;
                 for (int i = start; i < loweredSymbol.ParameterCount; i++)
@@ -847,9 +848,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     var frame = FrameOfType(syntax, frameType);
-                    parametersBuilder.Add(frame);
+                    argumetsBuilder.Add(frame);
                 }
-                parameters = parametersBuilder.ToImmutableAndFree();
+
+                // frame arguments are passed by ref
+                // add corresponding refkinds
+                var refkindsBuilder = ArrayBuilder<RefKind>.GetInstance(argumetsBuilder.Count);
+                if (!argRefKinds.IsDefault)
+                {
+                    refkindsBuilder.AddRange(argRefKinds);
+                }
+                else
+                {
+                    refkindsBuilder.AddMany(RefKind.None, arguments.Length);
+                }
+
+                refkindsBuilder.AddMany(RefKind.Ref, frameCount);
+
+                arguments = argumetsBuilder.ToImmutableAndFree();
+                argRefKinds = refkindsBuilder.ToImmutableAndFree();
             }
 
             method = loweredSymbol;
@@ -989,21 +1006,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.Method.MethodKind == MethodKind.LocalFunction)
             {
                 var args = VisitList(node.Arguments);
+                var argRefKinds = node.ArgumentRefKindsOpt;
                 var type = VisitType(node.Type);
+
+                Debug.Assert(node.ArgsToParamsOpt.IsDefault, "should be done with argument reordering by now");
 
                 RemapLocalFunction(
                     node.Syntax,
                     node.Method,
                     out var receiver,
                     out var method,
-                    ref args);
+                    ref args,
+                    ref argRefKinds);
 
                 return node.Update(
                     receiver,
                     method,
                     args,
                     node.ArgumentNamesOpt,
-                    node.ArgumentRefKindsOpt,
+                    argRefKinds,
                     node.IsDelegateCall,
                     node.Expanded,
                     node.InvokedAsExtensionMethod,
@@ -1256,12 +1277,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
             {
                 var arguments = default(ImmutableArray<BoundExpression>);
+                var argRefKinds = default(ImmutableArray<RefKind>);
+
                 RemapLocalFunction(
                     node.Syntax,
                     node.MethodOpt,
                     out var receiver,
                     out var method,
-                    ref arguments);
+                    ref arguments,
+                    ref argRefKinds);
 
                 return new BoundDelegateCreationExpression(
                     node.Syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -828,8 +828,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Build a new list of arguments to pass to the local function
                 // call that includes any necessary capture frames
-                var argumetsBuilder = ArrayBuilder<BoundExpression>.GetInstance(loweredSymbol.ParameterCount);
-                argumetsBuilder.AddRange(arguments);
+                var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(loweredSymbol.ParameterCount);
+                argumentsBuilder.AddRange(arguments);
 
                 var start = loweredSymbol.ParameterCount - frameCount;
                 for (int i = start; i < loweredSymbol.ParameterCount; i++)
@@ -848,12 +848,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     var frame = FrameOfType(syntax, frameType);
-                    argumetsBuilder.Add(frame);
+                    argumentsBuilder.Add(frame);
                 }
 
                 // frame arguments are passed by ref
                 // add corresponding refkinds
-                var refkindsBuilder = ArrayBuilder<RefKind>.GetInstance(argumetsBuilder.Count);
+                var refkindsBuilder = ArrayBuilder<RefKind>.GetInstance(argumentsBuilder.Count);
                 if (!argRefKinds.IsDefault)
                 {
                     refkindsBuilder.AddRange(argRefKinds);
@@ -865,7 +865,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 refkindsBuilder.AddMany(RefKind.Ref, frameCount);
 
-                arguments = argumetsBuilder.ToImmutableAndFree();
+                arguments = argumentsBuilder.ToImmutableAndFree();
                 argRefKinds = refkindsBuilder.ToImmutableAndFree();
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Optimize away unnecessary temporaries.
             // Necessary temporaries have their store instructions merged into the appropriate 
             // argument expression.
-            OptimizeTemporaries(actualArguments, refKinds, storesToTemps, temporariesBuilder);
+            OptimizeTemporaries(actualArguments, storesToTemps, temporariesBuilder);
 
             // Step two: If we have a params array, build the array and fill in the argument.
             if (expanded)
@@ -942,19 +942,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void OptimizeTemporaries(
             BoundExpression[] arguments,
-            ArrayBuilder<RefKind> refKinds,
             ArrayBuilder<BoundAssignmentOperator> storesToTemps,
             ArrayBuilder<LocalSymbol> temporariesBuilder)
         {
             Debug.Assert(arguments != null);
-            Debug.Assert(refKinds != null);
-            Debug.Assert(arguments.Length == refKinds.Count);
             Debug.Assert(storesToTemps != null);
             Debug.Assert(temporariesBuilder != null);
 
             if (storesToTemps.Count > 0)
             {
-                int tempsNeeded = MergeArgumentsAndSideEffects(arguments, refKinds, storesToTemps);
+                int tempsNeeded = MergeArgumentsAndSideEffects(arguments,storesToTemps);
                 if (tempsNeeded > 0)
                 {
                     foreach (BoundAssignmentOperator s in storesToTemps)
@@ -975,11 +972,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private static int MergeArgumentsAndSideEffects(
             BoundExpression[] arguments,
-            ArrayBuilder<RefKind> refKinds,
             ArrayBuilder<BoundAssignmentOperator> tempStores)
         {
             Debug.Assert(arguments != null);
-            Debug.Assert(refKinds != null);
             Debug.Assert(tempStores != null);
 
             int tempsRemainedInUse = tempStores.Count;
@@ -1024,11 +1019,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (correspondingStore != -1)
                     {
                         var value = tempStores[correspondingStore].Right;
-
-                        // When we created the temp, we dropped the argument RefKind
-                        // since the local contained its own RefKind. Since we're removing
-                        // the temp, the argument RefKind needs to be restored.
-                        refKinds[a] = ((BoundLocal)argument).LocalSymbol.RefKind;
 
                         // the matched store will not need to go into side-effects, only ones before it will
                         // remove the store to signal that we are not using its temp.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     throw ExceptionUtilities.UnexpectedValue(temps.Length);
                 }
 
-                rewrittenObjectCreation = node.UpdateArgumentsAndInitializer(rewrittenArguments, MakeObjectCreationInitializerForExpressionTree(node.InitializerExpressionOpt), changeTypeOpt: node.Constructor.ContainingType);
+                rewrittenObjectCreation = node.UpdateArgumentsAndInitializer(rewrittenArguments, argumentRefKindsOpt, MakeObjectCreationInitializerForExpressionTree(node.InitializerExpressionOpt), changeTypeOpt: node.Constructor.ContainingType);
 
                 if (node.Type.IsInterfaceType())
                 {
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return rewrittenObjectCreation;
             }
 
-            rewrittenObjectCreation = node.UpdateArgumentsAndInitializer(rewrittenArguments, newInitializerExpression: null, changeTypeOpt: node.Constructor.ContainingType);
+            rewrittenObjectCreation = node.UpdateArgumentsAndInitializer(rewrittenArguments, argumentRefKindsOpt, newInitializerExpression: null, changeTypeOpt: node.Constructor.ContainingType);
 
             // replace "new S()" with a default struct ctor with "default(S)"
             if (node.Constructor.IsDefaultValueTypeConstructor())

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -632,9 +632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundCall Call(BoundExpression receiver, MethodSymbol method, ImmutableArray<BoundExpression> args)
         {
             Debug.Assert(method.ParameterCount == args.Length);
+
             return new BoundCall(
                 Syntax, receiver, method, args,
-                default(ImmutableArray<String>), default(ImmutableArray<RefKind>), false, false, false,
+                default(ImmutableArray<String>), method.ParameterRefKinds, false, false, false,
                 default(ImmutableArray<int>), LookupResultKind.Viable, null, method.ReturnType,
                 hasErrors: method.OriginalDefinition is ErrorMethodSymbol)
             { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2595,6 +2595,12 @@ public static class Extensions
                 // (8,9): error CS1510: A ref or out value must be an assignable variable
                 //         (global, global) = global;
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(global, global) = global").WithLocation(8, 9),
+                // (8,9): error CS8352: Cannot use local '(global, global) = global' in this context because it may expose referenced variables outside of their declaration scope
+                //         (global, global) = global;
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "(global, global) = global").WithArguments("(global, global) = global").WithLocation(8, 9),
+                // (8,28): error CS8350: This combination of arguments to 'Extensions.Deconstruct(ref Span<int>, out Span<int>, out Span<int>)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
+                //         (global, global) = global;
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "global").WithArguments("Extensions.Deconstruct(ref System.Span<int>, out System.Span<int>, out System.Span<int>)", "x").WithLocation(8, 28),
                 // (8,28): error CS8129: No suitable Deconstruct instance or extension method was found for type 'Span<int>', with 2 out parameters and a void return type.
                 //         (global, global) = global;
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "global").WithArguments("System.Span<int>", "2").WithLocation(8, 28),


### PR DESCRIPTION
### Customer scenario

There are couple of code patterns that could result in incorrect IL emitted.
The cause is the same - we are losing ref-ness of the argument and attempt to pass an argument by value when targeting a byref parameter.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/23692
https://github.com/dotnet/roslyn/issues/24014

### Workarounds, if any

There is no workaround. User needs to change the code to not be affected by the bugs.

### Risk

Risk is low since the scenarios are in specific combinations of features.
Otherwise the behavior is correct and stays the same.

### Performance impact

Low perf impact because no extra allocations/no complexity changes.

### Is this a regression from a previous update?

No

### Root cause analysis

In the past the refKind of the argument at the call site was not always used in emit. As a result, some scenarios where the argument refKind was not set/preserved correctly or mismatched could be tolerated. With introduction of `in` arguments, the code was refactored to rely on refKinds in more cases and scenarios where refKinds are incorrect caused these failures.

Additional asserts were added to detect cases when argument refKinds happen to be in  inconsistent state with the refKind of the target parameters when we reach Emit phase.

Several benign (or lucky) cases of inconsistency were discovered via the asserts and fixed. 
(I.E. allowing occasional mismatch between `ref` and `out`, although not impacting IL right now, is unexpected and fragile since it may hide other bugs in lowering, fixed)

### How was the bug found?

Customer reported.

### Test documentation updated?

N/A

  