### PR TITLE
[WIP] Allow two symbols to be found at position in tuple (FAR, Highlighting)

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5299,6 +5299,8 @@ class C
 
             public bool IsComImport => throw new NotImplementedException();
 
+            public ImmutableArray<string> TupleElementNames => throw new NotImplementedException();
+
             #endregion
         }
 

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBloc
 Microsoft.CodeAnalysis.ILocalSymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.IMethodSymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByRefReadonly.get -> bool
+Microsoft.CodeAnalysis.INamedTypeSymbol.TupleElementNames.get -> System.Collections.Immutable.ImmutableArray<string>
 Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.IOperation.Accept(Microsoft.CodeAnalysis.Operations.OperationVisitor visitor) -> void
 Microsoft.CodeAnalysis.IOperation.Accept<TArgument, TResult>(Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult> visitor, TArgument argument) -> TResult

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -165,5 +165,7 @@ namespace Microsoft.CodeAnalysis
         /// If this type is not a tuple, then returns default.
         /// </summary>
         ImmutableArray<IFieldSymbol> TupleElements { get; }
+
+        ImmutableArray<string> TupleElementNames { get; }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1227,6 +1227,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property INamedTypeSymbol_TupleElementNames As ImmutableArray(Of String) Implements INamedTypeSymbol.TupleElementNames
+            Get
+                Return TupleElementNames
+            End Get
+        End Property
+
         Private ReadOnly Property INamedTypeSymbol_TupleUnderlyingType As INamedTypeSymbol Implements INamedTypeSymbol.TupleUnderlyingType
             Get
                 Return TupleUnderlyingType

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -121,6 +121,14 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 
             await FindSymbolReferencesAsync(
                 context, symbolAndProject?.symbol, symbolAndProject?.project, cancellationToken).ConfigureAwait(false);
+
+            // PROTOTYPE
+            var secondary = symbolAndProject.Value.secondary;
+            if (secondary != null)
+            {
+                await FindSymbolReferencesAsync(
+                    context, secondary, symbolAndProject?.project, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
@@ -362,7 +362,7 @@ class Program
         var y = ([|Alice|]:1, Bob: 2); // PROTOTYPE This probably should not be found
 
         var z = x.[|Alice|];
-        var z2 = x.Item1; // PROTOTYPE This should be found too
+        var z2 = x.[|Item1|];
     }
 }
         ]]>

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
@@ -346,5 +346,33 @@ namespace System
 </Workspace>
             Await TestAPIAndFeature(input)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(20115, "https://github.com/dotnet/roslyn/issues/20115")>
+        Public Async Function TestDualViewOnTupleElement() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class Program
+{
+    static void Main(int {|Definition:Alice|})
+    {
+        var x = ({|Definition:[|Ali$$ce|]|}, Bob: 2);
+        var y = ([|Alice|]:1, Bob: 2); // PROTOTYPE This probably should not be found
+
+        var z = x.[|Alice|];
+        var z2 = x.Item1; // PROTOTYPE This should be found too
+    }
+}
+        ]]>
+            <%= tuple2 %>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        ' PROTOTYPE test variants with different cursor positions
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.Tuples.vb
@@ -248,8 +248,8 @@ namespace System
     {
         static void Main(string[] args)
         {
-            var x = ({|Definition:Alice|}:1, Bob: 2);
-            var y = (Alice:1, Bob: 2);
+            var x = ([|{|Definition:Alice|}|]:1, Bob: 2);
+            var y = ([|Alice|]:1, Bob: 2); // PROTOTYPE confirm if this is desirable
 
             var z = x.$$[|Item1|];
         }
@@ -278,7 +278,7 @@ namespace System
             var x = ($$[|{|Definition:Alice|}|]:1, Bob: 2);
             var y = ([|Alice|]:1, Bob: 2);
 
-            var z = x.Item1;
+            var z = x.[|Item1|];
         }
     }
 
