### PR TITLE
Localization test failures 3

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -150,7 +150,7 @@ class C
 {
     [|NuGetType|] n;
 }",
-"Use local version '1.0'",
+string.Format(FeaturesResources.Use_local_version_0, "1.0"),
 parameters: new TestParameters(fixProviderData: data));
 
             await TestSmartTagTextAsync(
@@ -158,7 +158,7 @@ parameters: new TestParameters(fixProviderData: data));
 {
     [|NuGetType|] n;
 }",
-"Use local version '2.0'",
+string.Format(FeaturesResources.Use_local_version_0, "2.0"),
 index: 1,
 parameters: new TestParameters(fixProviderData: data));
 
@@ -167,7 +167,7 @@ parameters: new TestParameters(fixProviderData: data));
 {
     [|NuGetType|] n;
 }",
-"Find and install latest version",
+FeaturesResources.Find_and_install_latest_version,
 index: 2,
 parameters: new TestParameters(fixProviderData: data));
         }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -7486,7 +7486,7 @@ class C
     </Project>
 </Workspace>";
 
-            var expectedDescription = $"(field) int C.x";
+            var expectedDescription = $"({ FeaturesResources.field }) int C.x";
             await VerifyItemInLinkedFilesAsync(markup, "x", expectedDescription);
         }
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -4690,7 +4690,7 @@ class Program
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "int X", "parameter"));
+                Diagnostic(RudeEditKind.Renamed, "int X", FeaturesResources.parameter));
         }
 
         #endregion
@@ -6694,7 +6694,7 @@ class Program
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Renamed, "int X", "parameter"));
+                Diagnostic(RudeEditKind.Renamed, "int X", FeaturesResources.parameter));
         }
 
         [Fact]
@@ -8521,7 +8521,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.ModifiersUpdate, "static void F()", "method"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "static void F()", FeaturesResources.method));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -2641,7 +2641,7 @@ class Test
             var edits = GetTopEdits(src1, src2);
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.Delete, "await", CSharpFeaturesResources.await_expression),
-                Diagnostic(RudeEditKind.ModifiersUpdate, "public Task<int> WaitAsync()", "method"));
+                Diagnostic(RudeEditKind.ModifiersUpdate, "public Task<int> WaitAsync()", FeaturesResources.method));
         }
 
         [Fact]
@@ -7577,7 +7577,7 @@ class C
                 "Delete [set { Console.WriteLine(0); }]@46");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "int this[int a]", "indexer setter"));
+                Diagnostic(RudeEditKind.Delete, "int this[int a]", CSharpFeaturesResources.indexer_setter));
         }
 
         [Fact, WorkItem(17681, "https://github.com/dotnet/roslyn/issues/17681")]
@@ -7698,7 +7698,7 @@ class C
                 "Update [(int, int, int a) M() { return (1, 2, 3); }]@10 -> [(int, int) M() { return (1, 2); }]@10");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "(int, int) M()", "method"));
+                Diagnostic(RudeEditKind.TypeUpdate, "(int, int) M()", FeaturesResources.method));
         }
 
         [Fact]
@@ -7713,7 +7713,7 @@ class C
                 "Update [(int, int) M() { return (1, 2); }]@10 -> [(int, int, int a) M() { return (1, 2, 3); }]@10");
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.TypeUpdate, "(int, int, int a) M()", "method"));
+                Diagnostic(RudeEditKind.TypeUpdate, "(int, int, int a) M()", FeaturesResources.method));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -4798,7 +4798,7 @@ namespace MyNs
 ";
             using (var workspace = TestWorkspace.Create(XElement.Parse(workspaceDefinition), workspaceKind: WorkspaceKind.Interactive))
             {
-                await TestWithOptionsAsync(workspace, MainDescription("(parameter) int x = 1"));
+                await TestWithOptionsAsync(workspace, MainDescription($"({ FeaturesResources.parameter }) int x = 1"));
             }
         }
 
@@ -4843,7 +4843,7 @@ public class C
     }
 }
 " + TestResources.NetFX.ValueTuple.tuplelib_cs,
-                MainDescription("(local variable) ValueTuple y"));
+                MainDescription($"({ FeaturesResources.local_variable }) ValueTuple y"));
         }
 
         [WorkItem(18311, "https://github.com/dotnet/roslyn/issues/18311")]
