### PR TITLE
Suppress 'IDE0041 Null check can be simplified' for unconstraint generic parameters.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -36,7 +36,7 @@ class C
 {
     void M(string s)
     {
-        if (s == null)
+        if (s is null)
             return;
     }
 }");
@@ -62,7 +62,7 @@ class C
 {
     void M(string s)
     {
-        if (s == null)
+        if (s is null)
             return;
     }
 }");
@@ -88,7 +88,7 @@ class C
 {
     void M(string s)
     {
-        if (s == null)
+        if (s is null)
             return;
     }
 }");
@@ -114,7 +114,7 @@ class C
 {
     void M(string s)
     {
-        if (s == null)
+        if (s is null)
             return;
     }
 }");
@@ -140,7 +140,7 @@ class C
 {
     void M(string s)
     {
-        if (s != null)
+        if (!(s is null))
             return;
     }
 }");
@@ -183,8 +183,8 @@ class C
 {
     void M(string s1, string s2)
     {
-        if (s1 == null ||
-            s2 == null)
+        if (s1 is null ||
+            s2 is null)
             return;
     }
 }");
@@ -211,8 +211,8 @@ class C
 {
     void M(string s1, string s2)
     {
-        if (s1 == null ||
-            s2 == null)
+        if (s1 is null ||
+            s2 is null)
             return;
     }
 }");
