### PR TITLE
CheckPresenceOfTypeIdentifierAttribute - avoid requesting syntax trees if we know that we already decoded all well-known attributes.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -772,6 +772,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void CheckPresenceOfTypeIdentifierAttribute()
         {
+            // Have we already decoded well-known attributes?
+            if (_lazyCustomAttributesBag?.IsDecodedWellKnownAttributeDataComputed == true)
+            {
+                return;
+            }
+
             // We want this function to be as cheap as possible, it is called for every top level type
             // and we don't want to bind attributes attached to the declaration unless there is a chance
             // that one of them is TypeIdentifier attribute.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -1865,6 +1865,12 @@ public interface I1
             var i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1");
 
             Assert.True(i1.IsExplicitDefinitionOfNoPiaLocalType);
+
+            compilation = CreateStandardCompilation(code);
+            i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1");
+            i1.GetAttributes();
+
+            Assert.True(i1.IsExplicitDefinitionOfNoPiaLocalType);
         }
 
         [Fact]
@@ -1911,6 +1917,11 @@ namespace NS1
                 //     [alias1]
                 Diagnostic(ErrorCode.ERR_NotAnAttributeClass, "alias1").WithArguments("TypeIdentifier").WithLocation(8, 6)
                 );
+
+            compilation = CreateStandardCompilation(code);
+            i1 = compilation.SourceAssembly.GetTypeByMetadataName("NS1.I1");
+            i1.GetAttributes();
+            Assert.False(i1.IsExplicitDefinitionOfNoPiaLocalType);
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2293,6 +2293,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub CheckPresenceOfTypeIdentifierAttribute()
 
+            ' Have we already decoded well-known attributes?
+            If Me.m_lazyCustomAttributesBag?.IsDecodedWellKnownAttributeDataComputed Then
+                Return
+            End If
+
             ' We want this function to be as cheap as possible, it is called for every top level type
             ' and we don't want to bind attributes attached to the declaration unless there is a chance
             ' that one of them is TypeIdentifier attribute.

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/TypeTests.vb
@@ -3400,7 +3400,7 @@ BC30625: 'Module' statement must end with a matching 'End Module'.
 
         <Fact>
         Public Sub IsExplicitDefinitionOfNoPiaLocalType_01()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim sources =
 <compilation>
     <file><![CDATA[
 Imports System.Runtime.InteropServices
@@ -3409,10 +3409,16 @@ Imports System.Runtime.InteropServices
 Public Interface I1
 End Interface
     ]]></file>
-</compilation>)
+</compilation>
 
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(sources)
             Dim i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1")
 
+            Assert.True(i1.IsExplicitDefinitionOfNoPiaLocalType)
+
+            compilation = CompilationUtils.CreateCompilationWithMscorlib(sources)
+            i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1")
+            i1.GetAttributes()
             Assert.True(i1.IsExplicitDefinitionOfNoPiaLocalType)
         End Sub
 
@@ -3436,7 +3442,7 @@ End Interface
 
         <Fact>
         Public Sub IsExplicitDefinitionOfNoPiaLocalType_03()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim sources =
 <compilation>
     <file><![CDATA[
 Imports alias1 = System.Runtime.InteropServices.TypeIdentifier
@@ -3445,8 +3451,9 @@ Imports alias1 = System.Runtime.InteropServices.TypeIdentifier
 Public Interface I1
 End Interface
     ]]></file>
-</compilation>)
+</compilation>
 
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(sources)
             Dim i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1")
 
             Assert.False(i1.IsExplicitDefinitionOfNoPiaLocalType)
@@ -3460,6 +3467,11 @@ BC30182: Type expected.
 <alias1>
  ~~~~~~
 ]]></expected>)
+
+            compilation = CompilationUtils.CreateCompilationWithMscorlib(sources)
+            i1 = compilation.SourceAssembly.GetTypeByMetadataName("I1")
+            i1.GetAttributes()
+            Assert.False(i1.IsExplicitDefinitionOfNoPiaLocalType)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=537870.

### Customer scenario

Compilers unnecessary request syntax trees, which has negative perf impact for some IDE scenarios when the trees are unloaded from memory. 

### Bugs this fixes

https://devdiv.visualstudio.com/DevDiv/_workitems?id=537870

### Workarounds, if any

None

### Risk

Low, very localized, simple fix. The code path has good code coverage by unit-tests.

### Performance impact

Should improve performance because no extra allocations/no complexity changes and the fix prevents compiler from doing unnecessary work.

### Is this a regression from a previous update?

Yes.

### Root cause analysis

Caught by an existing RPS test   

### How was the bug found?

Caught by an existing RPS test   

### Test documentation updated?

N/A

