### PR TITLE
Add references to System.IO.Pipes.AccessControl

### DIFF
--- a/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
+++ b/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
@@ -92,7 +92,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             switch (name.Name)
             {
                 case "System.IO.Pipes.AccessControl":
-                    return TryRedirectToRuntimesDir(name);
+                    var assembly = TryRedirectToRuntimesDir(name);
+                    if (assembly != null)
+                    {
+                        return assembly;
+                    }
+                    break;
             }
 
             return Assembly.Load(name);
@@ -128,14 +133,17 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             if (File.Exists(assemblyPath))
             {
                 CompilerServerLogger.Log($"Loading from: {assemblyPath}");
-                return (Assembly)typeof(Assembly).GetTypeInfo()
-                    .GetDeclaredMethod("LoadFile")
-                    ?.Invoke(null, parameters: new object[] { assemblyPath });
+                return LoadAssemblyFromPath(assemblyPath);
             }
 
             CompilerServerLogger.Log($"File not found: {assemblyPath}");
 
             return null;
+
+            Assembly LoadAssemblyFromPath(string path)
+                => (Assembly)typeof(Assembly).GetTypeInfo()
+                    .GetDeclaredMethod("LoadFile")
+                    ?.Invoke(null, parameters: new object[] { assemblyPath });
         }
 
         private static bool KeysEqual(byte[] left, byte[] right)

--- a/src/Compilers/Extension/AssemblyRedirects.cs
+++ b/src/Compilers/Extension/AssemblyRedirects.cs
@@ -15,6 +15,7 @@ using Roslyn.VisualStudio.Setup;
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")]
+[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.AccessControl.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]

--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -57,6 +57,7 @@
     <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem.DriveInfo" />
     <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem.Primitives" />
     <NuGetPackageToIncludeInVsix Include="System.IO.Pipes" />
+    <NuGetPackageToIncludeInVsix Include="System.IO.Pipes.AccessControl" />
     <NuGetPackageToIncludeInVsix Include="System.Linq.Expressions" />
     <NuGetPackageToIncludeInVsix Include="System.Linq.Parallel" />
     <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -73,6 +73,7 @@
     <file src="Exes\Toolset\System.IO.FileSystem.DriveInfo.dll" target="tools" />
     <file src="Exes\Toolset\System.IO.FileSystem.Primitives.dll" target="tools" />
     <file src="Exes\Toolset\System.IO.Pipes.dll" target="tools" />
+    <file src="Exes\Toolset\System.IO.Pipes.AccessControl.dll" target="tools" />
     <file src="Exes\Toolset\System.Reflection.Metadata.dll" target="tools" />
     <file src="Exes\Toolset\System.Security.AccessControl.dll" target="tools" />
     <file src="Exes\Toolset\System.Security.Claims.dll" target="tools" />

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -550,7 +550,7 @@ Public Class BuildDevDivInsertionFiles
                                                                 packageName,
                                                                 packageVersion,
                                                                 isNative:=native IsNot Nothing,
-                                                                isFacade:=frameworkAssemblies IsNot Nothing))
+                                                                isFacade:=frameworkAssemblies IsNot Nothing OrElse packageName = "System.IO.Pipes.AccessControl"))
                     End If
                 Next
             Next
@@ -852,6 +852,7 @@ Public Class BuildDevDivInsertionFiles
         add("Exes\Toolset\System.IO.FileSystem.DriveInfo.dll")
         add("Exes\Toolset\System.IO.FileSystem.Primitives.dll")
         add("Exes\Toolset\System.IO.Pipes.dll")
+        add("Exes\Toolset\System.IO.Pipes.AccessControl.dll")
         add("Exes\Toolset\System.Reflection.Metadata.dll")
         add("Exes\Toolset\System.Security.AccessControl.dll")
         add("Exes\Toolset\System.Security.Claims.dll")

--- a/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
+++ b/src/Setup/DevDivPackages/Roslyn/DevDivPackagesRoslyn.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="System.IO.FileSystem" Version="$(SystemIOFileSystemVersion)" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(SystemIOFileSystemPrimitivesVersion)" />
     <PackageReference Include="System.IO.Pipes" Version="$(SystemIOPipesVersion)" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" />
     <PackageReference Include="System.Runtime.Numerics" Version="$(SystemRuntimeNumericsVersion)" />
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlVersion)" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemSecurityCryptographyAlgorithmsVersion)" />

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -44,6 +44,7 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.DriveInfo.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Pipes.dll vs.file.ngenArchitecture=all
+    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Pipes.AccessControl.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.AccessControl.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Claims.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll vs.file.ngenArchitecture=all

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=PortableFacades
-        version=1.5.0.0
+        version=1.6.0.0
 
 folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.AppContext\4.3.0\lib\net46\System.AppContext.dll" vs.file.ngen=yes
@@ -12,6 +12,7 @@ folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.IO.Compression\4.3.0\runtimes\win\lib\net46\System.IO.Compression.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.IO.FileSystem\4.3.0\lib\net46\System.IO.FileSystem.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.IO.FileSystem.Primitives\4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll" vs.file.ngen=yes
+    file source="$(NuGetPackageRoot)\System.IO.Pipes.AccessControl\4.3.0\runtimes\win\lib\net46\System.IO.Pipes.AccessControl.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.IO.Pipes\4.3.0\runtimes\win\lib\net46\System.IO.Pipes.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Net.Security\4.3.0\runtimes\win\lib\net46\System.Net.Security.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Net.Sockets\4.3.0\lib\net46\System.Net.Sockets.dll" vs.file.ngen=yes


### PR DESCRIPTION
### Customer scenario

The VS build is currently broken.

When adding the reference to System.IO.Pipes.AccessControl for the
compiler server to use on CoreCLR, I unified the pathway for the desktop
and CoreCLR server access control code. This means that
System.IO.Pipes.AccessControl needed to be added as a dependent DLL for
desktop too, but I forgot to do that. This change adds
System.IO.Pipes.AccessControl as a dependent DLL in all the places where
the build task is deployed.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/557536

### Workarounds, if any

None.

### Risk

This change mirrors our behavior for System.IO.Pipes pretty closely. Since any scenario which
needs System.IO.Pipes.AccessControl should also require System.IO.Pipes, it's unlikely that we've
missed a deployment scenario if we cover every scenario where System.IO.Pipes is deployed.

Overall, this change should be validated by RPS.

### Performance impact

Without this change, the compiler server does not work on desktop.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

The bootstrap process we use to test the compiler server in Roslyn is not exactly the same
as the binary layout we use in VS. In addition, we have multiple files which duplicate the
same information about binary layout. @jasonmalinowski has a PR (https://github.com/dotnet/roslyn/pull/22845) to help address the duplication issue. I have filed an issue
(https://github.com/dotnet/roslyn/issues/24456) to move our bootstrap
code closer to the VS layout, which should help catch these issues earlier. 

### How was the bug found?

RPS Failure