### PR TITLE
Fix Intellisense in debugger tool windows

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         where TPackage : AbstractPackage<TPackage, TLanguageService>
         where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
     {
-        protected readonly AbstractLanguageService<TPackage, TLanguageService> _languageService;
+        protected AbstractLanguageService<TPackage, TLanguageService> LanguageService { get; }
 
         protected AbstractVsTextViewFilter(
             AbstractLanguageService<TPackage, TLanguageService> languageService,
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             ICommandHandlerServiceFactory commandHandlerServiceFactory)
             : base(wpfTextView, commandHandlerServiceFactory, editorAdaptersFactoryService, languageService.SystemServiceProvider)
         {
-            _languageService = languageService;
+            LanguageService = languageService;
         }
 
         int IVsTextViewFilter.GetDataTipText(TextSpan[] pSpan, out string pbstrText)
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         {
             pbstrText = null;
 
-            var debugInfo = _languageService.LanguageDebugInfo;
+            var debugInfo = LanguageService.LanguageDebugInfo;
             if (debugInfo != null)
             {
                 var subjectBuffer = WpfTextView.GetBufferContainingCaret();
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             try
             {
                 int result = VSConstants.S_OK;
-                _languageService.Package.ComponentModel.GetService<IWaitIndicator>().Wait(
+                LanguageService.Package.ComponentModel.GetService<IWaitIndicator>().Wait(
                     "Intellisense",
                     allowCancel: true,
                     action: c => result = GetPairExtentsWorker(iLine, iIndex, pSpan, c.CancellationToken));
@@ -93,10 +93,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         private int GetPairExtentsWorker(int iLine, int iIndex, TextSpan[] pSpan, CancellationToken cancellationToken)
         {
-            var braceMatcher = _languageService.Package.ComponentModel.GetService<IBraceMatchingService>();
+            var braceMatcher = LanguageService.Package.ComponentModel.GetService<IBraceMatchingService>();
             return GetPairExtentsWorker(
                 WpfTextView,
-                _languageService.Workspace,
+                LanguageService.Workspace,
                 braceMatcher,
                 iLine,
                 iIndex,

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter`2.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         where TPackage : AbstractPackage<TPackage, TLanguageService>
         where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
     {
-        private readonly AbstractLanguageService<TPackage, TLanguageService> _languageService;
+        protected readonly AbstractLanguageService<TPackage, TLanguageService> _languageService;
 
         protected AbstractVsTextViewFilter(
             AbstractLanguageService<TPackage, TLanguageService> languageService,

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -52,6 +52,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             //     -> IVsCommandHandlerServiceAdapter (our command handlers migrated to the modern editor commanding)
             //            -> original next command filter
             var nextCommandFilter = _originalNextCommandFilter;
+            // The next filter is set in response to debugger calling IVsImmediateStatementCompletion2.InstallStatementCompletion(),
+            // followed IVsImmediateStatementCompletion2.SetCompletionContext() that sets the context.
+            // Check context in case debugger hasn't called IVsImmediateStatementCompletion2.SetCompletionContext() yet - before that
+            // we cannot set up command handling on correct view and buffer.
             if (_context != null)
             {
                 // Chain in editor command handler service. It will execute all our command handlers migrated to the modern editor commanding

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -45,7 +45,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
         internal void SetCommandHandlers(ITextBuffer buffer)
         {
             this.CurrentHandlers = _commandFactory.GetService(buffer);
-            // Chain in editor command handler service. It will execute all our command handlers migrated to the modern editor commanding.
+            // Chain in editor command handler service. It will execute all our command handlers migrated to the modern editor commanding
+            // on the same text view and buffer as this.CurrentHandlers.
             var componentModel = (IComponentModel)_languageService.SystemServiceProvider.GetService(typeof(SComponentModel));
             var vsCommandHandlerServiceAdapterFactory = componentModel.GetService<IVsCommandHandlerServiceAdapterFactory>();
             var vsCommandHandlerServiceAdapter = vsCommandHandlerServiceAdapterFactory.Create(ConvertTextView(), 
@@ -127,7 +128,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
                             {
                                 // We cannot just pass executeNextCommandTarget becuase it would execute TYPECHAR
                                 var showMemberListCmdGroupId = VSConstants.VSStd2K;
-                                NextCommandTarget.Exec(ref showMemberListCmdGroupId, (uint)VSConstants.VSStd2KCmdID.SHOWMEMBERLIST, executeInformation, pvaIn, pvaOut);
+                                NextCommandTarget.Exec(ref showMemberListCmdGroupId, (uint)VSConstants.VSStd2KCmdID.SHOWMEMBERLIST, 
+                                    executeInformation, pvaIn, pvaOut);
                             });
                         }
                     }

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerIntellisenseFilter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
                 case VSConstants.VSStd2KCmdID.SCROLLUP:
                     ExecuteCancel(subjectBuffer, contentType, () =>
                     {
-                        // We cannot just pass executeNextCommandTarget becuase it would execute TYPECHAR
+                        // We cannot just pass executeNextCommandTarget becuase it would execute SCROLLUP
                         var cancelCmdGroupId = VSConstants.VSStd2K;
                         NextCommandTarget.Exec(ref cancelCmdGroupId, (uint)VSConstants.VSStd2KCmdID.CANCEL, executeInformation, pvaIn, pvaOut);
                     });
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
                             // target isn't the one we want, because we've
                             // definitely remapped buffers. Ask our context for
                             // the real subject buffer.
-                            this.ExecuteInvokeCompletionList(_context.Buffer, _context.ContentType, () =>
+                            ExecuteInvokeCompletionList(_context.Buffer, _context.ContentType, () =>
                             {
                                 // We cannot just pass executeNextCommandTarget becuase it would execute TYPECHAR
                                 var showMemberListCmdGroupId = VSConstants.VSStd2K;

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpImmediate.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpImmediate : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpImmediate(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        {
+            VisualStudio.SolutionExplorer.CreateSolution(nameof(CSharpInteractive));
+            var testProj = new ProjectUtils.Project("TestProj");
+            VisualStudio.SolutionExplorer.AddProject(testProj, WellKnownProjectTemplates.ConsoleApplication, LanguageNames.CSharp);
+        }
+
+        [Fact]
+        public void DumpLocalVaribleValue()
+        {
+            VisualStudio.Editor.SetText(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int n1 = 42;
+        int n2 = 43;
+    }
+}
+");
+
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudio.Debugger.SetBreakPoint("Program.cs", "}");
+            VisualStudio.Debugger.Go(waitForBreakMode: true);
+            VisualStudio.ImmediateWindow.ShowImmediateWindow(clearAll: true);
+            VisualStudio.SendKeys.Send("?n");
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.CompletionSet);
+            VisualStudio.SendKeys.Send("1", VirtualKey.Enter);
+            Assert.Contains("?n1\r\n42", VisualStudio.ImmediateWindow.GetText());
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpImmediate.cs
@@ -29,8 +29,8 @@ class Program
 {
     static void Main(string[] args)
     {
-        int n1 = 42;
-        int n2 = 43;
+        int n1Var = 42;
+        int n2Var = 43;
     }
 }
 ");
@@ -41,8 +41,8 @@ class Program
             VisualStudio.ImmediateWindow.ShowImmediateWindow(clearAll: true);
             VisualStudio.SendKeys.Send("?n");
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.CompletionSet);
-            VisualStudio.SendKeys.Send("1", VirtualKey.Enter);
-            Assert.Contains("?n1\r\n42", VisualStudio.ImmediateWindow.GetText());
+            VisualStudio.SendKeys.Send("1", VirtualKey.Tab, VirtualKey.Enter);
+            Assert.Contains("?n1Var\r\n42", VisualStudio.ImmediateWindow.GetText());
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicImmediate.cs
@@ -27,8 +27,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
             VisualStudio.Editor.SetText(@"
 Module Module1
     Sub Main()
-        Dim n1 As Integer = 42
-        Dim n2 As Integer = 43
+        Dim n1Var As Integer = 42
+        Dim n2Var As Integer = 43
     End Sub
 End Module
 ");
@@ -39,8 +39,8 @@ End Module
             VisualStudio.ImmediateWindow.ShowImmediateWindow(clearAll: true);
             VisualStudio.SendKeys.Send("?");
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.CompletionSet);
-            VisualStudio.SendKeys.Send("n1", VirtualKey.Enter);
-            Assert.Contains("?n1\r\n42", VisualStudio.ImmediateWindow.GetText());
+            VisualStudio.SendKeys.Send("n1", VirtualKey.Tab, VirtualKey.Enter);
+            Assert.Contains("?n1Var\r\n42", VisualStudio.ImmediateWindow.GetText());
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicImmediate.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicImmediate.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicImmediate : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public BasicImmediate(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        {
+            VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicImmediate));
+            var testProj = new ProjectUtils.Project("TestProj");
+            VisualStudio.SolutionExplorer.AddProject(testProj, WellKnownProjectTemplates.ConsoleApplication, LanguageNames.VisualBasic);
+        }
+
+        [Fact]
+        public void DumpLocalVaribleValue()
+        {
+            VisualStudio.Editor.SetText(@"
+Module Module1
+    Sub Main()
+        Dim n1 As Integer = 42
+        Dim n2 As Integer = 43
+    End Sub
+End Module
+");
+
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudio.Debugger.SetBreakPoint("Module1.vb", "End Sub");
+            VisualStudio.Debugger.Go(waitForBreakMode: true);
+            VisualStudio.ImmediateWindow.ShowImmediateWindow(clearAll: true);
+            VisualStudio.SendKeys.Send("?");
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.CompletionSet);
+            VisualStudio.SendKeys.Send("n1", VirtualKey.Enter);
+            Assert.Contains("?n1\r\n42", VisualStudio.ImmediateWindow.GetText());
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
+{
+    internal class ImmediateWindow_InProc : InProcComponent
+    {
+        public static ImmediateWindow_InProc Create() => new ImmediateWindow_InProc();
+
+        public void ShowImmediateWindow()=> ExecuteCommand("Debug.Immediate");
+
+        public string GetText()
+        {
+            IVsUIShell vsUIShell = (IVsUIShell)ServiceProvider.GlobalProvider.GetService(typeof(SVsUIShell));
+            Guid guid = new Guid("ECB7191A-597B-41F5-9843-03A4CF275DDE");
+            IVsWindowFrame windowFrame;
+            int result = vsUIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFindFirst, ref guid, out windowFrame);
+            windowFrame.Show();
+            windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object docView);
+            var textView = docView as IVsTextView;
+            textView.GetBuffer(out IVsTextLines vsTextLines);
+            vsTextLines.GetLineCount(out int lineCount);
+            vsTextLines.GetLengthOfLine(lineCount - 1, out int lastLineLength);
+            vsTextLines.GetLineText(0, 0, lineCount - 1, lastLineLength, out string text);
+            return text;
+        }
+
+        public void ClearAll()
+        {
+            ShowImmediateWindow();
+            ExecuteCommand("Edit.ClearAll");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
@@ -16,16 +16,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public string GetText()
         {
             IVsUIShell vsUIShell = (IVsUIShell)ServiceProvider.GlobalProvider.GetService(typeof(SVsUIShell));
-            Guid guid = new Guid("ECB7191A-597B-41F5-9843-03A4CF275DDE");
-            IVsWindowFrame windowFrame;
-            int result = vsUIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFindFirst, ref guid, out windowFrame);
-            windowFrame.Show();
-            windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object docView);
-            var textView = docView as IVsTextView;
-            textView.GetBuffer(out IVsTextLines vsTextLines);
-            vsTextLines.GetLineCount(out int lineCount);
-            vsTextLines.GetLengthOfLine(lineCount - 1, out int lastLineLength);
-            vsTextLines.GetLineText(0, 0, lineCount - 1, lastLineLength, out string text);
+            Guid immediateWindowGuid = VSConstants.StandardToolWindows.Immediate;
+            IVsWindowFrame immediateWindowFrame;
+            ErrorHandler.ThrowOnFailure(vsUIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFindFirst, ref immediateWindowGuid, out immediateWindowFrame));
+            ErrorHandler.ThrowOnFailure(immediateWindowFrame.Show());
+            ErrorHandler.ThrowOnFailure(immediateWindowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object docView));
+            var vsTextView = (IVsTextView)docView;
+            ErrorHandler.ThrowOnFailure(vsTextView.GetBuffer(out IVsTextLines vsTextLines));
+            ErrorHandler.ThrowOnFailure(vsTextLines.GetLineCount(out int lineCount));
+            ErrorHandler.ThrowOnFailure(vsTextLines.GetLengthOfLine(lineCount - 1, out int lastLineLength));
+            ErrorHandler.ThrowOnFailure(vsTextLines.GetLineText(0, 0, lineCount - 1, lastLineLength, out string text));
             return text;
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/ImmediateWindow_InProc.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             IVsUIShell vsUIShell = (IVsUIShell)ServiceProvider.GlobalProvider.GetService(typeof(SVsUIShell));
             Guid immediateWindowGuid = VSConstants.StandardToolWindows.Immediate;
             IVsWindowFrame immediateWindowFrame;
-            ErrorHandler.ThrowOnFailure(vsUIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFindFirst, ref immediateWindowGuid, out immediateWindowFrame));
+            ErrorHandler.ThrowOnFailure(vsUIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, ref immediateWindowGuid, out immediateWindowFrame));
             ErrorHandler.ThrowOnFailure(immediateWindowFrame.Show());
             ErrorHandler.ThrowOnFailure(immediateWindowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object docView));
             var vsTextView = (IVsTextView)docView;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ImmediateWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/ImmediateWindow_OutOfProc.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
+{
+    public partial class ImmediateWindow_OutOfProc : OutOfProcComponent
+    {
+        private readonly ImmediateWindow_InProc _immediateWindowInProc;
+
+        public ImmediateWindow_OutOfProc(VisualStudioInstance visualStudioInstance) : base(visualStudioInstance)
+        {
+            _immediateWindowInProc = CreateInProcComponent<ImmediateWindow_InProc>(visualStudioInstance);
+        }
+
+        public void ShowImmediateWindow(bool clearAll = false)
+        {
+            _immediateWindowInProc.ShowImmediateWindow();
+            if (clearAll)
+            {
+                ClearAll();
+            }
+        }
+
+        public string GetText()
+        {
+            return _immediateWindowInProc.GetText();
+        }
+
+        public void ClearAll()
+        {
+            _immediateWindowInProc.ClearAll();
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -45,6 +45,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public GenerateTypeDialog_OutOfProc GenerateTypeDialog { get; }
 
+        public ImmediateWindow_OutOfProc ImmediateWindow { get; }
+
         public InlineRenameDialog_OutOfProc InlineRenameDialog { get; set; }
 
         public LocalsWindow_OutOfProc LocalsWindow { get; set; }
@@ -110,6 +112,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             FindReferencesWindow = new FindReferencesWindow_OutOfProc(this);
             GenerateTypeDialog = new GenerateTypeDialog_OutOfProc(this);
             InlineRenameDialog = new InlineRenameDialog_OutOfProc(this);
+            ImmediateWindow = new ImmediateWindow_OutOfProc(this);
             LocalsWindow = new LocalsWindow_OutOfProc(this);
             PreviewChangesDialog = new PreviewChangesDialog_OutOfProc(this);
             Shell = new Shell_OutOfProc(this);


### PR DESCRIPTION
<details><summary>Ask Mode template</summary>

### Customer scenario
When debugging a VB application, a customer opens Immediate window and types "?" to dump a value of a variable. Instead of showing a completion, "??" is written to the Immediate Window.

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/557166

### Workarounds, if any

N/A

### Risk

Low, the fix only affects DebuggerIntellisenseFilter class and follows the approach already used by VenusCommandFilter.

### Performance impact

No perf impact is expected as the fix just restores execution of existing command handlers in this scenario.

### Is this a regression from a previous update?
It's a regression from 15.6 Preview2 caused by migrating all Roslyn command handlers to the new editor commanding.

### Root cause analysis

We missed this issue in partner manual testing stage because we didn't include debugger team into the list of affected partners. Also this scenario is only covered by CQ tests, which took long to run and analyze.
This PR adds 2 basic C# and VB integration tests to cover this scenario in earlier development stage. 

### How was the bug found?

CQ test failure.

</details>

----------------------------------------------------------------------------
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/557166

DebuggerIntellisenseFilter, just like VenusCommandFilter routes commands to the legacy command handler service, which now is no-op for VB/C#. And so now (again, just like VenusCommandFilter) in order to execute command handlers migrated to the editor commanding it needs to hookup the new editor command handler service, configured to the correct text view and subject buffer.