### PR TITLE
Move checking of structure-options to a common location (so it will be picked up by all roslyn languages).

### DIFF
--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Structure
 {
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Structure
                 await provider.ProvideBlockStructureAsync(context).ConfigureAwait(false);
             }
 
-            return new BlockStructure(context.Spans);
+            return CreateBlockStructure(document, context);
         }
 
         public override BlockStructure GetBlockStructure(
@@ -61,7 +62,70 @@ namespace Microsoft.CodeAnalysis.Structure
                 provider.ProvideBlockStructure(context);
             }
 
-            return new BlockStructure(context.Spans);
+            return CreateBlockStructure(document, context);
+        }
+
+        private static BlockStructure CreateBlockStructure(Document document, BlockStructureContext context)
+        {
+            var options = context.Document.Project.Solution.Workspace.Options;
+            var language = context.Document.Project.Language;
+
+            var showIndentGuidesForCodeLevelConstructs = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs, language);
+            var showIndentGuidesForDeclarationLevelConstructs = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs, language);
+            var showIndentGuidesForCommentsAndPreprocessorRegions = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, language);
+            var showOutliningForCodeLevelConstructs = options.GetOption(BlockStructureOptions.ShowOutliningForCodeLevelConstructs, language);
+            var showOutliningForDeclarationLevelConstructs = options.GetOption(BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, language);
+            var showOutliningForCommentsAndPreprocessorRegions = options.GetOption(BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions, language);
+
+            var updatedSpans = ArrayBuilder<BlockSpan>.GetInstance();
+            foreach (var span in context.Spans)
+            {
+                var updatedSpan = UpdateBlockSpan(span,
+                    showIndentGuidesForCodeLevelConstructs,
+                    showIndentGuidesForDeclarationLevelConstructs,
+                    showIndentGuidesForCommentsAndPreprocessorRegions,
+                    showOutliningForCodeLevelConstructs,
+                    showOutliningForDeclarationLevelConstructs,
+                    showOutliningForCommentsAndPreprocessorRegions);
+                updatedSpans.Add(updatedSpan);
+            }
+
+            return new BlockStructure(updatedSpans.ToImmutableAndFree());
+        }
+
+        private static BlockSpan UpdateBlockSpan(BlockSpan blockSpan,
+            bool showIndentGuidesForCodeLevelConstructs,
+            bool showIndentGuidesForDeclarationLevelConstructs,
+            bool showIndentGuidesForCommentsAndPreprocessorRegions,
+            bool showOutliningForCodeLevelConstructs,
+            bool showOutliningForDeclarationLevelConstructs,
+            bool showOutliningForCommentsAndPreprocessorRegions)
+        {
+            var type = blockSpan.Type;
+
+            var isTopLevel = BlockTypes.IsDeclarationLevelConstruct(type);
+            var isMemberLevel = BlockTypes.IsCodeLevelConstruct(type);
+            var isComment = BlockTypes.IsCommentOrPreprocessorRegion(type);
+
+            if ((!showIndentGuidesForDeclarationLevelConstructs && isTopLevel) ||
+                (!showIndentGuidesForCodeLevelConstructs && isMemberLevel) ||
+                (!showIndentGuidesForCommentsAndPreprocessorRegions && isComment))
+            {
+                type = BlockTypes.Nonstructural;
+            }
+
+            var isCollapsible = blockSpan.IsCollapsible;
+            if (isCollapsible)
+            {
+                if ((!showOutliningForDeclarationLevelConstructs && isTopLevel) ||
+                    (!showOutliningForCodeLevelConstructs && isMemberLevel) ||
+                    (!showOutliningForCommentsAndPreprocessorRegions && isComment))
+                {
+                    isCollapsible = false;
+                }
+            }
+
+            return blockSpan.With(type: type, isCollapsible: isCollapsible);
         }
     }
 }

--- a/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
+++ b/src/Features/Core/Portable/Structure/Syntax/AbstractBlockStructureProvider.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -69,81 +67,12 @@ namespace Microsoft.CodeAnalysis.Structure
             BlockSpanCollector.CollectBlockSpans(
                 context.Document, syntaxRoot, _nodeProviderMap, _triviaProviderMap, spans, context.CancellationToken);
 
