### PR TITLE
Add INamedTypeSymbol.IsSerializable API

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureEnvironment.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             : SpecializedCollections.EmptyEnumerable<FieldSymbol>();
 
         // display classes for static lambdas do not have any data and can be serialized.
-        internal override bool IsSerializable => (object)SingletonCache != null;
+        public override bool IsSerializable => (object)SingletonCache != null;
 
         public override Symbol ContainingSymbol => _topLevelMethod.ContainingSymbol;
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return DefaultMarshallingCharSet; }
             }
 
-            internal override bool IsSerializable
+            public override bool IsSerializable
             {
                 get { return false; }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TemplateSymbol.cs
@@ -429,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return DefaultMarshallingCharSet; }
             }
 
-            internal override bool IsSerializable
+            public override bool IsSerializable
             {
                 get { return false; }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -686,8 +686,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
                 }
             }
-
-            public bool IsSerializable => false;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -686,6 +686,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
                 }
             }
+
+            public bool IsSerializable => false;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -491,7 +491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return DefaultMarshallingCharSet; }
         }
 
-        internal sealed override bool IsSerializable
+        public sealed override bool IsSerializable
         {
             get { return false; }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -113,11 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return true;
             }
 
-            if (this.IsSerializable)
-            {
-                return true;
-            }
-
             return false;
         }
 
@@ -613,21 +608,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     out _,
                     // Filter out [Obsolete], unless it was user defined
                     (IsByRefLikeType && ObsoleteAttributeData is null) ? AttributeDescription.ObsoleteAttribute : default);
-
-                if (IsSerializable)
-                {
-                    var attribute = this.ContainingAssembly.CorLibrary.GetTypeByMetadataName("System.SerializableAttribute");
-                    var ctor = attribute?.InstanceConstructors.Where(c => c.ParameterCount == 0).FirstOrDefault();
-                    if ((object)ctor != null)
-                    {
-                        var attributeData = new SynthesizedAttributeData(
-                            ctor,
-                            ImmutableArray<TypedConstant>.Empty,
-                            ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
-
-                        loadedCustomAttributes = loadedCustomAttributes.Concat(attributeData);
-                    }
-                }
 
                 ImmutableInterlocked.InterlockedInitialize(ref uncommon.lazyCustomAttributes, loadedCustomAttributes);
             }
@@ -2060,7 +2040,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool IsSerializable
+        public override bool IsSerializable
         {
             get { return (_flags & TypeAttributes.Serializable) != 0; }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1209,7 +1209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// True if the type is serializable (has Serializable metadata flag).
         /// </summary>
-        internal abstract bool IsSerializable { get; }
+        public abstract bool IsSerializable { get; }
 
         /// <summary>
         /// Type layout information (ClassLayout metadata and layout kind flags).

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ImplicitNamedTypeSymbol.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal sealed override bool IsSerializable
+        public sealed override bool IsSerializable
         {
             get { return false; }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -929,7 +929,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool IsSerializable
+        public sealed override bool IsSerializable
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override CharSet MarshallingCharSet => DefaultMarshallingCharSet;
 
-        internal override bool IsSerializable => false;
+        public override bool IsSerializable => false;
 
         internal override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedAttributeSymbol.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool ShouldAddWinRTMembers => false;
 
-        internal override bool IsSerializable => false;
+        public override bool IsSerializable => false;
 
         internal override TypeLayout Layout => default(TypeLayout);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1390,7 +1390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsSerializable
+        public override bool IsSerializable
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingType.MarshallingCharSet; }
         }
 
-        internal override bool IsSerializable
+        public override bool IsSerializable
         {
             get { return _underlyingType.IsSerializable; }
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -365,6 +365,7 @@ public class C4 : C3
                 Assert.Equal(1, iface.TypeArguments().Length);
                 TypeSymbol typeArg = iface.TypeArguments()[0];
                 Assert.True(typeArg.IsTupleType);
+                Assert.False(((INamedTypeSymbol)typeArg).IsSerializable);
                 Assert.Equal(2, typeArg.TupleElementTypes.Length);
                 Assert.All(typeArg.TupleElementTypes,
                    t => Assert.Equal(SpecialType.System_Int32, t.SpecialType));
@@ -721,6 +722,7 @@ references: s_valueTupleRefs);
             var tooFewNames = c.GetMember<FieldSymbol>("TooFewNames");
             Assert.True(tooFewNames.Type.IsErrorType());
             Assert.IsType<UnsupportedMetadataTypeSymbol>(tooFewNames.Type);
+            Assert.False(((INamedTypeSymbol)tooFewNames.Type).IsSerializable);
 
             var tooManyNames = c.GetMember<FieldSymbol>("TooManyNames");
             Assert.True(tooManyNames.Type.IsErrorType());

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5299,6 +5299,8 @@ class C
 
             public bool IsComImport => throw new NotImplementedException();
 
+            public bool IsSerializable => throw new NotImplementedException();
+
             #endregion
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -73,6 +73,9 @@ public class ClassA
                             data.Tree.FindNodeOrTokenByKind(SyntaxKind.NewKeyword, 5).Span,
                             9, 10, 11);
 
+            Assert.Equal("AnonymousTypePublicSymbol", info0.Type.GetType().Name);
+            Assert.False(((INamedTypeSymbol)info0.Type).IsSerializable);
+
             Assert.Equal(info0.Type, info2.Type);
             Assert.NotEqual(info0.Type, info1.Type);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -3245,6 +3245,11 @@ class C<T> : IT<T>
                 // (8,7): error CS0648: '' is a type not supported by the language
                 // class C<T> : IT<T>
                 Diagnostic(ErrorCode.ERR_BogusType, "C").WithArguments("").WithLocation(8, 7));