@@ -4879,7 +4879,7 @@ public class C
     }
 }
 " + TestResources.NetFX.ValueTuple.tuplelib_cs,
-                MainDescription("(local variable) ValueTuple<int> y"));
+                MainDescription($"({ FeaturesResources.local_variable }) ValueTuple<int> y"));
         }
 
         [WorkItem(18311, "https://github.com/dotnet/roslyn/issues/18311")]
@@ -4915,7 +4915,7 @@ public class C
     }
 }
 " + TestResources.NetFX.ValueTuple.tuplelib_cs,
-                MainDescription("(local variable) (int, int) y"));
+                MainDescription($"({ FeaturesResources.local_variable }) (int, int) y"));
         }
 
         [WorkItem(18311, "https://github.com/dotnet/roslyn/issues/18311")]
@@ -5189,7 +5189,7 @@ class Program
     }
 }
 ",
-            MainDescription("(parameter) ? b"));
+            MainDescription($"({ FeaturesResources.parameter }) ? b"));
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5,6 +5,7 @@ Imports System.Globalization
 Imports System.Threading
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Editor.Commands
 Imports Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
@@ -2761,10 +2762,10 @@ class Program
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(description:=
-"(extension) 'a[] System.Collections.Generic.IEnumerable<'a>.ToArray<'a>()
+$"({ CSharpFeaturesResources.extension }) 'a[] System.Collections.Generic.IEnumerable<'a>.ToArray<'a>()
 
-Anonymous Types:
-    'a is new { int x }")
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } new {{ int x }}")
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2471,10 +2471,10 @@ End Class
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(description:=
-"<Extension> Function IEnumerable(Of 'a).ToArray() As 'a()
+$"<{ VBFeaturesResources.Extension }> Function IEnumerable(Of 'a).ToArray() As 'a()
 
-Anonymous Types:
-    'a is New With { .x As Integer }")
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } New With {{ .x As Integer }}")
             End Using
         End Function
 
@@ -2494,10 +2494,10 @@ End Class
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(description:=
-"<Extension> Function IEnumerable(Of 'a).ToArray() As 'a()
+$"<{ VBFeaturesResources.Extension }> Function IEnumerable(Of 'a).ToArray() As 'a()
 
-Anonymous Types:
-    'a is New With { Key .x As Integer }")
+{ FeaturesResources.Anonymous_Types_colon }
+    'a { FeaturesResources.is_ } New With {{ Key .x As Integer }}")
             End Using
         End Function
 
@@ -2669,7 +2669,7 @@ End Class
             End Using
         End Function
 
-                <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestSnippetsNotExclusiveWhenAlwaysShowing() As Task
             Dim snippetProvider As CompletionProvider =
                 New VisualStudio.LanguageServices.VisualBasic.Snippets.
@@ -2692,7 +2692,7 @@ End Class
                                                                                     SnippetsRule.AlwaysInclude)
 
                 state.SendInvokeCompletionList()
-                await state.WaitForAsynchronousOperationsAsync()
+                Await state.WaitForAsynchronousOperationsAsync()
                 Assert.True(state.CompletionItemsContainsAll({"x", "Shortcut"}))
             End Using
         End Function
@@ -2949,20 +2949,20 @@ End Class
         End Function
 
         <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic), System.Composition.Shared>
-		Friend Class MockSnippetInfoService
-			Implements ISnippetInfoService
+        Friend Class MockSnippetInfoService
+            Implements ISnippetInfoService
 
-			Public Function GetSnippetsAsync_NonBlocking() As IEnumerable(Of SnippetInfo) Implements ISnippetInfoService.GetSnippetsIfAvailable
-				Return SpecializedCollections.SingletonEnumerable(New SnippetInfo("Shortcut", "Title", "Description", "Path"))
-			End Function
+            Public Function GetSnippetsAsync_NonBlocking() As IEnumerable(Of SnippetInfo) Implements ISnippetInfoService.GetSnippetsIfAvailable
+                Return SpecializedCollections.SingletonEnumerable(New SnippetInfo("Shortcut", "Title", "Description", "Path"))
+            End Function
 
-			Public Function ShouldFormatSnippet(snippetInfo As SnippetInfo) As Boolean Implements ISnippetInfoService.ShouldFormatSnippet
-				Return False
-			End Function
+            Public Function ShouldFormatSnippet(snippetInfo As SnippetInfo) As Boolean Implements ISnippetInfoService.ShouldFormatSnippet
+                Return False
+            End Function
 
