### PR TITLE
Limit compiler server pipe name length

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -371,6 +371,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Assert.Equal(name, BuildServerConnection.GetBasePipeName(path + Path.DirectorySeparatorChar));
                 Assert.Equal(name, BuildServerConnection.GetBasePipeName(path + Path.DirectorySeparatorChar + Path.DirectorySeparatorChar));
             }
+
+            [Fact]
+            public void GetBasePipeNameLength()
+            {
+                var path = string.Format(@"q:{0}the{0}path", Path.DirectorySeparatorChar);
+                var name = BuildServerConnection.GetBasePipeName(path);
+                // We only have ~50 total bytes to work with on mac, so the base path must be small
+                Assert.InRange(name.Length, 10, 30);
+            }
         }
     }
 }

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return null;
             }
 
-            return $"{userName}.{isAdmin}.{basePipeName}";
+            return $"{userName}.{(isAdmin ? 'T' : 'F')}.{basePipeName}";
         }
 
         internal static string GetBasePipeName(string compilerExeDirectory)

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -559,6 +559,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             {
                 var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(compilerExeDirectory));
                 basePipeName = Convert.ToBase64String(bytes)
+                    .Substring(0, 25) // We only have ~50 total characters on Mac, so strip this down
                     .Replace("/", "_")
                     .Replace("=", string.Empty);
             }


### PR DESCRIPTION

### Customer scenario

The current scenario: on Mac sometimes the compiler server can be left
spinning in an exception loop and non-responsive and the build silently
falls back to slower csc/vbc operation.

On MacOS pipes are implemented using Unix domain sockets. Unix domain
sockets must have a valid file path for their endpoint. The best place
is in the temp folder. Unfortunately, domain sockets on Unix also have a
very small path length limit of 104 characters. In addition, Mac temp
paths can be very long since they include randomly generated characters
from the OS. In total, this means that Roslyn has barely 50 characters
worth of space for its pipe identifiers.

This change cuts down on the bytes of the SHA256 hash used. This shouldn't
affect the security of the pipe, since the hash isn't used as a security boundary,
but should fit the pipe name into the length limitations.

### Bugs this fixes

Fixes #24137 

### Workarounds, if any

On Mac, for your `dotnet build` process, set your TMP environment variable to a short path, like `/tmp`.

### Risk

Low. The path name itself is not semantically meaningful to Roslyn.

### Performance impact

This is a perf fix. Should improve perf quite a lot (> 100% in my test).

### Is this a regression from a previous update?

No.

### Root cause analysis

This is a bug in a new feature that is caused by an OS peculiarity that only sometimes occurs
based on the user ID and randomized path generated by MacOS for the current session.

### How was the bug found?

First found by a developer when trying to repro a different bug, then customer reported.

