### PR TITLE
Add satellite assemblies to Microsoft.NETCore.Compilers

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -378,24 +378,13 @@
        since a rebuild may overwrite signed binaries in the output directory with unsigned binaries
        from the intermediate output directory. -->
   <Target Name="PublishWithoutBuilding"
-        DependsOnTargets="PreventProjectReferencesFromBuilding;
+        DependsOnTargets="BuildOnlySettings;
+                          PreventProjectReferencesFromBuilding;
                           ResolveReferences;
+                          PrepareForPublish;
                           ComputeAndCopyFilesToPublishDirectory;
                           GeneratePublishDependencyFile;
                           GeneratePublishRuntimeConfigurationFile" />                                                           
-
-  <!-- 
-    Work around bug in Microsoft.NET.Sdk < v2.0 where satellites were deployed on top of each other in root. 
-    https://github.com/dotnet/sdk/issues/1360
-  -->
-  <Target Name="WorkaroundIncorrectSatelliteDeployment" AfterTargets="ResolveLockFileCopyLocalProjectDeps">
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Remove="@(ResourceCopyLocalItems)" />
-      <ReferenceCopyLocalPaths Include="@(ResourceCopyLocalItems)"  Condition="'@(ResourceCopyLocalItems)' != ''">
-        <DestinationSubDirectory>$([System.IO.Directory]::GetParent(%(ResourceCopyLocalItems.FullPath)).get_Name())\</DestinationSubDirectory>
-      </ReferenceCopyLocalPaths>
-    </ItemGroup>
-  </Target>
 
   <!--
      Work around to fix Intellisense file generation for XAML projects

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -48,6 +48,12 @@
     <file src="Exes/VBCSCompiler/netcoreapp2.0/publish/VBCSCompiler.deps.json" target="tools/bincore" />
     <file src="Exes/VBCSCompiler/netcoreapp2.0/publish/VBCSCompiler.runtimeconfig.json" target="tools/bincore" />
 
+    <!-- Satellite assemblies -->
+    <file src="Dlls\MSBuildTask\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" target="tools" />
+    <file src="Dlls\CodeAnalysis\**\Microsoft.CodeAnalysis.resources.dll" target="tools/bincore" />
+    <file src="Dlls\CSharpCodeAnalysis\**\Microsoft.CodeAnalysis.CSharp.resources.dll" target="tools/bincore" />
+    <file src="Dlls\BasicCodeAnalysis\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll" target="tools/bincore" />
+
     <!-- References that are either not in the target framework or are a higher version -->
     <file src="Exes\csc\netcoreapp2.0\publish\System.*.dll" target="tools\bincore" />
     <file src="Exes\csc\netcoreapp2.0\publish\runtimes\**" target="tools\bincore\runtimes" />


### PR DESCRIPTION
Add satellite assemblies for the Roslyn assemblies that we ship in
Microsoft.NETCore.Compiler.nupkg. This includes
Microsoft.CodeAnalysis.dll, Microsoft.CodeAnalysis.CSharp.dll,
Microsoft.CodeAnalysis.VisualBasic.dll, and
Microsoft.Build.Tasks.CodeAnalysis.dll.

This increases the resulting .nupkg size from about 8,988KB to about
12,000KB.

### Customer scenario

This allows consumers of the Microsoft.NETCore.Compilers package to see localized strings when using the tools it contains. However, the immediate motivation for this change is to make it much simpler for the CLI to find and include these localized resources.

### Bugs this fixes

N/A

### Workarounds, if any

Currently the CLI has a complicated process for locating and pulling in these localized resources.

### Risk

Low.

### Performance impact

N/A

### Is this a regression from a previous update?

N/A

### Root cause analysis

N/A

### How was the bug found?

N/A

### Test documentation updated?

N/A