@@ -359,7 +359,7 @@ class Program
     static void Main(int {|Definition:Alice|})
     {
         var x = ({|Definition:[|Ali$$ce|]|}, Bob: 2);
-        var y = ([|Alice|]:1, Bob: 2); // PROTOTYPE This probably should not be found
+        var y = ([|Alice|]:1, Bob: 2);
 
         var z = x.[|Alice|];
         var z2 = x.[|Item1|];
@@ -373,6 +373,82 @@ class Program
             Await TestAPIAndFeature(input)
         End Function
 
-        ' PROTOTYPE test variants with different cursor positions
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(20115, "https://github.com/dotnet/roslyn/issues/20115")>
+        Public Async Function TestDualViewOnTupleElement2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class Program
+{
+    static void Main(int {|Definition:Al$$ice|})
+    {
+        var x = ([|Alice|], Bob: 2);
+        var y = (Alice:1, Bob: 2);
+
+        var z = x.Alice;
+        var z2 = x.Item1;
+    }
+}
+        ]]>
+            <%= tuple2 %>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(20115, "https://github.com/dotnet/roslyn/issues/20115")>
+        Public Async Function TestDualViewOnTupleElement3() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = ({|Definition:Alice|}, Bob: 2);
+        var y = ([|Alice|]:1, Bob: 2);
+
+        var z = x.[|Al$$ice|];
+        var z2 = x.[|Item1|];
+    }
+}
+        ]]>
+            <%= tuple2 %>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(20115, "https://github.com/dotnet/roslyn/issues/20115")>
+        Public Async Function TestDualViewOnTupleElement4() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = ({|Definition:Alice|}, Bob: 2);
+        var y = ([|Alice|]:1, Bob: 2);
+
+        var z = x.[|Alice|];
+        var z2 = x.[|It$$em1|];
+    }
+}
+        ]]>
+            <%= tuple2 %>
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities.RemoteHost
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Roslyn.Utilities
 
@@ -50,19 +51,22 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                                    Order By tag.Span.Start
                                    Let spanType = If(tag.Tag.Type = DefinitionHighlightTag.TagId, "Definition",
                                        If(tag.Tag.Type = WrittenReferenceHighlightTag.TagId, "WrittenReference", "Reference"))
-                                   Select spanType + ":" + tag.Span.Span.ToTextSpan().ToString()
+                                   Select (name:=spanType, Span:=tag.Span.Span.ToTextSpan())
 
-                Dim expectedTags As New List(Of String)
+                Dim expectedTags As New List(Of (name As String, span As TextSpan))
 
                 For Each hostDocument In workspace.Documents
                     For Each nameAndSpans In hostDocument.AnnotatedSpans
                         For Each span In nameAndSpans.Value
-                            expectedTags.Add(nameAndSpans.Key + ":" + span.ToString())
+                            expectedTags.Add((nameAndSpans.Key, span))
                         Next
                     Next
                 Next
 
-                AssertEx.Equal(expectedTags, producedTags)
+                AssertEx.Equal(expectedTags, producedTags,
+                                      message:=FindReferences.FindReferencesTests.PrintSpans(expectedTags,
+                                                                                             producedTags,
+                                                                                             document, messageOnly:=True))
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -49,7 +49,7 @@ class Program
     static void Main(int {|Definition:Alice|})
     {
         var x = ({|Definition:{|Reference:Al$$ice|}|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Probably should not be highlighted
+        var y = ({|Reference:Alice|}:1, Bob: 2);
 
         var z = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Item1|};
@@ -72,7 +72,7 @@ class Program
     static void Main(int Alice)
     {
         var x = ({|Definition:Alice|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Should not be highlighted
+        var y = ({|Reference:Alice|}:1, Bob: 2);
 
         var z = x.{|Reference:Al$$ice|};
         var z2 = x.{|Reference:Item1|};
@@ -94,10 +94,10 @@ class Program
 {
     static void Main(int Alice)
     {
-        var x = (Alice, Bob: 2); // PROTOTYPE Definition should be highlighted
-        var y = (Alice:1, Bob: 2);
+        var x = ({|Definition:Alice|}, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2);
 
-        var z = x.Alice; // PROTOTYPE Reference should be highlighted
+        var z = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Ite$$m1|};
     }
 }

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -52,18 +52,17 @@ class Program
         var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Probably should not be highlighted
 
         var z = x.{|Reference:Alice|};
-        var z2 = x.Item1; // PROTOTYPE Should be highlighted
+        var z2 = x.{|Reference:Item1|};
     }
 }
                         </Document>
                     </Project>
                 </Workspace>)
-            ' PROTOTYPE
         End Function
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestVerifyHighlightsForTupleElementUsage() As Task
+        Public Async Function TestVerifyHighlightsForNamedTupleElementUsage() As Task
             Await VerifyHighlightsAsync(
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -76,13 +75,35 @@ class Program
         var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Should not be highlighted
 
         var z = x.{|Reference:Al$$ice|};
-        var z2 = x.Item1; // PROTOTYPE Should be highlighted
+        var z2 = x.{|Reference:Item1|};
     }
 }
                         </Document>
                     </Project>
                 </Workspace>)
