### PR TITLE
Fix import of VisualBasic Core targets file

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -11,7 +11,7 @@
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <PropertyGroup>
     <CSharpCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
-    <BasicCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.VisualBasic.Core.targets</BasicCoreTargetsPath>
+    <VisualBasicCoreTargetsPath>$(MSBuildThisFileDirectory)..\tools\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>
 
   <!-- Set ToolPath/Exe to direct to the exes in this package -->


### PR DESCRIPTION
Fixes #24485

This is currently causing Corefx to workaround this by doing this hack: https://github.com/joperezr/buildtools/blob/ChangesInOrderToBuildUsingCLIMSBuild/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets#L10-L11

cc: @agocke @jaredpar 
