### PR TITLE
added and cleaned up logs around build and live diagnostics.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -112,6 +112,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         // perf optimization. check whether we want to analyze this project or not.
                         if (!FullAnalysisEnabled(project, forceAnalyzerRun))
                         {
+                            Logger.Log(FunctionId.Diagnostics_ProjectDiagnostic, p => $"FSA off ({p.FilePath ?? p.Name})", project);
+
                             return new ProjectAnalysisData(project.Id, VersionStamp.Default, existingData.Result, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty);
                         }
 
@@ -153,6 +155,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     // no result from compiler analyzer
                     return result;
                 }
+
+                Logger.Log(FunctionId.Diagnostics_ProjectDiagnostic, p => $"Failed to Load Successfully ({p.FilePath ?? p.Name})", project);
 
                 // get rid of any result except syntax from compiler analyzer result
                 var newCompilerAnalysisResult = new DiagnosticAnalysisResult(
@@ -451,7 +455,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return ImmutableArray<Diagnostic>.Empty;
                 }
 
-                if (!await SemanticAnalysisEnabled(document, analyzer, kind, cancellationToken).ConfigureAwait(false))
+                if (!await AnalysisEnabled(document, analyzer, kind, cancellationToken).ConfigureAwait(false))
                 {
                     return ImmutableArray<Diagnostic>.Empty;
                 }
@@ -478,14 +482,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
             }
 
-            private async Task<bool> SemanticAnalysisEnabled(Document document, DiagnosticAnalyzer analyzer, AnalysisKind kind, CancellationToken cancellationToken)
+            private async Task<bool> AnalysisEnabled(Document document, DiagnosticAnalyzer analyzer, AnalysisKind kind, CancellationToken cancellationToken)
             {
                 // if project is not loaded successfully then, we disable semantic errors for compiler analyzers
-                var disabled = kind != AnalysisKind.Syntax &&
-                               _owner.HostAnalyzerManager.IsCompilerDiagnosticAnalyzer(document.Project.Language, analyzer) &&
-                               !await document.Project.HasSuccessfullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+                if (kind == AnalysisKind.Syntax || !_owner.HostAnalyzerManager.IsCompilerDiagnosticAnalyzer(document.Project.Language, analyzer))
+                {
+                    return true;
+                }
 
-                return !disabled;
+                var enabled = await document.Project.HasSuccessfullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+
+                Logger.Log(FunctionId.Diagnostics_SemanticDiagnostic, (a, d, e) => $"{a.ToString()}, ({d.FilePath ?? d.Name}), Enabled:{e}", analyzer, document, enabled);
+
+                return enabled;
             }
 
             private void UpdateAnalyzerTelemetryData(
@@ -620,42 +629,42 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         // ignore these kinds
                         break;
                     case LocationKind.SourceFile:
+                    {
+                        if (project.GetDocument(location.SourceTree) == null)
                         {
-                            if (project.GetDocument(location.SourceTree) == null)
-                            {
-                                // Disallow diagnostics with source locations outside this project.
-                                throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_in_file_1_which_is_not_part_of_the_compilation_being_analyzed, id, location.SourceTree.FilePath), "diagnostic");
-                            }
-
-                            if (location.SourceSpan.End > location.SourceTree.Length)
-                            {
-                                // Disallow diagnostics with source locations outside this project.
-                                throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_1_in_file_2_which_is_outside_of_the_given_file, id, location.SourceSpan, location.SourceTree.FilePath), "diagnostic");
-                            }
+                            // Disallow diagnostics with source locations outside this project.
+                            throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_in_file_1_which_is_not_part_of_the_compilation_being_analyzed, id, location.SourceTree.FilePath), "diagnostic");
                         }
-                        break;
+
+                        if (location.SourceSpan.End > location.SourceTree.Length)
+                        {
+                            // Disallow diagnostics with source locations outside this project.
+                            throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_1_in_file_2_which_is_outside_of_the_given_file, id, location.SourceSpan, location.SourceTree.FilePath), "diagnostic");
+                        }
+                    }
+                    break;
                     case LocationKind.ExternalFile:
