### PR TITLE
Fix tests to avoid time zone dependent DateTime values

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7397,7 +7397,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var obj1 = new MyObject1 { MyDate = DateTime.Parse(""2017-11-13T14:25:00Z"") };
+        var obj1 = new MyObject1 { MyDate = new DateTime(636461511000000000L) };
         var obj2 = new MyObject2<MyObject1>(obj1);
 
         System.Console.WriteLine(obj1.MyDate.Ticks);
@@ -7448,7 +7448,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        var obj1 = new MyObject1 { MyDate = DateTime.Parse(""2017-11-13T14:25:00Z"") };
+        var obj1 = new MyObject1 { MyDate = new DateTime(636461511000000000L) };
         var obj2 = new MyObject2<MyObject1>(obj1);
 
         System.Console.WriteLine(obj1.MyDate.Ticks);

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ConditionalAccessTests.vb
@@ -9653,7 +9653,7 @@ Test
     <file name="a.vb">
 Module Module1
     Sub Main()
-        Dim obj1 As New MyObject1 With {.MyDate = CDate("2017-11-13T14:25:00Z")}
+        Dim obj1 As New MyObject1 With {.MyDate = New Date(636461511000000000L)}
         Dim obj2 As New MyObject2(Of MyObject1)(obj1)
 
         System.Console.WriteLine(obj1.MyDate.Ticks)
@@ -9709,7 +9709,7 @@ False
     <file name="a.vb">
 Module Module1
     Sub Main()
-        Dim obj1 As New MyObject1 With {.MyDate = CDate("2017-11-13T14:25:00Z")}
+        Dim obj1 As New MyObject1 With {.MyDate = New Date(636461511000000000L)}
         Dim obj2 As New MyObject2(Of MyObject1)(obj1)
 
         System.Console.WriteLine(obj1.MyDate.Ticks)


### PR DESCRIPTION
<details><summary>Ask Mode template completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Unable to successfully run compiler tests in Eastern time zone

### Bugs this fixes

N/A

### Workarounds, if any

N/A

### Risk

N/A

### Performance impact

N/A

### Is this a regression from a previous update?

No

### Root cause analysis

The tests in question were introduced in 706389986880e7d10e8a2adf502c8bac3e722134. An instance of `DateTime` is used as an example of a reference type in the tests for this fix, but the way in which those instances are constructed is time zone dependent; the `DateTime.Parse()` method always converts the date to `DateTimeKind.Local`, meaning that the actual value of `Ticks` will be different depending on where in the world the tests are run.

### How was the bug found?

While in the Eastern time zone, I cloned Roslyn and tried to run the tests.

### Test documentation updated?

N/A

</details>
