### PR TITLE
Locate implementations for reference assemblies using the GAC

### DIFF
--- a/src/Compilers/Shared/GlobalAssemblyCacheHelpers/FusionAssemblyIdentity.cs
+++ b/src/Compilers/Shared/GlobalAssemblyCacheHelpers/FusionAssemblyIdentity.cs
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis
 
                     throw new ArgumentException(Scripting.ScriptingResources.InvalidCharactersInAssemblyName, nameof(name));
 
-#elif WORKSPACE_DESKTOP
+#elif WORKSPACE_DESKTOP || EDITOR_FEATURES
 
                     throw new ArgumentException(Microsoft.CodeAnalysis.WorkspaceDesktopResources.Invalid_characters_in_assembly_name, nameof(name));
 
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis
 
                     throw new ArgumentException(Microsoft.CodeAnalysis.Scripting.ScriptingResources.InvalidCharactersInAssemblyName, nameof(name));
 
-#elif WORKSPACE_DESKTOP
+#elif WORKSPACE_DESKTOP || EDITOR_FEATURES
 
                     throw new ArgumentException(Microsoft.CodeAnalysis.WorkspaceDesktopResources.Invalid_characters_in_assembly_name, nameof(name));
 

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.EditorFeatures</AssemblyName>
     <TargetFramework>net46</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);EDITOR_FEATURES</DefineConstants>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj" />
@@ -93,6 +94,12 @@
     <InternalsVisibleToRemoteLS Include="Microsoft.VisualStudio.LanguageServices.Remote.CSharp" />
     <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\ClrGlobalAssemblyCache.cs" Link="Shared\GlobalAssemblyCacheHelpers\ClrGlobalAssemblyCache.cs" />
+    <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs" Link="Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs" />
+    <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\GlobalAssemblyCache.cs" Link="Shared\GlobalAssemblyCacheHelpers\GlobalAssemblyCache.cs" />
+    <Compile Include="..\..\Compilers\Shared\GlobalAssemblyCacheHelpers\MonoGlobalAssemblyCache.cs" Link="Shared\GlobalAssemblyCacheHelpers\MonoGlobalAssemblyCache.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="EditorFeaturesResources.Designer.cs">

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -200,13 +201,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(ReferenceAssemblyAttribute));
             if (isReferenceAssembly)
             {
-                // Attempt to resolve the assembly via the current process' binding path
                 try
                 {
                     var fullAssemblyName = symbol.ContainingAssembly.Identity.GetDisplayName();
-                    var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName == fullAssemblyName);
-                    var assembly = loadedAssembly ?? Assembly.ReflectionOnlyLoad(fullAssemblyName);
-                    assemblyLocation = assembly.Location;
+                    GlobalAssemblyCache.Instance.ResolvePartialName(fullAssemblyName, out assemblyLocation, preferredCulture: CultureInfo.CurrentCulture);
                 }
                 catch (Exception e) when (FatalError.ReportWithoutCrashUnlessCanceled(e))
                 {

--- a/src/Interactive/EditorFeatures/Core/Completion/GlobalAssemblyCacheCompletionHelper.cs
+++ b/src/Interactive/EditorFeatures/Core/Completion/GlobalAssemblyCacheCompletionHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+extern alias Scripting;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Completion.FileSystem
     internal sealed class GlobalAssemblyCacheCompletionHelper
     {
         private static readonly Lazy<List<string>> s_lazyAssemblySimpleNames =
-            new Lazy<List<string>>(() => GlobalAssemblyCache.Instance.GetAssemblySimpleNames().ToList());
+            new Lazy<List<string>>(() => Scripting::Microsoft.CodeAnalysis.GlobalAssemblyCache.Instance.GetAssemblySimpleNames().ToList());
 
         private readonly CompletionItemRules _itemRules;
 
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.Completion.FileSystem
 
         private IEnumerable<AssemblyIdentity> GetAssemblyIdentities(string partialName)
         {
-            return IOUtilities.PerformIO(() => GlobalAssemblyCache.Instance.GetAssemblyIdentities(partialName),
+            return IOUtilities.PerformIO(() => Scripting::Microsoft.CodeAnalysis.GlobalAssemblyCache.Instance.GetAssemblyIdentities(partialName),
                 SpecializedCollections.EmptyEnumerable<AssemblyIdentity>());
         }
     }


### PR DESCRIPTION
This pull request partially implements the "locate the runtime assembly" feature described in #24349, specifically for cases where the metadata reference resolves to a reference assembly (i.e. an assembly which does not contain IL for method bodies). Reference assemblies do not produce meaningful results when decompiled, and currently all references to the .NET Framework assemblies fall into this category. For common assemblies already located in the GAC, including the .NET Framework assemblies, this pull request allows the Navigate to Decompiled Sources feature to provide meaningful results.

Fixes #24185 (other related limitations will become separate bugs)

### Customer scenario

A user attempts to use the Navigate to Decompiled Sources feature to navigate to a member defined as part of the .NET Framework. The feature does not work as expected, because the decompiled source file shows the code for a reference assembly, which does not have any contents in the bodies of members.

### Bugs this fixes

Fixes #24185

### Workarounds, if any

None.

### Risk

Low. This only impacts the Navigate to Decompiled Sources feature, which is disabled by default and only exposed as an experimental option in the Advanced page of C# settings.

### Performance impact

This code is only in effect on the code paths where it is required.

### Is this a regression from a previous update?

No.

### Root cause analysis

Known limitation of a new feature.

### How was the bug found?

Known limitation of a new feature.

### Test documentation updated?

Yes.
