### PR TITLE
Internal error in Immediate Window when trying to create an already e…

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -21,14 +21,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly Symbol _memberSymbol;
         private readonly SyntaxNode _root;
-        private readonly Func<Binder, SyntaxNode, Binder> _rootBinderAdjusterOpt;
+        private readonly Action<Binder, SyntaxNode> _binderUpdatedHandler;
         private SmallDictionary<SyntaxNode, Binder> _lazyBinderMap;
         private ImmutableArray<MethodSymbol> _methodSymbolsWithYield;
 
-        internal ExecutableCodeBinder(SyntaxNode root, Symbol memberSymbol, Binder next, Func<Binder, SyntaxNode, Binder> rootBinderAdjusterOpt = null)
+        internal ExecutableCodeBinder(SyntaxNode root, Symbol memberSymbol, Binder next, Action<Binder, SyntaxNode> binderUpdatedHandler = null)
             : this(root, memberSymbol, next, next.Flags)
         {
-            _rootBinderAdjusterOpt = rootBinderAdjusterOpt;
+            _binderUpdatedHandler = binderUpdatedHandler;
         }
 
         internal ExecutableCodeBinder(SyntaxNode root, Symbol memberSymbol, Binder next, BinderFlags additionalFlags)
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var methodsWithYield = ArrayBuilder<SyntaxNode>.GetInstance();
                 var symbolsWithYield = ArrayBuilder<MethodSymbol>.GetInstance();
-                map = LocalBinderFactory.BuildMap(_memberSymbol, _root, this, methodsWithYield, _rootBinderAdjusterOpt);
+                map = LocalBinderFactory.BuildMap(_memberSymbol, _root, this, methodsWithYield, _binderUpdatedHandler);
                 foreach (var methodWithYield in methodsWithYield)
                 {
                     Binder binder;

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxNode syntax, 
             Binder enclosing, 
             ArrayBuilder<SyntaxNode> methodsWithYields,
-            Func<Binder, SyntaxNode, Binder> rootBinderAdjusterOpt = null)
+            Action<Binder, SyntaxNode> binderUpdatedHandler = null)
         {
             var builder = new LocalBinderFactory(containingMemberOrLambda, syntax, enclosing, methodsWithYields);
 
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 enclosing = new ExpressionVariableBinder(syntax, enclosing);
 
-                if ((object)rootBinderAdjusterOpt != null)
+                if ((object)binderUpdatedHandler != null)
                 {
-                    enclosing = rootBinderAdjusterOpt(enclosing, syntax);
+                    binderUpdatedHandler(enclosing, syntax);
                 }
 
                 builder.AddToMap(syntax, enclosing);
@@ -79,9 +79,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CSharpSyntaxNode embeddedScopeDesignator;
                 enclosing = builder.GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDesignator);
 
-                if ((object)rootBinderAdjusterOpt != null)
+                if ((object)binderUpdatedHandler != null)
                 {
-                    enclosing = rootBinderAdjusterOpt(enclosing, embeddedScopeDesignator);
+                    binderUpdatedHandler(enclosing, embeddedScopeDesignator);
                 }
 
                 if (embeddedScopeDesignator != null)
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if ((object)rootBinderAdjusterOpt != null)
+                if ((object)binderUpdatedHandler != null)
                 {
-                    enclosing = rootBinderAdjusterOpt(enclosing, null);
+                    binderUpdatedHandler(enclosing, null);
                 }
 
                 builder.Visit((CSharpSyntaxNode)syntax, enclosing);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -892,40 +892,39 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     binder);
             }
 
-            Binder originalRootBinder = null;
+            binder = new EEMethodBinder(method, substitutedSourceMethod, binder);
+
+            if (methodNotType)
+            {
+                binder = new SimpleLocalScopeBinder(method.LocalsForBinding, binder);
+            }
+
+            Binder actualRootBinder = null;
             SyntaxNode declaredLocalsScopeDesignator = null;
+
             var executableBinder = new ExecutableCodeBinder(syntax, substitutedSourceMethod, binder,
                                               (rootBinder, declaredLocalsScopeDesignatorOpt) =>
                                               {
-                                                  originalRootBinder = rootBinder;
+                                                  actualRootBinder = rootBinder;
                                                   declaredLocalsScopeDesignator = declaredLocalsScopeDesignatorOpt;
-                                                  binder = new EEMethodBinder(method, substitutedSourceMethod, rootBinder);
-
-                                                  if (methodNotType)
-                                                  {
-                                                      binder = new SimpleLocalScopeBinder(method.LocalsForBinding, binder);
-                                                  }
-
-                                                  return binder;
                                               });
 
             // We just need to trigger the process of building the binder map
             // so that the lambda above was executed.
             executableBinder.GetBinder(syntax);
 
-            Debug.Assert(originalRootBinder != null);
-            Debug.Assert(executableBinder.Next != binder);
+            Debug.Assert(actualRootBinder != null);
 
             if (declaredLocalsScopeDesignator != null)
             {
-                declaredLocals = originalRootBinder.GetDeclaredLocalsForScope(declaredLocalsScopeDesignator);
+                declaredLocals = actualRootBinder.GetDeclaredLocalsForScope(declaredLocalsScopeDesignator);
             }
             else
             {
                 declaredLocals = ImmutableArray<LocalSymbol>.Empty;
             }
 
-            return binder;
+            return actualRootBinder;
         }
 
         private static Imports BuildImports(CSharpCompilation compilation, PEModuleSymbol module, ImmutableArray<ImportRecord> importRecords, InContainerBinder binder)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override SyntaxToken IdentifierToken
         {
-            get { return default; }
+            get { throw ExceptionUtilities.Unreachable; }
         }
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbol.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override SyntaxToken IdentifierToken
         {
-            get { throw ExceptionUtilities.Unreachable; }
+            get { return default; }
         }
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -2181,7 +2181,6 @@ class C
 
     static void M()
     {
-#line 999
         F(out var x, out var y);
     }
 }";
@@ -2189,7 +2188,7 @@ class C
 
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 999);
+                var context = CreateMethodContext(runtime, "C.M");
 
                 DkmClrCompilationResultFlags flags;
                 CompilationTestData testData;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -2170,5 +2170,33 @@ class C
                 Assert.Equal("error CS0136: A local or parameter named 'x' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter", error);
             });     
         }
+
+        [Fact]
+        public void DuplicateDeclarationInOutVar()
+        {
+            var source =
+@"class C
+{
+    static void F(out double x, out int y) => x = y = 4;
+
+    static void M()
+    {
+#line 999
+        F(out var x, out var y);
+    }
+}";
+            var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
+
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 999);
+
+                DkmClrCompilationResultFlags flags;
+                CompilationTestData testData;
+                string error;
+                CompileDeclaration(context, "F(out var x, out var y)", out flags, out testData, out error);
+                Assert.Equal("error CS0136: A local or parameter named 'x' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter", error);
+            });
+        }
     }
 }


### PR DESCRIPTION
### Customer scenario

Customer debugs a code that has a variable declaration like
```
int x = 0;
System.Diagnostics.Debugger.Break();
```
At a breakpoint, customer tries to declare the same variable once again in the immediate window or in a watch window by executing
`int x = 1;`

Expected:
error CS0136: A local or parameter named 'x' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter

Actual:
Internal error in the C# compiler

### Bugs this fixes
https://github.com/dotnet/roslyn/issues/22599
https://github.com/dotnet/roslyn/issues/22474
#15132

### Workarounds, if any

None

### Risk

Low

### Performance impact

None

### Is this a regression from a previous update?
No

### How was the bug found?
Customer reported