### PR TITLE
Allow ref Deconstruct extensions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -171,6 +171,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(expr.Syntax.Kind() != SyntaxKind.Argument || valueKind == BindValueKind.RefOrOut);
                     break;
 
+                case BoundKind.DeconstructValuePlaceholder:
+                    // deconstruction placeholders are replaced with temps for any expression with side-effects
+                    Debug.Assert(valueKind == BindValueKind.RefOrOut);
+                    return expr;
+
                 case BoundKind.OutVariablePendingInference:
                 case BoundKind.OutDeconstructVarPendingInference:
                     Debug.Assert(valueKind == BindValueKind.RefOrOut);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1091,7 +1091,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 options: options,
                 parseOptions: parseOptions);
 
-
             return comp;
         }
 


### PR DESCRIPTION
### Customer scenario
Ref extension methods (`void Deconstruct(ref this ...)`) should allowed in deconstructions. 
Also verifying that `in` extension method works.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24160

@dotnet/roslyn-compiler for review. Thanks
