### PR TITLE
Override completion with in parameter should omit IsReadOnly attribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -440,14 +440,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if (FilterOutDecimalConstantAttribute())
                 {
                     // filter out DecimalConstantAttribute
-                    CustomAttributeHandle ignore1;
-                    CustomAttributeHandle ignore2;
                     var attributes = containingPEModuleSymbol.GetCustomAttributesForToken(
                         _handle,
-                        out ignore1,
-                        AttributeDescription.DecimalConstantAttribute,
-                        out ignore2,
-                        default(AttributeDescription));
+                        out _,
+                        AttributeDescription.DecimalConstantAttribute);
 
                     ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -20,7 +20,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     /// </summary>
     internal sealed class PEMethodSymbol : MethodSymbol
     {
-        private class SignatureData
+        /// <summary>
+        /// internal for testing purpose
+        /// </summary>
+        internal class SignatureData
         {
             public readonly SignatureHeader Header;
             public readonly ImmutableArray<ParameterSymbol> Parameters;
@@ -555,7 +558,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return false;
         }
 
-        private SignatureData Signature => _lazySignature ?? LoadSignature();
+        /// <summary>
+        /// internal for testing purpose
+        /// </summary>
+        internal SignatureData Signature => _lazySignature ?? LoadSignature();
 
         private SignatureData LoadSignature()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -275,46 +275,61 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             ImmutableInterlocked.InterlockedInitialize(ref customAttributes, loadedCustomAttributes);
         }
 
+        internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token,
+            out CustomAttributeHandle filteredOutAttribute1,
+            AttributeDescription filterOut1)
+        {
+            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out _, default, out _, default, out _, default);
+        }
+
         /// <summary>
-        /// Returns a possibly ExtensionAttribute filtered roArray of attributes. If
-        /// filterExtensionAttributes is set to true, the method will remove all ExtensionAttributes
-        /// from the returned array. If it is false, the parameter foundExtension will always be set to
-        /// false and can be safely ignored.
-        /// 
-        /// The paramArrayAttribute parameter is similar to the foundExtension parameter, but instead
-        /// of just indicating if the attribute was found, the parameter is set to the attribute handle
-        /// for the ParamArrayAttribute if any is found and is null otherwise. This allows NoPia to filter
-        /// the attribute out for the symbol but still cache it separately for emit.
+        /// Returns attributes with up-to four filters applied. For each filter, the last application of the
+        /// attribute will be tracked and returned.
         /// </summary>
         internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token,
             out CustomAttributeHandle filteredOutAttribute1,
             AttributeDescription filterOut1,
             out CustomAttributeHandle filteredOutAttribute2,
-            AttributeDescription filterOut2)
+            AttributeDescription filterOut2,
+            out CustomAttributeHandle filteredOutAttribute3,
+            AttributeDescription filterOut3,
+            out CustomAttributeHandle filteredOutAttribute4,
+            AttributeDescription filterOut4)
         {
-            filteredOutAttribute1 = default(CustomAttributeHandle);
-            filteredOutAttribute2 = default(CustomAttributeHandle);
+            filteredOutAttribute1 = default;
+            filteredOutAttribute2 = default;
+            filteredOutAttribute3 = default;
+            filteredOutAttribute4 = default;
             ArrayBuilder<CSharpAttributeData> customAttributesBuilder = null;
 
             try
             {
                 foreach (var customAttributeHandle in _module.GetCustomAttributesOrThrow(token))
                 {
-                    if (filterOut1.Signatures != null &&
-                        Module.GetTargetAttributeSignatureIndex(customAttributeHandle, filterOut1) != -1)
+                    // It is important to capture the last application of the attribute that we run into,
+                    // it makes a difference for default and constant values.
+
+                    if (matchesFilter(customAttributeHandle, filterOut1))
                     {
-                        // It is important to capture the last application of the attribute that we run into,
-                        // it makes a difference for default and constant values.
                         filteredOutAttribute1 = customAttributeHandle;
                         continue;
                     }
 
-                    if (filterOut2.Signatures != null &&
-                        Module.GetTargetAttributeSignatureIndex(customAttributeHandle, filterOut2) != -1)
+                    if (matchesFilter(customAttributeHandle, filterOut2))
                     {
-                        // It is important to capture the last application of the attribute that we run into,
-                        // it makes a difference for default and constant values.
                         filteredOutAttribute2 = customAttributeHandle;
+                        continue;
+                    }
+
+                    if (matchesFilter(customAttributeHandle, filterOut3))
+                    {
+                        filteredOutAttribute3 = customAttributeHandle;
+                        continue;
+                    }
+
+                    if (matchesFilter(customAttributeHandle, filterOut4))
+                    {
+                        filteredOutAttribute4 = customAttributeHandle;
                         continue;
                     }
 
@@ -335,18 +350,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
 
             return ImmutableArray<CSharpAttributeData>.Empty;
+
+            bool matchesFilter(CustomAttributeHandle handle, AttributeDescription filter)
+                => filter.Signatures != null && Module.GetTargetAttributeSignatureIndex(handle, filter) != -1;
         }
 
         internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token)
         {
             // Do not filter anything and therefore ignore the out results
-            CustomAttributeHandle ignore1;
-            CustomAttributeHandle ignore2;
-            return GetCustomAttributesForToken(token,
-                out ignore1,
-                default(AttributeDescription),
-                out ignore2,
-                default(AttributeDescription));
+            return GetCustomAttributesForToken(token, out _, default);
         }
 
         /// <summary>
@@ -358,13 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token,
             out CustomAttributeHandle paramArrayAttribute)
         {
-            CustomAttributeHandle ignore;
-            return GetCustomAttributesForToken(
-                token,
-                out paramArrayAttribute,
-                AttributeDescription.ParamArrayAttribute,
-                out ignore,
-                default(AttributeDescription));
+            return GetCustomAttributesForToken(token, out paramArrayAttribute, AttributeDescription.ParamArrayAttribute);
         }
 
 
