### PR TITLE
Verify MSBuild version in Developer CMD prompt

### DIFF
--- a/build/Targets/Tools.props
+++ b/build/Targets/Tools.props
@@ -6,5 +6,6 @@
     <dotnetSdkVersion>2.2.0-preview1-007622</dotnetSdkVersion>
     <nugetExeVersion>4.3.0</nugetExeVersion>
     <monoVersion>5.8.0.88</monoVersion>
+    <vsMinimumVersion>15.3</vsMinimumVersion>
   </PropertyGroup>
 </Project>

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -312,14 +312,20 @@ function Get-MSBuildKindAndDir([switch]$xcopy = $false) {
         return
     }
 
-    # MSBuild from an active VS command prompt.  
+    # MSBuild from an active VS command prompt. Use the MSBuild here so long as it's from a 
+    # compatible Visual Studio. If not though throw and error out. Given the number of 
+    # environment variable changes in a developer command prompt it's hard to make guarantees
+    # about subbing in a new MSBuild instance
     if (${env:VSINSTALLDIR} -ne $null) {
         $command = (Get-Command msbuild -ErrorAction SilentlyContinue)
-        if ($command -ne $null) {
+        if ((Test-SupportedVisualStudioVersion ${env:VSCMD_VER}) -and ($command -ne $null) ) {
             $p = Split-Path -parent $command.Path
             Write-Output "vscmd"
             Write-Output $p
             return
+        }
+        else {
+            throw "Developer Command Prompt for VS $(${env:VSCMD_VER}) is not recent enough. Please upgrade or build from a normal CMD window"
         }
     }
 
@@ -353,6 +359,19 @@ function Get-MSBuildDir([switch]$xcopy = $false) {
     return $both[1]
 }
 
+
+# Dose this version of Visual Studio meet our minimum requirements for building.
+function Test-SupportedVisualStudioVersion([string]$version) { 
+    if (-not ($version -match "^([\d.]+)(\+|-)?.*$")) { 
+        Write-Host "here"
+        return $false
+    }
+
+    $V = New-Object System.Version $matches[1]
+    $min = New-Object System.Version "15.3"
+    return $v -ge $min;
+}
+
 # Get the directory and instance ID of the first Visual Studio version which 
 # meets our minimal requirements for the Roslyn repo.
 function Get-VisualStudioDirAndId() {
@@ -365,10 +384,8 @@ function Get-VisualStudioDirAndId() {
         # set of SDK fixes. Parsing the installationName is the only place where this is 
         # recorded in that form.
         $name = $obj.installationName
-        if ($name -match "VisualStudio(Preview)?/([\d.]+)(\+|-).*") { 
-            $minVersion = New-Object System.Version "15.3.0"
-            $version = New-Object System.Version $matches[2]
-            if ($version -ge $minVersion) {
+        if ($name -match "VisualStudio(Preview)?/(.*)") { 
+            if (Test-SupportedVisualStudioVersion $matches[2]) {
                 Write-Output $obj.installationPath
                 Write-Output $obj.instanceId
                 return

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -362,6 +362,9 @@ function Get-MSBuildDir([switch]$xcopy = $false) {
 
 # Dose this version of Visual Studio meet our minimum requirements for building.
 function Test-SupportedVisualStudioVersion([string]$version) { 
+    # This regex allows us to strip off any pre-release info that gets attached 
+    # to the version string. VS uses NuGet style pre-release by suffing version
+    # with -<pre-release info>
     if (-not ($version -match "^([\d.]+)(\+|-)?.*$")) { 
         return $false
     }

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -325,7 +325,8 @@ function Get-MSBuildKindAndDir([switch]$xcopy = $false) {
             return
         }
         else {
-            throw "Developer Command Prompt for VS $(${env:VSCMD_VER}) is not recent enough. Please upgrade or build from a normal CMD window"
+            $vsMinimumVersion = Get-ToolVersion "vsMinimum"
+            throw "Developer Command Prompt for VS $(${env:VSCMD_VER}) is not recent enough. Please upgrade to {$vsMinimumVersion} or build from a normal CMD window"
         }
     }
 
@@ -369,8 +370,9 @@ function Test-SupportedVisualStudioVersion([string]$version) {
         return $false
     }
 
+    $vsMinimumVersion = Get-ToolVersion "vsMinimum"
     $V = New-Object System.Version $matches[1]
-    $min = New-Object System.Version "15.3"
+    $min = New-Object System.Version $vsMinimumVersion
     return $v -ge $min;
 }
 

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -363,7 +363,6 @@ function Get-MSBuildDir([switch]$xcopy = $false) {
 # Dose this version of Visual Studio meet our minimum requirements for building.
 function Test-SupportedVisualStudioVersion([string]$version) { 
     if (-not ($version -match "^([\d.]+)(\+|-)?.*$")) { 
-        Write-Host "here"
         return $false
     }
 


### PR DESCRIPTION
Roslyn is designed to have the simplest possible contribution story:
clone then build. Every pre-req needed is either located on the machine
or bootstrapped via NuGet. All the way down to using an xcopy MSBuild if
needed.

The one case which causes a problem is the VS command prompt. In this
case MSBuild is pre-installed on the machine and may or may not be
suitable for building Roslyn.

Previously when building from a VS command prompt we just used whatever
MSBuild was provided. The assumption being a developer command prompt
was an explicit statement of whath MSBuild you wanted to use. Based on
all of our customer reports though this does not seem to be the
assumption that consumers of our repo have. The build gave them no
explicit errors about the provided toolset and hence when the build
failed they assigned flakiness to our repo.

Going forward we are applying the same version validation to MSBuild
when provided via a developer command prompt. If it doesn't match we
will refuse to build asking the user to upgrade VS or build from a
normal command prompt.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