+
+            var m = ((NamedTypeSymbol)compilation.GetMember("C1")).GetMember("I.M");
+            var constraintType = ((SourceOrdinaryMethodSymbol)m).TypeParameters[0].ConstraintTypesNoUseSiteDiagnostics[0];
+            Assert.IsType<UnsupportedMetadataTypeSymbol>(constraintType);
+            Assert.False(((INamedTypeSymbol)constraintType).IsSerializable);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -734,6 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var appNS = (NamespaceSymbol)assemblies[0].Modules[0].GlobalNamespace.GetMember("Interop");
             var dfoo = (NamedTypeSymbol)appNS.GetMember("DFoo");
+            // Pseudo - Serializable
             Assert.Equal(2, dfoo.GetAttributes().Length);
 
             // get attr by NamedTypeSymbol

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -734,8 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var appNS = (NamespaceSymbol)assemblies[0].Modules[0].GlobalNamespace.GetMember("Interop");
             var dfoo = (NamedTypeSymbol)appNS.GetMember("DFoo");
-            // Pseudo - Serializable
-            Assert.Equal(2, dfoo.GetAttributes().Length);
+            Assert.Equal(3, dfoo.GetAttributes().Length);
 
             // get attr by NamedTypeSymbol
             var attrObj = (NamedTypeSymbol)interopNS.GetTypeMembers("ComVisibleAttribute").Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingAttributes.cs
@@ -734,7 +734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var appNS = (NamespaceSymbol)assemblies[0].Modules[0].GlobalNamespace.GetMember("Interop");
             var dfoo = (NamedTypeSymbol)appNS.GetMember("DFoo");
-            Assert.Equal(3, dfoo.GetAttributes().Length);
+            Assert.Equal(2, dfoo.GetAttributes().Length);
 
             // get attr by NamedTypeSymbol
             var attrObj = (NamedTypeSymbol)interopNS.GetTypeMembers("ComVisibleAttribute").Single();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPia.cs
@@ -301,6 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Same(localTypes1_8, ambiguous.EmbeddingAssembly);
             Assert.Same(pia4_8.GlobalNamespace.GetTypeMembers("I1").Single(), ambiguous.FirstCandidate);
             Assert.Same(pia1_8.GlobalNamespace.GetTypeMembers("I1").Single(), ambiguous.SecondCandidate);
+            Assert.False(((INamedTypeSymbol)ambiguous).IsSerializable);
 
             Assert.Equal(SymbolKind.ErrorType, param[1].Type.Kind);
             Assert.IsType<NoPiaAmbiguousCanonicalTypeSymbol>(param[1].Type);
@@ -526,6 +527,7 @@ public class LocalTypes2
             Assert.Equal(varI1.ToTestDisplayString(), missing.FullTypeName);
             Assert.Null(missing.Scope);
             Assert.Null(missing.Identifier);
+            Assert.False(((INamedTypeSymbol)missing).IsSerializable);
 
             Assert.Equal(SymbolKind.ErrorType, param[1].Type.Kind);
             Assert.IsType<NoPiaMissingCanonicalTypeSymbol>(param[1].Type);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockNamedTypeSymbol.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             get { return DefaultMarshallingCharSet; }
         }
 
-        internal override bool IsSerializable
+        public override bool IsSerializable
         {
             get { return false; }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -447,6 +447,29 @@ public class Test : short { }
         }
 
         [Fact]
+        [WorkItem(3898, "https://github.com/dotnet/roslyn/issues/3898")]
+        public void Retarget_IsSerializable()
+        {
+            var source = @"
+public class Test { }
+[System.Serializable]
+public class TestS { }
+";
+
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var retargetingAssembly = new RetargetingAssemblySymbol((SourceAssemblySymbol)comp.Assembly, isLinked: false);
+            var retargetingType = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
+            Assert.IsType<RetargetingNamedTypeSymbol>(retargetingType);
+            Assert.False(((INamedTypeSymbol)retargetingType).IsSerializable);
+
+            var retargetingTypeS = retargetingAssembly.GlobalNamespace.GetMember<NamedTypeSymbol>("TestS");
+            Assert.IsType<RetargetingNamedTypeSymbol>(retargetingTypeS);
+            Assert.True(((INamedTypeSymbol)retargetingTypeS).IsSerializable);
+        }
+
+        [Fact]
         [WorkItem(604878, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/604878")]
         public void RetargetInvalidBaseType_Struct()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -1036,6 +1036,7 @@ public class ClassC : ClassB {}
             Assert.IsType<Retargeting.RetargetingNamedTypeSymbol>(B2);
             Assert.Same(B1, ((Retargeting.RetargetingNamedTypeSymbol)B2).UnderlyingNamedType);
             Assert.Same(C.BaseType(), B2);
+            Assert.False(((INamedTypeSymbol)B2).IsSerializable);
 
             var errorBase = B2.BaseType() as ErrorTypeSymbol;
             var er = errorBase.ErrorInfo;

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBloc
 Microsoft.CodeAnalysis.ILocalSymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.IMethodSymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByRefReadonly.get -> bool
+Microsoft.CodeAnalysis.INamedTypeSymbol.IsSerializable.get -> bool
 Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.IOperation.Accept(Microsoft.CodeAnalysis.Operations.OperationVisitor visitor) -> void
 Microsoft.CodeAnalysis.IOperation.Accept<TArgument, TResult>(Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult> visitor, TArgument argument) -> TResult

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -165,5 +165,10 @@ namespace Microsoft.CodeAnalysis
         /// If this type is not a tuple, then returns default.
         /// </summary>
         ImmutableArray<IFieldSymbol> TupleElements { get; }
+
+        /// <summary>
+        /// True if the type is serializable (has Serializable metadata flag).
+        /// </summary>
+        bool IsSerializable { get; }
     }
 }

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -140,7 +140,7 @@ Friend Class MockNamedTypeSymbol
         End Get
     End Property
 
-    Friend Overrides ReadOnly Property IsSerializable As Boolean
+    Public Overrides ReadOnly Property IsSerializable As Boolean
         Get
             Return False
         End Get

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrame.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrame.vb
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return _singletonCache IsNot Nothing
             End Get

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return False
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+            Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
                 Get
                     Return False
                 End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+            Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
                 Get
                     Return False
                 End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
