### PR TITLE
Use NET46 for CreateStandardCompilation

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private static readonly ImmutableArray<MetadataReference> s_stdRefs = CoreClrShim.IsRunningOnCoreClr
             ? ImmutableArray.Create<MetadataReference>(NetStandard20.NetStandard, NetStandard20.MscorlibRef, NetStandard20.SystemRuntimeRef, NetStandard20.SystemDynamicRuntimeRef)
-            : ImmutableArray.Create(MscorlibRef);
+            : ImmutableArray.Create(MscorlibRef_v46);
 
         // Careful! Make sure everything in s_desktopRefsToRemove is constructed with
         // the same object identity, since MetadataReference uses reference equality.


### PR DESCRIPTION
This changes the CreateStandardCompilation helper to use the net46 version of
mscorlib. Previously it was using the net40 version.

This method is a helper to create a minimal compilation across both our desktop
and coreclr test executions. The coreclr version uses netstandard20 and hence
using net40 created a substantial API gap. This better eliminates the gap.

Note: I realize net461 is a slightly more correct choice. However that ref
assembly isn't checked into our code yet and I wanted to avoid a giant resource
update here unless we need it. Our tests focus on the intersection of the
two API sets hence it's unlikely to be an issueo here.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
