### PR TITLE
NormalizeWhitespace: no need for space after colon in interpolation format clause

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
             if (token.IsKind(SyntaxKind.ColonToken))
             {
-                return true;
+                return !token.Parent.IsKind(SyntaxKind.InterpolationFormatClause);
             }
 
             if (next.IsKind(SyntaxKind.ColonToken))

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -275,6 +275,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        [WorkItem(24454, "https://github.com/dotnet/roslyn/issues/24454")]
+        public void TestSpacingOnInterpolatedString()
+        {
+            TestNormalizeExpression("$\"{3:C}\"", "$\"{3:C}\"");
+            TestNormalizeExpression("$\"{3: C}\"", "$\"{3: C}\"");
+        }
+
+        [Fact]
         [WorkItem(23618, "https://github.com/dotnet/roslyn/issues/23618")]
         public void TestSpacingOnMethodConstraint()
         {


### PR DESCRIPTION
### Customer scenario
Invoke `NormalizeWhitespace` on string interpolation with format, such as `:N`. No space should be injected after the colon.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24454