### PR TITLE
fix a case where persistent storage registration fails and some clean…

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Storage
             }
 
             // check whether the solution actually exist on disk
-            if (!EnsureSolutionFileExist(solution.FilePath))
+            if (!CheckSolutionFileExist(solution.FilePath))
             {
                 return NoOpPersistentStorage.Instance;
             }
@@ -78,16 +78,19 @@ namespace Microsoft.CodeAnalysis.Storage
             return GetStorage(solution, workingFolderPath);
         }
 
-        private bool EnsureSolutionFileExist(string solutionFilePath)
+        private bool CheckSolutionFileExist(string solutionFilePath)
         {
             if (!string.Equals(solutionFilePath, _lastSolutionPath, StringComparison.OrdinalIgnoreCase))
             {
                 // check whether the solution actually exist on disk
-                return File.Exists(solutionFilePath);
+                var exist = File.Exists(solutionFilePath);
+
+                // cache current result.
+                _lastSolutionPath = exist ? solutionFilePath : null;
+
+                return exist;                
             }
 
-            // cache current result.
-            _lastSolutionPath = solutionFilePath;
             return true;
         }
 

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistentStorageService.cs
@@ -24,9 +24,9 @@ namespace Microsoft.CodeAnalysis.Storage
 
         private readonly bool _testing;
         private readonly object _lookupAccessLock;
+        private readonly PrimaryStorageInfo _primaryStorage;
 
         private string _lastSolutionPath;
-        private PrimaryStorageInfo _primaryStorage;
 
         protected AbstractPersistentStorageService(
             IOptionService optionService,

--- a/src/Workspaces/Remote/Core/Services/AssetService.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetService.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal class AssetService
     {
-        // PREVIEW: unfortunately, I need dummy workspace since workspace services can be workspace specific
         private static readonly Serializer s_serializer = new Serializer(SolutionService.PrimaryWorkspace);
 
         private readonly int _scopeId;

--- a/src/Workspaces/Remote/Core/Services/AssetService.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Remote
     internal class AssetService
     {
         // PREVIEW: unfortunately, I need dummy workspace since workspace services can be workspace specific
-        private static readonly Serializer s_serializer = new Serializer(new AdhocWorkspace(RoslynServices.HostServices, workspaceKind: "dummy"));
+        private static readonly Serializer s_serializer = new Serializer(SolutionService.PrimaryWorkspace);
 
         private readonly int _scopeId;
         private readonly AssetStorage _assetStorage;

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -263,10 +263,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private static AbstractPersistentStorageService GetPersistentStorageService()
         {
-            // A bit slimy.  We just create an adhoc workspace so it will create the singleton
-            // PersistentStorageService.  This service will be shared among all Workspaces we 
-            // create in this process.  So updating it will be seen by all.
-            var workspace = new AdhocWorkspace(RoslynServices.HostServices);
+            var workspace = SolutionService.PrimaryWorkspace;
             var persistentStorageService = workspace.Services.GetService<IPersistentStorageService>() as AbstractPersistentStorageService;
             return persistentStorageService;
         }


### PR DESCRIPTION
… up code around it.

### Customer scenario

User creates a new solution with "Projects and Solutions" -> "Save new projects when created" option off  and then later save the solution. and see yellow info bar on issues on Roslyn OOP a few seconds later.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/545739

### Workarounds, if any

No workaround

### Risk

No risk

### Performance impact

There is no change on perf since there is no change on persistent service's behavior.

### Is this a regression from a previous update?

No

### Root cause analysis

code was expecting very specific order of API calls from Host (here VS) when solution location is changed. basically, it expected register/unregisterPrimarySolution to be always called in pair. and this bug found one corner case which doesn't follow the expectation. in this specific case, VS won't raise events which will in turn make us to call unregister/register call, rather it will make us to call register twice with same solution. since we can't control host's behavior (this code is in lower layer than VS), code is changed to handle this kind of case properly. 

### How was the bug found?

user feedback.
