### PR TITLE
FindAllReferences on Deconstruct should consider all documents

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -78,6 +78,35 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(24184, "https://github.com/dotnet/roslyn/issues/24184")>
+        Public Async Function FindReferences_DeconstructionInAnotherDocument() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+public static class Extensions
+{
+    public void {|Definition:Decons$$truct|}(this C c, out int x1, out int x2) { x1 = 1; x2 = 2; }
+}
+        </Document>
+        <Document>
+class C
+{
+    public void M()
+    {
+        [|var (x1, x2)|] = this;
+        foreach ([|var (y1, y2)|] in new[] { this }) { }
+        [|(x1, (x2, _))|] = (1, this);
+        (x1, x2) = (1, 2);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
         <WorkItem(18963, "https://github.com/dotnet/roslyn/issues/18963")>
         Public Async Function FindReferences_ForEachDeconstructionOnItsOwn() As Task
             Dim input =

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -394,6 +394,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             }, cancellationToken);
         }
 
+        protected Task<ImmutableArray<Document>> FindDocumentsWithDeconstructionAsync(Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
+        {
+            return FindDocumentsAsync(project, documents, async (d, c) =>
+            {
+                var info = await SyntaxTreeIndex.GetIndexAsync(d, c).ConfigureAwait(false);
+                return info.ContainsDeconstruction;
+            }, cancellationToken);
+        }
+
         protected async Task<ImmutableArray<ReferenceLocation>> FindReferencesInForEachStatementsAsync(
             ISymbol symbol,
             Document document,

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -93,7 +93,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 ? await FindDocumentsWithForEachStatementsAsync(project, documents, cancellationToken).ConfigureAwait(false)
                 : ImmutableArray<Document>.Empty;
 
-            return ordinaryDocuments.Concat(forEachDocuments);
+            var deconstructDocuments = IsDeconstructMethod(methodSymbol)
+                ? await FindDocumentsWithDeconstructionAsync(project, documents, cancellationToken).ConfigureAwait(false)
+                : ImmutableArray<Document>.Empty;
+
+            return ordinaryDocuments.Concat(forEachDocuments).Concat(deconstructDocuments);
         }
 
         private bool IsForEachMethod(IMethodSymbol methodSymbol)


### PR DESCRIPTION
### Customer scenario
Use FindAllReferences on a `Deconstruct` method. Only references in the same document will be found, but all documents (that are indexed as having at least one deconstruction) should be considered.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24184

### Workarounds, if any
None

### Risk
### Performance impact
Low. This is following the design of FindAllReferences for `GetEnumerator` methods very closely. The new code is only invoked when using FAR on a method called `Deconstruct`.

### Is this a regression from a previous update?
No.

### Root cause analysis
I should have included a test case with multiple documents, and also done some testing with dev hive on Roslyn codebase.

### How was the bug found?
FAR for Deconstruct has not shipped yet (I implemented it in 15.6, in PR https://github.com/dotnet/roslyn/pull/22934) and I found this problem while using it on Roslyn codebase.

Verified the fix on Roslyn:
![image](https://user-images.githubusercontent.com/12466233/34902716-fb92804e-f7d5-11e7-9a50-987de158643b.png)
