### PR TITLE
Await in local function inside lock is now working as expected

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -101,6 +101,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Groups
 
         AllClearedAtExecutableCodeBoundary = InLockBody | InCatchBlock | InCatchFilter | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,
-        AllClearedAtInMethodBoundary = InLockBody | InCatchBlock | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -101,5 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Groups
 
         AllClearedAtExecutableCodeBoundary = InLockBody | InCatchBlock | InCatchFilter | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,
+        AllClearedAtInMethodBoundary = InLockBody | InCatchBlock | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -36,8 +36,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public InMethodBinder(MethodSymbol owner, Binder enclosing)
-            : base(enclosing, enclosing.Flags & ~BinderFlags.AllClearedAtInMethodBoundary)
+            : base(enclosing, enclosing.Flags & ~BinderFlags.AllClearedAtExecutableCodeBoundary)
         {
+            Debug.Assert(!enclosing.Flags.Includes(BinderFlags.InCatchFilter));
             Debug.Assert((object)owner != null);
             _methodSymbol = owner;
         }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public InMethodBinder(MethodSymbol owner, Binder enclosing)
-            : base(enclosing)
+            : base(enclosing, enclosing.Flags & ~BinderFlags.AllClearedAtInMethodBoundary)
         {
             Debug.Assert((object)owner != null);
             _methodSymbol = owner;


### PR DESCRIPTION
The InMethodBinder constructor was edited to pass the desired BinderFlags. Some flags were being passed by mistake to LocalScopeBinder while visiting local functions.

Also, a few tests were added to assure correct behavior.

Fixes #18644 
Fixes https://github.com/dotnet/roslyn/issues/24102