### PR TITLE
Make Microsoft.NETCore.Compilers a release package

### DIFF
--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -161,10 +161,7 @@ var PreReleaseOnlyPackages = new HashSet<string>
     
     // C# Interactive on CoreCLR is pre-release
     "Microsoft.Net.CSharp.Interactive.netcore",
-    
-    // Pre-release package, API and structure not finalized
-    "Microsoft.NETCore.Compilers",
-    
+
     "Microsoft.CodeAnalysis.Remote.Razor.ServiceHub",
     "Microsoft.CodeAnalysis.Remote.ServiceHub",
     "Microsoft.CodeAnalysis.Remote.Workspaces",


### PR DESCRIPTION
This is an infrastructure-only change to make the Microsoft.NETCore.Compilers package a release package.