### PR TITLE
Optimize switch on conditional access

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1058,6 +1058,12 @@
     <Field Name="LabelExpressionOpt" Type="BoundLabel" Null="allow"/>
   </Node>
 
+  <!-- only used by codegen -->
+  <Node Name="BoundGotoExpression" Base="BoundExpression">
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Label" Type="LabelSymbol" Null="disallow"/>
+  </Node>
+
   <!-- 
   This represents a statement which has been labeled.
   This allows us to recursively bind the labeled expression during binding.

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -308,6 +308,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitThrowExpression((BoundThrowExpression)expression, used);
                     break;
 
+                case BoundKind.GotoExpression:
+                    EmitGotoExpression((BoundGotoExpression)expression, used);
+                    break;
+
                 default:
                     // Code gen should not be invoked if there are errors.
                     Debug.Assert(expression.Kind != BoundKind.BadExpression);
@@ -315,6 +319,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // node should have been lowered:
                     throw ExceptionUtilities.UnexpectedValue(expression.Kind);
             }
+        }
+
+        private void EmitGotoExpression(BoundGotoExpression node, bool used)
+        {
+            _builder.EmitBranch(ILOpCode.Br, node.Label);
+
+            // to satisfy invariants, we push a default value to pretend to adjust the stack height
+            EmitDefaultValue(node.Type, used, node.Syntax);
         }
 
         private void EmitThrowExpression(BoundThrowExpression node, bool used)

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -113,6 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         Parameter,
         LabelStatement,
         GotoStatement,
+        GotoExpression,
         LabeledStatement,
         Label,
         StatementList,
@@ -3867,6 +3868,48 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundGotoExpression : BoundExpression
+    {
+        public BoundGotoExpression(SyntaxNode syntax, LabelSymbol label, TypeSymbol type, bool hasErrors)
+            : base(BoundKind.GotoExpression, syntax, type, hasErrors)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Label = label;
+        }
+
+        public BoundGotoExpression(SyntaxNode syntax, LabelSymbol label, TypeSymbol type)
+            : base(BoundKind.GotoExpression, syntax, type)
+        {
+
+            Debug.Assert(label != null, "Field 'label' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+
+            this.Label = label;
+        }
+
+
+        public LabelSymbol Label { get; }
+
+        public override BoundNode Accept(BoundTreeVisitor visitor)
+        {
+            return visitor.VisitGotoExpression(this);
+        }
+
+        public BoundGotoExpression Update(LabelSymbol label, TypeSymbol type)
+        {
+            if (label != this.Label || type != this.Type)
+            {
+                var result = new BoundGotoExpression(this.Syntax, label, type, this.HasErrors);
+                result.WasCompilerGenerated = this.WasCompilerGenerated;
+                return result;
+            }
+            return this;
+        }
+    }
+
     internal sealed partial class BoundLabeledStatement : BoundStatement
     {
         public BoundLabeledStatement(SyntaxNode syntax, LabelSymbol label, BoundStatement body, bool hasErrors = false)
@@ -6342,6 +6385,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitLabelStatement(node as BoundLabelStatement, arg);
                 case BoundKind.GotoStatement: 
                     return VisitGotoStatement(node as BoundGotoStatement, arg);
+                case BoundKind.GotoExpression: 
+                    return VisitGotoExpression(node as BoundGotoExpression, arg);
                 case BoundKind.LabeledStatement: 
                     return VisitLabeledStatement(node as BoundLabeledStatement, arg);
                 case BoundKind.Label: 
@@ -6833,6 +6878,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.DefaultVisit(node, arg);
         }
         public virtual R VisitGotoStatement(BoundGotoStatement node, A arg)
+        {
+            return this.DefaultVisit(node, arg);
+        }
+        public virtual R VisitGotoExpression(BoundGotoExpression node, A arg)
         {
             return this.DefaultVisit(node, arg);
         }
@@ -7437,6 +7486,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.DefaultVisit(node);
         }
         public virtual BoundNode VisitGotoStatement(BoundGotoStatement node)
+        {
+            return this.DefaultVisit(node);
+        }
+        public virtual BoundNode VisitGotoExpression(BoundGotoExpression node)
         {
             return this.DefaultVisit(node);
         }
@@ -8150,6 +8203,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             this.Visit(node.CaseExpressionOpt);
             this.Visit(node.LabelExpressionOpt);
+            return null;
+        }
+        public override BoundNode VisitGotoExpression(BoundGotoExpression node)
+        {
             return null;
         }
         public override BoundNode VisitLabeledStatement(BoundLabeledStatement node)
