### PR TITLE
Fix up some NuGet private package definitions

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -16,7 +16,7 @@
       $commitPathMessage$
     </description>
     <dependencies>
-      <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="$version$" />
+      <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />
     </dependencies>
 
     <language>en-US</language>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -17,8 +17,8 @@
       $commitPathMessage$
     </description>
     <dependencies>
-      <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
-      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />
+      <dependency id="Microsoft.CodeAnalysis.Common" version="$version$" />
+      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$version$" />
       <dependency id="System.Composition" version="$SystemCompositionVersion$" />
     </dependencies>
 


### PR DESCRIPTION
We produce a number of pre-release packages for partner teams to get copies of certain APIs we haven't ratified. We never produce 'stable' versions of those packages because they aren't stable in any meaningful way. But sometimes, you want to mix those pre-release packages and their equivalent stable packages in the same build, which is something that ASP.NET needs to do. This means that we can't use strict package version rules that require exact versions everywhere, or else a 1.2.3-beta1 package will be "incompatible" with 1.2.3 the final release.

The easiest fix for this is to change the package dependencies that go from private unofficial packages to official packages as being a "or higher" version requirement, so it works. There's no promise this will work at runtime, but since there's prerelease packages in the mix in the first place there never really was such a promise.

This is an infrastructure only change (and only changing some non-shipping NuGet package metadata), so no ask mode is required.