-			Public Function SnippetShortcutExists_NonBlocking(shortcut As String) As Boolean Implements ISnippetInfoService.SnippetShortcutExists_NonBlocking
-				Return shortcut = "Shortcut"
-			End Function
-		End Class
-	End Class
+            Public Function SnippetShortcutExists_NonBlocking(shortcut As String) As Boolean Implements ISnippetInfoService.SnippetShortcutExists_NonBlocking
+                Return shortcut = "Shortcut"
+            End Function
+        End Class
+    End Class
 End Namespace

--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -764,7 +764,7 @@ End Class
                         </Document>
                     </Project>
                 </Workspace>,
-                "(ExampleClass Events)",
+                $"(ExampleClass { FeaturesResources.Events })",
                 Function(items) items.First(Function(i) i.Text = "ExampleEvent"),
                 <Result>
 Public Class ExampleClass

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7073,7 +7073,7 @@ End Class]]>
                              </Project>
                          </Workspace>.ToString().NormalizeLineEndings()
 
-            Dim expectedDescription = $"(field) C.x As Integer"
+            Dim expectedDescription = $"({ FeaturesResources.field }) C.x As Integer"
             Await VerifyItemInLinkedFilesAsync(markup, "x", expectedDescription)
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -163,7 +163,7 @@ New TestParameters(fixProviderData:=New ProviderData(installerServiceMock.Object
 Class C
     Dim n As [|NuGetType|]
 End Class",
-"Use local version '1.0'",
+String.Format(FeaturesResources.Use_local_version_0, "1.0"),
 parameters:=New TestParameters(fixProviderData:=data))
 
             Await TestSmartTagTextAsync(
@@ -171,7 +171,7 @@ parameters:=New TestParameters(fixProviderData:=data))
 Class C
     Dim n As [|NuGetType|]
 End Class",
-"Use local version '2.0'",
+String.Format(FeaturesResources.Use_local_version_0, "2.0"),
 index:=1,
 parameters:=New TestParameters(fixProviderData:=data))
 
@@ -180,7 +180,7 @@ parameters:=New TestParameters(fixProviderData:=data))
 Class C
     Dim n As [|NuGetType|]
 End Class",
