### PR TITLE
Oop cleanup

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/RemoteHostCrashInfoBar.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/RemoteHostCrashInfoBar.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Remote
+{
+    /// <summary>
+    /// Mock for test framework
+    /// </summary>
+    internal static class RemoteHostCrashInfoBar
+    {
+        public static void ShowInfoBar()
+        {
+            // do nothing
+        }
+
+        public static void ShowInfoBar(Workspace workspace)
+        {
+            // do nothing
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Remote;
 using Roslyn.Utilities;
 using StreamJsonRpc;
@@ -173,8 +171,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             return true;
         }
 
-        private static bool s_reported = false;
-
         /// <summary>
         /// Show info bar and throw its own cancellation exception until 
         /// we figure out this issue.
@@ -185,15 +181,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         /// </summary>
         private void ThrowOwnCancellationToken()
         {
-            if (CodeAnalysis.PrimaryWorkspace.Workspace != null && !s_reported)
-            {
-                // do not report it multiple times
-                s_reported = true;
-
-                // use info bar to show warning to users
-                CodeAnalysis.PrimaryWorkspace.Workspace.Services.GetService<IErrorReportingService>()?.ShowGlobalErrorInfo(
-                    ServicesVSResources.Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio);
-            }
+            RemoteHostCrashInfoBar.ShowInfoBar();
 
             // log disconnect information before throw
             LogDisconnectInfo(_debuggingLastDisconnectReason, _debuggingLastDisconnectCallstack);

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -10,12 +9,10 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Experiments;
-using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
@@ -26,9 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     {
         public class RemoteHostClientService : ForegroundThreadAffinitizedObject, IRemoteHostClientService
         {
-            // OOP killed more info page link
-            private const string OOPKilledMoreInfoLink = "https://go.microsoft.com/fwlink/?linkid=842308";
-
             /// <summary>
             /// this hold onto last remoteHostClient to make debugging easier
             /// </summary>
@@ -269,29 +263,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     // report NFW when connection is closed unless it is proper shutdown
                     WatsonReporter.Report(new Exception("Connection to remote host closed"));
 
-                    // use info bar to show warning to users
-                    var infoBarUIs = new List<InfoBarUI>();
-
-                    infoBarUIs.Add(
-                        new InfoBarUI(ServicesVSResources.Learn_more, InfoBarUI.UIKind.HyperLink, () =>
-                            BrowserHelper.StartBrowser(new Uri(OOPKilledMoreInfoLink)), closeAfterAction: false));
-
-                    var allowRestarting = _workspace.Options.GetOption(RemoteHostOptions.RestartRemoteHostAllowed);
-                    if (allowRestarting)
-                    {
-                        // this is hidden restart option. by default, user can't restart remote host that got killed
-                        // by users
-                        infoBarUIs.Add(
-                            new InfoBarUI("Restart external process", InfoBarUI.UIKind.Button, () =>
-                            {
-                                // start off new remote host
-                                var unused = RequestNewRemoteHostAsync(CancellationToken.None);
-                            }, closeAfterAction: true));
-                    }
-
-                    _workspace.Services.GetService<IErrorReportingService>().ShowGlobalErrorInfo(
-                        ServicesVSResources.Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio,
-                        infoBarUIs.ToArray());
+                    RemoteHostCrashInfoBar.ShowInfoBar(_workspace);
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Remote
+{
+    /// <summary>
+    /// Helper type to show remote host crash info bar
+    /// </summary>
+    internal static class RemoteHostCrashInfoBar
+    {
+        // OOP killed more info page link
+        private const string OOPKilledMoreInfoLink = "https://go.microsoft.com/fwlink/?linkid=842308";
+
+        private static bool s_infoBarReported = false;
+
+        public static void ShowInfoBar()
+        {
+            ShowInfoBar(CodeAnalysis.PrimaryWorkspace.Workspace);
+        }
+
+        public static void ShowInfoBar(Workspace workspace)
+        {
+            // use info bar to show warning to users
+            if (workspace == null || s_infoBarReported)
+            {
+                return;
+            }
+
+            s_infoBarReported = true;
+
+            // use info bar to show warning to users
+            var infoBarUIs = new List<InfoBarUI>();
+
+            infoBarUIs.Add(
+                new InfoBarUI(ServicesVSResources.Learn_more, InfoBarUI.UIKind.HyperLink, () =>
+                    BrowserHelper.StartBrowser(new Uri(OOPKilledMoreInfoLink)), closeAfterAction: false));
+
+            var service = workspace.Services.GetService<IRemoteHostClientService>();
+            var allowRestarting = workspace.Options.GetOption(RemoteHostOptions.RestartRemoteHostAllowed);
+            if (allowRestarting && service != null)
+            {
+                // this is hidden restart option. by default, user can't restart remote host that got killed
+                // by users
+                infoBarUIs.Add(
+                    new InfoBarUI("Restart external process", InfoBarUI.UIKind.Button, () =>
+                    {
+                        // start off new remote host
+                        var unused = service.RequestNewRemoteHostAsync(CancellationToken.None);
+                        s_infoBarReported = false;
+                    }, closeAfterAction: true));
+            }
+
+            workspace.Services.GetService<IErrorReportingService>().ShowGlobalErrorInfo(
+                ServicesVSResources.Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio,
+                infoBarUIs.ToArray());
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Execution;
-using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Remote;
@@ -331,7 +329,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             }
 
             // operation timed out, more than we are willing to wait
-            ShowInfoBar();
+            RemoteHostCrashInfoBar.ShowInfoBar();
 
             // user didn't ask for cancellation, but we can't fullfill this request. so we
             // create our own cancellation token and then throw it. this doesn't guarantee
@@ -418,22 +416,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 // report service hub logs along with dump
                 (new Exception("RequestServiceAsync Timeout")).ReportServiceHubNFW("RequestServiceAsync Timeout");
-            }
-        }
-
-        private static bool s_infoBarReported = false;
-
-        private static void ShowInfoBar()
-        {
-            // use info bar to show warning to users
-            if (CodeAnalysis.PrimaryWorkspace.Workspace != null && !s_infoBarReported)
-            {
-                // do not report it multiple times
-                s_infoBarReported = true;
-
-                // use info bar to show warning to users
-                CodeAnalysis.PrimaryWorkspace.Workspace.Services.GetService<IErrorReportingService>()?.ShowGlobalErrorInfo(
-                    ServicesVSResources.Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio);
             }
         }
         #endregion

--- a/src/Workspaces/Core/Portable/Utilities/SoftCrashException.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SoftCrashException.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// this represents soft crash request compared to hard crash which will bring down VS.
+    /// 
+    /// by soft crash, it means everything same as hard crash except it should use NFW and info bar
+    /// to inform users about unexpected condition instead of killing VS as traditional crash did.
+    /// 
+    /// in other words, no one should ever try to recover from this exception. but they must try to not hard crash.
+    /// 
+    /// this exception is based on cancellation exception since, in Roslyn code, cancellation exception is so far
+    /// only safest exception to throw without worrying about crashing VS 99%. there is still 1% case it will bring
+    /// down VS and those places should be guarded on this exception as we find such place.
+    /// 
+    /// for now, this is an opt-in based. if a feature wants to move to soft crash (ex, OOP), one should catch
+    /// exception and translate that to this exception and then add handler which report NFW and info bar in their
+    /// code path and make sure it doesn't bring down VS.
+    /// 
+    /// as we use soft-crash in more places, we should come up with more general framework.
+    /// </summary>
+    internal class SoftCrashException : OperationCanceledException
+    {
+        public SoftCrashException() : base() { }
+
+        public SoftCrashException(string message) : base(message) { }
+        public SoftCrashException(CancellationToken token) : base(token) { }
+
+        public SoftCrashException(string message, Exception innerException) : base(message, innerException) { }
+        public SoftCrashException(string message, CancellationToken token) : base(message, token) { }
+        public SoftCrashException(string message, Exception innerException, CancellationToken token) : base(message, innerException, token) { }
+    }
+}


### PR DESCRIPTION
### Customer scenario

OOP crashed and users see more than 1 info bar stating out of process had problem.

### Bugs this fixes

this is more of clean up than bug fixing

### Workarounds, if any

No workaround

### Risk

I don't see any risk.

### Performance impact

No perf impact

### Is this a regression from a previous update?

No

### Root cause analysis

info bar was added one by one as we find places where exception can bring down VS and that caused in certain case where there are multiple failures, we showed multiple info bars. this merge those to 1.

### How was the bug found?

dogfooding