@@ -403,12 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal ImmutableArray<CSharpAttributeData> GetCustomAttributesFilterExtensions(EntityHandle token, out bool foundExtension)
         {
             CustomAttributeHandle extensionAttribute;
-            CustomAttributeHandle ignore;
-            var result = GetCustomAttributesForToken(token,
-                out extensionAttribute,
-                AttributeDescription.CaseSensitiveExtensionAttribute,
-                out ignore,
-                default(AttributeDescription));
+            var result = GetCustomAttributesForToken(token, out extensionAttribute, AttributeDescription.CaseSensitiveExtensionAttribute);
 
             foundExtension = !extensionAttribute.IsNil;
             return result;
@@ -535,7 +536,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        private NamedTypeSymbol GetTypeSymbolForWellKnownType(WellKnownType type)
+        /// <summary>
+        /// internal for testing purpose
+        /// </summary>
+        internal NamedTypeSymbol GetTypeSymbolForWellKnownType(WellKnownType type)
         {
             MetadataTypeName emittedName = MetadataTypeName.FromFullName(type.GetMetadataName(), useCLSCompliantNameArityEncoding: true);
             // First, check this module

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -536,10 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        /// <summary>
-        /// internal for testing purpose
-        /// </summary>
-        internal NamedTypeSymbol GetTypeSymbolForWellKnownType(WellKnownType type)
+        private NamedTypeSymbol GetTypeSymbolForWellKnownType(WellKnownType type)
         {
             MetadataTypeName emittedName = MetadataTypeName.FromFullName(type.GetMetadataName(), useCLSCompliantNameArityEncoding: true);
             // First, check this module

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -607,7 +607,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     MightContainExtensionMethods ? AttributeDescription.CaseSensitiveExtensionAttribute : default,
                     out _,
                     // Filter out [Obsolete], unless it was user defined
-                    (IsByRefLikeType && ObsoleteAttributeData is null) ? AttributeDescription.ObsoleteAttribute : default);
+                    (IsByRefLikeType && ObsoleteAttributeData is null) ? AttributeDescription.ObsoleteAttribute : default,
+                    out _,
+                    // Filter out [IsReadOnly]
+                    IsReadOnly ? AttributeDescription.IsReadOnlyAttribute : default,
+                    out _,
+                    // Filter out [IsByRefLike]
+                    IsByRefLikeType ? AttributeDescription.IsByRefLikeAttribute : default);
 
                 ImmutableInterlocked.InterlockedInitialize(ref uncommon.lazyCustomAttributes, loadedCustomAttributes);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers,
                 out bool isBad) :
                     base(moduleSymbol, containingSymbol, ordinal, isByRef, type, handle,
-                         refCustomModifiers.NullToEmpty().Length + customModifiers.NullToEmpty().Length, 
+                         refCustomModifiers.NullToEmpty().Length + customModifiers.NullToEmpty().Length,
                          out isBad)
             {
                 _customModifiers = CSharpCustomModifier.Convert(customModifiers);
@@ -744,18 +744,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     }
                 }
 
