### PR TITLE
Add ref-reassignment tests for conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expression is BoundStackAllocArrayCreation boundStackAlloc)
             {
                 var type = new PointerTypeSymbol(boundStackAlloc.ElementType);
-                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, refKind: refKind);
+                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, isRefVariable: refKind != RefKind.None);
             }
 
             // Certain expressions (null literals, method groups and anonymous functions) have no type of 
@@ -903,7 +903,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (kind != LocalDeclarationKind.FixedVariable)
                     {
                         // If this is for a fixed statement, we'll do our own conversion since there are some special cases.		
-                        initializerOpt = GenerateConversionForAssignment(declTypeOpt, initializerOpt, localDiagnostics, refKind: localSymbol.RefKind);
+                        initializerOpt = GenerateConversionForAssignment(
+                            declTypeOpt,
+                            initializerOpt,
+                            localDiagnostics,
+                            isRefVariable: localSymbol.RefKind != RefKind.None);
                     }
                 }
             }
@@ -1251,7 +1255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Build bound conversion. The node might not be used if this is a dynamic conversion 
                 // but diagnostics should be reported anyways.
-                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics);
+                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics, isRefVariable: isRef);
 
                 // If the result is a dynamic assignment operation (SetMember or SetIndex), 
                 // don't generate the boxing conversion to the dynamic type.
@@ -1522,7 +1526,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundStatements.ToImmutableAndFree());
         }
 
-        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, RefKind refKind = RefKind.None)
+        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, bool isRefVariable = false)
         {
             Debug.Assert((object)targetType != null);
             Debug.Assert(expression != null);
@@ -1545,7 +1549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(expression.Syntax, useSiteDiagnostics);
 
             // UNDONE: cast in code
-            if (refKind != RefKind.None)
+            if (isRefVariable)
             {
                 if (conversion.Kind != ConversionKind.Identity)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expression is BoundStackAllocArrayCreation boundStackAlloc)
             {
                 var type = new PointerTypeSymbol(boundStackAlloc.ElementType);
-                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, isRefVariable: refKind != RefKind.None);
+                expression = GenerateConversionForAssignment(type, boundStackAlloc, diagnostics, isRefAssignment: refKind != RefKind.None);
             }
 
             // Certain expressions (null literals, method groups and anonymous functions) have no type of 
@@ -907,7 +907,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             declTypeOpt,
                             initializerOpt,
                             localDiagnostics,
-                            isRefVariable: localSymbol.RefKind != RefKind.None);
+                            isRefAssignment: localSymbol.RefKind != RefKind.None);
                     }
                 }
             }
@@ -1255,7 +1255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Build bound conversion. The node might not be used if this is a dynamic conversion 
                 // but diagnostics should be reported anyways.
-                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics, isRefVariable: isRef);
+                var conversion = GenerateConversionForAssignment(op1.Type, op2, diagnostics, isRefAssignment: isRef);
 
                 // If the result is a dynamic assignment operation (SetMember or SetIndex), 
                 // don't generate the boxing conversion to the dynamic type.
@@ -1526,7 +1526,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundStatements.ToImmutableAndFree());
         }
 
-        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, bool isRefVariable = false)
+        internal BoundExpression GenerateConversionForAssignment(TypeSymbol targetType, BoundExpression expression, DiagnosticBag diagnostics, bool isDefaultParameter = false, bool isRefAssignment = false)
         {
             Debug.Assert((object)targetType != null);
             Debug.Assert(expression != null);
@@ -1548,8 +1548,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var conversion = this.Conversions.ClassifyConversionFromExpression(expression, targetType, ref useSiteDiagnostics);
             diagnostics.Add(expression.Syntax, useSiteDiagnostics);
 
-            // UNDONE: cast in code
-            if (isRefVariable)
+            if (isRefAssignment)
             {
                 if (conversion.Kind != ConversionKind.Identity)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -13,6 +13,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class CodeGenRefLocalTests : CompilingTestBase
     {
         [Fact]
+        public void RefReassignDifferentTupleNames()
+        {
+            var comp = CreateStandardCompilation(@"
+using System;
+class C
+{
+    public static void Main()
+    {
+        var t = (x: 0, y: 0);
+        ref (int x, int y) rt = ref t;
+
+        var t2 = (a: 2, b: 2);
+        rt = ref t2;
+
+        Console.Write(rt.x);
+        Console.Write(rt.y);
+    }
+}", references: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, options: TestOptions.ReleaseExe);
+
+            CompileAndVerify(comp, expectedOutput: "22");
+        }
+
+        [Fact]
         public void RefReassignParamByVal()
         {
             var comp = CompileAndVerify(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -13,6 +13,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     public class RefLocalsAndReturnsTests : CompilingTestBase
     {
         [Fact]
+        public void RefReassignIdentityConversion()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    void M()
+    {
+        string s = ""s"";
+        object o = s;
+        ref string rs = ref s;
+        ref object ro = ref o;
+
+        rs = ref (string)o;
+        ro = ref s;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (11,18): error CS1510: A ref or out value must be an assignable variable
+                //         rs = ref (string)o;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(string)o").WithLocation(11, 18),
+                // (12,18): error CS8173: The expression must be of type 'object' because it is being assigned by reference
+                //         ro = ref s;
+                Diagnostic(ErrorCode.ERR_RefAssignmentMustHaveIdentityConversion, "s").WithArguments("object").WithLocation(12, 18));
+        }
+
+        [Fact]
         public void RefReassign71()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -27,6 +27,7 @@ class C
 
         rs = ref (string)o;
         ro = ref s;
+        ro = s;
     }
 }");
             comp.VerifyDiagnostics(


### PR DESCRIPTION
These tests are meant are focused on the rule that only types with identity conversions are allowed for ref assignments.