### PR TITLE
Make a perf tweak in the DataTipInfoGetter

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/DataTipInfoGetter.cs
@@ -20,7 +20,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
         {
             try
             {
-                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                // Try to fetch the syntax tree synchronously. We are blocking the UI thread when we are doing this,
+                // and if the tree isn't available we will then have our UI thread blocked on waiting for the thread
+                // pool to complete, which might take awhile. There are still some async-only helpers we call further
+                // down but we shouldn't block the fast path for that.
+                var root = document.GetSyntaxRootSynchronously(cancellationToken);
                 if (root == null)
                 {
                     return default;

--- a/src/VisualStudio/VisualBasic/Impl/Debugging/DataTipInfoGetter.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Debugging/DataTipInfoGetter.vb
@@ -13,8 +13,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Debugging
     ' TODO: Make this class static when we add that functionality to VB.
     Namespace DataTipInfoGetter
         Friend Module DataTipInfoGetterModule
+#Disable Warning BC42356 ' This async method lacks 'Await' operators and so will run synchronously
             Friend Async Function GetInfoAsync(document As Document, position As Integer, cancellationToken As CancellationToken) As Task(Of DebugDataTipInfo)
-                Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
+#Enable Warning BC42356 ' This async method lacks 'Await' operators and so will run synchronously
+                Dim root = document.GetSyntaxRootSynchronously(cancellationToken)
                 Dim token = root.FindToken(position)
 
                 If token.IsKind(SyntaxKind.CommaToken) Then


### PR DESCRIPTION
Often, these only require fetching the syntax tree, which we now do synchronously. Since this is called on the UI thread, it's good practice not to call GetSyntaxRootAsync, as if we do have to recompute it it means we're having the UI thread wait for the thread pool which might be backed up. By having the UI thread do it directly, it'll always be faster.

I noticed this while working with @ivanbasov investigate some other perf issues. Awhile back we did an "async everything" approach, and have since learned that was perhaps overly aggressive, at least when that's stuff that's on the UI thread. We saw a user complaint of this taking longer than it should have, and this might help a lot, and won't hurt at all.

<details><summary>Ask Mode template</summary>

### Customer scenario

User mouses over an expression, and they get a dialog saying we're computing this. The user doesn't want that dialog.

### Bugs this fixes

Observed while investigating customer issue with @ivanbasov.

### Workarounds, if any

None, but this is just a perf fix.

### Risk

Very low: localized fix replacing with a faster but equivalent method.

### Performance impact

Should improve things. Can't make things worse.

### Is this a regression from a previous update?

Nope, this has been like this in Roslyn for awhile.

### Root cause analysis

A few years ago in Roslyn we did an async-pass where we converted as much as possible to async. We observed that in a few cases this made things worse for perf: if you are on the UI thread responding to a legacy API call, calling an async API and awaiting it is potentially worse for perf than doing the work synchronously: it means you're giving up your thread (which was running code!) and waiting for a thread pool that might be backed up. @ivanbasov and I were looking at this code for another bug, and I noticed this wasn't following the current best practice, and might help the customer in the case we were looking at. We don't have traces to confirm this might be their problem, but the fix is cheap and zero-risk.

### How was the bug found?

Customer report.

</details>
