### PR TITLE
Update docs and add logging for x-plat contributors

### DIFF
--- a/build/scripts/obtain_dotnet.sh
+++ b/build/scripts/obtain_dotnet.sh
@@ -21,8 +21,12 @@ install_dotnet () {
     then
         if [[ "${FORCE_DOWNLOAD:-false}" != true && "$(dotnet --version)" = "${DOTNET_SDK_VERSION}" ]]
         then
+            echo "Using existing .NET CLI at \"$(command -v dotnet)\""
             return 0
         fi
+        echo "\"$(command -v dotnet)\" from the PATH is not the correct version"
+    else
+        echo "No \"dotnet\" exists on the PATH"
     fi
 
     if [[ ! -x "${DOTNET_PATH}/dotnet" || "$(${DOTNET_PATH}/dotnet --version)" != "${DOTNET_SDK_VERSION}" ]]
@@ -34,6 +38,7 @@ install_dotnet () {
         curl https://dot.net/v1/dotnet-install.sh | \
             /usr/bin/env bash -s -- --version "${DOTNET_RUNTIME_VERSION}" --shared-runtime --install-dir "${DOTNET_PATH}"
     fi
+    echo "Using downloaded .NET CLI at \"${DOTNET_PATH}/dotnet\""
 
     export PATH="${DOTNET_PATH}:${PATH}"
 }

--- a/docs/infrastructure/cross-platform.md
+++ b/docs/infrastructure/cross-platform.md
@@ -10,11 +10,11 @@ Build all cross-platform projects with:
 
 ```
 cd <roslyn-git-directory>
-./build/scripts/restore.sh
-dotnet build Compilers.sln
+./build.sh --restore
+./build.sh --build
 ```
 
-If you do not have a system-wide `dotnet` install, you can obtain one with `./build/scripts/obtain_dotnet.sh`. This will install a compatible version of the CLI to `./Binaries/Tools/dotnet` - add this to your PATH before trying to build `Compilers.sln`. Alternatively, sourcing the script with `source ./build/scripts/obtain_dotnet.sh` will add it to your PATH for you.
+If you do not have a system-wide `dotnet` install, or it does not match the required version, the build script will install a compatible version of the CLI to `./Binaries/Tools/dotnet` and use that version for all build tasks.
 
 ## Using the compiler
 


### PR DESCRIPTION
The `build.sh` script was added in November and is a much easier starting point for new contributors than the various commands previously recommended by the docs.

A bit of additional logging was also added to `obtain_dotnet.sh`, to help new contributors understand how the build is interacting with any existing dotnet installations (and particularly to help allay fears about the error message generated by `dotnet version` as part of that script, when the system installation does not include the required version).