### PR TITLE
Produce hidden diagnostics for UseExplicitType

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.TypeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
@@ -1054,7 +1053,7 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeNotificationLevelNone()
         {
-            var source =
+            var before =
 @"using System;
 class C
 {
@@ -1063,8 +1062,23 @@ class C
         [|var|] n1 = new C();
     }
 }";
-            await TestMissingInRegularAndScriptAsync(source,
-                new TestParameters(options: ExplicitTypeNoneEnforcement()));
+
+   var after =
+@"using System;
+class C
+{
+    static void M()
+    {
+        C n1 = new C();
+    }
+}";
+
+            await TestInRegularAndScriptAsync(before, after, options: ExplicitTypeNoneEnforcement());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ExplicitTypeNoneEnforcement(),
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1048,10 +1048,9 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVarOnBuiltInType_Literal_WithOption()
+        public async Task SuggestVarHiddenOnBuiltInType_Literal_WithOption()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1059,14 +1058,28 @@ class C
     {
         [|int|] s = 5;
     }
-}", new TestParameters(options: ImplicitTypeButKeepIntrinsics()));
+}";
+            string after = @"using System;
+
+class C
+{
+    static void M()
+    {
+        var s = 5;
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeButKeepIntrinsics());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeButKeepIntrinsics(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVarOnBuiltInType_WithOption()
+        public async Task SuggestVarHiddenOnBuiltInType_WithOption()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1076,14 +1089,30 @@ class C
     {
         [|int|] s = (unchecked(maxValue + 10));
     }
-}", new TestParameters(options: ImplicitTypeButKeepIntrinsics()));
+}";
+            string after = @"using System;
+
+class C
+{
+    private const int maxValue = int.MaxValue;
+
+    static void M()
+    {
+        var s = (unchecked(maxValue + 10));
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeButKeepIntrinsics());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeButKeepIntrinsics(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task DoNotSuggestVarOnFrameworkTypeEquivalentToBuiltInType()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1093,7 +1122,24 @@ class C
     {
         [|Int32|] s = (unchecked(maxValue + 10));
     }
-}", new TestParameters(options: ImplicitTypeButKeepIntrinsics()));
+}";
+            string after = @"using System;
+
+class C
+{
+    private const int maxValue = int.MaxValue;
+
+    static void M()
+    {
+        var s = (unchecked(maxValue + 10));
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeButKeepIntrinsics());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeButKeepIntrinsics(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1145,10 +1191,9 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVarWhereTypeIsEvident_Literals()
+        public async Task SuggestVarHiddenWhereTypeIsEvident_Literals()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1156,7 +1201,23 @@ class C
     {
         [|int|] text = 5;
     }
-}", new TestParameters(options: ImplicitTypeWhereApparent()));
+}";
+            string after = @"using System;
+
+class C
+{
+    public void Process()
+    {
+        var text = 5;
+    }
+}";
+
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeWhereApparent(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1210,10 +1271,9 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVar_BuiltInTypesRulePrecedesOverTypeIsApparentRule1()
+        public async Task SuggestVarHidden_BuiltInTypesRulePrecedesOverTypeIsApparentRule1()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1222,14 +1282,29 @@ class C
         object o = int.MaxValue;
         [|int|] i = (Int32)o;
     }
