### PR TITLE
Localization test failures 2 [WIP]

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
@@ -154,8 +154,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     Assert.Null(assembly);
                     AssertEx.Equal(new[]
                     {
-                        "(1,5): error CS1733: Expected expression",
-                        "(1,1): error CS1525: Invalid expression term '??'"
+                        $"(1,5): error CS1733: { CSharpResources.ERR_ExpressionExpected }",
+                        $"(1,1): error CS1525: { string.Format(CSharpResources.ERR_InvalidExprTerm, "??") }",
                     }, errorMessages);
 
                     Assert.True(methodTokens.IsEmpty);
@@ -195,8 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     Assert.Null(assembly);
                     AssertEx.Equal(new[]
                     {
-                        "(1,1): error CS0103: The name 'z' does not exist in the current context",
-                        "(1,6): error CS0103: The name 'z' does not exist in the current context"
+                        $"(1,1): error CS0103: { string.Format(CSharpResources.ERR_NameNotInContext,"z") }",
+                        $"(1,6): error CS0103: { string.Format(CSharpResources.ERR_NameNotInContext,"z") }",
                     }, errorMessages);
                     Assert.True(methodTokens.IsEmpty);
                 });
@@ -229,12 +229,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     Assert.Null(assembly);
                     AssertEx.Equal(new[]
                     {
-                        $"error CS7013: Name '<{longName}>i__Field' exceeds the maximum length allowed in metadata.",
-                        $"error CS7013: Name '<{longName}>j__TPar' exceeds the maximum length allowed in metadata.",
-                        $"error CS7013: Name '<{longName}>i__Field' exceeds the maximum length allowed in metadata.",
-                        $"error CS7013: Name 'get_{longName}' exceeds the maximum length allowed in metadata.",
-                        $"error CS7013: Name '{longName}' exceeds the maximum length allowed in metadata.",
-                        $"error CS7013: Name '{longName}' exceeds the maximum length allowed in metadata."
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"<{longName}>i__Field") }",
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"<{longName}>j__TPar") }",
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"<{longName}>i__Field") }",
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"get_{longName}") }",
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"{longName}") }",
+                        $"error CS7013: { string.Format(CSharpResources.ERR_MetadataNameTooLong, $"{longName}") }",
                     }, errorMessages);
 
                     Assert.True(methodTokens.IsEmpty);
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                         out var errorMessages);
                     Assert.Null(assembly);
                     AssertEx.Equal(
-                        new[] { "(1,11): error CS8185: A declaration is not allowed in this context." },
+                        new[] { $"(1,11): error CS8185: { CSharpResources.ERR_DeclarationExpressionNotPermitted }" },
                         errorMessages);
                     Assert.True(methodTokens.IsEmpty);
                 });
@@ -380,9 +380,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     Assert.Null(assembly);
                     AssertEx.Equal(new[]
                     {
-                        "(1,1): error CS0103: The name '$exception' does not exist in the current context",
-                        "(1,1): error CS0103: The name '$1' does not exist in the current context",
-                        "(1,7): error CS0103: The name '$unknown' does not exist in the current context",
+                        $"(1,1): error CS0103: { string.Format(CSharpResources.ERR_NameNotInContext, "$exception") }",
+                        $"(1,1): error CS0103: { string.Format(CSharpResources.ERR_NameNotInContext, "$1") }",
+                        $"(1,7): error CS0103: { string.Format(CSharpResources.ERR_NameNotInContext, "$unknown") }",
                     }, errorMessages);
                     Assert.True(methodTokens.IsEmpty);
                 });

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -665,7 +665,7 @@ class C
                     out errorMessage);
 
                 Assert.Equal(2, numRetries); // Ensure that we actually retried and that we bailed out on the second retry if the same identity was seen in the diagnostics.
-                Assert.Equal($"error CS0012: The type 'MissingType' is defined in an assembly that is not referenced. You must add a reference to assembly '{missingIdentity}'.", errorMessage);
+                Assert.Equal($"error CS0012: { string.Format(CSharpResources.ERR_NoTypeDef, "MissingType", missingIdentity)}", errorMessage);
             });
         }
 


### PR DESCRIPTION
Fix for #23837.
Follow up for #24407.

This is the second of a series of PRs meant to resolve the unit test failures caused by missing localizations.

This PR includes test related to expression compiler

### Roslyn.ExpressionEvaluator.CSharp.ExpressionCompiler.UnitTests 
Done. Tested local (de-DE).
### Roslyn.ExpressionEvaluator.VisualBasic.ExpressionCompiler.UnitTests
Upcoming.