+                    {
+                        var filePath = location.GetLineSpan().Path;
+                        var document = TryGetDocumentWithFilePath(project, filePath);
+                        if (document == null)
                         {
-                            var filePath = location.GetLineSpan().Path;
-                            var document = TryGetDocumentWithFilePath(project, filePath);
-                            if (document == null)
-                            {
-                                // this is not a roslyn file. we don't care about this file.
-                                return;
-                            }
-
-                            // this can be potentially expensive since it will load text if it is not already loaded.
-                            // but, this text is most likely already loaded since producer of this diagnostic (Document/ProjectDiagnosticAnalyzers)
-                            // should have loaded it to produce the diagnostic at the first place. once loaded, it should stay in memory until
-                            // project cache goes away. when text is already there, await should return right away.
-                            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                            if (location.SourceSpan.End > text.Length)
-                            {
-                                // Disallow diagnostics with locations outside this project.
-                                throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_1_in_file_2_which_is_outside_of_the_given_file, id, location.SourceSpan, filePath), "diagnostic");
-                            }
+                            // this is not a roslyn file. we don't care about this file.
+                            return;
                         }
-                        break;
+
+                        // this can be potentially expensive since it will load text if it is not already loaded.
+                        // but, this text is most likely already loaded since producer of this diagnostic (Document/ProjectDiagnosticAnalyzers)
+                        // should have loaded it to produce the diagnostic at the first place. once loaded, it should stay in memory until
+                        // project cache goes away. when text is already there, await should return right away.
+                        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                        if (location.SourceSpan.End > text.Length)
+                        {
+                            // Disallow diagnostics with locations outside this project.
+                            throw new ArgumentException(string.Format(FeaturesResources.Reported_diagnostic_0_has_a_source_location_1_in_file_2_which_is_outside_of_the_given_file, id, location.SourceSpan, filePath), "diagnostic");
+                        }
+                    }
+                    break;
                     default:
                         throw ExceptionUtilities.Unreachable;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -284,32 +284,32 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         private static string GetDocumentLogMessage(string title, Document document, DiagnosticAnalyzer analyzer)
         {
-            return string.Format($"{title}: {document.FilePath ?? document.Name}, {analyzer.ToString()}");
+            return $"{title}: ({document.FilePath ?? document.Name}), ({analyzer.ToString()})";
         }
 
         private static string GetProjectLogMessage(Project project, IEnumerable<StateSet> stateSets)
         {
-            return string.Format($"project: {project.FilePath ?? project.Name}, {string.Join(",", stateSets.Select(s => s.Analyzer.ToString()))}");
+            return $"project: ({project.FilePath ?? project.Name}), ({string.Join(Environment.NewLine, stateSets.Select(s => s.Analyzer.ToString()))})";
         }
 
         private static string GetResetLogMessage(Document document)
         {
-            return string.Format($"document close/reset: {document.FilePath ?? document.Name}");
+            return $"document close/reset: ({document.FilePath ?? document.Name})";
         }
 
         private static string GetOpenLogMessage(Document document)
         {
-            return string.Format($"document open: {document.FilePath ?? document.Name}");
+            return $"document open: ({document.FilePath ?? document.Name})";
         }
 
         private static string GetRemoveLogMessage(DocumentId id)
         {
-            return string.Format($"document remove: {id.ToString()}");
+            return $"document remove: {id.ToString()}";
         }
 
         private static string GetRemoveLogMessage(ProjectId id)
         {
-            return string.Format($"project remove: {id.ToString()}");
+            return $"project remove: {id.ToString()}";
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
 
@@ -17,41 +18,44 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     {
         public async Task SynchronizeWithBuildAsync(Workspace workspace, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> map)
         {
-            DebugVerifyDiagnosticLocations(map);
-
-            if (!PreferBuildErrors(workspace))
+            using (Logger.LogBlock(FunctionId.DiagnosticIncrementalAnalyzer_SynchronizeWithBuildAsync, (w, m) => LogSynchronizeWithBuild(w, m), workspace, map, CancellationToken.None))
             {
-                // prefer live errors over build errors
-                return;
-            }
+                DebugVerifyDiagnosticLocations(map);
 
-            var solution = workspace.CurrentSolution;
-            foreach (var projectEntry in map)
-            {
-                var project = solution.GetProject(projectEntry.Key);
-                if (project == null)
+                if (!PreferBuildErrors(workspace))
                 {
-                    continue;
+                    // prefer live errors over build errors
+                    return;
                 }
 
-                // REVIEW: is build diagnostic contains suppressed diagnostics?
-                var stateSets = _stateManager.CreateBuildOnlyProjectStateSet(project);
-                var result = await CreateProjectAnalysisDataAsync(project, stateSets, projectEntry.Value).ConfigureAwait(false);
-
-                foreach (var stateSet in stateSets)
+                var solution = workspace.CurrentSolution;
+                foreach (var projectEntry in map)
                 {
-                    var state = stateSet.GetProjectState(project.Id);
-                    await state.SaveAsync(project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
+                    var project = solution.GetProject(projectEntry.Key);
+                    if (project == null)
+                    {
+                        continue;
+                    }
+
+                    // REVIEW: is build diagnostic contains suppressed diagnostics?
+                    var stateSets = _stateManager.CreateBuildOnlyProjectStateSet(project);
+                    var result = await CreateProjectAnalysisDataAsync(project, stateSets, projectEntry.Value).ConfigureAwait(false);
+
+                    foreach (var stateSet in stateSets)
+                    {
+                        var state = stateSet.GetProjectState(project.Id);
+                        await state.SaveAsync(project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
+                    }
+
+                    // REVIEW: this won't handle active files. might need to tweak it later.
+                    RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
                 }
 
-                // REVIEW: this won't handle active files. might need to tweak it later.
-                RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
-            }
-
-            if (PreferLiveErrorsOnOpenedFiles(workspace))
-            {
-                // enqueue re-analysis of open documents.
-                this.Owner.Reanalyze(workspace, documentIds: workspace.GetOpenDocumentIds(), highPriority: true);
+                if (PreferLiveErrorsOnOpenedFiles(workspace))
+                {
+                    // enqueue re-analysis of open documents.
+                    this.Owner.Reanalyze(workspace, documentIds: workspace.GetOpenDocumentIds(), highPriority: true);
+                }
             }
         }
 
@@ -125,12 +129,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                    result.Others).ToImmutableArray();
         }
 
-        private bool PreferBuildErrors(Workspace workspace)
+        private static bool PreferBuildErrors(Workspace workspace)
         {
             return workspace.Options.GetOption(InternalDiagnosticsOptions.PreferBuildErrorsOverLiveErrors);
         }
 
-        private bool PreferLiveErrorsOnOpenedFiles(Workspace workspace)
+        private static bool PreferLiveErrorsOnOpenedFiles(Workspace workspace)
         {
             return workspace.Options.GetOption(InternalDiagnosticsOptions.PreferLiveErrorsOnOpenedFiles);
         }
@@ -207,6 +211,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 descriptor.Description.ToString(CultureInfo.CurrentUICulture),
                 descriptor.HelpLinkUri,
                 isSuppressed: diagnostic.IsSuppressed);
+        }
+
+        private static string LogSynchronizeWithBuild(Workspace workspace, ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>> map)
+        {
+            using (var pooledObject = SharedPools.Default<StringBuilder>().GetPooledObject())
+            {
+                var sb = pooledObject.Object;
+                sb.Append($"PreferBuildError:{PreferBuildErrors(workspace)}, PreferLiveOnOpenFiles:{PreferLiveErrorsOnOpenedFiles(workspace)}");
+
+                if (map.Count > 0)
+                {
+                    foreach (var kv in map)
+                    {
+                        sb.AppendLine($"{kv.Key}, Count: {kv.Value.Length}");
+
+                        foreach (var diagnostic in kv.Value)
+                        {
+                            sb.AppendLine($"    {diagnostic.ToString()}");
+                        }
+                    }
+                }
+
+                return sb.ToString();
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         try
                         {
-                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, source.Token))
+                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, w => w.ToString(), workItem, source.Token))
                             {
                                 var cancellationToken = source.Token;
                                 var document = solution.GetDocument(documentId);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             private partial class IncrementalAnalyzerProcessor
             {
-                private static readonly Func<int, object, bool, string> s_enqueueLogger = (t, i, s) => string.Format("[{0}] {1} : {2}", t, i.ToString(), s);
+                private static readonly Func<int, object, bool, string> s_enqueueLogger = (t, i, s) => string.Format("Tick:{0}, Id:{1}, Replaced:{2}", t, i.ToString(), s);
 
                 private readonly Registration _registration;
                 private readonly IAsynchronousOperationListener _listener;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         try
                         {
-                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessProjectAsync, source.Token))
+                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessProjectAsync, w => w.ToString(), workItem, source.Token))
                             {
                                 var cancellationToken = source.Token;
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                         try
                         {
-                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, source.Token))
+                            using (Logger.LogBlock(FunctionId.WorkCoordinator_ProcessDocumentAsync, w => w.ToString(), workItem, source.Token))
                             {
                                 var cancellationToken = source.Token;
                                 var document = _processingSolution.GetDocument(documentId);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.WorkItem.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.WorkItem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
@@ -156,6 +157,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         this.Analyzers,
                         this.IsRetry,
                         asyncToken);