-                if (filterOutParamArrayAttribute || filterOutConstantAttributeDescription.Signatures != null)
+                bool filterIsReadOnlyAttribute = this.RefKind == RefKind.In;
+
+                if (filterOutParamArrayAttribute || filterOutConstantAttributeDescription.Signatures != null || filterIsReadOnlyAttribute)
                 {
                     CustomAttributeHandle paramArrayAttribute;
                     CustomAttributeHandle constantAttribute;
+                    CustomAttributeHandle isReadOnlyAttribute;
 
                     ImmutableArray<CSharpAttributeData> attributes =
                         containingPEModuleSymbol.GetCustomAttributesForToken(
                             _handle,
                             out paramArrayAttribute,
-                            filterOutParamArrayAttribute ? AttributeDescription.ParamArrayAttribute : default(AttributeDescription),
+                            filterOutParamArrayAttribute ? AttributeDescription.ParamArrayAttribute : default,
                             out constantAttribute,
-                            filterOutConstantAttributeDescription);
+                            filterOutConstantAttributeDescription,
+                            out isReadOnlyAttribute,
+                            filterIsReadOnlyAttribute ? AttributeDescription.IsReadOnlyAttribute : default,
+                            out _,
+                            default);
 
                     if (!paramArrayAttribute.IsNil || !constantAttribute.IsNil)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -532,7 +532,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             if (_lazyCustomAttributes.IsDefault)
             {
                 var containingPEModuleSymbol = (PEModuleSymbol)this.ContainingModule;
-                containingPEModuleSymbol.LoadCustomAttributes(_handle, ref _lazyCustomAttributes);
+
+                ImmutableArray<CSharpAttributeData> attributes = containingPEModuleSymbol.GetCustomAttributesForToken(
+                      _handle,
+                      out _,
+                      this.RefKind == RefKind.RefReadOnly ? AttributeDescription.IsReadOnlyAttribute : default);
+
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
             }
             return _lazyCustomAttributes;
         }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9478,7 +9478,7 @@ public class C
 
             MetadataReaderUtils.VerifyPEMetadata(exe,
                 new[] { "TypeDefinition:<Module>", "TypeDefinition:C" },
-                new[] { "MethodDefinition:Void Main()", "MethodDefinition:Void PrivateMethod()", "MethodDefinition:Void .ctor()" },
+                new[] { "MethodDefinition:Void C.Main()", "MethodDefinition:Void C.PrivateMethod()", "MethodDefinition:Void C..ctor()" },
                 new[] { "CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute" }
                 );
 
@@ -9513,7 +9513,7 @@ public class C
             // See issue https://github.com/dotnet/roslyn/issues/17612
             MetadataReaderUtils.VerifyPEMetadata(refDll,
                 new[] { "TypeDefinition:<Module>", "TypeDefinition:C" },
-                new[] { "MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()" },
+                new[] { "MethodDefinition:Void C.Main()", "MethodDefinition:Void C..ctor()" },
                 new[] { "CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "ReferenceAssemblyAttribute" }
                 );
 
@@ -9596,7 +9596,7 @@ class C
             // See issue https://github.com/dotnet/roslyn/issues/17612
             MetadataReaderUtils.VerifyPEMetadata(refDll,
                 new[] { "TypeDefinition:<Module>", "TypeDefinition:C", "TypeDefinition:S" },
-                new[] { "MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()" },
+                new[] { "MethodDefinition:Void C.Main()", "MethodDefinition:Void C..ctor()" },
                 new[] { "CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "ReferenceAssemblyAttribute" }
                 );
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -38,7 +38,7 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
             }
 
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate);
@@ -89,11 +89,10 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 AssertReferencedIsByRefLike(type);
-                Assert.Equal(Accessibility.Internal, ((PEModuleSymbol)module).GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                Assert.Equal(Accessibility.Internal, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Internal);
             }
 
             CompileAndVerify(text, symbolValidator: validate);
@@ -670,7 +669,7 @@ class Test
                 if (module is PEModuleSymbol peModule)
                 {
                     Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                    Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+                    AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
                 }
             };
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -38,7 +38,7 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
             }
 
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate);
@@ -92,7 +92,7 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Internal);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Internal);
             }
 
             CompileAndVerify(text, symbolValidator: validate);
@@ -669,7 +669,7 @@ class Test
                 if (module is PEModuleSymbol peModule)
                 {
                     Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
-                    AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
+                    AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
                 }
             };
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using System.Collections.Immutable;
-using System.Linq;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -29,11 +31,17 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            void validate(ModuleSymbol module)
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name);
-            });
+                AssertReferencedIsByRefLike(type);
+
+                var peModule = (PEModuleSymbol)module;
+                Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
+                Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+            }
+
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate);
         }
 
         [Fact]
@@ -46,7 +54,7 @@ ref struct S1{}
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(type);
             });
         }
 
@@ -63,7 +71,7 @@ class Test
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(type);
             });
         }
 