-            UpdateAndAddSpans(context, spans);
-
-            spans.Free();
-        }
-
-        internal static void UpdateAndAddSpans(BlockStructureContext context, ArrayBuilder<BlockSpan> spans)
-        {
-            var options = context.Document.Project.Solution.Workspace.Options;
-            var language = context.Document.Project.Language;
-
-            var showIndentGuidesForCodeLevelConstructs = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForCodeLevelConstructs, language);
-            var showIndentGuidesForDeclarationLevelConstructs = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForDeclarationLevelConstructs, language);
-            var showIndentGuidesForCommentsAndPreprocessorRegions = options.GetOption(BlockStructureOptions.ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, language);
-            var showOutliningForCodeLevelConstructs = options.GetOption(BlockStructureOptions.ShowOutliningForCodeLevelConstructs, language);
-            var showOutliningForDeclarationLevelConstructs = options.GetOption(BlockStructureOptions.ShowOutliningForDeclarationLevelConstructs, language);
-            var showOutliningForCommentsAndPreprocessorRegions = options.GetOption(BlockStructureOptions.ShowOutliningForCommentsAndPreprocessorRegions, language);
-
             foreach (var span in spans)
             {
-                var updatedSpan = UpdateBlockSpan(span,
-                        showIndentGuidesForCodeLevelConstructs,
-                        showIndentGuidesForDeclarationLevelConstructs,
-                        showIndentGuidesForCommentsAndPreprocessorRegions,
-                        showOutliningForCodeLevelConstructs,
-                        showOutliningForDeclarationLevelConstructs,
-                        showOutliningForCommentsAndPreprocessorRegions);
-                context.AddBlockSpan(updatedSpan);
-            }
-        }
-
-        internal static BlockSpan UpdateBlockSpan(BlockSpan blockSpan,
-            bool showIndentGuidesForCodeLevelConstructs,
-            bool showIndentGuidesForDeclarationLevelConstructs,
-            bool showIndentGuidesForCommentsAndPreprocessorRegions,
-            bool showOutliningForCodeLevelConstructs,
-            bool showOutliningForDeclarationLevelConstructs,
-            bool showOutliningForCommentsAndPreprocessorRegions)
-        {
-            var type = blockSpan.Type;
-
-            var isTopLevel = BlockTypes.IsDeclarationLevelConstruct(type);
-            var isMemberLevel = BlockTypes.IsCodeLevelConstruct(type);
-            var isComment = BlockTypes.IsCommentOrPreprocessorRegion(type);
-
-            if (!showIndentGuidesForDeclarationLevelConstructs && isTopLevel)
-            {
-                type = BlockTypes.Nonstructural;
-            }
-            else if (!showIndentGuidesForCodeLevelConstructs && isMemberLevel)
-            {
-                type = BlockTypes.Nonstructural;
-            }
-            else if (!showIndentGuidesForCommentsAndPreprocessorRegions && isComment)
-            {
-                type = BlockTypes.Nonstructural;
+                context.AddBlockSpan(span);
             }
 
-            var isCollapsible = blockSpan.IsCollapsible;
-            if (isCollapsible)
-            {
-                if (!showOutliningForDeclarationLevelConstructs && isTopLevel)
-                {
-                    isCollapsible = false;
-                }
-                else if (!showOutliningForCodeLevelConstructs && isMemberLevel)
-                {
-                    isCollapsible = false;
-                }
-                else if (!showOutliningForCommentsAndPreprocessorRegions && isComment)
-                {
-                    isCollapsible = false;
-                }
-            }
-
-            return blockSpan.With(type: type, isCollapsible: isCollapsible);
+            spans.Free();
         }
     }
 }


### PR DESCRIPTION
Discovered during https://github.com/Microsoft/visualfsharp/pull/4227

Currently, Roslyn has options to control outlining and structure-guide behavior for C# and VB.  However, these options can be moved to a core location so that they can be used in F# and TS/JS as well.