@@ -159,7 +159,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+        Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return False
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -214,7 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return (_flags And TypeAttributes.Serializable) <> 0
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -187,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         '''  True if this type is considered serializable (metadata flag Serializable is set).
         ''' </summary>
-        Friend MustOverride ReadOnly Property IsSerializable As Boolean
+        Public MustOverride ReadOnly Property IsSerializable As Boolean Implements INamedTypeSymbol.IsSerializable
 
         ''' <summary>
         ''' Type layout information (ClassLayout metadata and layout kind flags).

--- a/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
@@ -19,6 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Sub New(pointedAtType As TypeSymbol, customModifiers As ImmutableArray(Of CustomModifier))
             Debug.Assert(pointedAtType IsNot Nothing)
+
             _pointedAtType = pointedAtType
             _customModifiers = customModifiers.NullToEmpty()
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PointerTypeSymbol.vb
@@ -19,7 +19,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Sub New(pointedAtType As TypeSymbol, customModifiers As ImmutableArray(Of CustomModifier))
             Debug.Assert(pointedAtType IsNot Nothing)
-
             _pointedAtType = pointedAtType
             _customModifiers = customModifiers.NullToEmpty()
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
@@ -255,7 +255,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return _underlyingType.IsSerializable
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return False
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2383,7 +2383,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+        Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Dim data = GetDecodedWellKnownAttributeData()
                 Return data IsNot Nothing AndAlso data.HasSerializableAttribute

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -912,7 +912,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End Get
                 End Property
 
-                Friend Overrides ReadOnly Property IsSerializable As Boolean
+                Public Overrides ReadOnly Property IsSerializable As Boolean
                     Get
                         Return False
                     End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+        Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return OriginalDefinition.IsSerializable
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
@@ -332,7 +332,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return False
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -277,7 +277,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return Me._underlyingType.IsSerializable
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
         End Function
 
-        Friend NotInheritable Class ConstructedSymbol
+        Private NotInheritable Class ConstructedSymbol
             Inherits UnboundGenericType
 
             Private ReadOnly _originalDefinition As NamedTypeSymbol
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Class
 
-        Friend NotInheritable Class ConstructedFromSymbol
+        Private NotInheritable Class ConstructedFromSymbol
             Inherits UnboundGenericType
 
             Public ReadOnly Constructed As ConstructedSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
+        Public NotOverridable Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return OriginalDefinition.IsSerializable
             End Get
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
         End Function
 
-        Private NotInheritable Class ConstructedSymbol
+        Friend NotInheritable Class ConstructedSymbol
             Inherits UnboundGenericType
 
             Private ReadOnly _originalDefinition As NamedTypeSymbol
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Class
 
-        Private NotInheritable Class ConstructedFromSymbol
+        Friend NotInheritable Class ConstructedFromSymbol
             Inherits UnboundGenericType
 
             Public ReadOnly Constructed As ConstructedSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.vb
@@ -175,7 +175,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return Me._underlyingType.IsSerializable
             End Get

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -1950,6 +1950,7 @@ End Module
             Assert.False(DirectCast(gt.Value, TypeSymbol).IsErrorType)
             Dim arg = DirectCast(gt.Value, UnboundGenericType)
             Assert.Equal("ClassLibrary1.C1(Of )", arg.ToDisplayString)
+            Assert.False(DirectCast(arg, INamedTypeSymbol).IsSerializable)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -434,6 +434,93 @@ End Class
             CompileAndVerify(source, sourceSymbolValidator:=attributeValidator)
         End Sub
 
+        <Fact>
+        <WorkItem(3898, "https://github.com/dotnet/roslyn/issues/3898")>
+        Sub SerializableFromPE()
+            Dim lib_vb =
+<compilation>
+    <file name="attr.vb"><![CDATA[
+Imports System
+<Serializable, Bob>
+Public Class C
+End Class
+
+<AttributeUsage(AttributeTargets.Class)>
+Public Class BobAttribute
+    Inherits Attribute
+End Class
+    ]]></file>
+</compilation>
+            Dim lib_comp = CreateCompilationWithMscorlibAndVBRuntime(lib_vb)
+
+            Dim typeC As INamedTypeSymbol = lib_comp.GetTypeByMetadataName("C")
+            AssertEx.SetEqual({"System.SerializableAttribute", "BobAttribute"}, typeC.GetAttributes().Select(Function(a) a.ToString()))
+            Assert.True(typeC.IsSerializable)
+
+            Dim typeBobAttribute As INamedTypeSymbol = lib_comp.GetTypeByMetadataName("BobAttribute")
+            Assert.False(typeBobAttribute.IsSerializable)
+
+            Dim empty_vb =
+<compilation>
+    <file name="attr.vb"></file>
+</compilation>
+
+            Dim client1 = CreateCompilationWithMscorlibAndVBRuntime(empty_vb, additionalRefs:={lib_comp.ToMetadataReference()})
+
+            Dim typeC1 As INamedTypeSymbol = client1.GetTypeByMetadataName("C")
+            AssertEx.SetEqual({"System.SerializableAttribute", "BobAttribute"}, typeC1.GetAttributes().Select(Function(a) a.ToString()))
+            Assert.True(typeC1.IsSerializable)
+
+            Dim typeBobAttribute1 As INamedTypeSymbol = client1.GetTypeByMetadataName("BobAttribute")
+            Assert.False(typeBobAttribute1.IsSerializable)
+
+            Dim client2 = CreateCompilationWithMscorlibAndVBRuntime(empty_vb, additionalRefs:={lib_comp.EmitToImageReference()})
+
+            Dim typeC2 As INamedTypeSymbol = client2.GetTypeByMetadataName("C")
+            AssertEx.SetEqual({"BobAttribute"}, typeC2.GetAttributes().Select(Function(a) a.ToString()))
+            Assert.True(typeC2.IsSerializable)
+
+            Dim typeBobAttribute2 As INamedTypeSymbol = client2.GetTypeByMetadataName("BobAttribute")
+            Assert.False(typeBobAttribute2.IsSerializable)
+        End Sub
+
+        <Fact>
+        <WorkItem(3898, "https://github.com/dotnet/roslyn/issues/3898")>
+        Sub SerializableSubstitutedType()
+            Dim lib_vb =
+<compilation>
+    <file name="attr.vb"><![CDATA[
+Imports System
+
+<Serializable>
+Public Class C(Of T)
+End Class
+
+' Not serializable
+Public Class D(Of T)
+End Class
+
+Public Class C2
+    Inherits C(Of Integer)
+End Class
+Public Class D2
+    Inherits D(Of Integer)
+End Class
+            ]]></file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(lib_vb)
+
+            Dim cOfInt = comp.GetTypeByMetadataName("C2").BaseType()
+            Assert.IsType(GetType(SubstitutedNamedType.ConstructedInstanceType), cOfInt)
+            Assert.True(DirectCast(cOfInt, INamedTypeSymbol).IsSerializable)
+            Assert.True(DirectCast(cOfInt.ConstructedFrom, INamedTypeSymbol).IsSerializable)
+
+            Dim dOfInt = comp.GetTypeByMetadataName("D2").BaseType()
+            Assert.IsType(GetType(SubstitutedNamedType.ConstructedInstanceType), dOfInt)
+            Assert.False(DirectCast(dOfInt, INamedTypeSymbol).IsSerializable)
+            Assert.False(DirectCast(dOfInt.ConstructedFrom, INamedTypeSymbol).IsSerializable)
+        End Sub
+
         <WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")>
         <Fact()>
         Public Sub DateTimeConstantAttribute()