@@ -77,11 +85,18 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            void validate(ModuleSymbol module)
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
-            });
+                AssertReferencedIsByRefLike(type);
+                Assert.Equal(Accessibility.Internal, ((PEModuleSymbol)module).GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+
+                var peModule = (PEModuleSymbol)module;
+                Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
+                Assert.Equal(Accessibility.Internal, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+            }
+
+            CompileAndVerify(text, symbolValidator: validate);
         }
 
         [Fact]
@@ -97,7 +112,7 @@ class Test<T>
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(type);
             });
         }
 
@@ -123,7 +138,7 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, referenceA.Compilation.AssemblyName);
+                AssertReferencedIsByRefLike(type);
                 AssertNoIsByRefLikeAttributeExists(module.ContainingAssembly);
             });
         }
@@ -417,7 +432,7 @@ public class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, reference.Display);
+                AssertReferencedIsByRefLike(type);
                 AssertNoIsByRefLikeAttributeExists(module.ContainingAssembly);
             });
         }
@@ -567,7 +582,7 @@ public ref struct S1{}
 
                 var property = type.GetMember<PEPropertySymbol>("Property");
                 Assert.NotNull(property);
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, property.Type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(property.Type);
             });
 
             var code = @"
@@ -640,27 +655,26 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            void validate(ModuleSymbol module)
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
 
-                var accessibility = Accessibility.Public;
-                var attributes = type.GetAttributes();
-                Assert.Equal(2, attributes.Count());
-
                 var assemblyName = module.ContainingAssembly.Name;
 
-                var attributeType = attributes[0].AttributeClass;
-                Assert.Equal("System.Runtime.CompilerServices.IsByRefLikeAttribute", attributeType.ToDisplayString());
-                Assert.Equal(assemblyName, attributeType.ContainingAssembly.Name);
-                Assert.Equal(accessibility, attributeType.DeclaredAccessibility);
-
-                var attribute = attributes[1];
+                var attribute = type.GetAttributes().Single();
                 Assert.Equal("System.ObsoleteAttribute", attribute.AttributeClass.ToDisplayString());
                 Assert.Equal("hello", attribute.ConstructorArguments.ElementAt(0).Value);
                 Assert.Equal(true, attribute.ConstructorArguments.ElementAt(1).Value);
-            });
+
+                if (module is PEModuleSymbol peModule)
+                {
+                    Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
+                    Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute).DeclaredAccessibility);
+                }
+            };
+
+            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate, sourceSymbolValidator: validate);
         }
 
         [Fact]
@@ -686,7 +700,7 @@ namespace System
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Public, type, module.ContainingAssembly.Name, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false);
             });
         }
 
@@ -730,18 +744,7 @@ class Test
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
 
-                var accessibility = Accessibility.Public;
-                var attributes = type.GetAttributes();
-                Assert.Equal(2, attributes.Count());
-
-                var assemblyName = module.ContainingAssembly.Name;
-
-                var attributeType = attributes[0].AttributeClass;
-                Assert.Equal("System.Runtime.CompilerServices.IsByRefLikeAttribute", attributeType.ToDisplayString());
-                Assert.Equal(assemblyName, attributeType.ContainingAssembly.Name);
-                Assert.Equal(accessibility, attributeType.DeclaredAccessibility);
-
-                var attribute = attributes[1];
+                var attribute = type.GetAttributes().Single();
                 Assert.Equal("Windows.Foundation.Metadata.DeprecatedAttribute", attribute.AttributeClass.ToDisplayString());
                 Assert.Equal(42u, attribute.ConstructorArguments.ElementAt(2).Value);
             });
@@ -788,20 +791,12 @@ class Test
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsByRefLikeType);
 
-                var accessibility = Accessibility.Public;
                 var attributes = type.GetAttributes();
 
-                Assert.Equal(3, attributes.Length);
-                Assert.Equal("Windows.Foundation.Metadata.DeprecatedAttribute", attributes[2].AttributeClass.ToDisplayString());
+                Assert.Equal(2, attributes.Length);
+                Assert.Equal("Windows.Foundation.Metadata.DeprecatedAttribute", attributes[1].AttributeClass.ToDisplayString());
 
-                var assemblyName = module.ContainingAssembly.Name;
-
-                var attributeType = attributes[0].AttributeClass;
-                Assert.Equal("System.Runtime.CompilerServices.IsByRefLikeAttribute", attributeType.ToDisplayString());
-                Assert.Equal(assemblyName, attributeType.ContainingAssembly.Name);
-                Assert.Equal(accessibility, attributeType.DeclaredAccessibility);
-
-                var attribute = attributes[1];
+                var attribute = attributes[0];
                 Assert.Equal("System.ObsoleteAttribute", attribute.AttributeClass.ToDisplayString());
                 Assert.Equal(0, attribute.ConstructorArguments.Count());
             });