@@ -220,7 +220,7 @@ class C
 
         [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
-        public async Task TestMissingIfValueParameterTypeIsUnconstraintGeneric()
+        public async Task TestValueParameterTypeIsUnconstraintGeneric()
         {
             await TestInRegularAndScriptAsync(
 @"
@@ -270,7 +270,7 @@ class C
 {
     public static void NotNull<T>(T value) where T:class
     {
-        if (value == null)
+        if (value is null)
         {
             return;
         }

--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -226,22 +226,22 @@ class C
 @"
 class C
 {
-    public static void NotNull<T>(T value, string parameterName)
+    public static void NotNull<T>(T value)
     {
         if ([||]ReferenceEquals(value, null))
         {
-            throw new System.ArgumentNullException(parameterName);
+            return;
         }
     }
 }
 ", @"
 class C
 {
-    public static void NotNull<T>(T value, string parameterName)
+    public static void NotNull<T>(T value)
     {
         if (value == null)
         {
-            throw new System.ArgumentNullException(parameterName);
+            return;
         }
     }
 }
@@ -250,17 +250,17 @@ class C
 
         [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
-        public async Task TestValueParameterTypeIsConstraintGeneric()
+        public async Task TestValueParameterTypeIsRefConstraintGeneric()
         {
             await TestInRegularAndScriptAsync(
 @"
 class C
 {
-    public static void NotNull<T>(T value, string parameterName) where T:class
+    public static void NotNull<T>(T value) where T:class
     {
         if ([||]ReferenceEquals(value, null))
         {
-            throw new System.ArgumentNullException(parameterName);
+            return;
         }
     }
 }
@@ -268,11 +268,30 @@ class C
 @"
 class C
 {
-    public static void NotNull<T>(T value, string parameterName) where T:class
+    public static void NotNull<T>(T value) where T:class
     {
         if (value == null)
         {
-            throw new System.ArgumentNullException(parameterName);
+            return;
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestValueParameterTypeIsValueConstraintGeneric()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    public static void NotNull<T>(T value) where T:struct
+    {
+        if ([||]ReferenceEquals(value, null))
+        {
+            return;
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -220,7 +220,7 @@ class C
 
         [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
-        public async Task TestValueParameterTypeIsUnconstraintGeneric()
+        public async Task TestValueParameterTypeIsUnconstrainedGeneric()
         {
             await TestInRegularAndScriptAsync(
 @"

--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -36,7 +36,7 @@ class C
 {
     void M(string s)
     {
-        if (s is null)
+        if (s == null)
             return;
     }
 }");
@@ -62,7 +62,7 @@ class C
 {
     void M(string s)
     {
-        if (s is null)
+        if (s == null)
             return;
     }
 }");
@@ -88,7 +88,7 @@ class C
 {
     void M(string s)
     {
-        if (s is null)
+        if (s == null)
             return;
     }
 }");
@@ -114,7 +114,7 @@ class C
 {
     void M(string s)
     {
-        if (s is null)
+        if (s == null)
             return;
     }
 }");
@@ -140,7 +140,7 @@ class C
 {
     void M(string s)
     {
-        if (!(s is null))
+        if (s != null)
             return;
     }
 }");
@@ -183,8 +183,8 @@ class C
 {
     void M(string s1, string s2)
     {
-        if (s1 is null ||
-            s2 is null)
+        if (s1 == null ||
+            s2 == null)
             return;
     }
 }");
@@ -211,8 +211,8 @@ class C
 {
     void M(string s1, string s2)
     {
-        if (s1 is null ||
-            s2 is null)
+        if (s1 == null ||
+            s2 == null)
             return;
     }
 }");
@@ -222,13 +222,24 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
         public async Task TestMissingIfValueParameterTypeIsUnconstraintGeneric()
         {
-            await TestMissingAsync(
+            await TestInRegularAndScriptAsync(
 @"
 class C
 {
     public static void NotNull<T>(T value, string parameterName)
     {
         if ([||]ReferenceEquals(value, null))
+        {
+            throw new System.ArgumentNullException(parameterName);
+        }
+    }
+}
+", @"
+class C
+{
+    public static void NotNull<T>(T value, string parameterName)
+    {
+        if (value == null)
         {
             throw new System.ArgumentNullException(parameterName);
         }
@@ -259,7 +270,7 @@ class C
 {
     public static void NotNull<T>(T value, string parameterName) where T:class
     {
-        if (value is null)
+        if (value == null)
         {
             throw new System.ArgumentNullException(parameterName);
         }

--- a/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIsNullCheck/UseIsNullCheckTests.cs
@@ -217,5 +217,55 @@ class C
     }
 }");
         }
+
+        [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestMissingIfValueParameterTypeIsUnconstraintGeneric()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    public static void NotNull<T>(T value, string parameterName)
+    {
+        if ([||]ReferenceEquals(value, null))
+        {
+            throw new System.ArgumentNullException(parameterName);
+        }
+    }
+}
+");
+        }
+
+        [WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestValueParameterTypeIsConstraintGeneric()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    public static void NotNull<T>(T value, string parameterName) where T:class
+    {
+        if ([||]ReferenceEquals(value, null))
+        {
+            throw new System.ArgumentNullException(parameterName);
+        }
+    }
+}
+",
+@"
+class C
+{
+    public static void NotNull<T>(T value, string parameterName) where T:class
+    {
+        if (value is null)
+        {
+            throw new System.ArgumentNullException(parameterName);
+        }
+    }
+}
+");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/UseIsNullCheck/UseIsNullCheckTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseIsNullCheck/UseIsNullCheckTests.vb
@@ -181,5 +181,20 @@ class C
     end sub
 end class")
         End Function
+
+        <WorkItem(23581, "https://github.com/dotnet/roslyn/issues/23581")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)>
+        Public Async Function TestValueParameterTypeIsValueConstraintGeneric() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Imports System
+
+class C
+    sub M(Of T As Structure)(v as T)
+        if ([||]ReferenceEquals(Nothing, v))
+            return
+        end if
+    end sub
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
@@ -17,12 +17,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
         protected override string GetIsNotNullTitle()
             => GetIsNullTitle();
 
-        protected override SyntaxNode CreateIsNullCheck(SyntaxNode argument)
-            => SyntaxFactory.IsPatternExpression(
+        private static SyntaxNode CreateNullCheck(SyntaxNode argument, SyntaxKind comparisonOperator)
+            => SyntaxFactory.BinaryExpression(
+                comparisonOperator,
                 (ExpressionSyntax)argument,
-                SyntaxFactory.ConstantPattern(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))).Parenthesize();
+                SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)).Parenthesize();
+
+        protected override SyntaxNode CreateIsNullCheck(SyntaxNode argument)
+            => CreateNullCheck(argument, SyntaxKind.EqualsExpression);
 
         protected override SyntaxNode CreateIsNotNullCheck(SyntaxNode notExpression, SyntaxNode argument)
-            => ((PrefixUnaryExpressionSyntax)notExpression).WithOperand((ExpressionSyntax)CreateIsNullCheck(argument));
+            => CreateNullCheck(argument, SyntaxKind.NotEqualsExpression);
     }
 }

--- a/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
@@ -31,13 +31,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
         private static SyntaxNode CreateIsNotNullCheck(SyntaxNode notExpression, SyntaxNode argument)
             => ((PrefixUnaryExpressionSyntax)notExpression).WithOperand((ExpressionSyntax)CreateIsNullCheck(argument));
 
-        protected override SyntaxNode CreateNullCheck(SyntaxNode argument, bool isUnconstraintGeneric)
-            => isUnconstraintGeneric
+        protected override SyntaxNode CreateNullCheck(SyntaxNode argument, bool isUnconstrainedGeneric)
+            => isUnconstrainedGeneric
                 ? CreateEqualsNullCheck(argument, SyntaxKind.EqualsExpression)
                 : CreateIsNullCheck(argument);
 
-        protected override SyntaxNode CreateNotNullCheck(SyntaxNode notExpression, SyntaxNode argument, bool isUnconstraintGeneric)
-            => isUnconstraintGeneric
+        protected override SyntaxNode CreateNotNullCheck(SyntaxNode notExpression, SyntaxNode argument, bool isUnconstrainedGeneric)
+            => isUnconstrainedGeneric
                 ? CreateEqualsNullCheck(argument, SyntaxKind.NotEqualsExpression)
                 : CreateIsNotNullCheck(notExpression, argument);
     }

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
     internal abstract class AbstractUseIsNullCheckCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         public const string Negated = nameof(Negated);
-        public const string UnconstraintGeneric = nameof(UnconstraintGeneric);
+        public const string UnconstrainedGeneric = nameof(UnconstrainedGeneric);
 
         public override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(IDEDiagnosticIds.UseIsNullCheckDiagnosticId);
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             {
                 var invocation = diagnostic.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken: cancellationToken);
                 var negate = diagnostic.Properties.ContainsKey(Negated);
-                var isUnconstraintGeneric = diagnostic.Properties.ContainsKey(UnconstraintGeneric);
+                var isUnconstraintGeneric = diagnostic.Properties.ContainsKey(UnconstrainedGeneric);
 
                 var arguments = syntaxFacts.GetArgumentsOfInvocationExpression(invocation);
                 var argument = syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(arguments[0]))

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
 
         protected abstract string GetIsNullTitle();
         protected abstract string GetIsNotNullTitle();
-        protected abstract SyntaxNode CreateNullCheck(SyntaxNode argument, bool isUnconstraintGeneric);
-        protected abstract SyntaxNode CreateNotNullCheck(SyntaxNode notExpression, SyntaxNode argument, bool isUnconstraintGeneric);
+        protected abstract SyntaxNode CreateNullCheck(SyntaxNode argument, bool isUnconstrainedGeneric);
+        protected abstract SyntaxNode CreateNotNullCheck(SyntaxNode notExpression, SyntaxNode argument, bool isUnconstrainedGeneric);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             {
                 var invocation = diagnostic.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken: cancellationToken);
                 var negate = diagnostic.Properties.ContainsKey(Negated);
-                var isUnconstraintGeneric = diagnostic.Properties.ContainsKey(UnconstrainedGeneric);
+                var isUnconstrainedGeneric = diagnostic.Properties.ContainsKey(UnconstrainedGeneric);
 
                 var arguments = syntaxFacts.GetArgumentsOfInvocationExpression(invocation);
                 var argument = syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(arguments[0]))
@@ -59,8 +59,8 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
 
                 var toReplace = negate ? invocation.Parent : invocation;
                 var replacement = negate
-                    ? CreateNotNullCheck(invocation.Parent, argument, isUnconstraintGeneric)
-                    : CreateNullCheck(argument, isUnconstraintGeneric);
+                    ? CreateNotNullCheck(invocation.Parent, argument, isUnconstrainedGeneric)
+                    : CreateNullCheck(argument, isUnconstrainedGeneric);
 
                 editor.ReplaceNode(
                     toReplace,

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullCodeFixProvider.cs
@@ -18,14 +18,15 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
     internal abstract class AbstractUseIsNullCheckCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         public const string Negated = nameof(Negated);
+        public const string UnconstraintGeneric = nameof(UnconstraintGeneric);
 
         public override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(IDEDiagnosticIds.UseIsNullCheckDiagnosticId);
 
         protected abstract string GetIsNullTitle();
         protected abstract string GetIsNotNullTitle();
-        protected abstract SyntaxNode CreateIsNullCheck(SyntaxNode argument);
-        protected abstract SyntaxNode CreateIsNotNullCheck(SyntaxNode notExpression, SyntaxNode argument);
+        protected abstract SyntaxNode CreateNullCheck(SyntaxNode argument, bool isUnconstraintGeneric);
+        protected abstract SyntaxNode CreateNotNullCheck(SyntaxNode notExpression, SyntaxNode argument, bool isUnconstraintGeneric);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -49,6 +50,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
             {
                 var invocation = diagnostic.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken: cancellationToken);
                 var negate = diagnostic.Properties.ContainsKey(Negated);
+                var isUnconstraintGeneric = diagnostic.Properties.ContainsKey(UnconstraintGeneric);
 
                 var arguments = syntaxFacts.GetArgumentsOfInvocationExpression(invocation);
                 var argument = syntaxFacts.IsNullLiteralExpression(syntaxFacts.GetExpressionOfArgument(arguments[0]))
@@ -56,7 +58,9 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                     : syntaxFacts.GetExpressionOfArgument(arguments[0]);
 
                 var toReplace = negate ? invocation.Parent : invocation;
-                var replacement = negate ? CreateIsNotNullCheck(invocation.Parent, argument) : CreateIsNullCheck(argument);
+                var replacement = negate
+                    ? CreateNotNullCheck(invocation.Parent, argument, isUnconstraintGeneric)
+                    : CreateNullCheck(argument, isUnconstraintGeneric);
 
                 editor.ReplaceNode(
                     toReplace,
@@ -68,7 +72,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) 
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
                 : base(title, createChangedDocument, title)
             {
             }

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
@@ -109,11 +109,6 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                 return;
             }
 
-            if (HasUnconstraintGenericParameter(syntaxFacts, semanticModel, arguments[0], arguments[1], cancellationToken))
-            {
-                return;
-            }
-
             var additionalLocations = ImmutableArray.Create(invocation.GetLocation());
             var properties = ImmutableDictionary<string, string>.Empty;
 
@@ -128,22 +123,6 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                 Diagnostic.Create(
                     GetDescriptorWithSeverity(severity), nameNode.GetLocation(),
                     additionalLocations, properties));
-        }
-
-        private static bool HasUnconstraintGenericParameter(ISyntaxFactsService syntaxFacts, SemanticModel semanticModel, SyntaxNode node1, SyntaxNode node2, CancellationToken cancellationToken)
-        {
-            var valueNode = syntaxFacts.IsNullLiteralExpression(node1) ? node2 : node1;
-            var argumentExpression = syntaxFacts.GetExpressionOfArgument(valueNode);
-            if (argumentExpression != null)
-            {
-                var parameterType = semanticModel.GetTypeInfo(argumentExpression, cancellationToken).Type;
-                if (parameterType is ITypeParameterSymbol typeParameter)
-                {
-                    return !typeParameter.HasReferenceTypeConstraint;
-                }
-            }
-
-            return false;
         }
 
         private static bool MatchesPattern(ISyntaxFactsService syntaxFacts, SyntaxNode node1, SyntaxNode node2)

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
                 if (!genericParameterSymbol.HasReferenceTypeConstraint)
                 {
                     // Needs special casing for C# as long as
-                    // https://github.com/dotnet/csharplang/issues/1261
+                    // https://github.com/dotnet/csharplang/issues/1284
                     // is not implemented.
                     properties = properties.Add(AbstractUseIsNullCheckCodeFixProvider.UnconstrainedGeneric, "");
                 }

--- a/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseIsNullCheck/AbstractUseIsNullDiagnosticAnalyzer.cs
@@ -126,7 +126,9 @@ namespace Microsoft.CodeAnalysis.UseIsNullCheck
 
                 if (!genericParameterSymbol.HasReferenceTypeConstraint)
                 {
-                    // Needs special casing for C#
+                    // Needs special casing for C# as long as
+                    // https://github.com/dotnet/csharplang/issues/1261
+                    // is not implemented.
                     properties = properties.Add(AbstractUseIsNullCheckCodeFixProvider.UnconstrainedGeneric, "");
                 }
             }

--- a/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
@@ -18,13 +18,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
             Return VBFeaturesResources.Use_IsNot_Nothing_check
         End Function
 
-        Protected Overrides Function CreateNullCheck(argument As SyntaxNode, isUnconstraintGeneric As Boolean) As SyntaxNode
+        Protected Overrides Function CreateNullCheck(argument As SyntaxNode, isUnconstrainedGeneric As Boolean) As SyntaxNode
             Return SyntaxFactory.IsExpression(
                 DirectCast(argument, ExpressionSyntax).Parenthesize(),
                 SyntaxFactory.NothingLiteralExpression(SyntaxFactory.Token(SyntaxKind.NothingKeyword))).Parenthesize()
         End Function
 
-        Protected Overrides Function CreateNotNullCheck(notExpression As SyntaxNode, argument As SyntaxNode, isUnconstraintGeneric As Boolean) As SyntaxNode
+        Protected Overrides Function CreateNotNullCheck(notExpression As SyntaxNode, argument As SyntaxNode, isUnconstrainedGeneric As Boolean) As SyntaxNode
             Return SyntaxFactory.IsNotExpression(
                 DirectCast(argument, ExpressionSyntax).Parenthesize(),
                 SyntaxFactory.NothingLiteralExpression(SyntaxFactory.Token(SyntaxKind.NothingKeyword))).Parenthesize()

--- a/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
@@ -11,20 +11,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
         Inherits AbstractUseIsNullCheckCodeFixProvider
 
         Protected Overrides Function GetIsNullTitle() As String
-            Return VBFeaturesResources.use_Is_Nothing_check
+            Return VBFeaturesResources.Use_Is_Nothing_check
         End Function
 
         Protected Overrides Function GetIsNotNullTitle() As String
-            Return VBFeaturesResources.use_IsNot_Nothing_check
+            Return VBFeaturesResources.Use_IsNot_Nothing_check
         End Function
 
-        Protected Overrides Function CreateIsNullCheck(argument As SyntaxNode) As SyntaxNode
+        Protected Overrides Function CreateNullCheck(argument As SyntaxNode, isUnconstraintGeneric As Boolean) As SyntaxNode
             Return SyntaxFactory.IsExpression(
                 DirectCast(argument, ExpressionSyntax).Parenthesize(),
                 SyntaxFactory.NothingLiteralExpression(SyntaxFactory.Token(SyntaxKind.NothingKeyword))).Parenthesize()
         End Function
 
-        Protected Overrides Function CreateIsNotNullCheck(notExpression As SyntaxNode, argument As SyntaxNode) As SyntaxNode
+        Protected Overrides Function CreateNotNullCheck(notExpression As SyntaxNode, argument As SyntaxNode, isUnconstraintGeneric As Boolean) As SyntaxNode
             Return SyntaxFactory.IsNotExpression(
                 DirectCast(argument, ExpressionSyntax).Parenthesize(),
                 SyntaxFactory.NothingLiteralExpression(SyntaxFactory.Token(SyntaxKind.NothingKeyword))).Parenthesize()


### PR DESCRIPTION
### Customer scenario

`IDE0041 Null check can be simplified` is shown for the `ReferenceEquals` method and a fix is offered. The fix generates code which might have the compiler error 'Can not convert null to type parameter T because it could be a non-nullable value type.'. This fix suppresses IDE0041 if the parameter passed to ReferenceEquals is ~an unconstraint generic type parameter~ Update 01/17/2018: a value type constraint generic type parameter.

### Bugs this fixes

#23581

### Workarounds, if any

Suppress IDE0041 with a pragma or change the generated code from `(value is null)`to `(value == null)`.

### Risk

Low. Small additional check.

### Performance impact

Low. Syntax and semantic analysis has already been done by other checks on the code path before. This adds some more checks.

### Is this a regression from a previous update?

/

### Root cause analysis

/

### How was the bug found?

Customer reported #23581

### Test documentation updated?

/
