### PR TITLE
Allow VB command-line arguments to add CorLibrary even if there are unresolved references

### DIFF
--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
@@ -66,59 +66,60 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             resolved As List(Of MetadataReference)
             ) As Boolean
 
-            If MyBase.ResolveMetadataReferences(metadataResolver, diagnostics, messageProvider, resolved) Then
+            Dim result = MyBase.ResolveMetadataReferences(metadataResolver, diagnostics, messageProvider, resolved)
 
-                ' If there were no references, don't try to add default Cor library reference.
-                If Me.DefaultCoreLibraryReference IsNot Nothing AndAlso resolved.Count > 0 Then
-                    ' All references from arguments were resolved successfully. Let's see if we have a reference that can be used as a Cor library.
-                    For Each reference In resolved
-                        Dim refProps = reference.Properties
-
-                        ' The logic about deciding what assembly is a candidate for being a Cor library here and in
-                        ' CommonReferenceManager<TCompilation, TAssemblySymbol>.IndexOfCorLibrary
-                        ' should be equivalent.
-                        If Not refProps.EmbedInteropTypes AndAlso refProps.Kind = MetadataImageKind.Assembly Then
-                            Try
-                                Dim assemblyMetadata = TryCast(DirectCast(reference, PortableExecutableReference).GetMetadataNoCopy(), AssemblyMetadata)
-
-                                If assemblyMetadata Is Nothing OrElse Not assemblyMetadata.IsValidAssembly() Then
-                                    ' There will be some errors reported later.
-                                    Return True
-                                End If
-
-                                Dim assembly As PEAssembly = assemblyMetadata.GetAssembly()
-
-                                If assembly.AssemblyReferences.Length = 0 AndAlso Not assembly.ContainsNoPiaLocalTypes AndAlso assembly.DeclaresTheObjectClass Then
-                                    ' This reference looks like a valid Cor library candidate, bail out.
-                                    Return True
-                                End If
-
-                            Catch e As BadImageFormatException
-                                ' error reported later
-                                Return True
-                            Catch e As IOException
-                                ' error reported later
-                                Return True
-                            End Try
-                        End If
-                    Next
-
-                    ' None of the supplied references could be used as a Cor library. Let's add a default one.
-                    Dim defaultCorLibrary = ResolveMetadataReference(Me.DefaultCoreLibraryReference.Value, metadataResolver, diagnostics, messageProvider).FirstOrDefault()
-
-                    If defaultCorLibrary Is Nothing OrElse defaultCorLibrary.IsUnresolved Then
-                        Debug.Assert(diagnostics Is Nothing OrElse diagnostics.Any())
-                        Return False
-                    Else
-                        resolved.Insert(0, defaultCorLibrary)
-                        Return True
+            ' If there were no references, don't try to add default Cor library reference.
+            If Me.DefaultCoreLibraryReference IsNot Nothing AndAlso resolved.Count > 0 Then
+                ' All references from arguments were resolved successfully. Let's see if we have a reference that can be used as a Cor library.
+                For Each reference In resolved
+                    If TypeOf reference Is UnresolvedMetadataReference Then
+                        Continue For
                     End If
-                End If
 
-                Return True
+                    Dim refProps = reference.Properties
+
+                    ' The logic about deciding what assembly is a candidate for being a Cor library here and in
+                    ' CommonReferenceManager<TCompilation, TAssemblySymbol>.IndexOfCorLibrary
+                    ' should be equivalent.
+                    If Not refProps.EmbedInteropTypes AndAlso refProps.Kind = MetadataImageKind.Assembly Then
+                        Try
+                            Dim assemblyMetadata = TryCast(DirectCast(reference, PortableExecutableReference).GetMetadataNoCopy(), AssemblyMetadata)
+
+                            If assemblyMetadata Is Nothing OrElse Not assemblyMetadata.IsValidAssembly() Then
+                                ' There will be some errors reported later.
+                                Return result
+                            End If
+
+                            Dim assembly As PEAssembly = assemblyMetadata.GetAssembly()
+
+                            If assembly.AssemblyReferences.Length = 0 AndAlso Not assembly.ContainsNoPiaLocalTypes AndAlso assembly.DeclaresTheObjectClass Then
+                                ' This reference looks like a valid Cor library candidate, bail out.
+                                Return result
+                            End If
+
+                        Catch e As BadImageFormatException
+                            ' error reported later
+                            Return result
+                        Catch e As IOException
+                            ' error reported later
+                            Return result
+                        End Try
+                    End If
+                Next
+
+                ' None of the supplied references could be used as a Cor library. Let's add a default one.
+                Dim defaultCorLibrary = ResolveMetadataReference(Me.DefaultCoreLibraryReference.Value, metadataResolver, diagnostics, messageProvider).FirstOrDefault()
+
+                If defaultCorLibrary Is Nothing OrElse defaultCorLibrary.IsUnresolved Then
+                    Debug.Assert(diagnostics Is Nothing OrElse diagnostics.Any())
+                    Return False
+                Else
+                    resolved.Insert(0, defaultCorLibrary)
+                    Return result
+                End If
             End If
 