+                }
+
+                public override string ToString()
+                {
+                    return $"{DocumentId?.ToString() ?? ProjectId.ToString()}, ({InvocationReasons.ToString()}), LowPriority:{IsLowPriority}, ActiveMember:{ActiveMember != null}, Retry:{IsRetry}, ({string.Join("|", Analyzers.Select(a => a.GetType().Name))})";
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
             private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
             {
-                using (Logger.LogBlock(FunctionId.LiveTableDataSource_OnDiagnosticsUpdated, GetDiagnosticUpdatedMessage, e, CancellationToken.None))
+                using (Logger.LogBlock(FunctionId.LiveTableDataSource_OnDiagnosticsUpdated, a => GetDiagnosticUpdatedMessage(a), e, CancellationToken.None))
                 {
                     if (_workspace != e.Workspace)
                     {
@@ -550,7 +550,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     id = analyzer.Analyzer.ToString();
                 }
 
-                return $"{e.Workspace.Kind} {id} {e.Kind} {(object)e.DocumentId ?? e.ProjectId} {e.Diagnostics.Length}";
+                return $"Kind:{e.Workspace.Kind}, Analyzer:{id}, Update:{e.Kind}, {(object)e.DocumentId ?? e.ProjectId}, ({string.Join(Environment.NewLine, e.Diagnostics)})";
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -515,7 +516,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 var errors = GetErrorSet(map, key);
                 foreach (var diagnostic in diagnostics)
                 {
-                    errors.Add(diagnostic, GetNextIncrement());
+                    AddError(errors, diagnostic);
                 }
             }
 
@@ -530,6 +531,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 // add only new errors
                 if (!errors.TryGetValue(diagnostic, out _))
                 {
+                    Logger.Log(FunctionId.ExternalErrorDiagnosticUpdateSource_AddError, d => d.ToString(), diagnostic);
+
                     errors.Add(diagnostic, GetNextIncrement());
                 }
             }

--- a/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
+++ b/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices
+{
+    /// <summary>
+    /// Let people to inject <see cref="TraceSource"/> to monitor Roslyn activity
+    /// 
+    /// Here, we don't technically use TraceSource as it is meant to be used. but just as an easy 
+    /// way to log data to listeners.
+    /// 
+    /// this also involves creating string, boxing and etc. so, perf wise, it will impact VS quite a bit.
+    /// this also won't collect trace from Roslyn OOP for now. only in proc activity
+    /// </summary>
+    internal static class RoslynActivityLogger
+    {
+        private static readonly object s_gate = new object();
+
+        public static void SetLogger(TraceSource traceSource)
+        {
+            Contract.ThrowIfNull(traceSource);
+
+            lock (s_gate)
+            {
+                // internally, it just uses our existing ILogger
+                Logger.SetLogger(AggregateLogger.AddOrReplace(new TraceSourceLogger(traceSource), Logger.GetLogger(), l => (l as TraceSourceLogger)?.TraceSource == traceSource));
+            }
+        }
+
+        public static void RemoveLogger(TraceSource traceSource)
+        {
+            Contract.ThrowIfNull(traceSource);
+
+            lock (s_gate)
+            {
+                // internally, it just uses our existing ILogger
+                Logger.SetLogger(AggregateLogger.Remove(Logger.GetLogger(), l => (l as TraceSourceLogger)?.TraceSource == traceSource));
+            }
+        }
+
+        private class TraceSourceLogger : ILogger
+        {
+            private const int LogEventId = 0;
+            private const int StartEventId = 1;
+            private const int EndEventId = 2;
+
+            private static readonly ImmutableDictionary<FunctionId, string> s_functionIdCache;
+
+            public readonly TraceSource TraceSource;
+
+            static TraceSourceLogger()
+            {
+                // build enum to string cache
+                s_functionIdCache =
+                    Enum.GetValues(typeof(FunctionId)).Cast<FunctionId>().ToImmutableDictionary(f => f, f => f.ToString());
+            }
+
+            public TraceSourceLogger(TraceSource traceSource)
+            {
+                TraceSource = traceSource;
+            }
+
+            public bool IsEnabled(FunctionId functionId)
+            {
+                // we log every roslyn activity
+                return true;
+            }
+
+            public void Log(FunctionId functionId, LogMessage logMessage)
+            {
+                TraceSource.TraceData(TraceEventType.Verbose, LogEventId, s_functionIdCache[functionId], logMessage.GetMessage());
+            }
+
+            public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
+            {
+                TraceSource.TraceData(TraceEventType.Verbose, StartEventId, s_functionIdCache[functionId], uniquePairId);
+            }
+
+            public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
+            {
+                TraceSource.TraceData(TraceEventType.Verbose, EndEventId, s_functionIdCache[functionId], uniquePairId, cancellationToken.IsCancellationRequested, delta, logMessage.GetMessage());
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -403,5 +403,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         MetadataOnlyImage_EmitFailure,
         LiveTableDataSource_OnDiagnosticsUpdated,
         Experiment_KeybindingsReset,
+        ExternalErrorDiagnosticUpdateSource_AddError,
+        DiagnosticIncrementalAnalyzer_SynchronizeWithBuildAsync,
     }
 }

--- a/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
+++ b/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
@@ -61,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             get
             {
                 EnsureMap();
-                return _map?.Count > 0;
+                return _map.Count > 0;
             }
         }
 
@@ -91,17 +90,21 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             if (_propertySetter != null)
             {
                 _propertySetter = null;
-                s_pool.Free(this);
             }
+
+            // always pool it back
+            s_pool.Free(this);
         }
 
         private void EnsureMap()
         {
-            if (_map == null && _propertySetter != null)
+            // always create _map
+            if (_map == null)
             {
                 _map = SharedPools.Default<Dictionary<string, object>>().AllocateAndClear();
-                _propertySetter(_map);
             }
+
+            _propertySetter?.Invoke(_map);
         }
     }
 

