### PR TITLE
Disable navigate to decompiled sources for assemblies with SuppressIldasmAttribute

### DIFF
--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.Decompiler;
@@ -114,6 +115,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
                                                                      .GetDocument(temporaryProjectInfoAndDocumentId.Item2);
 
                     var useDecompiler = allowDecompilation;
+                    if (useDecompiler)
+                    {
+                        useDecompiler = !symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(SuppressIldasmAttribute));
+                    }
+
                     if (useDecompiler)
                     {
                         try


### PR DESCRIPTION
### Customer scenario

A customer enables the Navigate to Decompiled Sources feature, accepts the terms for use, and navigates to a symbol defined in an assembly that has `SuppressIldasmAttribute` applied to it. The source code for the symbol is shown when only the metadata should be showing.

### Bugs this fixes

Fixes #24175

### Workarounds, if any

None.

### Risk

Low.

### Performance impact

Low.

### Is this a regression from a previous update?

No.

### Root cause analysis

The initial ILSpy integration (behind a feature flag and disabled by default) was not tested for this case. Manual testing revealed the bug.

### How was the bug found?

Manual compliance testing.

### Test documentation updated?

A manual test scenario was added.