@@ -8982,6 +9039,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression caseExpressionOpt = (BoundExpression)this.Visit(node.CaseExpressionOpt);
             BoundLabel labelExpressionOpt = (BoundLabel)this.Visit(node.LabelExpressionOpt);
             return node.Update(node.Label, caseExpressionOpt, labelExpressionOpt);
+        }
+        public override BoundNode VisitGotoExpression(BoundGotoExpression node)
+        {
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(node.Label, type);
         }
         public override BoundNode VisitLabeledStatement(BoundLabeledStatement node)
         {
@@ -10273,6 +10335,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 new TreeDumperNode("label", node.Label, null),
                 new TreeDumperNode("caseExpressionOpt", null, new TreeDumperNode[] { Visit(node.CaseExpressionOpt, null) }),
                 new TreeDumperNode("labelExpressionOpt", null, new TreeDumperNode[] { Visit(node.LabelExpressionOpt, null) })
+            }
+            );
+        }
+        public override TreeDumperNode VisitGotoExpression(BoundGotoExpression node, object arg)
+        {
+            return new TreeDumperNode("gotoExpression", null, new TreeDumperNode[]
+            {
+                new TreeDumperNode("label", node.Label, null),
+                new TreeDumperNode("type", node.Type, null)
             }
             );
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -2070,46 +2070,46 @@ public static class Program
             string expectedOutput = @"Val Val ";
             string expectedIL = @"
 {
-  // Code size       81 (0x51)
-  .maxstack  3
+  // Code size       82 (0x52)
+  .maxstack  2
   .locals init (Program.IGoo<string> V_0, //i
-  Program.GooVal V_1, //e
-  Program.GooVal? V_2,
-  Program.IGoo<string> V_3)
+                Program.GooVal V_1, //e
+                Program.GooVal? V_2, //n
+                Program.IGoo<string> V_3)
   IL_0000:  ldnull
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  initobj    ""Program.GooVal""
-  IL_000a:  ldloc.1
-  IL_000b:  newobj     ""Program.GooVal?..ctor(Program.GooVal)""
-  IL_0010:  ldloc.0
-  IL_0011:  dup
-  IL_0012:  brtrue.s   IL_001b
-  IL_0014:  pop
-  IL_0015:  ldloc.1
-  IL_0016:  box        ""Program.GooVal""
-  IL_001b:  stloc.0
-  IL_001c:  ldloc.0
-  IL_001d:  callvirt   ""string Program.IGoo<string>.Goo()""
-  IL_0022:  call       ""void System.Console.Write(string)""
-  IL_0027:  ldnull
-  IL_0028:  stloc.0
-  IL_0029:  stloc.2
-  IL_002a:  ldloca.s   V_2
-  IL_002c:  call       ""bool Program.GooVal?.HasValue.get""
-  IL_0031:  brtrue.s   IL_0036
-  IL_0033:  ldloc.0
-  IL_0034:  br.s       IL_0044
-  IL_0036:  ldloca.s   V_2
-  IL_0038:  call       ""Program.GooVal Program.GooVal?.GetValueOrDefault()""
-  IL_003d:  box        ""Program.GooVal""
-  IL_0042:  stloc.3
-  IL_0043:  ldloc.3
-  IL_0044:  stloc.0
-  IL_0045:  ldloc.0
-  IL_0046:  callvirt   ""string Program.IGoo<string>.Goo()""
-  IL_004b:  call       ""void System.Console.Write(string)""
-  IL_0050:  ret
+  IL_000a:  ldloca.s   V_2
+  IL_000c:  ldloc.1
+  IL_000d:  call       ""Program.GooVal?..ctor(Program.GooVal)""
+  IL_0012:  ldloc.0
+  IL_0013:  dup
+  IL_0014:  brtrue.s   IL_001d
+  IL_0016:  pop
+  IL_0017:  ldloc.1
+  IL_0018:  box        ""Program.GooVal""
+  IL_001d:  stloc.0
+  IL_001e:  ldloc.0
+  IL_001f:  callvirt   ""string Program.IGoo<string>.Goo()""
+  IL_0024:  call       ""void System.Console.Write(string)""
+  IL_0029:  ldnull
+  IL_002a:  stloc.0
+  IL_002b:  ldloca.s   V_2
+  IL_002d:  call       ""bool Program.GooVal?.HasValue.get""
+  IL_0032:  brtrue.s   IL_0037
+  IL_0034:  ldloc.0
+  IL_0035:  br.s       IL_0045
+  IL_0037:  ldloca.s   V_2
+  IL_0039:  call       ""Program.GooVal Program.GooVal?.GetValueOrDefault()""
+  IL_003e:  box        ""Program.GooVal""
+  IL_0043:  stloc.3
+  IL_0044:  ldloc.3
+  IL_0045:  stloc.0
+  IL_0046:  ldloc.0
+  IL_0047:  callvirt   ""string Program.IGoo<string>.Goo()""
+  IL_004c:  call       ""void System.Console.Write(string)""
+  IL_0051:  ret
 }";
             CompileAndVerify(source, expectedOutput: expectedOutput).VerifyIL("Program.Main", expectedIL);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -1058,37 +1058,14 @@ public class C
             var compilation = CompileAndVerify(source, expectedOutput: string.Empty);
             compilation.VerifyIL("C.Nullable_a_Implicit_b_to_a0_null_a", @"
 {
-  // Code size       31 (0x1f)
+  // Code size       29 (0x1d)
   .maxstack  1
   .locals init (char V_0, //b
-  int? V_1)
+                int? V_1) //a
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  initobj    ""int?""
-  IL_000a:  ldloc.1
-  IL_000b:  stloc.1
-  IL_000c:  ldloca.s   V_1
-  IL_000e:  call       ""bool int?.HasValue.get""
-  IL_0013:  brtrue.s   IL_0017
-  IL_0015:  ldloc.0
-  IL_0016:  ret
-  IL_0017:  ldloca.s   V_1
-  IL_0019:  call       ""int int?.GetValueOrDefault()""
-  IL_001e:  ret
-}
-");
-            compilation.VerifyIL("C.Nullable_a_Implicit_b_to_a0_constant_non_null_a", @"
-{
-  // Code size       29 (0x1d)
-  .maxstack  1
-  .locals init (char V_0, //b
-  int? V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.s   10
-  IL_0004:  newobj     ""int?..ctor(int)""
-  IL_0009:  stloc.1
   IL_000a:  ldloca.s   V_1
   IL_000c:  call       ""bool int?.HasValue.get""
   IL_0011:  brtrue.s   IL_0015
@@ -1097,13 +1074,34 @@ public class C
   IL_0015:  ldloca.s   V_1
   IL_0017:  call       ""int int?.GetValueOrDefault()""
   IL_001c:  ret
+}
+");
+            compilation.VerifyIL("C.Nullable_a_Implicit_b_to_a0_constant_non_null_a", @"
+{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  .locals init (char V_0, //b
+                int? V_1) //a
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.s   10
+  IL_0006:  call       ""int?..ctor(int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  call       ""bool int?.HasValue.get""
+  IL_0012:  brtrue.s   IL_0016
+  IL_0014:  ldloc.0
+  IL_0015:  ret
+  IL_0016:  ldloca.s   V_1
+  IL_0018:  call       ""int int?.GetValueOrDefault()""
+  IL_001d:  ret
 }");
             compilation.VerifyIL("C.Nullable_a_Implicit_b_to_a0_not_null_a", @"
 {
   // Code size       23 (0x17)
   .maxstack  1
   .locals init (char V_0, //b
-  int? V_1)
+                int? V_1) //a
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldarg.1
@@ -1191,24 +1189,22 @@ public class C
             var compilation = CompileAndVerify(source, expectedOutput: string.Empty);
             compilation.VerifyIL("C.Nullable_a_Implicit_b_to_a0_null_a", @"
 {
-  // Code size       31 (0x1f)
+  // Code size       29 (0x1d)
   .maxstack  1
   .locals init (char V_0, //b
-  int? V_1)
+                int? V_1) //a
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  initobj    ""int?""
-  IL_000a:  ldloc.1
-  IL_000b:  stloc.1
-  IL_000c:  ldloca.s   V_1
-  IL_000e:  call       ""bool int?.HasValue.get""
-  IL_0013:  brtrue.s   IL_0017
-  IL_0015:  ldloc.0
-  IL_0016:  ret
-  IL_0017:  ldloca.s   V_1
-  IL_0019:  call       ""int int?.GetValueOrDefault()""
-  IL_001e:  ret
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  call       ""bool int?.HasValue.get""
+  IL_0011:  brtrue.s   IL_0015
+  IL_0013:  ldloc.0
+  IL_0014:  ret
+  IL_0015:  ldloca.s   V_1
+  IL_0017:  call       ""int int?.GetValueOrDefault()""
+  IL_001c:  ret
 }");
         }
 
@@ -1265,25 +1261,23 @@ public class C
             var compilation = CompileAndVerify(source, expectedOutput: string.Empty);
             compilation.VerifyIL("C.ImplicitReference_a_to_b_null_a_nullable", @"
 {
-  // Code size       36 (0x24)
+  // Code size       34 (0x22)
   .maxstack  1
   .locals init (int? V_0, //b
-  char? V_1)
+                char? V_1) //a
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
   IL_0004:  initobj    ""char?""
-  IL_000a:  ldloc.1
-  IL_000b:  stloc.1
-  IL_000c:  ldloca.s   V_1
-  IL_000e:  call       ""bool char?.HasValue.get""
-  IL_0013:  brtrue.s   IL_0017
-  IL_0015:  ldloc.0
-  IL_0016:  ret
-  IL_0017:  ldloca.s   V_1
-  IL_0019:  call       ""char char?.GetValueOrDefault()""
-  IL_001e:  newobj     ""int?..ctor(int)""
-  IL_0023:  ret
+  IL_000a:  ldloca.s   V_1
+  IL_000c:  call       ""bool char?.HasValue.get""
+  IL_0011:  brtrue.s   IL_0015
+  IL_0013:  ldloc.0
+  IL_0014:  ret
+  IL_0015:  ldloca.s   V_1
+  IL_0017:  call       ""char char?.GetValueOrDefault()""
+  IL_001c:  newobj     ""int?..ctor(int)""
+  IL_0021:  ret
 }");
 
             compilation.VerifyIL("C.Null_Literal_a", @"
@@ -3108,34 +3102,33 @@ class Program
 
             verifier.VerifyIL("Program.Main", @"
 {
-  // Code size       70 (0x46)
-  .maxstack  1
-  .locals init (SnapshotPoint V_0,
-  SnapshotPoint? V_1)
+  // Code size       69 (0x45)
+  .maxstack  2
+  .locals init (SnapshotPoint? V_0, //s
+                SnapshotPoint? V_1, //s2
+                SnapshotPoint V_2)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""SnapshotPoint""
-  IL_0008:  ldloc.0
-  IL_0009:  newobj     ""SnapshotPoint?..ctor(SnapshotPoint)""
-  IL_000e:  stloc.1
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  call       ""bool SnapshotPoint?.HasValue.get""
-  IL_0016:  brfalse.s  IL_0025
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  call       ""SnapshotPoint SnapshotPoint?.GetValueOrDefault()""
-  IL_001f:  call       ""int SnapshotPoint.op_Implicit(SnapshotPoint)""
-  IL_0024:  pop
-  IL_0025:  ldloca.s   V_1
-  IL_0027:  initobj    ""SnapshotPoint?""
-  IL_002d:  ldloc.1
-  IL_002e:  stloc.1
-  IL_002f:  ldloca.s   V_1
-  IL_0031:  call       ""bool SnapshotPoint?.HasValue.get""
-  IL_0036:  brfalse.s  IL_0045
-  IL_0038:  ldloca.s   V_1
-  IL_003a:  call       ""SnapshotPoint SnapshotPoint?.GetValueOrDefault()""
-  IL_003f:  call       ""int SnapshotPoint.op_Implicit(SnapshotPoint)""
-  IL_0044:  pop
-  IL_0045:  ret
+  IL_0002:  ldloca.s   V_2
+  IL_0004:  initobj    ""SnapshotPoint""
+  IL_000a:  ldloc.2
+  IL_000b:  call       ""SnapshotPoint?..ctor(SnapshotPoint)""
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       ""bool SnapshotPoint?.HasValue.get""
+  IL_0017:  brfalse.s  IL_0026
+  IL_0019:  ldloca.s   V_0
+  IL_001b:  call       ""SnapshotPoint SnapshotPoint?.GetValueOrDefault()""
+  IL_0020:  call       ""int SnapshotPoint.op_Implicit(SnapshotPoint)""
+  IL_0025:  pop
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  initobj    ""SnapshotPoint?""
+  IL_002e:  ldloca.s   V_1
+  IL_0030:  call       ""bool SnapshotPoint?.HasValue.get""
+  IL_0035:  brfalse.s  IL_0044
+  IL_0037:  ldloca.s   V_1
+  IL_0039:  call       ""SnapshotPoint SnapshotPoint?.GetValueOrDefault()""
+  IL_003e:  call       ""int SnapshotPoint.op_Implicit(SnapshotPoint)""
+  IL_0043:  pop
+  IL_0044:  ret
 }");
         }
 
@@ -4673,7 +4666,7 @@ class Program
 {
   // Code size       21 (0x15)
   .maxstack  1
-  .locals init (Program.cls1 V_0)
+  .locals init (Program.cls1 V_0) //f1
   IL_0000:  ldnull
   IL_0001:  stloc.0
   IL_0002:  ldloc.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -2400,6 +2400,56 @@ class Program
 }");
         }
 
+        [WorkItem(21962, "https://github.com/dotnet/roslyn/issues/21962")]
+        [Fact()]
+        public void ConditionalAccessAsSwitchExpression()
+        {
+            var text = @"
+using System;
+class Program
+{
+    static void Main()
+    {
+        M(null);
+        M("""");
+    }
+
+    static void M(string str)
+    {
+        switch(str?.Length)
+        {
+            case null:
+                Console.Write(0);
+                break;
+            case 0:
+                Console.Write(1);
+                break;
+
+        }
+    }
+}";
+            CompileAndVerify(text, expectedOutput: "01").VerifyIL("Program.M",
+@"{
+  // Code size       28 (0x1c)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_000e
+  IL_0003:  ldarg.0
+  IL_0004:  call       ""int string.Length.get""
+  IL_0009:  stloc.0
+  IL_000a:  ldloc.0
+  IL_000b:  brfalse.s  IL_0015
+  IL_000d:  ret
+  IL_000e:  ldc.i4.0
+  IL_000f:  call       ""void System.Console.Write(int)""
+  IL_0014:  ret
+  IL_0015:  ldc.i4.1
+  IL_0016:  call       ""void System.Console.Write(int)""
+  IL_001b:  ret
+}");
+        }
+
         [WorkItem(543967, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543967")]
         [Fact()]
         public void NullableAsSwitchExpression_02()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/SwitchTests.cs
@@ -2424,7 +2424,6 @@ class Program
             case 0:
                 Console.Write(1);
                 break;
-
         }
     }
 }";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -2222,17 +2222,9 @@ struct X
                 // (9,13): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
                 //     switch (x)
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 13),
-                // (9,5): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                // (9,13): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
                 //     switch (x)
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"switch (x)
-    {
-      case null:
-        Console.WriteLine(""null"");
-        break;
-      case 1:
-        Console.WriteLine(1);
-        break;
-    }").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 5)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 13)
                 );
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/21962

Generates the following:
```
  // Code size       28 (0x1c)
  .maxstack  1
  .locals init (int V_0)
  IL_0000:  ldarg.0
  IL_0001:  brfalse.s  IL_000e
  IL_0003:  ldarg.0
  IL_0004:  call       ""int string.Length.get""
  IL_0009:  stloc.0
  IL_000a:  ldloc.0
  IL_000b:  brfalse.s  IL_0015
  IL_000d:  ret
  IL_000e:  ldc.i4.0
  IL_000f:  call       ""void System.Console.Write(int)""
  IL_0014:  ret
  IL_0015:  ldc.i4.1
  IL_0016:  call       ""void System.Console.Write(int)""
  IL_001b:  ret
```
Instead of:
```
  // Code size 61 (0x3d)
  .maxstack 1
  .locals init (
      [0] valuetype [mscorlib]System.Nullable`1<int32>,
      [1] valuetype [mscorlib]System.Nullable`1<int32>,
      [2] int32
  )

  IL_0000: ldarg.0
  IL_0001: brtrue.s IL_000e
  IL_0003: ldloca.s 1
  IL_0005: initobj valuetype [mscorlib]System.Nullable`1<int32>
  IL_000b: ldloc.1
  IL_000c: br.s IL_0019
  IL_000e: ldarg.0
  IL_000f: call instance int32 [mscorlib]System.String::get_Length()
  IL_0014: newobj instance void valuetype [mscorlib]System.Nullable`1<int32>::.ctor(!0)
  IL_0019: stloc.0
  IL_001a: ldloca.s 0
  IL_001c: call instance bool valuetype [mscorlib]System.Nullable`1<int32>::get_HasValue()
  IL_0021: brfalse.s IL_002f
  IL_0023: ldloca.s 0
  IL_0025: call instance !0 valuetype [mscorlib]System.Nullable`1<int32>::GetValueOrDefault()
  IL_002a: stloc.2
  IL_002b: ldloc.2
  IL_002c: brfalse.s IL_0036
  IL_002e: ret
  IL_002f: ldc.i4.0
  IL_0030: call void [mscorlib]System.Console::Write(int32)
  IL_0035: ret
  IL_0036: ldc.i4.1
  IL_0037: call void [mscorlib]System.Console::Write(int32)
  IL_003c: ret
```
For this method:
```cs
    static void M(string str)
    {
        switch(str?.Length)
        {
            case null:
                Console.Write(0);
                break;
            case 0:
                Console.Write(1);
                break;
        }
    }
```