### PR TITLE
Disable NuGet package restore in Visual Studio for Roslyn.sln

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,7 @@
     <!-- Currently, the repository's version of NuGet.exe and Visual Studio's version
          fight over the format of project.lock.json because the one in the respository
          is newer. To prevent that, turn off package restore. -->
-    <add key="automatic" value="false" />
+    <add key="enabled" value="false" />
   </packageRestore>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />


### PR DESCRIPTION
Infrastructure only change.

This change results in a 50+% reduction in the amount of data allocated during solution load.

Time to fully load Roslyn.sln _after_ running Restore.cmd (i.e. NuGet restore is a NOP):

* Without this change: 1:37-1:51
* With this change: 1:29