### PR TITLE
Small cleanup of completion logic.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -356,20 +356,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                 var usingDirective = name.GetAncestorOrThis<UsingDirectiveSyntax>();
                 if (usingDirective != null && usingDirective.Alias == null)
                 {
-                    if (usingDirective.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
-                    {
-                        return symbols.WhereAsArray(s => !s.IsDelegateType() && !s.IsInterfaceType());
-                    }
-                    else
-                    {
-                        symbols = symbols.WhereAsArray(s => s.IsNamespace());
-                    }
+                    return usingDirective.StaticKeyword.IsKind(SyntaxKind.StaticKeyword)
+                        ? symbols.WhereAsArray(s => !s.IsDelegateType() && !s.IsInterfaceType())
+                        : symbols.WhereAsArray(s => s.IsNamespace());
                 }
 
-                if (symbols.Any())
-                {
-                    return symbols;
-                }
+                return symbols;
             }
 
             return ImmutableArray<ISymbol>.Empty;


### PR DESCRIPTION
Was looking at this code to make sure we didn't have any issues where we wouldn't offer "System.Enum" in a constraint clause.  Noticed it was doing things that seemed unnecessary (And were likely holdovers from days when we used IEnumerable).  