### PR TITLE
Add a link to Tools>Options>…>Code Style to link to EditorConfig documentation. Bug#23513

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -481,7 +481,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig..
+        ///   Looks up a localized string similar to The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files..
         /// </summary>
         internal static string Code_style_header_use_editor_config {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -481,6 +481,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig..
+        /// </summary>
+        internal static string Code_style_header_use_editor_config {
+            get {
+                return ResourceManager.GetString("Code_style_header_use_editor_config", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to prefer auto properties.
         /// </summary>
         internal static string codegen_prefer_auto_properties {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1016,6 +1016,6 @@ I agree to all of the foregoing:</value>
     <value>Decompiler Legal Notice</value>
   </data>
   <data name="Code_style_header_use_editor_config" xml:space="preserve">
-    <value>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</value>
+    <value>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1015,4 +1015,7 @@ I agree to all of the foregoing:</value>
   <data name="Decompiler_Legal_Notice_Title" xml:space="preserve">
     <value>Decompiler Legal Notice</value>
   </data>
+  <data name="Code_style_header_use_editor_config" xml:space="preserve">
+    <value>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1498,6 +1498,11 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <target state="translated">Právní doložka pro dekompilátor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1499,8 +1499,8 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1498,6 +1498,11 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <target state="translated">Rechtlicher Hinweis zum Decompiler</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1499,8 +1499,8 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1499,8 +1499,8 @@ Estoy de acuerdo con todo lo anterior:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1498,6 +1498,11 @@ Estoy de acuerdo con todo lo anterior:</target>
         <target state="translated">Aviso legal del Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1499,8 +1499,8 @@ Je suis d'accord avec tout ce qui précède :</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1498,6 +1498,11 @@ Je suis d'accord avec tout ce qui précède :</target>
         <target state="translated">Décompileur - Mention légale</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1498,6 +1498,11 @@ L'utente accetta le condizioni sopra riportate:</target>
         <target state="translated">Note legali sul decompilatore</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1499,8 +1499,8 @@ L'utente accetta le condizioni sopra riportate:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">デコンパイラの法的通知</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1499,8 +1499,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">디컴파일러 법적 고지 사항</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1499,8 +1499,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1499,8 +1499,8 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1498,6 +1498,11 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <target state="translated">Informacje prawne dotyczące Dekompilatora</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1499,8 +1499,8 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1498,6 +1498,11 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <target state="translated">Aviso Legal do Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">Юридическая информация для декомпилятора</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1499,8 +1499,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1499,8 +1499,8 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1498,6 +1498,11 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <target state="translated">Derleme Ayırıcı Yasal Bildirim</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">Decompiler 法律声明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1499,8 +1499,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">解編程式的法律聲明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_style_header_use_editor_config">
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1499,8 +1499,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</source>
-        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig.</target>
+        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
+        <target state="new">The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -5,7 +5,7 @@
     xmlns:converters="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options.Converters"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:options="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options"
     xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
@@ -21,9 +21,9 @@
                     <Setter.Value>
                         <Style TargetType="DataGridCell">
                             <Setter Property="BorderThickness" Value="1" />
-                            <Setter Property="IsTabStop" 
-                                    Value="{Binding 
-                                        Path=Column, 
+                            <Setter Property="IsTabStop"
+                                    Value="{Binding
+                                        Path=Column,
                                         Converter={StaticResource ColumnToTabStopConverter},
                                         RelativeSource={RelativeSource Self}}"/>
                         </Style>
@@ -35,12 +35,18 @@
             <converters:MarginConverter x:Key="MarginConverter" />
         </Grid.Resources>
         <Grid.RowDefinitions>
+            <RowDefinition Height="30" />
             <RowDefinition Height="*" />
             <RowDefinition Height="5" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+        <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}" >
+            <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
+                <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreText}"/>
+            </Hyperlink>
+        </TextBlock>
         <DataGrid
-            Grid.Row="0"
+            Grid.Row="1"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
             Margin="0,5,0,0"
@@ -88,7 +94,7 @@
             </DataGrid.GroupStyle>
             <DataGrid.Columns>
                 <DataGridTemplateColumn
-                    x:Name="description" 
+                    x:Name="description"
                     Header="{x:Static local:GridOptionPreviewControl.DescriptionHeader}"
                     Width="4.5*"
                     IsReadOnly="True">
@@ -106,8 +112,8 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn 
-                    x:Name="preference" 
+                <DataGridTemplateColumn
+                    x:Name="preference"
                     Header="{x:Static local:GridOptionPreviewControl.PreferenceHeader}"
                     Width="3*">
                     <DataGridTemplateColumn.CellTemplate>
@@ -115,7 +121,7 @@
                             <ComboBox
                                     ItemsSource="{Binding Preferences}"
                                     DisplayMemberPath="Name"
-                                    SelectedItem="{Binding SelectedPreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                    SelectedItem="{Binding SelectedPreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     VerticalContentAlignment="Center"
                                     HorizontalContentAlignment="Left">
                                 <ComboBox.ItemContainerStyle>
@@ -127,8 +133,8 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn 
-                    x:Name="severity" 
+                <DataGridTemplateColumn
+                    x:Name="severity"
                     Header="{x:Static local:GridOptionPreviewControl.SeverityHeader}"
                     Width="2.5*">
                     <DataGridTemplateColumn.CellTemplate>
@@ -147,12 +153,12 @@
                                                 <ColumnDefinition Width="*"/>
                                             </Grid.ColumnDefinitions>
                                             <imaging:CrispImage
-                                            Height="16" 
-                                            Width="16" 
+                                            Height="16"
+                                            Width="16"
                                             Moniker="{Binding Moniker}"
                                             Grid.Column="0"/>
-                                            <TextBlock 
-                                            Margin="5, 0, 0, 0" 
+                                            <TextBlock
+                                            Margin="5, 0, 0, 0"
                                             Text="{Binding Notification}"
                                             Grid.Column="1"/>
                                         </Grid>
@@ -169,8 +175,8 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <GridSplitter Grid.Row="1" HorizontalAlignment="Stretch"></GridSplitter>
-        <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1">
+        <GridSplitter Grid.Row="2" HorizontalAlignment="Stretch"></GridSplitter>
+        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>
         </Border>
     </Grid>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -35,12 +35,14 @@
             <converters:MarginConverter x:Key="MarginConverter" />
         </Grid.Resources>
         <Grid.RowDefinitions>
-            <RowDefinition Height="30" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="5" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}" >
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}"/>
+            <Run Text=" "/>
             <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
                 <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreText}"/>
             </Hyperlink>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -12,12 +12,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
     internal partial class GridOptionPreviewControl : AbstractOptionPageControl
     {
-        private const string useEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
+        private const string UseEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
         internal AbstractOptionPreviewViewModel ViewModel;
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
 
-        public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(useEditorConfigUrl);
+        public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(UseEditorConfigUrl);
         public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config;
         public static string CodeStylePageHeaderLearnMoreText => ServicesVSResources.Learn_more;
         public static string DescriptionHeader => ServicesVSResources.Description;

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -16,19 +16,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
     internal partial class GridOptionPreviewControl : AbstractOptionPageControl
     {
-        private static string useEditorConfigUrl = "https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference";
+        private static string useEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
         internal AbstractOptionPreviewViewModel ViewModel;
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
 
-        // to leave a space between the end of sentence and "learn more" link
-        public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config + " ";
+        public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(useEditorConfigUrl);
+        public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config;
         public static string CodeStylePageHeaderLearnMoreText => ServicesVSResources.Learn_more;
-        public static Uri CodeStylePageHeaderLearnMoreUri = new Uri(useEditorConfigUrl);
         public static string DescriptionHeader => ServicesVSResources.Description;
         public static string PreferenceHeader => ServicesVSResources.Preference;
         public static string SeverityHeader => ServicesVSResources.Severity;
-
+        
         internal GridOptionPreviewControl(IServiceProvider serviceProvider,
             Func<OptionSet, IServiceProvider,
             AbstractOptionPreviewViewModel> createViewModel)

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Navigation;
+using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
@@ -14,19 +20,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
 
+        public static string CodeStylePageHeader = "The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig. ";
+        public static string CodeStylePageHeaderLearnMoreText = "Learn more";
+        public static Uri CodeStylePageHeaderLearnMoreUri = new Uri("https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference");
         public static string DescriptionHeader => ServicesVSResources.Description;
         public static string PreferenceHeader => ServicesVSResources.Preference;
         public static string SeverityHeader => ServicesVSResources.Severity;
 
-        internal GridOptionPreviewControl(IServiceProvider serviceProvider, 
-            Func<OptionSet, IServiceProvider, 
-            AbstractOptionPreviewViewModel> createViewModel) 
+        internal GridOptionPreviewControl(IServiceProvider serviceProvider,
+            Func<OptionSet, IServiceProvider,
+            AbstractOptionPreviewViewModel> createViewModel)
             : base(serviceProvider)
         {
             InitializeComponent();
 
             _serviceProvider = serviceProvider;
             _createViewModel = createViewModel;
+        }
+
+        private void LearnMoreHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (e.Uri == null)
+            {
+                return;
+            }
+
+            BrowserHelper.StartBrowser(e.Uri);
+            e.Handled = true;
         }
 
         private void Options_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
     internal partial class GridOptionPreviewControl : AbstractOptionPageControl
     {
-        private static string useEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
+        private const string useEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
         internal AbstractOptionPreviewViewModel ViewModel;
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -16,13 +16,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
     internal partial class GridOptionPreviewControl : AbstractOptionPageControl
     {
+        private static string useEditorConfigUrl = "https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference";
         internal AbstractOptionPreviewViewModel ViewModel;
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
 
-        public static string CodeStylePageHeader = "The settings configured here only apply to your machine. To configure these settings to travel with your solution, use EditorConfig. ";
-        public static string CodeStylePageHeaderLearnMoreText = "Learn more";
-        public static Uri CodeStylePageHeaderLearnMoreUri = new Uri("https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference");
+        // to leave a space between the end of sentence and "learn more" link
+        public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config + " ";
+        public static string CodeStylePageHeaderLearnMoreText => ServicesVSResources.Learn_more;
+        public static Uri CodeStylePageHeaderLearnMoreUri = new Uri(useEditorConfigUrl);
         public static string DescriptionHeader => ServicesVSResources.Description;
         public static string PreferenceHeader => ServicesVSResources.Preference;
         public static string SeverityHeader => ServicesVSResources.Severity;


### PR DESCRIPTION
Fixes : #23513 

### Customer scenario
Add a link to EditorConfig documentation in Tools>Options>…>Code Style 

### Bugs this fixes
https://github.com/dotnet/roslyn/issues/23513

### Workarounds, if any
Not needed

### Risk
low risk because it only adds a hyper link the code style page

### Performance impact
Low perf impact because no extra allocations/no complexity changes

### Is this a regression from a previous update?
No

### Root cause analysis
Not needed. 

### How was the bug found?
Not applicable

### Test documentation updated?
Not needed