@@ -855,7 +850,7 @@ class Test
             CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(type);
             });
         }
 
@@ -962,17 +957,17 @@ namespace System
             CompileAndVerify(compilation1, verify: Verification.Fails, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false);
 
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.ArgIterator");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false);
 
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.RuntimeArgumentHandle");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false);
 
                 // control case. Not a special type.
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.NotTypedReference");
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name, hasObsolete: true);
+                AssertReferencedIsByRefLike(type, hasObsolete: true);
             });
         }
 
@@ -990,24 +985,17 @@ namespace System
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
 
-                AssertReferencedIsByRefLikeAttributes(Accessibility.Internal, type, module.ContainingAssembly.Name);
+                AssertReferencedIsByRefLike(type);
             });
         }
 
-        private static void AssertReferencedIsByRefLikeAttributes(
-            Accessibility accessibility, 
-            TypeSymbol type, 
-            string assemblyName,
-            bool hasObsolete = true)
+        private static void AssertReferencedIsByRefLike(TypeSymbol type, bool hasObsolete = true)
         {
             var peType = (PENamedTypeSymbol)type;
             Assert.True(peType.IsByRefLikeType);
 
-            // Single(), as there is no [Obsolete] attribute returned
-            var isByRefLikeAttribute = peType.GetAttributes().Single().AttributeClass;
-            Assert.Equal("System.Runtime.CompilerServices.IsByRefLikeAttribute", isByRefLikeAttribute.ToDisplayString());
-            Assert.Equal(assemblyName, isByRefLikeAttribute.ContainingAssembly.Name);
-            Assert.Equal(accessibility, isByRefLikeAttribute.DeclaredAccessibility);
+            // there is no [Obsolete] or [IsByRef] attribute returned
+            Assert.Empty(peType.GetAttributes());
 
             var peModule = (PEModuleSymbol)peType.ContainingModule;
             var obsoleteAttribute = peModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(peType.Handle, ignoreByRefLikeMarker: false);
@@ -1026,7 +1014,7 @@ namespace System
 
         private static void AssertNotReferencedIsByRefLikeAttribute(ImmutableArray<CSharpAttributeData> attributes)
         {
-            foreach(var attr in attributes)
+            foreach (var attr in attributes)
             {
                 Assert.NotEqual("IsByRefLikeAttribute", attr.AttributeClass.Name);
             }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
@@ -38,7 +38,7 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)type).Handle));
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
@@ -38,7 +38,7 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)type).Handle));
-                Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_ReadOnlyStruct.cs
@@ -34,8 +34,11 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
+                Assert.Empty(type.GetAttributes());
 
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Public, type.GetAttributes(), module.ContainingAssembly.Name);
+                var peModule = (PEModuleSymbol)module;
+                Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)type).Handle));
+                Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
             });
         }
 
@@ -50,8 +53,7 @@ readonly struct S1{}
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Internal, type.GetAttributes(), module.ContainingAssembly.Name);
+                Assert.Empty(type.GetAttributes());
             });
         }
 
@@ -69,8 +71,7 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Internal, type.GetAttributes(), module.ContainingAssembly.Name);
+                Assert.Empty(type.GetAttributes());
             });
         }
 
@@ -88,8 +89,7 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Internal, type.GetAttributes(), module.ContainingAssembly.Name);
+                Assert.Empty(type.GetAttributes());
             });
         }
 
@@ -107,8 +107,7 @@ class Test<T>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Internal, type.GetAttributes(), module.ContainingAssembly.Name);
+                Assert.Empty(type.GetAttributes());
             });
         }
 
@@ -134,8 +133,7 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Public, type.GetAttributes(), referenceA.Compilation.AssemblyName);
+                Assert.Empty(type.GetAttributes());
                 AssertNoIsReadOnlyAttributeExists(module.ContainingAssembly);
             });
         }
@@ -429,8 +427,7 @@ public class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsReadOnly);
-
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Public, type.GetAttributes(), reference.Display);
+                Assert.Empty(type.GetAttributes());
                 AssertNoIsReadOnlyAttributeExists(module.ContainingAssembly);
             });
         }
@@ -580,7 +577,7 @@ public readonly struct S1{}
 
                 var property = type.GetMember<PEPropertySymbol>("Property");
                 Assert.NotNull(property);
-                AssertReferencedIsReadOnlyAttribute(Accessibility.Internal, property.Type.GetAttributes(), module.ContainingAssembly.Name);
+                AssertNotReferencedIsReadOnlyAttribute(type.GetAttributes());
             });
 
             var code = @"
@@ -637,17 +634,9 @@ public class Test
                 );
         }
 
