### PR TITLE
fixing AccessViolationException on ReadMetadataHeader

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -51,7 +51,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             // Add a dummy data item to the appdomain to add it to the disposal queue when the debugged process is shutting down.
             // This should prevent from attempts to use the Metadata pointer for dead debugged processes.
-            appDomain.SetDataItem(DkmDataCreationDisposition.CreateNew, new AppDomainLifetimeDataItem());
+            if (appDomain.GetDataItem<AppDomainLifetimeDataItem>() == null)
+            {
+                appDomain.SetDataItem(DkmDataCreationDisposition.CreateNew, new AppDomainLifetimeDataItem());
+            }
 
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -49,6 +49,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             DkmClrAppDomain appDomain, 
             ImmutableArray<MetadataBlock> previousMetadataBlocks)
         {
+            // Add a dummy data item to the appdomain to add it to the disposal queue when the debugged process is shutting down.
+            // This should prevent from attempts to use the Metadata pointer for dead debugged processes.
+            appDomain.SetDataItem(DkmDataCreationDisposition.CreateNew, new AppDomainLifetimeDataItem());
+
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;
             uint size;
@@ -324,5 +328,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 this.MetadataContext = metadataContext;
             }
         }
+
+        private sealed class AppDomainLifetimeDataItem : DkmDataItem { }
     }
 }


### PR DESCRIPTION
### Customer scenario

The user debugging process crashed during the execution https://github.com/dotnet/roslyn/blob/f9ebce0a3056646064cf52208eb40487b80b8aca/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs#L63 in the debugger.  The pointer created just above 
https://github.com/dotnet/roslyn/blob/f9ebce0a3056646064cf52208eb40487b80b8aca/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs#L61 points to a bad block.

The debugger crashes with 
CLR_EXCEPTION_System.AccessViolationException_80004003_System.Reflection.Metadata.dll!System.Reflection.Metadata.MetadataReader.ReadMetadataHeader

### Bugs this fixes

VSO 187805

### Workarounds, if any

No

### Risk

Low

### Performance impact
No

### Is this a regression from a previous update?
No

### Root cause analysis
This happens on the edge between Roslyn, Visual Studio and user debugging processes. There are various interactions between processes with different timings. Not all of them were considered.

### How was the bug found?
Watson