### PR TITLE
Restore correct SemanticModel behavior for Default Property Transformation scenarios.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -429,14 +429,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     tmpDiagnostics.Clear()
 
                     If withoutArgs.Kind = BoundKind.PropertyAccess Then
-                        If DirectCast(withoutArgs, BoundPropertyAccess).ReceiverOpt?.Syntax Is withoutArgs.Syntax Then
+                        Dim receiverOpt As BoundExpression = DirectCast(withoutArgs, BoundPropertyAccess).ReceiverOpt
+                        If receiverOpt?.Syntax Is withoutArgs.Syntax AndAlso Not receiverOpt.WasCompilerGenerated Then
                             withoutArgs.MakeCompilerGenerated()
                         End If
 
                         withoutArgs = MakeRValue(withoutArgs, diagnostics)
 
-                    ElseIf DirectCast(withoutArgs, BoundCall).ReceiverOpt?.Syntax Is withoutArgs.Syntax Then
-                        withoutArgs.MakeCompilerGenerated()
+                    Else
+                        Dim receiverOpt As BoundExpression = DirectCast(withoutArgs, BoundCall).ReceiverOpt
+                        If receiverOpt?.Syntax Is withoutArgs.Syntax AndAlso Not receiverOpt.WasCompilerGenerated Then
+                            withoutArgs.MakeCompilerGenerated()
+                        End If
                     End If
 
                     If withoutArgs.Kind = BoundKind.BadExpression Then

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -2152,5 +2152,129 @@ End Class
 ",
             MainDescription("Sub Program.Test(Of Bar)()"))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(548762, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762")>
+        Public Async Function DefaultPropertyTransformation_01() As Task
+            Await TestAsync("
+<System.Reflection.DefaultMember(""Item"")>
+Class C1
+    Default Public Property Item(x As String) As String
+        Get
+            Return """"
+        End Get
+        Set(value As String)
+
+        End Set
+    End Property
+End Class
+
+Class C2
+    Public Property ViewData As C1
+End Class
+
+Class C3
+    Inherits C2
+
+    Sub Test()
+        View$$Data(""Title"") = ""About""
+    End Sub
+End Class",
+            MainDescription("Property C2.ViewData As C1"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(548762, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762")>
+        Public Async Function DefaultPropertyTransformation_02() As Task
+            Await TestAsync("
+<System.Reflection.DefaultMember(""Item"")>
+Class C1
+    Default Public Property Item(x As String) As String
+        Get
+            Return """"
+        End Get
+        Set(value As String)
+
+        End Set
+    End Property
+End Class
+
+Class C2
+    Public Shared Property ViewData As C1
+End Class
+
+Class C3
+    Inherits C2
+
+    Sub Test()
+        View$$Data(""Title"") = ""About""
+    End Sub
+End Class",
+            MainDescription("Property C2.ViewData As C1"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(548762, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762")>
+        Public Async Function DefaultPropertyTransformation_03() As Task
+            Await TestAsync("
+<System.Reflection.DefaultMember(""Item"")>
+Class C1
+    Default Public Property Item(x As String) As String
+        Get
+            Return """"
+        End Get
+        Set(value As String)
+
+        End Set
+    End Property
+End Class
+
+Class C2
+    Public Function ViewData As C1
+        Return Nothing
+    End Function
+End Class
+
+Class C3
+    Inherits C2
+
+    Sub Test()
+        View$$Data(""Title"") = ""About""
+    End Sub
+End Class",
+            MainDescription("Function C2.ViewData() As C1"))
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)>
+        <WorkItem(548762, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762")>
+        Public Async Function DefaultPropertyTransformation_04() As Task
+            Await TestAsync("
+<System.Reflection.DefaultMember(""Item"")>
+Class C1
+    Default Public Property Item(x As String) As String
+        Get
+            Return """"
+        End Get
+        Set(value As String)
+
+        End Set
+    End Property
+End Class
+
+Class C2
+    Public Shared Function ViewData As C1
+        Return Nothing
+    End Function
+End Class
+
+Class C3
+    Inherits C2
+
+    Sub Test()
+        View$$Data(""Title"") = ""About""
+    End Sub
+End Class",
+            MainDescription("Function C2.ViewData() As C1"))
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762

Fixes regression from https://github.com/dotnet/roslyn/pull/23343

### Customer scenario

Create a new .vbhtml file with below contents:
```
@Code
    ViewData("Title") = "About"
End Code
``` 
Delete couple of space before ViewData on line 2
Move focus to line 3(or anywhere else)
ViewData on line 2 gets changed to Item. Buffer contents after end of step 4:
```
@Code
    Item("Title") = "About"
End Code
```

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems?id=548762

### Workarounds, if any

No

### Risk

Low

### Performance impact

Low perf impact because no extra allocations/no complexity changes.

### Is this a regression from a previous update?

Yes. Caused by https://github.com/dotnet/roslyn/pull/23343

### Root cause analysis

There was a test gap. Added unit-tests to close it.

### How was the bug found?

Reported by internal customer