-"Find and install latest version",
+FeaturesResources.Find_and_install_latest_version,
 index:=2,
 parameters:=New TestParameters(fixProviderData:=data))
         End Function

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
@@ -4227,7 +4227,7 @@ End Structure
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Async Function TestDisposePatternWhenAdditionalImportsAreIntroduced1() As Task
             Await TestInRegularAndScriptAsync(
-"Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of Integer)
+$"Interface I(Of T, U As T) : Inherits System.IDisposable, System.IEquatable(Of Integer)
     Function M(a As System.Collections.Generic.Dictionary(Of T, System.Collections.Generic.List(Of U)), b As T, c As U) As System.Collections.Generic.List(Of U)
     Function M(Of TT, UU As TT)(a As System.Collections.Generic.Dictionary(Of TT, System.Collections.Generic.List(Of UU)), b As TT, c As UU) As System.Collections.Generic.List(Of UU)
 End Interface
@@ -4265,33 +4265,33 @@ Class _
     End Function
 
 #Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
+    Private disposedValue As Boolean ' { FeaturesResources.To_detect_redundant_calls }
 
     ' IDisposable
     Protected Overridable Sub Dispose(disposing As Boolean)
         If Not disposedValue Then
             If disposing Then
-                ' TODO: dispose managed state (managed objects).
+                ' { FeaturesResources.TODO_colon_dispose_managed_state_managed_objects }
             End If
 
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
+            ' { VBFeaturesResources.TODO_colon_free_unmanaged_resources_unmanaged_objects_and_override_Finalize_below }
+            ' { FeaturesResources.TODO_colon_set_large_fields_to_null }
         End If
         disposedValue = True
     End Sub
 
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
+    ' { VBFeaturesResources.TODO_colon_override_Finalize_only_if_Dispose_disposing_As_Boolean_above_has_code_to_free_unmanaged_resources }
     'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
+    '    ' { VBFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_disposing_As_Boolean_above }
     '    Dispose(False)
     '    MyBase.Finalize()
     'End Sub
 
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
+    ' {VBFeaturesResources.This_code_added_by_Visual_Basic_to_correctly_implement_the_disposable_pattern }
     Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
+        ' { VBFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_disposing_As_Boolean_above }
         Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
+        ' { VBFeaturesResources.TODO_colon_uncomment_the_following_line_if_Finalize_is_overridden_above }
         ' GC.SuppressFinalize(Me)
     End Sub
 #End Region
@@ -4307,7 +4307,7 @@ End Class",
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Async Function TestDisposePatternWhenAdditionalImportsAreIntroduced2() As Task
             Await TestInRegularAndScriptAsync(
-"Class C
+$"Class C
 End Class
 
 Partial Class C
@@ -4342,33 +4342,33 @@ Partial Class C
     End Function
 
 #Region ""IDisposable Support""
-    Private disposedValue As Boolean ' To detect redundant calls
+    Private disposedValue As Boolean ' { FeaturesResources.To_detect_redundant_calls }
 
     ' IDisposable
     Protected Overridable Sub Dispose(disposing As Boolean)
         If Not disposedValue Then
             If disposing Then
-                ' TODO: dispose managed state (managed objects).
+                ' { FeaturesResources.TODO_colon_dispose_managed_state_managed_objects }
             End If
 
-            ' TODO: free unmanaged resources (unmanaged objects) and override Finalize() below.
-            ' TODO: set large fields to null.
+            ' { VBFeaturesResources.TODO_colon_free_unmanaged_resources_unmanaged_objects_and_override_Finalize_below }
+            ' { FeaturesResources.TODO_colon_set_large_fields_to_null }
         End If
         disposedValue = True
     End Sub
 
-    ' TODO: override Finalize() only if Dispose(disposing As Boolean) above has code to free unmanaged resources.
+    ' { VBFeaturesResources.TODO_colon_override_Finalize_only_if_Dispose_disposing_As_Boolean_above_has_code_to_free_unmanaged_resources }
     'Protected Overrides Sub Finalize()
-    '    ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
+    '    ' { VBFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_disposing_As_Boolean_above }
     '    Dispose(False)
     '    MyBase.Finalize()
     'End Sub
 
-    ' This code added by Visual Basic to correctly implement the disposable pattern.
+    ' { VBFeaturesResources.This_code_added_by_Visual_Basic_to_correctly_implement_the_disposable_pattern }
     Public Sub Dispose() Implements IDisposable.Dispose
-        ' Do not change this code.  Put cleanup code in Dispose(disposing As Boolean) above.
+        ' { VBFeaturesResources.Do_not_change_this_code_Put_cleanup_code_in_Dispose_disposing_As_Boolean_above }
         Dispose(True)
-        ' TODO: uncomment the following line if Finalize() is overridden above.
+        ' { VBFeaturesResources.TODO_colon_uncomment_the_following_line_if_Finalize_is_overridden_above }
         ' GC.SuppressFinalize(Me)
     End Sub
 #End Region

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -717,16 +717,18 @@ class C1
         public void TestOpenProject_WithInvalidFileExtension()
         {
             // make sure the file does in fact exist, but with an unrecognized extension
+            const string projFileName = @"CSharpProject\CSharpProject.csproj.nyi";
             CreateFiles(GetSimpleCSharpSolutionFiles()
-                .WithFile(@"CSharpProject\CSharpProject.csproj.nyi", GetResourceText("CSharpProject_CSharpProject.csproj")));
+                .WithFile(projFileName, GetResourceText("CSharpProject_CSharpProject.csproj")));
 
             AssertThrows<InvalidOperationException>(delegate
             {
-                MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"CSharpProject\CSharpProject.csproj.nyi")).Wait();
+                MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(projFileName)).Wait();
             },
             (e) =>
             {
-                Assert.Equal(true, e.Message.Contains("extension"));
+                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, GetSolutionFileName(projFileName), ".nyi");
+                Assert.Equal(expected, e.Message);
             });
         }
 
@@ -734,17 +736,19 @@ class C1
         public void TestOpenProject_ProjectFileExtensionAssociatedWithUnknownLanguage()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles());
