### PR TITLE
make sure OOP inherit same culture as VS otherwise culture sensitive …

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -34,7 +34,10 @@ namespace Roslyn.Test.Utilities.Remote
             // make sure connection is done right
             var current = $"VS ({Process.GetCurrentProcess().Id})";
             var telemetrySession = default(string);
-            var host = await instance._rpc.InvokeAsync<string>(nameof(IRemoteHostService.Connect), current, telemetrySession).ConfigureAwait(false);
+            var uiCultureLCIDE = 0;
+            var cultureLCID = 0;
+
+            var host = await instance._rpc.InvokeAsync<string>(nameof(IRemoteHostService.Connect), current, uiCultureLCIDE, cultureLCID, telemetrySession).ConfigureAwait(false);
 
             // TODO: change this to non fatal watson and make VS to use inproc implementation
             Contract.ThrowIfFalse(host == current.ToString());

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,9 +94,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     workspace, primary.Logger, await RequestServiceAsync(primary, WellKnownServiceHubServices.SnapshotService, hostGroup, timeout, cancellationToken).ConfigureAwait(false));
                 client = new ServiceHubRemoteHostClient(workspace, primary, hostGroup, new ReferenceCountedDisposable<RemotableDataJsonRpc>(remotableDataRpc), remoteHostStream);
 
+                var uiCultureLCID = CultureInfo.CurrentUICulture.LCID;
+                var cultureLCID = CultureInfo.CurrentCulture.LCID;
+
                 // make sure connection is done right
                 var host = await client._rpc.InvokeWithCancellationAsync<string>(
-                    nameof(IRemoteHostService.Connect), new object[] { current, TelemetryService.DefaultSession.SerializeSettings() }, cancellationToken).ConfigureAwait(false);
+                    nameof(IRemoteHostService.Connect), new object[] { current, uiCultureLCID, cultureLCID, TelemetryService.DefaultSession.SerializeSettings() }, cancellationToken).ConfigureAwait(false);
 
                 return client;
             }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             using (var remoteHostService = CreateService())
             {
                 var input = "Test";
-                var output = remoteHostService.Connect(input, serializedSession: null, cancellationToken: CancellationToken.None);
+                var output = remoteHostService.Connect(input, uiCultureLCID: 0, cultureLCID: 0, serializedSession: null, cancellationToken: CancellationToken.None);
 
                 Assert.Equal(input, output);
             }

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal interface IRemoteHostService
     {
-        string Connect(string host, string serializedSession, CancellationToken cancellationToken);
+        string Connect(string host, int uiCultureLCID, int cultureLCID, string serializedSession, CancellationToken cancellationToken);
         Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken);
         Task SynchronizeGlobalAssetsAsync(Checksum[] checksums, CancellationToken cancellationToken);
 


### PR DESCRIPTION
…resource such as xml doc comment will not work properly

### Customer scenario

User sets VS language to something else than system language (culture), but in some cases, still get descriptions such as xml documment or diagnostic description in system language in some features 

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/24317

### Workarounds, if any

there is no workaround

### Risk

the fix is quite straight forward. and low risk

### Performance impact

I don't see any impact on perf

### Is this a regression from a previous update?

No

### Root cause analysis

Roslyn out of process didn't set default culture for its app domain and use default system culture when VS supports setting different culture than system culture.

### How was the bug found?

Dogfooding, customer report