-}", new TestParameters(options: ImplicitTypeWhereApparent()));
+}";
+            string after = @"using System;
+
+class C
+{
+    public void Process()
+    {
+        object o = int.MaxValue;
+        var i = (Int32)o;
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeWhereApparent(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVar_BuiltInTypesRulePrecedesOverTypeIsApparentRule2()
+        public async Task SuggestVarHidden_BuiltInTypesRulePrecedesOverTypeIsApparentRule2()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1238,14 +1313,31 @@ class C
         object o = int.MaxValue;
         [|Int32|] i = (Int32)o;
     }
-}", new TestParameters(options: ImplicitTypeWhereApparent()));
+}";
+
+            string after = @"using System;
+
+class C
+{
+    public void Process()
+    {
+        object o = int.MaxValue;
+        var i = (Int32)o;
+    }
+}";
+
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeWhereApparent(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
-        public async Task DoNotSuggestVarWhereTypeIsEvident_IsExpression()
+        public async Task SuggestVarHiddenWhereTypeIsEvident_IsExpression()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"using System;
+            string before = @"using System;
 
 class C
 {
@@ -1262,7 +1354,34 @@ class A : IInterface
 
 interface IInterface
 {
-}", new TestParameters(options: ImplicitTypeWhereApparent()));
+}";
+
+
+            string after = @"using System;
+
+class C
+{
+    public void Process()
+    {
+        A a = new A();
+        var s = a is IInterface;
+    }
+}
+
+class A : IInterface
+{
+}
+
+interface IInterface
+{
+}";
+
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeWhereApparent(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1442,7 +1561,7 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarNotificationLevelNone()
         {
-            var source =
+            var before =
 @"using System;
 class C
 {
@@ -1451,8 +1570,22 @@ class C
         [|C|] n1 = new C();
     }
 }";
-            await TestMissingInRegularAndScriptAsync(source,
-                new TestParameters(options: ImplicitTypeNoneEnforcement()));
+
+            var after =
+@"using System;
+class C
+{
+    static void M()
+    {
+        var n1 = new C();
+    }
+}";
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeNoneEnforcement());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeNoneEnforcement(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1535,8 +1668,12 @@ namespace System
 
             await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeEverywhere());
 
-            // We would rather this refactoring also worked. See https://github.com/dotnet/roslyn/issues/11094
-            await TestMissingInRegularAndScriptAsync(before, new TestParameters(options: ImplicitTypeWhereApparent()));
+            await TestInRegularAndScriptAsync(before, after, options: ImplicitTypeWhereApparent());
+
+            await TestDiagnosticInfoAsync(before,
+                options: ImplicitTypeWhereApparent(),
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
+                diagnosticSeverity: DiagnosticSeverity.Hidden);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1738,7 +1875,7 @@ options: ImplicitTypeEverywhere());
 using System;
 namespace System
 {
-    public readonly ref struct Span<T> 
+    public readonly ref struct Span<T>
     {
         unsafe public Span(void* pointer, int length) { }
     }
@@ -1760,7 +1897,7 @@ class C
 using System;
 namespace System
 {
-    public readonly ref struct Span<T> 
+    public readonly ref struct Span<T>
     {
         unsafe public Span(void* pointer, int length) { }
     }
@@ -1782,7 +1919,7 @@ class C
 using System;
 namespace System
 {
-    public readonly ref struct Span<T> 
+    public readonly ref struct Span<T>
     {
         unsafe public Span(void* pointer, int length) { }
     }

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             using (var workspace = CreateWorkspaceFromOptions(initialMarkup, parameters))
             {
                 var actions = await GetCodeActionsAsync(workspace, parameters);
-                Assert.True(actions.Length == 0);
+                Assert.True(actions.Length == 0, "Expected no code actions");
             }
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         {
             TypeSyntax declaredType;
             State state = null;
-            var shouldAnalyze = false;
+            var isStylePreferred = false;
             var declarationStatement = context.Node;
             var options = context.Options;
             var syntaxTree = context.Node.SyntaxTree;
@@ -71,12 +71,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var declaration = (VariableDeclarationSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeVariableDeclaration(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (ShouldAnalyzeVariableDeclaration(declaration, semanticModel, cancellationToken))
                 {
                     state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: true, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    isStylePreferred = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
                 }
             }
             else if (declarationStatement.IsKind(SyntaxKind.ForEachStatement))
@@ -84,12 +82,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var declaration = (ForEachStatementSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeForEachStatement(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (ShouldAnalyzeForEachStatement(declaration, semanticModel, cancellationToken))
                 {
                     state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    isStylePreferred = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
                 }
             }
             else if (declarationStatement.IsKind(SyntaxKind.DeclarationExpression))
@@ -97,12 +93,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var declaration = (DeclarationExpressionSyntax) declarationStatement;
                 declaredType = declaration.Type;
 
-                shouldAnalyze = ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
-
-                if (shouldAnalyze)
+                if (ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken))
                 {
                     state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
-                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    isStylePreferred = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
                 }
             }
             else
@@ -111,13 +105,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 return;
             }
 
-            if (shouldAnalyze)
+            if (state != null)
             {
-                Debug.Assert(state != null, "analyzing a declaration and state is null.");
                 if (TryAnalyzeVariableDeclaration(declaredType, semanticModel, optionSet, cancellationToken, out var diagnosticSpan))
                 {
-                    // The severity preference is not Hidden, as indicated by shouldAnalyze.
-                    var descriptor = GetDescriptorWithSeverity(state.GetDiagnosticSeverityPreference());
+                    var descriptor = GetDescriptorWithSeverity(isStylePreferred ? state.GetDiagnosticSeverityPreference() : DiagnosticSeverity.Hidden);
                     context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, diagnosticSpan));
                 }
             }

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -37,9 +37,15 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
             var root = editor.OriginalRoot;
+            var fixSingle = diagnostics.Count() == 1;
 
             foreach (var diagnostic in diagnostics)
             {
+                if (!fixSingle && diagnostic.Severity == DiagnosticSeverity.Hidden)
+                {
+                    continue;
+                }
+
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
                 await HandleDeclarationAsync(document, editor, node, cancellationToken).ConfigureAwait(false);
             }

--- a/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
@@ -34,9 +34,15 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
             var root = editor.OriginalRoot;
+            var fixSingle = diagnostics.Count() == 1;
 
             foreach (var diagnostic in diagnostics)
             {
+                if (!fixSingle && diagnostic.Severity == DiagnosticSeverity.Hidden)
+                {
+                    continue;
+                }
+
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 
                 var implicitType = SyntaxFactory.IdentifierName("var")


### PR DESCRIPTION
### Customer scenario
Produce hidden diagnostics for fixable `var` regardless of preferences, so that the fix can be invoked manually.
Same applies to UseImplicitType.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24227

### Workarounds, if any
Fix the type by hand, or set code style to trigger.

### Risk
### Performance impact
The change is simple, but there is potential impact since we're analyzing many more nodes.
@sharwell Any thoughts?

### Is this a regression from a previous update?
No.

### Root cause analysis
New feature.

PROTOTYPE: this new behavior makes a lot of existing tests for different behaviors for different preferences insensitive to breaks. Need to find a way to keep them discriminative.

PROTOTYPE: I made this PR for 15.7, but we can move if desired.