### PR TITLE
Add a Jenkins job to determine Loc status

### DIFF
--- a/build/scripts/check-locstatus.ps1
+++ b/build/scripts/check-locstatus.ps1
@@ -1,0 +1,42 @@
+# Checks for localizable resources that have not yet been translated.
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+try {
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+    $srcDir = Join-Path $repoDir "src"
+
+    # Look for two patterns: one for completely new items that have no translation,
+    # and one for items with a translation that is out-of-date with respect to the
+    # original English.
+    $searchPatterns = 'state="new"', 'state="needs-review-translation"'
+
+    $foundUntranslatedResources = $false
+
+    # Find all the .xlf files.
+    $xliffFiles = Get-ChildItem -Recurse -Path $srcDir -Include *.xlf
+
+    # Loop over the .xlf files. Print out the paths of the ones that require
+    # translation, and set the flag indicating we have untranslated resources.
+    $xliffFiles |
+    where { $_ | Select-String -Pattern $searchPatterns } |
+    % {
+        Write-Host "Untranslated resources in $($_.FullName)"
+        $foundUntranslatedResources = $true
+    }
+
+    # If we have untranslated resources, fail the script.
+    if ($foundUntranslatedResources) {
+        Write-Host "Found untranslated resources!"
+        exit 1
+    }
+    else {
+        Write-Host "Found no untranslated resources."
+        exit 0
+    }
+}
+catch {
+    Write-Host $_.Exception.Message
+    exit 1
+}


### PR DESCRIPTION
This is an infrastructure-only change.

Add a Jenkin's job to check that all localizable resources in a branch have, in fact, been localized. If unlocalized resources are found the job will fail. Otherwise, it will succeed. This will allow us to use Jenkins to verify that we've taken care of all the translations prior to shipping out of a release branch.

By default it is turned off for PRs (since it will, by design, fail a lot), but I leave open the option of turning it on for PRs to release branches. This would prevent unlocalized resources from slipping in.