### PR TITLE
Recommend "when" keyword after case-pattern-switch-label

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 }
                 else
                 {
-                    var result = (await RecommendKeywordsAsync(position, context)).Single();
-                    Assert.NotNull(result);
+                    var result = (await RecommendKeywordsAsync(position, context))?.Single();
+                    Assert.True(result != null, "No recommended keywords");
                     Assert.Equal(keywordText, result.Keyword);
                     if (matchPriority != null)
                     {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                 }
                 else
                 {
-                    var result = (await RecommendKeywordsAsync(position, context))?.Single();
+                    var result = (await RecommendKeywordsAsync(position, context)).Single();
                     Assert.True(result != null, "No recommended keywords");
                     Assert.Equal(keywordText, result.Keyword);
                     if (matchPriority != null)

--- a/src/EditorFeatures/CSharpTest2/Recommendations/WhenKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/WhenKeywordRecommenderTests.cs
@@ -63,5 +63,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             await VerifyAbsenceAsync(AddInsideMethod(
 @"try {} catch (Exception e) when (true) $$"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(24113, "https://github.com/dotnet/roslyn/issues/24113")]
+        public async Task TestInCasePattern()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"switch (1) { case int i $$ }"));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
@@ -20,13 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             }
 
             // case int i $$
-            if (IsIdentifierInCasePattern(context.LeftToken.Parent))
-            {
-                return true;
-            }
-
             // case int i w$$
-            if (IsIdentifierInCasePattern(context.LeftToken.GetPreviousToken().Parent))
+            if (IsIdentifierInCasePattern(context.TargetToken.Parent))
             {
                 return true;
             }
@@ -37,8 +33,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         private static bool IsIdentifierInCasePattern(SyntaxNode node)
         {
             return node.IsKind(SyntaxKind.SingleVariableDesignation)
-                && node.Parent.IsKind(SyntaxKind.DeclarationPattern)
-                && node.Parent.Parent.IsKind(SyntaxKind.CasePatternSwitchLabel);
+                && node.IsParentKind(SyntaxKind.DeclarationPattern)
+                && node.Parent.IsParentKind(SyntaxKind.CasePatternSwitchLabel);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/WhenKeywordRecommender.cs
@@ -14,7 +14,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            return context.IsCatchFilterContext;
+            if (context.IsCatchFilterContext)
+            {
+                return true;
+            }
+
+            // case int i $$
+            if (IsIdentifierInCasePattern(context.LeftToken.Parent))
+            {
+                return true;
+            }
+
+            // case int i w$$
+            if (IsIdentifierInCasePattern(context.LeftToken.GetPreviousToken().Parent))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsIdentifierInCasePattern(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.SingleVariableDesignation)
+                && node.Parent.IsKind(SyntaxKind.DeclarationPattern)
+                && node.Parent.Parent.IsKind(SyntaxKind.CasePatternSwitchLabel);
         }
     }
 }


### PR DESCRIPTION
### Customer scenario
Type a switch/case with a pattern, such as `case DeclarationExpressionSyntax declExpr $$`. At this point, `when` should be offered as a completion.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24113

### Workarounds, if any
Type "when" manually.

### Risk
### Performance impact
Low. The change only impacts the when keyword recommender and only adds a couple of kind checks on the syntax.

### Is this a regression from a previous update?
No

### How was the bug found?
Reported by me. Discovered by typing such code.