### PR TITLE
SignatureHelp: fix display or ref-returning indexer

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -52,6 +52,52 @@ class D
             await TestAsync(markup, expectedOrderedItems);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [WorkItem(24311, "https://github.com/dotnet/roslyn/issues/24311")]
+        public async Task TestInvocationWithParametersOn1_WithRefReturn()
+        {
+            var markup = @"
+class C
+{
+    public ref int this[int a]
+    {
+        get { throw null; }
+    }
+    void Goo(C c)
+    {
+        [|c[$$]|]
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("ref int C[int a]", string.Empty, string.Empty, currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [WorkItem(24311, "https://github.com/dotnet/roslyn/issues/24311")]
+        public async Task TestInvocationWithParametersOn1_WithRefReadonlyReturn()
+        {
+            var markup = @"
+class C
+{
+    public ref readonly int this[int a]
+    {
+        get { throw null; }
+    }
+    void Goo(C c)
+    {
+        [|c[$$]|]
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("ref readonly int C[int a]", string.Empty, string.Empty, currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
         [WorkItem(636117, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/636117")]
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task TestInvocationOnExpression()

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -246,6 +246,19 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         {
             var result = new List<SymbolDisplayPart>();
 
+            if (indexer.ReturnsByRef)
+            {
+                result.Add(Keyword(SyntaxKind.RefKeyword));
+                result.Add(Space());
+            }
+            else if (indexer.ReturnsByRefReadonly)
+            {
+                result.Add(Keyword(SyntaxKind.RefKeyword));
+                result.Add(Space());
+                result.Add(Keyword(SyntaxKind.ReadOnlyKeyword));
+                result.Add(Space());
+            }
+
             result.AddRange(indexer.Type.ToMinimalDisplayParts(semanticModel, position));
             result.Add(Space());
             result.AddRange(indexer.ContainingType.ToMinimalDisplayParts(semanticModel, position));


### PR DESCRIPTION
### Customer scenario
SignatureHelp on a ref-returning or ref-readonly-returning indexer should display the "ref" or "ref readonly" modifiers, as the screenshot shows (post fix).

![image](https://user-images.githubusercontent.com/12466233/35189069-f0d74234-fdf7-11e7-96a6-30a75a631547.png)

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24311

### Risk
### Performance impact
Low. Just adding a check for ref-returning symbols in the SignatureHelp and adding a couple of parts to display when appropriate.

### Is this a regression from a previous update?
No

### Root cause analysis
The SignatureHelper only relies on the SymbolDisplayVisitor to display parts of an indexer's signature. The SymbolDisplayVisitor would display `ref int C.this[...]`, but the SignatureHelper wants to display `ref int C[...]`. This non-standard behavior is the reason why the fix in SymbolDisplayVisitor did not automatically handle this scenario.

### How was the bug found?
Reported by customer.

@dotnet/roslyn-ide for review. Thanks
Tagging @VSadov @OmarTawfik as FYI