--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons.cs
@@ -59,5 +59,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             return _reasons.GetEnumerator();
         }
+
+        public override string ToString()
+        {
+            return string.Join("|", _reasons ?? ImmutableHashSet<string>.Empty);
+        }
     }
 }


### PR DESCRIPTION
also added RoslynActivityLogger that can be enabled through project-system-tool

### Customer scenario

There is no user experience change in this PR. 

This PR is to let our project-system-tool (https://github.com/heejaechang/project-system-tools) to inject Roslyn logger so that we can use that tool to see roslyn activity around build/live errors and behavior of error list.

### Bugs this fixes

this doesn't fix any issue. but hopefully, help us to figure out what is causing this issue (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/364961)

### Workarounds, if any

No workaround

### Risk

All these changes are no-op if Roslyn logger is not enabled explicitly through the tool.

### Performance impact

All these changes are no-op if Roslyn logger is not enabled explicitly through the tool.

### Is this a regression from a previous update?

No

### Root cause analysis

we are getting bunch of bugs around error list (error not showing, error not going away, build and live errors not consistent and etc). but since error list is just presentation that reflects current state, either dump or etl are not enough to find out how error list got to this state. this change let us to monitor activities around error list so that we can get better idea on how things moved to this state.

### How was the bug found?

Feedbacks.