-        private static void AssertReferencedIsReadOnlyAttribute(Accessibility accessibility, ImmutableArray<CSharpAttributeData> attributes, string assemblyName)
-        {
-            var attributeType = attributes.Single().AttributeClass;
-            Assert.Equal("System.Runtime.CompilerServices.IsReadOnlyAttribute", attributeType.ToDisplayString());
-            Assert.Equal(assemblyName, attributeType.ContainingAssembly.Name);
-            Assert.Equal(accessibility, attributeType.DeclaredAccessibility);
-        }
-
         private static void AssertNotReferencedIsReadOnlyAttribute(ImmutableArray<CSharpAttributeData> attributes)
         {
-            foreach(var attr in attributes)
+            foreach (var attr in attributes)
             {
                 Assert.NotEqual("IsReadOnlyAttribute", attr.AttributeClass.Name);
             }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -47,7 +47,8 @@ class Test
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEMethodSymbol)method).Signature.ReturnParam.Handle));
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEParameterSymbol)parameter).Handle));
-                Assert.Equal(Accessibility.Public, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
+
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
             });
         }
 
@@ -70,7 +71,8 @@ class Test
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEParameterSymbol)parameter).Handle));
-                Assert.Equal(Accessibility.Internal, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
+
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -48,7 +48,7 @@ class Test
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEMethodSymbol)method).Signature.ReturnParam.Handle));
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEParameterSymbol)parameter).Handle));
 
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Public);
             });
         }
 
@@ -72,7 +72,7 @@ class Test
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PEParameterSymbol)parameter).Handle));
 
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -824,7 +824,7 @@ class Program
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)test).Handle));
-                Assert.Equal(Accessibility.Internal, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
+                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
             }
             CompileAndVerify(comp, symbolValidator: validate);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -824,7 +824,7 @@ class Program
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)test).Handle));
-                AssertHasAttribute(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
+                AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute, Accessibility.Internal);
             }
             CompileAndVerify(comp, symbolValidator: validate);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -114,7 +115,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1}, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"12");
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef, ref1 }, parseOptions: TestOptions.Regular, verify: Verification.Fails, expectedOutput: @"12");
 
             comp.VerifyIL("Program.Main", @"
 {
@@ -817,6 +818,16 @@ class Program
             Assert.Equal(RefKind.In, namedType.GetMethod("M1").ThisParameter.RefKind);
             Assert.Equal(RefKind.In, namedType.GetMethod("ToString").ThisParameter.RefKind);
 
+            void validate(ModuleSymbol module)
+            {
+                var test = module.ContainingAssembly.GetTypeByMetadataName("Program+S1");
+
+                var peModule = (PEModuleSymbol)module;
+                Assert.True(peModule.Module.HasIsReadOnlyAttribute(((PENamedTypeSymbol)test).Handle));
+                Assert.Equal(Accessibility.Internal, peModule.GetTypeSymbolForWellKnownType(WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute).DeclaredAccessibility);
+            }
+            CompileAndVerify(comp, symbolValidator: validate);
+
             // S1<T>
             namedType = comp.GetTypeByMetadataName("Program+S1`1");
             Assert.True(namedType.IsReadOnly);
@@ -882,6 +893,14 @@ class Program
             type = (TypeSymbol)comp.CreateTupleTypeSymbol(ImmutableArray.Create<ITypeSymbol>(comp.ObjectType, comp.ObjectType));
             Assert.False(type.IsReadOnly);
 
+            // S1 from image
+            var clientComp = CreateStandardCompilation("", references: new[] { comp.EmitToImageReference() });
+            NamedTypeSymbol s1 = clientComp.GetTypeByMetadataName("Program+S1");
+            Assert.True(s1.IsReadOnly);
+            Assert.Empty(s1.GetAttributes());
+            Assert.Equal(RefKind.Out, s1.Constructors[0].ThisParameter.RefKind);
+            Assert.Equal(RefKind.In, s1.GetMethod("M1").ThisParameter.RefKind);
+            Assert.Equal(RefKind.In, s1.GetMethod("ToString").ThisParameter.RefKind);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -532,10 +532,10 @@ public class C
                 var reader = assembly.GetMetadataReader();
                 var attributes = reader.GetAssemblyDefinition().GetCustomAttributes();
                 AssertEx.Equal(new[] {
-                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute.ctor(Int32)",
-                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.ctor()",
-                        "MemberReference:Void System.Diagnostics.DebuggableAttribute.ctor(DebuggingModes)",
-                        "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute.ctor()"
+                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(Int32)",
+                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor()",
+                        "MemberReference:Void System.Diagnostics.DebuggableAttribute..ctor(DebuggingModes)",
+                        "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute..ctor()"
                     },
                     attributes.Select(a => MetadataReaderUtils.Dump(reader, reader.GetCustomAttribute(a).Constructor)));
             };
@@ -554,9 +554,9 @@ public class C
                 var attributes = reader.GetAssemblyDefinition().GetCustomAttributes();
                 AssertEx.SetEqual(attributes.Select(a => MetadataReaderUtils.Dump(reader, reader.GetCustomAttribute(a).Constructor)),
                     new string[] {
-                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute.ctor(Int32)",
-                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.ctor()",
-                        "MemberReference:Void System.Diagnostics.DebuggableAttribute.ctor(DebuggingModes)"
+                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(Int32)",
+                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor()",
+                        "MemberReference:Void System.Diagnostics.DebuggableAttribute..ctor(DebuggingModes)"
                     });
             };
 
