### PR TITLE
Update string text for keybindings reset.

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -672,6 +672,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disabling the extension &apos;{0}&apos; unbound your keyboard bindings..
+        /// </summary>
+        internal static string Disabling_the_extension_0_unbound_your_keyboard_bindings {
+            get {
+                return ResourceManager.GetString("Disabling_the_extension_0_unbound_your_keyboard_bindings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DocumentPath is illegal.
         /// </summary>
         internal static string DocumentPath_is_illegal {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -2626,16 +2626,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor..
-        /// </summary>
-        internal static string We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor {
-            get {
-                return ResourceManager.GetString("We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_" +
-                        "continue_to_navigate_and_refactor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to When generating properties:.
         /// </summary>
         internal static string When_generating_properties {
@@ -2686,15 +2676,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string You_must_select_at_least_one_member {
             get {
                 return ResourceManager.GetString("You_must_select_at_least_one_member", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Your keybindings are no longer mapped to Visual Studio commands..
-        /// </summary>
-        internal static string Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands {
-            get {
-                return ResourceManager.GetString("Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands", resourceCulture);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1015,4 +1015,8 @@ I agree to all of the foregoing:</value>
   <data name="Decompiler_Legal_Notice_Title" xml:space="preserve">
     <value>Decompiler Legal Notice</value>
   </data>
+  <data name="Disabling_the_extension_0_unbound_your_keyboard_bindings" xml:space="preserve">
+    <value>Disabling the extension '{0}' unbound your keyboard bindings.</value>
+    <comment>0 is an extension name</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -992,12 +992,6 @@ Additional information: {1}</value>
   <data name="Use_Keybindings_for_extensions" xml:space="preserve">
     <value>Use keybindings for ReSharper/IntelliJ/Vim/etc.</value>
   </data>
-  <data name="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands" xml:space="preserve">
-    <value>Your keybindings are no longer mapped to Visual Studio commands.</value>
-  </data>
-  <data name="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor" xml:space="preserve">
-    <value>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</value>
-  </data>
   <data name="Enable_navigation_to_decompiled_sources" xml:space="preserve">
     <value>Enable navigation to decompiled sources (experimental)</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1457,16 +1457,6 @@ Pro aktuální řešení je povolené zjednodušené načtení řešení. Jeho z
         <target state="translated">Použijte vazby kláves pro ReSharper/IntelliJ/Vim/etc.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Vaše vazby kláves už nejsou namapované na příkazy sady Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Všimli jsme si, že jste pozastavili ReSharper Ultimate. Pokud chcete pokračovat v navigaci a refaktoringu, obnovte vazby kláves pro Visual Studio.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Povolit navigaci na dekompilované zdroje (experimentální)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1498,6 +1498,11 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <target state="translated">Právní doložka pro dekompilátor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1498,6 +1498,11 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <target state="translated">Rechtlicher Hinweis zum Decompiler</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1457,16 +1457,6 @@ Für die aktuelle Projektmappe ist die Option "Lightweight-Ladevorgang für Proj
         <target state="translated">Verwenden Sie Tastenzuordnungen für ReSharper/IntelliJ/Vim usw.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Ihre Tastenzuordnungen sind nicht länger Visual Studio-Befehlen zugeordnet.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Wir haben festgestellt, dass Sie "ReSharper Ultimate" angehalten haben. Stellen Sie die Visual Studio-Tastenzuordnungen wieder her, um Navigation und Refactoring fortzusetzen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Aktivieren der Navigation zu dekompilierten Quellen (experimentell)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1498,6 +1498,11 @@ Estoy de acuerdo con todo lo anterior:</target>
         <target state="translated">Aviso legal del Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1457,16 +1457,6 @@ La opción "Carga de solución ligera" está habilitada para la solución actual
         <target state="translated">Use enlaces de teclado para ReSharper/IntelliJ/Vim/etc.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Los enlaces de teclado ya no están asignados a los comandos de Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Hemos observado que ha suspendido "ReSharper Ultimate". Restaure los enlaces de teclado de Visual Studio para seguir navegando y refactorizando.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Habilitar la navegación a orígenes decompilados (experimental)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1457,16 +1457,6 @@ Informations supplémentaires : {1}</target>
         <target state="translated">Utiliser des combinaisons de touches pour ReSharper/IntelliJ/Vim/etc.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Vos combinaisons de touches ne sont plus mappées aux commandes Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Nous avons remarqué que vous avez suspendu 'ReSharper Ultimate'. Restaurez les combinaisons de touches Visual Studio pour continuer à naviguer et à refactoriser.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Activer la navigation vers des sources décompilées (expérimental)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1498,6 +1498,11 @@ Je suis d'accord avec tout ce qui précède :</target>
         <target state="translated">Décompileur - Mention légale</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1457,16 +1457,6 @@ L'opzione 'Caricamento leggero soluzioni' è abilitata per la soluzione corrente
         <target state="translated">Usa i tasti di scelta rapida per ReSharper/IntelliJ/Vim e così via.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">I tasti di scelta rapida non sono più associati a comandi di Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">È stato notato che ‘ReSharper Ultimate’ è stato sospeso. Per continuare a esplorare e a eseguire il refactoring, ripristinare i tasti di scelta rapida di Visual Studio.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Abilita lo spostamento in origini decompilate (sperimentale)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1498,6 +1498,11 @@ L'utente accetta le condizioni sopra riportate:</target>
         <target state="translated">Note legali sul decompilatore</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1457,16 +1457,6 @@ Additional information: {1}</source>
         <target state="translated">ReSharper/IntelliJ/Vim などのキー バインドを使用します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Visual Studio コマンドとのキー バインドのマップが解除されました。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">‘ReSharper Ultimate’ が中断されたものと思われます。Visual Studio キー バインドを復元し、ナビゲートとリファクターを続行してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">逆コンパイルされたソースへのナビゲーションを有効にする (試験段階)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">デコンパイラの法的通知</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1457,16 +1457,6 @@ Additional information: {1}</source>
         <target state="translated">ReSharper/IntelliJ/Vim/etc에 대해 키 바인딩을 사용하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">키 바인딩이 더 이상 Visual Studio 명령에 매핑되지 않습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">'ReSharper Ultimate'를 일시 중단했습니다. Visual Studio 키 바인딩을 복원하여 계속 탐색하고 리팩터링하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">디컴파일된 소스에 탐색을 사용하도록 설정(실험적)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">디컴파일러 법적 고지 사항</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1457,16 +1457,6 @@ Funkcja „Uproszczone ładowanie rozwiązania” jest włączona dla bieżąceg
         <target state="translated">Użyj powiązań klawiszy dla programu ReSharper/IntelliJ/Vim/etc.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Twoje powiązania klawiszy nie są już zamapowane na polecenia programu Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Zauważyliśmy, że program „ReSharper Ultimate” został przez Ciebie zawieszony. Przywróć powiązania klawiszy programu Visual Studio, aby kontynuować nawigowanie i refaktoryzację.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Włącz nawigowanie do dekompilowanych źródeł (funkcja eksperymentalna)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1498,6 +1498,11 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <target state="translated">Informacje prawne dotyczące Dekompilatora</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1498,6 +1498,11 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <target state="translated">Aviso Legal do Descompilador</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1457,16 +1457,6 @@ O 'Carregamento da solução leve' está habilitado para a solução atual. Desa
         <target state="translated">Use associações de teclas para ReSharper/IntelliJ/Vim/etc.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Suas associações de teclas não são mais mapeadas para comandos do Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Observamos que você suspendeu o 'ReSharper Ultimate'. Restaure as associações de teclas do Visual Studio para continuar a navegar e refatorar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Habilitar a navegação para origens descompiladas (experimental)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1457,16 +1457,6 @@ Additional information: {1}</source>
         <target state="translated">Используйте настраиваемые сочетания клавиш для ReSharper, IntelliJ, Vim и т. д.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Ваши настраиваемые сочетания клавиш больше не сопоставлены с командами Visual Studio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">Мы обратили внимание, что вы перестали использовать "ReSharper Ultimate". Восстановите настраиваемые сочетания клавиш Visual Studio, чтобы возобновить навигацию и рефакторинг.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Включить переход к декомпилированным источникам (экспериментальная функция)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">Юридическая информация для декомпилятора</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1498,6 +1498,11 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <target state="translated">Derleme Ayırıcı Yasal Bildirim</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1457,16 +1457,6 @@ Geçerli durum için 'basit çözüm yükü' etkin. Hata ayıklama başlatıldı
         <target state="translated">ReSharper/IntelliJ/Vim/vb. için anahtar bağlamalarını kullanma</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">Anahtar bağlamalarınız artık Visual Studio komutlarına eşlenmiş değil.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">‘ReSharper Ultimate’ı askıya aldığınızı fark ettik. Gezinmek ve yeniden düzenlemek için Visual Studio anahtar bağlamalarını geri yükleyin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">Derlemesi ayrılan kaynaklar için gezintiyi etkinleştirme (deneysel)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">Decompiler 法律声明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1457,16 +1457,6 @@ Additional information: {1}</source>
         <target state="translated">使用 ReSharper/IntelliJ/Vim 等的键绑定。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">你的键绑定不再映射到 Visual Studio 命令。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">我们注意到你已挂起 "ReSharper Ultimate"。请还原 Visual Studio 键绑定以继续导航和重构。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">支持导航到反编译源(实验)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1498,6 +1498,11 @@ I agree to all of the foregoing:</source>
         <target state="translated">解編程式的法律聲明</target>
         <note />
       </trans-unit>
+      <trans-unit id="Disabling_the_extension_0_unbound_your_keyboard_bindings">
+        <source>Disabling the extension '{0}' unbound your keyboard bindings.</source>
+        <target state="new">Disabling the extension '{0}' unbound your keyboard bindings.</target>
+        <note>0 is an extension name</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1457,16 +1457,6 @@ Additional information: {1}</source>
         <target state="translated">使用適用於 Resharper/Intellij/Vim/等的按鍵繫結關係</target>
         <note />
       </trans-unit>
-      <trans-unit id="Your_keybindings_are_no_longer_mapped_to_Visual_Studio_commands">
-        <source>Your keybindings are no longer mapped to Visual Studio commands.</source>
-        <target state="translated">您的按鍵繫結關係已不再對應 Visual Studio 命令。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="We_noticed_you_suspended_ReSharper_Ultimate_Restore_Visual_Studio_keybindings_to_continue_to_navigate_and_refactor">
-        <source>We noticed you suspended ‘ReSharper Ultimate’. Restore Visual Studio keybindings to continue to navigate and refactor.</source>
-        <target state="translated">我們注意到您已暫停 ‘ReSharper Ultimate’。請還原 Visual Studio 按鍵繫結關係以繼續瀏覽及重構。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Enable_navigation_to_decompiled_sources">
         <source>Enable navigation to decompiled sources (experimental)</source>
         <target state="translated">啟用反編譯來源的瀏覽 (實驗性)</target>


### PR DESCRIPTION
<details><summary>Ask Mode template completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

When a customer disables an extension that messes up keybindings, the displayed notification can cause confusion as to what actually broke the bindings.

### Bugs this fixes

N/A

### Workarounds, if any

None

### Risk

Little. This just updates the text of a gold bar and adds a call to string.Format.

### Performance impact

None. Only new code is a call to string.Format.

### Is this a regression from a previous update?

N/A

### Root cause analysis

N/A

### How was the bug found?

N/A

### Test documentation updated?

N/A

</details>