-            ' PROTOTYPE
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForUnnamedTupleElementUsage() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = (Alice, Bob: 2); // PROTOTYPE Definition should be highlighted
+        var y = (Alice:1, Bob: 2);
+
+        var z = x.Alice; // PROTOTYPE Reference should be highlighted
+        var z2 = x.{|Reference:Ite$$m1|};
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
         End Function
 
         <WpfFact>

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -39,6 +39,30 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForParameterUsedAsTupleElement() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int {|Definition:Al$$ice|})
+    {
+        var x = ({|Reference:Alice|}, Bob: 2);
+        var y = (Alice:1, Bob: 2);
+        var z = (Alice:1, Carol: 2);
+
+        var z1 = x.Alice;
+        var z2 = x.Item1;
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
         Public Async Function TestVerifyHighlightsForTupleElement() As Task
             Await VerifyHighlightsAsync(
                 <Workspace>
@@ -49,9 +73,58 @@ class Program
     static void Main(int {|Definition:Alice|})
     {
         var x = ({|Definition:{|Reference:Al$$ice|}|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
+        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
 
         var z = x.{|Reference:Alice|};
+        var z2 = x.{|Reference:Item1|};
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForNamedTupleElement() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = (Alice, Bob: 2);
+        var y = ({|Definition:Ali$$ce|}:1, Bob: 2);
+        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE seems strange this is highlighted, but not Alice on x
+
+        var z1 = x.{|Reference:Alice|};
+        var z2 = x.{|Reference:Item1|};
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForNamedTupleElement2() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = (Alice, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2);
+        var z = ({|Definition:Al$$ice|}:1, Carol: 2); // PROTOTYPE There is a bug in test infrastructure, which falsely fails this test
+
+        var z1 = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Item1|};
     }
 }
@@ -71,10 +144,11 @@ class Program
 {
     static void Main(int Alice)
     {
-        var x = ({|Definition:Alice|}, Bob: 2);
+        var x = ({|Definition:Alice|}, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
         var y = ({|Reference:Alice|}:1, Bob: 2);
+        var z = ({|Reference:Alice|}:1, Carol: 2);
 
-        var z = x.{|Reference:Al$$ice|};
+        var z1 = x.{|Reference:Al$$ice|};
         var z2 = x.{|Reference:Item1|};
     }
 }
@@ -95,10 +169,34 @@ class Program
     static void Main(int Alice)
     {
         var x = ({|Definition:Alice|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
+        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
 
-        var z = x.{|Reference:Alice|};
+        var z1 = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Ite$$m1|};
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForOtherNamedTupleElement() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int {|Definition:Alice|})
+    {
+        var x = (Other: 1, Bob: 2);
+        var z = ({|Definition:{|Reference:Al$$ice|}|}, Carol: 2);
+
+        var z1 = x.Other;
+        var z2 = x.{|Reference:Item1|} // PROTOTYPE I'm not entirely sure why this gets highlighted;
     }
 }
                         </Document>

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -39,6 +39,54 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForTupleElement() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int Alice) // PROTOTYPE Should be highlighted
+    {
+        var x = ({|Definition:Al$$ice|}, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Probably should not be highlighted
+
+        var z = x.{|Reference:Alice|};
+        var z2 = x.Item1; // PROTOTYPE Should be highlighted
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+            ' PROTOTYPE
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
+        Public Async Function TestVerifyHighlightsForTupleElementUsage() As Task
+            Await VerifyHighlightsAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Program
+{
+    static void Main(int Alice)
+    {
+        var x = ({|Definition:Alice|}, Bob: 2);
+        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Should not be highlighted
+
+        var z = x.{|Reference:Al$$ice|};
+        var z2 = x.Item1; // PROTOTYPE Should be highlighted
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>)
+            ' PROTOTYPE
+        End Function
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
         Public Async Function TestVerifyHighlightsForScriptReference() As Task
             Await VerifyHighlightsAsync(
                 <Workspace>

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -63,7 +63,7 @@ class Program
 
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.ReferenceHighlighting)>
-        Public Async Function TestVerifyHighlightsForTupleElement() As Task
+        Public Async Function TestVerifyHighlightsForInferredTupleElement() As Task
             Await VerifyHighlightsAsync(
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
@@ -73,8 +73,8 @@ class Program
     static void Main(int {|Definition:Alice|})
     {
         var x = ({|Definition:{|Reference:Al$$ice|}|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
-        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
+        var y = ({|Reference:Alice|}:1, Bob: 2);
+        var z = (Alice:1, Carol: 2);
 
         var z = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Item1|};
@@ -96,9 +96,9 @@ class Program
 {
     static void Main(int Alice)
     {
-        var x = (Alice, Bob: 2);
+        var x = (Alice, Bob: 2); // PROTOTYPE This probably should be highlighted, although the field name is inferred
         var y = ({|Definition:Ali$$ce|}:1, Bob: 2);
-        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE seems strange this is highlighted, but not Alice on x
+        var z = (Alice:1, Carol: 2);
 
         var z1 = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Item1|};
@@ -121,11 +121,11 @@ class Program
     static void Main(int Alice)
     {
         var x = (Alice, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2);
-        var z = ({|Definition:Al$$ice|}:1, Carol: 2); // PROTOTYPE There is a bug in test infrastructure, which falsely fails this test
+        var y = (Alice:1, Bob: 2);
+        var z = ({|Definition:Al$$ice|}:1, Carol: 2);
 
-        var z1 = x.{|Reference:Alice|};
-        var z2 = x.{|Reference:Item1|};
+        var z1 = x.Alice;
+        var z2 = x.Item1;
     }
 }
                         </Document>
@@ -144,9 +144,9 @@ class Program
 {
     static void Main(int Alice)
     {
-        var x = ({|Definition:Alice|}, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
+        var x = ({|Definition:Alice|}, Bob: 2);
         var y = ({|Reference:Alice|}:1, Bob: 2);
-        var z = ({|Reference:Alice|}:1, Carol: 2);
+        var z = (Alice:1, Carol: 2);
 
         var z1 = x.{|Reference:Al$$ice|};
         var z2 = x.{|Reference:Item1|};
@@ -169,8 +169,8 @@ class Program
     static void Main(int Alice)
     {
         var x = ({|Definition:Alice|}, Bob: 2);
-        var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
-        var z = ({|Reference:Alice|}:1, Carol: 2); // PROTOTYPE I'm not entirely sure why this gets highlighted
+        var y = ({|Reference:Alice|}:1, Bob: 2);
+        var z = (Alice:1, Carol: 2);
 
         var z1 = x.{|Reference:Alice|};
         var z2 = x.{|Reference:Ite$$m1|};
@@ -196,7 +196,7 @@ class Program
         var z = ({|Definition:{|Reference:Al$$ice|}|}, Carol: 2);
 
         var z1 = x.Other;
-        var z2 = x.{|Reference:Item1|} // PROTOTYPE I'm not entirely sure why this gets highlighted;
+        var z2 = x.Item1;
     }
 }
                         </Document>

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -46,9 +46,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                         <Document>
 class Program
 {
-    static void Main(int Alice) // PROTOTYPE Should be highlighted
+    static void Main(int {|Definition:Alice|})
     {
-        var x = ({|Definition:Al$$ice|}, Bob: 2);
+        var x = ({|Definition:{|Reference:Al$$ice|}|}, Bob: 2);
         var y = ({|Reference:Alice|}:1, Bob: 2); // PROTOTYPE Probably should not be highlighted
 
         var z = x.{|Reference:Alice|};

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public ImmutableArray<INamedTypeSymbol> Interfaces => _symbol.Interfaces;
             public ImmutableArray<INamedTypeSymbol> AllInterfaces => _symbol.AllInterfaces;
             public ImmutableArray<IFieldSymbol> TupleElements => _symbol.TupleElements;
+            public ImmutableArray<string> TupleElementNames => _symbol.TupleElementNames;
 
             public ImmutableArray<CustomModifier> GetTypeArgumentCustomModifiers(int ordinal)
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 var symbolToMatch = symbolInfoToMatch.Symbol;
                 var symbolToMatchCompilation = model.Compilation;
 
-                if (SymbolFinder.OriginalSymbolsMatch(searchSymbol, symbolInfoToMatch.Symbol, solution, null, symbolToMatchCompilation, cancellationToken))
+                if (SymbolFinder.OriginalSymbolsMatch(searchSymbol, symbolToMatch, solution, null, symbolToMatchCompilation, cancellationToken))
                 {
                     return (matched: true, CandidateReason.None);
                 }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols.Finders
@@ -22,6 +23,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             var symbol = symbolAndProjectId.Symbol;
+            if (symbol.IsTupleField())
+            {
+                // get the "other" field, if any
+                // PROTOTYPE
+                return Task.FromResult(
+                    ImmutableArray.Create(symbolAndProjectId.WithSymbol((ISymbol)symbol.CorrespondingTupleField)));
+            }
             if (symbol.AssociatedSymbol != null)
             {
                 return Task.FromResult(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -45,6 +45,24 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return semanticInfo.GetAnySymbol(includeType: false);
         }
 
+        internal static async Task<(ISymbol primary, ISymbol secondary)> FindSymbolExAtPositionAsync(
+            SemanticModel semanticModel,
+            int position,
+            Workspace workspace,
+            CancellationToken cancellationToken = default)
+        {
+            var semanticInfo = await GetSemanticInfoAtPositionAsync(
+                semanticModel, position, workspace, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // PROTOTYPE also should handle anonymous types
+            if (semanticInfo.DeclaredSymbol?.IsTupleField() == true && semanticInfo.ReferencedSymbols.Length == 1)
+            {
+                return (semanticInfo.DeclaredSymbol, semanticInfo.ReferencedSymbols[0]);
+            }
+
+            return (semanticInfo.GetAnySymbol(includeType: false), null);
+        }
+
         internal static async Task<TokenSemanticInfo> GetSemanticInfoAtPositionAsync(
             SemanticModel semanticModel,
             int position,

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -362,6 +362,21 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                         }
                     }
 
+                    var xElementNames = x.TupleElementNames;
+                    var yElementNames = y.TupleElementNames;
+                    if (xElementNames.Length != yElementNames.Length)
+                    {
+                        return false;
+                    }
+
+                    for (int i = 0; i < xElementNames.Length; i++)
+                    {
+                        if (xElementNames[i] != yElementNames[i])
+                        {
+                            return false;
+                        }
+                    }
+
                     return true;
                 }
 


### PR DESCRIPTION
Here's what FAR looks like with the current PR:

![image](https://user-images.githubusercontent.com/12466233/36634824-9f57e520-195f-11e8-804e-5b89fde283e9.png)

![image](https://user-images.githubusercontent.com/12466233/36634839-cb2eff1c-195f-11e8-83e3-f32e61a0024a.png)

![image](https://user-images.githubusercontent.com/12466233/36634875-44c1d458-1960-11e8-9d87-a8fd236c55a7.png)

![image](https://user-images.githubusercontent.com/12466233/36634851-e6d1e6e4-195f-11e8-9c75-756a1868ee8e.png)

![image](https://user-images.githubusercontent.com/12466233/36634852-f111cc14-195f-11e8-9ecc-421e6e0809b5.png)

![image](https://user-images.githubusercontent.com/12466233/36634854-ffc61d14-195f-11e8-9d75-84e83163356a.png)

![image](https://user-images.githubusercontent.com/12466233/36634858-11feb234-1960-11e8-928f-679c176f6329.png)

### Customer scenario
In tuple syntax, such as `(Alice, Bob)`, positioning the cursor on `Alice` is both referencing the declaration of a tuple field (so `t.Alice` and `t.Item1`) and the usage of local `Alice`.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/20115

### Risk

### Performance impact

### Is this a regression from a previous update?
No

### Root cause analysis
### How was the bug found?
Known issue from 15.0 (when tuples shipped in C# 7.0 and VB 15.0) and also reported by customers since.

Note: I noticed that highlighting doesn't recompute when the cursor is placed on a highlight. This used to make sense as placing the cursor on the highlight previously did not affect what would be highlighted (it was symmetrical). I think that is ok to leave as-is.

Note 2: I'm still debating whether tuples equivalence should factor or ignore tuple names. This PR modified the logic of a common component (to identify if two symbols are "equivalent") so that tuples names would be factored. This results in fewer and more selective highlights. If we choose to ignore tuple names, then highlighting the first element of tuple `(Alice: alice, Bob: 3)` would also highlight the first element of tuple `(Alice, alice, Carol: 2)`.