### PR TITLE
Remove ExtensionInstallation* properties from VisualStudioSetup.Dependencies project

### DIFF
--- a/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
@@ -17,8 +17,6 @@
     <RuntimeIdentifier>$(RoslynDesktopRuntimeIdentifier)</RuntimeIdentifier>
     <RoslynProjectType>Vsix</RoslynProjectType>
     <IsProductComponent>true</IsProductComponent>
-    <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
-    <ExtensionInstallationFolder>Microsoft\ManagedLanguages\VBCSharp\Dependencies</ExtensionInstallationFolder>
     <Ngen>true</Ngen>
     <NgenArchitecture>All</NgenArchitecture>
     <NgenPriority>3</NgenPriority>


### PR DESCRIPTION
These properties are used at build time to generate a catalog file that
tells the setup engine to install the extension to a specified location.
However, this extension is a per-user extension so the catalog file is
ignored. Additionally, it appears this extension is only used during F5
anyway, so the VSSDK would ignore the properties in the catalog there
too.

The reason this fix is needed is that in future versions of the VSSDK,
building a per-user extension with an ExtensionInstallationRoot of
CommonExtensions will cause an error (in order to reduce confusion at
install time and to protect ourselves in case the SetupEngine begins to
install per-user extensions).

<details><summary>Ask Mode template</summary>


Is ask mode required for master? I'm not sure. In any case, here it is:

### Customer scenario

This doesn't affect customers other than developers building roslyn. It's to prevent a future issue if roslyn were to adopt the latest versions of the VSSDK.

### Bugs this fixes

I didn't create an issue to track this but I can if you'd like.

### Workarounds, if any

No workarounds at build time other than removing those properties.

### Risk

Low risk if the assumptions are correct about this only be used for F5. If this is used for dogfooding/installation, then there's a bit more of a risk - if vsixinstaller is invoked with `/a`, this would be break that installation in that the extension would install to a random folder in Extensions other than CommonExtensions. In that case, though, the fix should be to mark this extension as a per-machine extension in the vsixmanifest.

### Performance impact

None.

### Is this a regression from a previous update?

No.

### Root cause analysis

Not sure how this project was created in the first place, need confirmation from Tomas.

### How was the bug found?

I found the build issue when testing building Roslyn against the changes I made in the VSSDK (slated for 15.8 but we might release the packages under preview to get some testing).

### Test documentation updated?

</details>