-            Return False
+            Return result
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Me.DefaultCoreLibraryReference IsNot Nothing AndAlso resolved.Count > 0 Then
                 ' All references from arguments were resolved successfully. Let's see if we have a reference that can be used as a Cor library.
                 For Each reference In resolved
-                    If TypeOf reference Is UnresolvedMetadataReference Then
+                    If reference.IsUnresolved Then
                         Continue For
                     End If
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2172,7 +2172,7 @@ End Module").Path
             Assert.Contains(references, Function(r) r.IsUnresolved)
             Assert.Contains(references, Function(r)
                                             Dim peRef = TryCast(r, PortableExecutableReference)
-                                            Return peRef Is Nothing OrElse
+                                            Return peRef IsNot Nothing AndAlso
                                                    peRef.FilePath.EndsWith("mscorlib.dll", StringComparison.Ordinal)
                                         End Function)
         End Sub
@@ -2188,7 +2188,7 @@ End Module").Path
             Assert.DoesNotContain(references, Function(r) r.IsUnresolved)
             Assert.Contains(references, Function(r)
                                             Dim peRef = TryCast(r, PortableExecutableReference)
-                                            Return peRef Is Nothing OrElse
+                                            Return peRef IsNot Nothing AndAlso
                                                    peRef.FilePath.EndsWith("mscorlib.dll", StringComparison.Ordinal)
                                         End Function)
         End Sub

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2133,6 +2133,66 @@ End Module").Path
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_BadSwitch).WithArguments("/reference-:")) ' TODO: Dev11 reports ERR_ArgumentRequired
         End Sub
 
+        Private Class SimpleMetadataResolver
+            Inherits MetadataReferenceResolver
+
+            Private ReadOnly _pathResolver As RelativePathResolver
+
+            Public Sub New(baseDirectory As String)
+                _pathResolver = New RelativePathResolver(ImmutableArray(Of String).Empty, baseDirectory)
+            End Sub
+
+            Public Overrides Function ResolveReference(reference As String, baseFilePath As String, properties As MetadataReferenceProperties) As ImmutableArray(Of PortableExecutableReference)
+                Dim resolvedPath = _pathResolver.ResolvePath(reference, baseFilePath)
+
+                If resolvedPath Is Nothing OrElse Not File.Exists(reference) Then
+                    Return Nothing
+                End If
+
+                Return ImmutableArray.Create(MetadataReference.CreateFromFile(resolvedPath, properties))
+            End Function
+
+            Public Overrides Function Equals(other As Object) As Boolean
+                Return True
+            End Function
+
+            Public Overrides Function GetHashCode() As Integer
+                Return 1
+            End Function
+        End Class
+
+        <Fact>
+        Public Sub Reference_CorLibraryAddedWhenThereAreUnresolvedReferences()
+            Dim parsedArgs = DefaultParse({"/r:unresolved", "a.vb"}, _baseDirectory)
+
+            Dim metadataResolver = New SimpleMetadataResolver(_baseDirectory)
+            Dim references = parsedArgs.ResolveMetadataReferences(metadataResolver).ToImmutableArray()
+
+            Assert.Equal(4, references.Length)
+            Assert.Contains(references, Function(r) r.IsUnresolved)
+            Assert.Contains(references, Function(r)
+                                            Dim peRef = TryCast(r, PortableExecutableReference)
+                                            Return peRef Is Nothing OrElse
+                                                   peRef.FilePath.EndsWith("mscorlib.dll", StringComparison.Ordinal)
+                                        End Function)
+        End Sub
+
+        <Fact>
+        Public Sub Reference_CorLibraryAddedWhenThereAreNoUnresolvedReferences()
+            Dim parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
+
+            Dim metadataResolver = New SimpleMetadataResolver(_baseDirectory)
+            Dim references = parsedArgs.ResolveMetadataReferences(metadataResolver).ToImmutableArray()
+
+            Assert.Equal(3, references.Length)
+            Assert.DoesNotContain(references, Function(r) r.IsUnresolved)
+            Assert.Contains(references, Function(r)
+                                            Dim peRef = TryCast(r, PortableExecutableReference)
+                                            Return peRef Is Nothing OrElse
+                                                   peRef.FilePath.EndsWith("mscorlib.dll", StringComparison.Ordinal)
+                                        End Function)
+        End Sub
+
         <Fact>
         Public Sub ParseAnalyzers()
             Dim parsedArgs = DefaultParse({"/a:goo.dll", "a.vb"}, _baseDirectory)


### PR DESCRIPTION
Previously, calling `CommandLineArguements.ResolveMetadataReferences(...)` for VB would
not add the CorLibrary if any of the metadata references were unresolved. So, consumers would
need to remove any unresolved references prior to calling `CommandLineParser.Parse(...)` in
order to receive a valid metadata reference for mscorlib. This makes it very challenging to get a
correct set of references using the command-line compiler arguments produced by MSBuild.

This change updates `CommandLineArguments.ResolveMetadataReferences(...)` to compute the
CorLibrary even if there are unresolved metadata references.