-
+            var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+            var language = "lingo";
             AssertThrows<InvalidOperationException>(delegate
             {
                 var ws = MSBuildWorkspace.Create();
-                ws.AssociateFileExtensionWithLanguage("csproj", "lingo"); // non-existent language
-                ws.OpenProjectAsync(GetSolutionFileName(@"CSharpProject\CSharpProject.csproj")).Wait();
+                ws.AssociateFileExtensionWithLanguage("csproj", language); // non-existent language
+                ws.OpenProjectAsync(projFileName).Wait();
             },
             (e) =>
             {
                 // the exception should tell us something about the language being unrecognized.
-                Assert.Equal(true, e.Message.Contains("language"));
+                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_language_1_is_not_supported, projFileName, language);
+                Assert.Equal(expected, e.Message);
             });
         }
 
@@ -1037,9 +1041,10 @@ class C1
         public void TestOpenSolution_WithUnrecognizedProjectTypeGuidAndUnrecognizedExtension_WithSkipFalse_Fails()
         {
             // proves that if both project type guid and file extension are unrecognized, then open project fails.
+            const string noProjFileName = @"CSharpProject\CSharpProject.noproj";
             CreateFiles(GetSimpleCSharpSolutionFiles()
                 .WithFile(@"TestSolution.sln", GetResourceText("TestSolution_CSharp_UnknownProjectTypeGuidAndUnknownExtension.sln"))
-                .WithFile(@"CSharpProject\CSharpProject.noproj", GetResourceText("CSharpProject_CSharpProject.csproj")));
+                .WithFile(noProjFileName, GetResourceText("CSharpProject_CSharpProject.csproj")));
 
             AssertThrows<InvalidOperationException>(() =>
             {
@@ -1049,7 +1054,9 @@ class C1
             },
             e =>
             {
-                Assert.Equal(true, e.Message.Contains("extension"));
+                var noProjFullFileName = GetSolutionFileName(noProjFileName);
+                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, noProjFullFileName, ".noproj");
+                Assert.Equal(expected, e.Message);
             });
         }
 
@@ -1070,7 +1077,9 @@ class C1
             },
             e =>
             {
-                Assert.Equal(true, e.Message.Contains("extension"));
+                var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projFileName, ".csproj");
+                Assert.Equal(expected, e.Message);
             });
         }
 
@@ -1093,7 +1102,10 @@ class C1
             var solution = ws.OpenSolutionAsync(GetSolutionFileName(@"TestSolution.sln")).Result;
 
             Assert.Equal(1, dx.Count);
-            Assert.True(dx[0].Message.Contains("extension"));
+
+            var projFileName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+            var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projFileName, ".csproj");
+            Assert.Equal(expected, dx[0].Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -1102,15 +1114,16 @@ class C1
         {
             // proves that if the language libraries are missing then the appropriate error occurs
             CreateFiles(GetSimpleCSharpSolutionFiles());
-
+            var ws = MSBuildWorkspace.Create(_hostServicesWithoutCSharp);
+            var projectName = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             AssertThrows<InvalidOperationException>(() =>
             {
-                var ws = MSBuildWorkspace.Create(_hostServicesWithoutCSharp);
-                var project = ws.OpenProjectAsync(GetSolutionFileName(@"CSharpProject\CSharpProject.csproj")).Result;
+                var project = ws.OpenProjectAsync(projectName).Result;
             },
             e =>
             {
-                Assert.Equal(true, e.Message.Contains("extension"));
+                var expected = string.Format(WorkspacesResources.Cannot_open_project_0_because_the_file_extension_1_is_not_associated_with_a_language, projectName, ".csproj");
+                Assert.Equal(expected, e.Message);
             });
         }
 
@@ -2899,7 +2912,7 @@ class C { }";
                 Assert.Equal(false, projFileText.Contains(@"<Reference Include=""System.Xaml,"));
             }
         }
- 
+
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16301")]
         [Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestAddRemoveMetadataReference_ReferenceAssembly()


### PR DESCRIPTION
Fix for #23837.
Follow up for #24407 and #24424
This is the third of a series of PRs meant to resolve the unit test failures caused by missing localizations.

This PR includes test related to the editor and workspace:

### Roslyn.Services.Editor2.UnitTests 
Done. Tested local (de-DE) and CI (en-US).
### Roslyn.Services.Editor.CSharp.UnitTests 
Done. Tested local (de-DE) and CI (en-US).
### Roslyn.Services.Editor.VisualBasic.UnitTests 
Done. Tested local (de-DE) and CI (en-US).
### Roslyn.Services.UnitTests 
Done. Tested local (de-DE) and CI (en-US).