@@ -575,10 +575,10 @@ public class C
                 var reader = assembly.GetMetadataReader();
                 var attributes = reader.GetAssemblyDefinition().GetCustomAttributes();
                 AssertEx.Equal(new string[] {
-                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute.ctor(Int32)",
-                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.ctor()",
-                        "MemberReference:Void System.Diagnostics.DebuggableAttribute.ctor(DebuggingModes)",
-                        "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute.ctor()"
+                        "MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(Int32)",
+                        "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor()",
+                        "MemberReference:Void System.Diagnostics.DebuggableAttribute..ctor(DebuggingModes)",
+                        "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute..ctor()"
                     },
                     attributes.Select(a => MetadataReaderUtils.Dump(reader, reader.GetCustomAttribute(a).Constructor)));
             };

--- a/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
@@ -35,8 +35,17 @@ public class Test
     }
 }";
 
-            CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "5");
-            CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "5");
+            var verifier = CompileAndVerify(code, additionalRefs: new[] { reference.ToMetadataReference() }, expectedOutput: "5");
+            verifyParameter(verifier.Compilation);
+
+            verifier = CompileAndVerify(code, additionalRefs: new[] { reference.EmitToImageReference() }, expectedOutput: "5");
+            verifyParameter(verifier.Compilation);
+
+            void verifyParameter(Compilation comp)
+            {
+                var m = (IMethodSymbol)comp.GetMember("TestRef.M");
+                Assert.Empty(m.Parameters[0].GetAttributes());
+            }
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -871,11 +871,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return attributes.Select(a => a.AttributeClass.Name);
         }
 
-        internal void AssertHasAttribute(PEModuleSymbol peModule, WellKnownType type, Accessibility expectedAccessibility)
-        {
-            var name = MetadataTypeName.FromFullName(type.GetMetadataName());
-            Assert.Equal(expectedAccessibility, peModule.LookupTopLevelMetadataType(ref name).DeclaredAccessibility);
-        }
         #endregion
 
         #region Documentation Comments

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -871,6 +871,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return attributes.Select(a => a.AttributeClass.Name);
         }
 