@@ -2985,6 +3072,201 @@ BC30662: Attribute 'NonSerializedAttribute' cannot be applied to 'e2' because th
     <NonSerialized>
      ~~~~~~~~~~~~~
 ]]></expected>)
+        End Sub
+
+        <Fact>
+        <WorkItem(3898, "https://github.com/dotnet/roslyn/issues/3898")>
+        Public Sub TestIsSerializableProperty()
+            Dim missing =
+<compilation>
+    <file name="missing.vb"><![CDATA[
+Public Class TopLevel
+    Public Class Nested
+    End Class
+End Class
+Public Class TopLevel(Of T)
+    Public Class Nested(Of U)
+    End Class
+End Class
+Public Class Constructed(Of T)
+End Class
+]]></file>
+</compilation>
+
+            Dim source =
+<compilation>
+    <file name="source.vb"><![CDATA[
+Public Class C(Of T)
+    Public Class Nested
+    End Class
+End Class
+
+<System.Serializable>
+Public Class CS(Of T)
+    <System.Serializable>
+    Public Class NestedS
+    End Class
+
+    Public Class Nested(Of U)
+    End Class
+
+    <System.Serializable>
+    Public Class NestedS(Of U)
+    End Class
+End Class
+
+Public Class SubstitutedNested
+    Inherits C(Of Integer).Nested
+End Class
+Public Class SubstitutedNestedS
+    Inherits CS(Of Integer).NestedS
+End Class
+
+Public Class Constructed
+    Inherits C(Of Integer)
+End Class
+Public Class ConstructedS
+    Inherits CS(Of Integer)
+End Class
+Public Class MissingTopLevel
+    Inherits TopLevel
+End Class
+Public Class MissingNested
+    Inherits TopLevel.Nested
+End Class
+Public Class MissingConstructed
+    Inherits Constructed(Of Integer)
+End Class
+
+Public Class MissingSubstitutedNested(Of T, U)
+    Inherits TopLevel(Of T).Nested(Of U)
+End Class
+
+Public Class SpecializedGenericType
+    Inherits CS(Of Integer).Nested(Of Integer)
+End Class
+Public Class SpecializedGenericTypeS
+    Inherits CS(Of Integer).NestedS(Of Integer)
+End Class
+
+Namespace System
+    <System.Serializable>
+    Public Structure ValueTuple(Of T1, T2)
+    End Structure
+
+    Public Class InNamespace
+    End Class
+
+    <System.Serializable>
+    Public Class InNamespaceS
+    End Class
+End Namespace
+
+Public Class ValueTupleS
+    Function M() As (Integer, Integer)
+        Throw New System.Exception()
+    End Function
+End Class
+]]></file>
+</compilation>
+
+            Dim errors =
+<compilation>
+    <file name="errors.vb"><![CDATA[
+Public Class ExtendedError
+    Inherits ExtendedErrorBase
+End Class
+Public Class Unbound
+    Inherits Constructed(Of )
+End Class
+]]></file>
+</compilation>
+            Dim lib1 = CreateCompilationWithMscorlib45AndVBRuntime(missing)
+            lib1.VerifyDiagnostics()
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source, additionalRefs:={lib1.EmitToImageReference()})
+            comp.VerifyDiagnostics()
+            Dim comp2 = CreateCompilationWithMscorlib45AndVBRuntime(errors, additionalRefs:={comp.EmitToImageReference()})
+
+            Dim substitutedNested = comp.GetTypeByMetadataName("SubstitutedNested").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.SpecializedNonGenericType)(substitutedNested)
+            Assert.False(DirectCast(substitutedNested, INamedTypeSymbol).IsSerializable)
+
+            Dim substitutedNestedS = comp.GetTypeByMetadataName("SubstitutedNestedS").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.SpecializedNonGenericType)(substitutedNestedS)
+            Assert.True(DirectCast(substitutedNestedS, INamedTypeSymbol).IsSerializable)
+
+            Dim specialized = comp.GetTypeByMetadataName("SpecializedGenericType").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.ConstructedSpecializedGenericType)(specialized)
+            Assert.False(DirectCast(specialized, INamedTypeSymbol).IsSerializable)
+
+            Dim specializedS = comp.GetTypeByMetadataName("SpecializedGenericTypeS").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.ConstructedSpecializedGenericType)(specializedS)
+            Assert.True(DirectCast(specializedS, INamedTypeSymbol).IsSerializable)
+
+            Dim valueTupleS = DirectCast(comp.GetTypeByMetadataName("ValueTupleS").GetMember("M"), SourceMemberMethodSymbol).ReturnType
+            Assert.IsType(Of TupleTypeSymbol)(valueTupleS)
+            Assert.True(DirectCast(valueTupleS, INamedTypeSymbol).IsSerializable)
+
+            Dim constructed = comp.GetTypeByMetadataName("Constructed").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.ConstructedInstanceType)(constructed)
+            Assert.False(DirectCast(constructed, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedPE = comp2.GetTypeByMetadataName("Constructed").BaseType().ConstructedFrom
+            Assert.IsType(Of PENamedTypeSymbol)(constructedPE)
+            Assert.False(DirectCast(constructedPE, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedFrom = constructed.ConstructedFrom
+            Assert.IsType(Of SourceNamedTypeSymbol)(constructedFrom)
+            Assert.False(DirectCast(constructedFrom, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedS = comp.GetTypeByMetadataName("ConstructedS").BaseType()
+            Assert.IsType(Of SubstitutedNamedType.ConstructedInstanceType)(constructedS)
+            Assert.True(DirectCast(constructedS, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedSPE = comp2.GetTypeByMetadataName("ConstructedS").BaseType().ConstructedFrom
+            Assert.IsType(Of PENamedTypeSymbol)(constructedSPE)
+            Assert.True(DirectCast(constructedSPE, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedFromS = constructedS.ConstructedFrom
+            Assert.IsType(Of SourceNamedTypeSymbol)(constructedFromS)
+            Assert.True(DirectCast(constructedFromS, INamedTypeSymbol).IsSerializable)
+
+            Dim extendedError = comp2.GetTypeByMetadataName("ExtendedError").BaseType()
+            Assert.IsType(Of ExtendedErrorTypeSymbol)(extendedError)
+            Assert.False(DirectCast(extendedError, INamedTypeSymbol).IsSerializable)
+
+            Dim topLevel = comp2.GetTypeByMetadataName("MissingTopLevel").BaseType()
+            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(topLevel)
+            Assert.False(DirectCast(topLevel, INamedTypeSymbol).IsSerializable)
+
+            Dim nested = comp2.GetTypeByMetadataName("MissingNested").BaseType()
+            Assert.IsType(Of MissingMetadataTypeSymbol.Nested)(nested)
+            Assert.False(DirectCast(nested, INamedTypeSymbol).IsSerializable)
+
+            Dim constructedError = comp2.GetTypeByMetadataName("MissingConstructed").BaseType()
+            Assert.IsType(Of SubstitutedErrorType)(constructedError)
+            Assert.False(DirectCast(constructedError, INamedTypeSymbol).IsSerializable)
+
+            Dim nestedSubstitutedError = comp2.GetTypeByMetadataName("MissingSubstitutedNested`2").BaseType().ConstructedFrom
+            Assert.IsType(Of SubstitutedErrorType)(nestedSubstitutedError)
+            Assert.False(DirectCast(nestedSubstitutedError, INamedTypeSymbol).IsSerializable)
+
+            'Dim unbound = comp2.GetTypeByMetadataName("Unbound").BaseType().TypeArgumentsNoUseSiteDiagnostics(0)
+            'Assert.IsType(Of NamedTypeSymbol)(unbound)
+            'Assert.False(DirectCast(unbound, INamedTypeSymbol).IsSerializable)
+
+            Dim script = CreateCompilation("", parseOptions:=TestOptions.Script)
+            Dim scriptClass = script.GetTypeByMetadataName("Script")
+            Assert.IsType(Of ImplicitNamedTypeSymbol)(scriptClass)
+            Assert.False(DirectCast(scriptClass, INamedTypeSymbol).IsSerializable)
+
+            Dim inNamespace = comp2.GetTypeByMetadataName("System.InNamespace")
+            Assert.IsType(Of PENamedTypeSymbolWithEmittedNamespaceName)(inNamespace)
+            Assert.False(DirectCast(inNamespace, INamedTypeSymbol).IsSerializable)
+
+            Dim inNamespaceS = comp2.GetTypeByMetadataName("System.InNamespaceS")
+            Assert.IsType(Of PENamedTypeSymbolWithEmittedNamespaceName)(inNamespaceS)
+            Assert.True(DirectCast(inNamespaceS, INamedTypeSymbol).IsSerializable)
         End Sub
 #End Region
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -4677,6 +4677,7 @@ BC30311: Value of type '(Integer, String, C As Integer)' cannot be converted to 
             Dim xSymbol = DirectCast(model.GetDeclaredSymbol(x), LocalSymbol).Type
             Assert.Equal("(System.Int32, A As System.String)", xSymbol.ToTestDisplayString())
             Assert.True(xSymbol.IsTupleType)
+            Assert.False(DirectCast(xSymbol, INamedTypeSymbol).IsSerializable)
 
             Assert.Equal({"System.Int32", "System.String"}, xSymbol.TupleElementTypes.SelectAsArray(Function(t) t.ToTestDisplayString()))
             Assert.Equal({Nothing, "A"}, xSymbol.TupleElementNames)
@@ -9744,10 +9745,12 @@ additionalReferences:=s_valueTupleRefs)
             Assert.True(validFieldWithAttribute.Type.IsErrorType())
             Assert.False(validFieldWithAttribute.Type.IsTupleType)
             Assert.IsType(Of UnsupportedMetadataTypeSymbol)(validFieldWithAttribute.Type)
+            Assert.False(DirectCast(validFieldWithAttribute.Type, INamedTypeSymbol).IsSerializable)
 
             Dim tooFewNames = c.GetMember(Of FieldSymbol)("TooFewNames")
             Assert.True(tooFewNames.Type.IsErrorType())
             Assert.IsType(Of UnsupportedMetadataTypeSymbol)(tooFewNames.Type)
+            Assert.False(DirectCast(tooFewNames.Type, INamedTypeSymbol).IsSerializable)
 
             Dim tooManyNames = c.GetMember(Of FieldSymbol)("TooManyNames")
             Assert.True(tooManyNames.Type.IsErrorType())

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
@@ -2,8 +2,6 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
@@ -2,6 +2,8 @@
 
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousDelegates/AnonymousDelegates_CreationAndEmit.vb
@@ -310,6 +310,9 @@ End Module
             Assert.Equal(MethodKind.Ordinary, x16.GetMember(Of MethodSymbol)("EndInvoke").MethodKind)
             Assert.Equal("Function <generated method>.EndInvoke(ByRef Pp1 As System.Int64, DelegateAsyncResult As System.IAsyncResult) As System.Int64", x16.GetMember("EndInvoke").ToTestDisplayString())
 
+            Assert.IsType(GetType(AnonymousTypeManager.AnonymousDelegatePublicSymbol), x16)
+            Assert.False(DirectCast(x16, INamedTypeSymbol).IsSerializable)
+
             Dim node15 As ModifiedIdentifierSyntax = CompilationUtils.FindBindingText(Of ModifiedIdentifierSyntax)(compilation, "a.vb", 15)
             Dim x15 = DirectCast(semanticModel.GetDeclaredSymbol(node15), LocalSymbol).Type
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesEmittedSymbolsTests.vb
@@ -583,6 +583,8 @@ End Module
                                                         Dim node0 = DirectCast(tree.FindNodeOrTokenByKind(SyntaxKind.AnonymousObjectCreationExpression).AsNode(), ExpressionSyntax)
                                                         Dim info0 = model.GetSemanticInfoSummary(node0)
                                                         Assert.NotNull(info0.Type)
+                                                        Assert.IsType(GetType(AnonymousTypeManager.AnonymousTypePublicSymbol), info0.Type)
+                                                        Assert.False(DirectCast(info0.Type, INamedTypeSymbol).IsSerializable)
 
                                                         Dim expr1 = SyntaxFactory.ParseExpression(<text>New With { .aa = 1, .BB = "", .CCC = new SSS() }</text>.Value)
                                                         Dim info1 = model.GetSpeculativeTypeInfo(position, expr1, SpeculativeBindingOption.BindAsExpression)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
@@ -408,6 +408,7 @@ End Module
 
         Private Sub CheckAnonymousTypeImplicit(local As LocalSymbol, location As Location, anotherType As TypeSymbol, isType As Boolean, ParamArray locations() As Location)
             Dim localType = local.Type
+            Assert.True(localType.IsAnonymousType)
 
             ' IsImplicitlyDeclared: Return true. The new { } clause is 
             '                       a reference to an implicit declaration.

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AnonymousTypes/AnonymousTypesSemanticsTests.vb
@@ -394,18 +394,20 @@ End Module
             ' check 'b'
             Dim posB As Integer = text.IndexOf("del_b", StringComparison.Ordinal)
             Dim declaratorB = tree.GetRoot().FindToken(posB).Parent.FirstAncestorOrSelf(Of VariableDeclaratorSyntax)()
+            Dim delegateA = DirectCast(model.GetDeclaredSymbol(declaratorA.Names(0)), LocalSymbol).Type
             CheckAnonymousTypeImplicit(DirectCast(model.GetDeclaredSymbol(declaratorB.Names(0)), LocalSymbol),
                                        tree.GetRoot().FindToken(sub2).Parent.Parent.GetLocation,
-                                       DirectCast(model.GetDeclaredSymbol(declaratorA.Names(0)), LocalSymbol).Type,
+                                       delegateA,
                                        False,
                                        tree.GetRoot().FindToken(x2 - 2).GetLocation(),
                                        tree.GetRoot().FindToken(y2 - 2).GetLocation())
 
+            Assert.IsType(Of AnonymousTypeManager.AnonymousDelegatePublicSymbol)(delegateA)
+            Assert.False(DirectCast(delegateA, INamedTypeSymbol).IsSerializable)
         End Sub
 
         Private Sub CheckAnonymousTypeImplicit(local As LocalSymbol, location As Location, anotherType As TypeSymbol, isType As Boolean, ParamArray locations() As Location)
             Dim localType = local.Type
-            Assert.True(localType.IsAnonymousType)
 
             ' IsImplicitlyDeclared: Return true. The new { } clause is 
             '                       a reference to an implicit declaration.

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/NoPia.vb
@@ -218,6 +218,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
             Dim ambiguous As NoPiaAmbiguousCanonicalTypeSymbol
             Assert.Equal(SymbolKind.ErrorType, param(0).[Type].Kind)
             ambiguous = DirectCast(param(0).[Type], NoPiaAmbiguousCanonicalTypeSymbol)
+            Assert.False(DirectCast(param(0).Type, INamedTypeSymbol).IsSerializable)
             Assert.Same(localTypes1_8, ambiguous.EmbeddingAssembly)
             Assert.Same(pia4_8.GlobalNamespace.GetTypeMembers("I1").Single(), ambiguous.FirstCandidate)
             Assert.Same(pia1_8.GlobalNamespace.GetTypeMembers("I1").Single(), ambiguous.SecondCandidate)
@@ -772,6 +773,7 @@ End Class
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test2").ReturnType.Kind)
             Assert.Equal(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test3").ReturnType.Kind)
             Dim illegal As NoPiaIllegalGenericInstantiationSymbol = DirectCast(localTypes3.GetMember(Of MethodSymbol)("Test3").ReturnType, NoPiaIllegalGenericInstantiationSymbol)
+            Assert.False(DirectCast(illegal, INamedTypeSymbol).IsSerializable)
             Assert.Equal("C31(Of I1).I31(Of C33)", illegal.UnderlyingSymbol.ToTestDisplayString())
             Assert.NotEqual(SymbolKind.ErrorType, localTypes3.GetMember(Of MethodSymbol)("Test4").ReturnType.Kind)
             Assert.IsType(Of NoPiaIllegalGenericInstantiationSymbol)(localTypes3.GetMember(Of MethodSymbol)("Test5").ReturnType)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
@@ -393,6 +393,7 @@ End Class
             Dim missing As NoPiaMissingCanonicalTypeSymbol
             Assert.Equal(SymbolKind.ErrorType, param(0).[Type].Kind)
             missing = DirectCast(param(0).[Type], NoPiaMissingCanonicalTypeSymbol)
+            Assert.False(DirectCast(missing, INamedTypeSymbol).IsSerializable)
             Assert.Same(localTypes2_3, missing.EmbeddingAssembly)
             Assert.Null(missing.Guid)
             Assert.Equal(varS1.ToTestDisplayString(), missing.FullTypeName)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/RetargetCustomModifiers.vb
@@ -75,6 +75,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Retargeting
             Assert.Equal(0, p6.CustomModifiers.Length)
 
             Assert.True(p6.[Type].IsErrorType())
+            Assert.IsType(Of PointerTypeSymbol)(p6.Type)
+            Assert.False(DirectCast(p6.Type, INamedTypeSymbol).IsSerializable)
 
             Assert.[False](m7.IsSub)
             Assert.Equal(1, m7.ReturnTypeCustomModifiers.Length)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
@@ -2510,7 +2510,7 @@ BC31035: Interface 'IFoo' is not implemented by this class.
         Public Sub GenericInterface()
             Dim comp = CompilationUtils.CreateCompilationWithMscorlib(
     <compilation name="SimpleImplementation">
-        <file name="a.vb">
+        <file name="a.vb"><![CDATA[
 Option Strict On
 Imports System.Collections.Generic
 
@@ -2529,8 +2529,12 @@ Class Outer(Of X)
         Public Sub M2(b As List(Of Y), c As X) Implements Outer(Of X).IFoo(Of X, List(Of Y)).SayItWithStyle
         End Sub
     End Class
+
+    <System.Serializable>
+    Class FooS(Of T, U)
+    End Class
 End Class
-    </file>
+    ]]></file>
     </compilation>)
 
             Dim globalNS = comp.GlobalNamespace
@@ -2540,6 +2544,13 @@ End Class
             Dim outerOfX = DirectCast(globalNS.GetMembers("Outer").First(), NamedTypeSymbol)
             Dim outerOfInt = outerOfX.Construct(comp.GetSpecialType(SpecialType.System_Int32))
             Dim iFooOfIntTU = DirectCast(outerOfInt.GetMembers("IFoo").First(), NamedTypeSymbol)
+            Assert.IsType(Of SubstitutedNamedType.SpecializedGenericType)(iFooOfIntTU)
+            Assert.False(iFooOfIntTU.IsSerializable)
+
+            Dim fooSOfIntTU = DirectCast(outerOfInt.GetMembers("FooS").First(), NamedTypeSymbol)
+            Assert.IsType(Of SubstitutedNamedType.SpecializedGenericType)(fooSOfIntTU)
+            Assert.True(fooSOfIntTU.IsSerializable)
+
             Dim iFooOfIntIntListOfString = iFooOfIntTU.Construct(comp.GetSpecialType(SpecialType.System_Int32), listOfString)
             Dim fooOfIntY = DirectCast(outerOfInt.GetMembers("Foo").First(), NamedTypeSymbol)
             Dim fooOfIntString = fooOfIntY.Construct(comp.GetSpecialType(SpecialType.System_String))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
@@ -2545,7 +2545,7 @@ End Class
             Dim outerOfInt = outerOfX.Construct(comp.GetSpecialType(SpecialType.System_Int32))
             Dim iFooOfIntTU = DirectCast(outerOfInt.GetMembers("IFoo").First(), NamedTypeSymbol)
             Assert.IsType(Of SubstitutedNamedType.SpecializedGenericType)(iFooOfIntTU)
-            Assert.False(iFooOfIntTU.IsSerializable)
+            Assert.False(DirectCast(iFooOfIntTU, INamedTypeSymbol).IsSerializable)
 
             Dim fooSOfIntTU = DirectCast(outerOfInt.GetMembers("FooS").First(), NamedTypeSymbol)
             Assert.IsType(Of SubstitutedNamedType.SpecializedGenericType)(fooSOfIntTU)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ImplementsTests.vb
@@ -2549,7 +2549,7 @@ End Class
 
             Dim fooSOfIntTU = DirectCast(outerOfInt.GetMembers("FooS").First(), NamedTypeSymbol)
             Assert.IsType(Of SubstitutedNamedType.SpecializedGenericType)(fooSOfIntTU)
-            Assert.True(fooSOfIntTU.IsSerializable)
+            Assert.True(DirectCast(fooSOfIntTU, INamedTypeSymbol).IsSerializable)
 
             Dim iFooOfIntIntListOfString = iFooOfIntTU.Construct(comp.GetSpecialType(SpecialType.System_Int32), listOfString)
             Dim fooOfIntY = DirectCast(outerOfInt.GetMembers("Foo").First(), NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -6120,6 +6120,7 @@ BC30573: Error in project-level import '<xmlns="default2">' at '<xmlns="default2
 ]]></errors>)
             Dim embedded = compilation.GetTypeByMetadataName("Microsoft.VisualBasic.Embedded")
             Assert.IsType(Of EmbeddedSymbolManager.EmbeddedNamedTypeSymbol)(embedded)
+            Assert.False(DirectCast(embedded, INamedTypeSymbol).IsSerializable)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -6118,6 +6118,8 @@ End Class
 BC30573: Error in project-level import '<xmlns:p="p2">' at '<xmlns:p="p2">' : XML namespace prefix 'p' is already declared.
 BC30573: Error in project-level import '<xmlns="default2">' at '<xmlns="default2">' : XML namespace prefix '' is already declared.
 ]]></errors>)
+            Dim embedded = compilation.GetTypeByMetadataName("Microsoft.VisualBasic.Embedded")
+            Assert.IsType(Of EmbeddedSymbolManager.EmbeddedNamedTypeSymbol)(embedded)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
@@ -267,22 +267,22 @@ End Class
             Dim c6 = c3.GetTypeMembers("C6").Single()
 
             Dim u_c3 = c3.ConstructUnboundGenericType()
-            Assert.IsType(Of UnboundGenericType.ConstructedSymbol)(u_c3)
+            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundGenericType+ConstructedSymbol", u_c3.GetType().FullName)
             Assert.False(DirectCast(u_c3, INamedTypeSymbol).IsSerializable)
 
             Dim c3c6 = u_c3.GetMember("C6")
-            Assert.IsType(Of UnboundGenericType.ConstructedFromSymbol)(c3c6)
+            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundGenericType+ConstructedFromSymbol", c3c6.GetType().FullName)
             Assert.False(DirectCast(c3c6, INamedTypeSymbol).IsSerializable)
 
             Dim c3s = compilation.GetTypeByMetadataName("C3S`1")
             Dim c6s = c3s.GetTypeMembers("C6S").Single()
 
             Dim u_c3s = c3s.ConstructUnboundGenericType()
-            Assert.IsType(Of UnboundGenericType.ConstructedSymbol)(u_c3s)
+            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundGenericType+ConstructedSymbol", u_c3s.GetType().FullName)
             Assert.True(DirectCast(u_c3s, INamedTypeSymbol).IsSerializable)
 
             Dim c3c6s = u_c3s.GetMember("C6S")
-            Assert.IsType(Of UnboundGenericType.ConstructedFromSymbol)(c3c6s)
+            Assert.Equal("Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundGenericType+ConstructedFromSymbol", c3c6s.GetType().FullName)
             Assert.True(DirectCast(c3c6s, INamedTypeSymbol).IsSerializable)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/UnboundGenericType.vb
@@ -112,6 +112,7 @@ End Class
             Assert.Equal(u__c3.GetHashCode(), u_c3.GetHashCode())
             Assert.Equal("C4, C6", String.Join(", ", u_c3.MemberNames))
             Assert.Equal("C3(Of ).C4, C3(Of ).C6(Of T1)", String.Join(", ", u_c3.GetMembers().Select(Function(s) s.ToTestDisplayString())))
+
             Assert.Equal(0, u_c3.GetMembers().As(Of NamedTypeSymbol)().Where(Function(s) Not s.ContainingType.IsUnboundGenericType OrElse s.IsUnboundGenericType <> (s.Arity = 0)).Count)
             Assert.Equal("C3(Of ).C6(Of T1)", String.Join(", ", u_c3.GetMembers("c6").Select(Function(s) s.ToTestDisplayString())))
             Assert.Equal(0, u_c3.GetMembers("c6").As(Of NamedTypeSymbol)().Where(Function(s) Not s.ContainingType.IsUnboundGenericType OrElse s.IsUnboundGenericType <> (s.Arity = 0)).Count)
@@ -238,6 +239,51 @@ End Class
             Assert.Same(u_c7.ContainingSymbol, u_c7_cf.ContainingSymbol)
             Assert.Same(u_c7_cf, u_c7_cf.ConstructedFrom)
             Assert.Same(u_c7, u_c7_cf.ConstructUnboundGenericType())
+        End Sub
+
+        <Fact>
+        <WorkItem(3898, "https://github.com/dotnet/roslyn/issues/3898")>
+        Public Sub UnboundGenericType_IsSerializable()
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="C">
+    <file name="a.vb"><![CDATA[
+
+Class C3(Of T)
+    Class C6(Of T1)
+    End Class
+End Class
+
+<System.Serializable>
+Class C3S(Of T)
+    <System.Serializable>
+    Class C6S(Of T1)
+    End Class
+End Class
+    ]]></file>
+</compilation>)
+
+            Dim c3 = compilation.GetTypeByMetadataName("C3`1")
+            Dim c6 = c3.GetTypeMembers("C6").Single()
+
+            Dim u_c3 = c3.ConstructUnboundGenericType()
+            Assert.IsType(Of UnboundGenericType.ConstructedSymbol)(u_c3)
+            Assert.False(DirectCast(u_c3, INamedTypeSymbol).IsSerializable)
+
+            Dim c3c6 = u_c3.GetMember("C6")
+            Assert.IsType(Of UnboundGenericType.ConstructedFromSymbol)(c3c6)
+            Assert.False(DirectCast(c3c6, INamedTypeSymbol).IsSerializable)
+
+            Dim c3s = compilation.GetTypeByMetadataName("C3S`1")
+            Dim c6s = c3s.GetTypeMembers("C6S").Single()
+
+            Dim u_c3s = c3s.ConstructUnboundGenericType()
+            Assert.IsType(Of UnboundGenericType.ConstructedSymbol)(u_c3s)
+            Assert.True(DirectCast(u_c3s, INamedTypeSymbol).IsSerializable)
+
+            Dim c3c6s = u_c3s.GetMember("C6S")
+            Assert.IsType(Of UnboundGenericType.ConstructedFromSymbol)(c3c6s)
+            Assert.True(DirectCast(c3c6s, INamedTypeSymbol).IsSerializable)
         End Sub
 
     End Class

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
-        internal override bool IsSerializable
+        public override bool IsSerializable
         {
             get { return false; }
         }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
@@ -213,7 +213,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Friend Overrides ReadOnly Property IsSerializable As Boolean
+        Public Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return False
             End Get

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -142,6 +142,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             ITypeSymbol ITypeSymbol.OriginalDefinition => _symbol.OriginalDefinition;
             public new INamedTypeSymbol OriginalDefinition => this;
+
+            public bool IsSerializable => throw new NotImplementedException();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -52,5 +52,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public override bool IsNamespace => false;
 
         public override bool IsType => true;
+
+        public bool IsSerializable => false;
     }
 }


### PR DESCRIPTION
### Customer scenario
Symbols for serializable types are marked with a flag when emitted to metadata. This PR exposes the flag on INamedTypeSymbol.

### Bugs this fixes
Mostly fixes https://github.com/dotnet/roslyn/issues/3898

### Workarounds, if any
None

### Risk

### Performance impact

### Is this a regression from a previous update?
No.

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?
Reported by customers and internally.

Note: there are some types I didn't manage to test:
- Embedded: didn't manage to make a serializable one
- Synthesized/Frames/Environments/Templates
- TopLevelWithCustomErrorInfo