+        internal void AssertHasAttribute(PEModuleSymbol peModule, WellKnownType type, Accessibility expectedAccessibility)
+        {
+            var name = MetadataTypeName.FromFullName(type.GetMetadataName());
+            Assert.Equal(expectedAccessibility, peModule.LookupTopLevelMetadataType(ref name).DeclaredAccessibility);
+        }
         #endregion
 
         #region Documentation Comments

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8499,7 +8499,7 @@ End Class")
 
             MetadataReaderUtils.VerifyPEMetadata(exe,
                 {"TypeDefinition:<Module>", "TypeDefinition:C"},
-                {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()", "MethodDefinition:Void PrivateMethod()"},
+                {"MethodDefinition:Void C.Main()", "MethodDefinition:Void C..ctor()", "MethodDefinition:Void C.PrivateMethod()"},
                 {"CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "STAThreadAttribute"}
                 )
 
@@ -8536,7 +8536,7 @@ a
             ' See issue https://github.com/dotnet/roslyn/issues/17612
             MetadataReaderUtils.VerifyPEMetadata(refDll,
                 {"TypeDefinition:<Module>", "TypeDefinition:C"},
-                {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()"},
+                {"MethodDefinition:Void C.Main()", "MethodDefinition:Void C..ctor()"},
                 {"CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "STAThreadAttribute", "ReferenceAssemblyAttribute"}
                 )
 
@@ -8619,7 +8619,7 @@ End Class")
             ' See issue https://github.com/dotnet/roslyn/issues/17612
             MetadataReaderUtils.VerifyPEMetadata(refDll,
                 {"TypeDefinition:<Module>", "TypeDefinition:C", "TypeDefinition:S"},
-                {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()"},
+                {"MethodDefinition:Void C.Main()", "MethodDefinition:Void C..ctor()"},
                 {"CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "STAThreadAttribute", "ReferenceAssemblyAttribute"}
                 )
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -373,10 +373,10 @@ End Class"
                     Dim reader = assembly.GetMetadataReader()
                     Dim attributes = reader.GetAssemblyDefinition().GetCustomAttributes()
                     AssertEx.Equal(
-                        {"MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute.ctor(Int32)",
-                            "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.ctor()",
-                            "MemberReference:Void System.Diagnostics.DebuggableAttribute.ctor(DebuggingModes)",
-                            "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute.ctor()"
+                        {"MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(Int32)",
+                            "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor()",
+                            "MemberReference:Void System.Diagnostics.DebuggableAttribute..ctor(DebuggingModes)",
+                            "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute..ctor()"
                         },
                         attributes.Select(Function(a) MetadataReaderUtils.Dump(reader, reader.GetCustomAttribute(a).Constructor)))
                 End Sub
@@ -412,10 +412,10 @@ End Class"
                     Dim reader = assembly.GetMetadataReader()
                     Dim attributes = reader.GetAssemblyDefinition().GetCustomAttributes()
                     AssertEx.Equal(
-                        {"MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute.ctor(Int32)",
-                            "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.ctor()",
-                            "MemberReference:Void System.Diagnostics.DebuggableAttribute.ctor(DebuggingModes)",
-                            "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute.ctor()"
+                        {"MemberReference:Void System.Runtime.CompilerServices.CompilationRelaxationsAttribute..ctor(Int32)",
+                            "MemberReference:Void System.Runtime.CompilerServices.RuntimeCompatibilityAttribute..ctor()",
+                            "MemberReference:Void System.Diagnostics.DebuggableAttribute..ctor(DebuggingModes)",
+                            "MemberReference:Void System.Runtime.CompilerServices.ReferenceAssemblyAttribute..ctor()"
                         },
                         attributes.Select(Function(a) MetadataReaderUtils.Dump(reader, reader.GetCustomAttribute(a).Constructor)))
                 End Sub

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -269,12 +269,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             bool usePreviousCharAsTrigger, bool checkForAbsence,
             int? glyph, int? matchPriority, bool? hasSuggestionModeItem)
         {
-            Glyph? expectedGlyph = null;
-            if (glyph.HasValue)
-            {
-                expectedGlyph = (Glyph)glyph.Value;
-            }
-
             var document1 = WorkspaceFixture.UpdateDocument(code, sourceCodeKind);
             await CheckResultsAsync(
                 document1, position, expectedItemOrNull, 

--- a/src/Test/Utilities/Portable/CommonTestBase.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Test.Utilities;
@@ -499,6 +500,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 minorSubsystemVersion: 0,
                 linkerMajorVersion: 0,
                 linkerMinorVersion: 0);
+        }
+
+        internal void AssertDeclaresType(PEModuleSymbol peModule, WellKnownType type, Accessibility expectedAccessibility)
+        {
+            var name = MetadataTypeName.FromFullName(type.GetMetadataName());
+            Assert.Equal(expectedAccessibility, peModule.LookupTopLevelMetadataType(ref name).DeclaredAccessibility);
         }
 
         #endregion

--- a/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
+++ b/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
@@ -309,7 +309,7 @@ namespace Roslyn.Test.Utilities
                         var decoder = new SignatureDecoder<string, object>(ConstantSignatureVisualizer.Instance, reader, genericContext: null);
                         var signature = decoder.DecodeMethodSignature(ref blob);
                         var parameters = signature.ParameterTypes.Join(", ");
-                        return $"{signature.ReturnType} {reader.GetString(method.Name)}({parameters})";
+                        return $"{signature.ReturnType} {DumpRec(reader, method.GetDeclaringType())}.{reader.GetString(method.Name)}({parameters})";
                     }
                 case HandleKind.MemberReference:
                     {
@@ -318,7 +318,7 @@ namespace Roslyn.Test.Utilities
                         var decoder = new SignatureDecoder<string, object>(ConstantSignatureVisualizer.Instance, reader, genericContext: null);
                         var signature = decoder.DecodeMethodSignature(ref blob);
                         var parameters = signature.ParameterTypes.Join(", ");
-                        return $"{signature.ReturnType} {DumpRec(reader, member.Parent)}{reader.GetString(member.Name)}({parameters})";
+                        return $"{signature.ReturnType} {DumpRec(reader, member.Parent)}.{reader.GetString(member.Name)}({parameters})";
                     }
                 case HandleKind.TypeReference:
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/24490
Fixes https://github.com/dotnet/roslyn/issues/24615

Update: the PR now filters the `IsReadOnly` and `IsByRefLike` attributes in the compiler `GetAttributes()` API.
