### PR TITLE
set parent operation right away in non lazy IOperation implementation

### DIFF
--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public AddressOfExpression(IOperation reference, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Reference = Operation.SetParentOperation(reference, this);
+            Reference = SetParentOperation(reference, this);
         }
 
         public override IOperation Reference { get; }
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyReference = reference ?? throw new System.ArgumentNullException(nameof(reference));
         }
 
-        public override IOperation Reference => Operation.SetParentOperation(_lazyReference.Value, this);
+        public override IOperation Reference => SetParentOperation(_lazyReference.Value, this);
     }
 
     /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public NameOfExpression(IOperation argument, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Argument = Operation.SetParentOperation(argument, this);
+            Argument = SetParentOperation(argument, this);
         }
 
         public override IOperation Argument { get; }
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArgument = argument ?? throw new System.ArgumentNullException(nameof(argument));
         }
 
-        public override IOperation Argument => Operation.SetParentOperation(_lazyArgument.Value, this);
+        public override IOperation Argument => SetParentOperation(_lazyArgument.Value, this);
     }
 
     /// <summary>
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ThrowExpression(IOperation exception, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Exception = Operation.SetParentOperation(exception, this);
+            Exception = SetParentOperation(exception, this);
 
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyException = exception ?? throw new System.ArgumentNullException(nameof(exception));
         }
 
-        public override IOperation Exception => Operation.SetParentOperation(_lazyException.Value, this);
+        public override IOperation Exception => SetParentOperation(_lazyException.Value, this);
     }
 
     /// <summary>
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ArgumentOperation(IOperation value, ArgumentKind argumentKind, IParameterSymbol parameter, IConvertibleConversion inConversionOpt, IConvertibleConversion outConversionOpt, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) : 
             base(argumentKind, parameter, inConversionOpt, outConversionOpt, semanticModel, syntax, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Value { get; }
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value;
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -328,8 +328,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public ArrayCreationExpression(ImmutableArray<IOperation> dimensionSizes, IArrayInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            DimensionSizes = Operation.SetParentOperation(dimensionSizes, this);
-            Initializer = Operation.SetParentOperation(initializer, this);
+            DimensionSizes = SetParentOperation(dimensionSizes, this);
+            Initializer = SetParentOperation(initializer, this);
         }
 
         public override ImmutableArray<IOperation> DimensionSizes { get; }
@@ -351,8 +351,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInitializer = initializer ?? throw new System.ArgumentNullException(nameof(initializer));
         }
 
-        public override ImmutableArray<IOperation> DimensionSizes => Operation.SetParentOperation(_lazyDimensionSizes.Value, this);
-        public override IArrayInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
+        public override ImmutableArray<IOperation> DimensionSizes => SetParentOperation(_lazyDimensionSizes.Value, this);
+        public override IArrayInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
     }
 
     /// <summary>
@@ -409,8 +409,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public ArrayElementReferenceExpression(IOperation arrayReference, ImmutableArray<IOperation> indices, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ArrayReference = Operation.SetParentOperation(arrayReference, this);
-            Indices = Operation.SetParentOperation(indices, this);
+            ArrayReference = SetParentOperation(arrayReference, this);
+            Indices = SetParentOperation(indices, this);
         }
 
         public override IOperation ArrayReference { get; }
@@ -432,8 +432,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyIndices = indices;
         }
 
-        public override IOperation ArrayReference => Operation.SetParentOperation(_lazyArrayReference.Value, this);
-        public override ImmutableArray<IOperation> Indices => Operation.SetParentOperation(_lazyIndices.Value, this);
+        public override IOperation ArrayReference => SetParentOperation(_lazyArrayReference.Value, this);
+        public override ImmutableArray<IOperation> Indices => SetParentOperation(_lazyIndices.Value, this);
     }
 
     /// <summary>
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ArrayInitializer(ImmutableArray<IOperation> elementValues, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, constantValue, isImplicit)
         {
-            ElementValues = Operation.SetParentOperation(elementValues, this);
+            ElementValues = SetParentOperation(elementValues, this);
         }
 
         public override ImmutableArray<IOperation> ElementValues { get; }
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyElementValues = elementValues;
         }
 
-        public override ImmutableArray<IOperation> ElementValues => Operation.SetParentOperation(_lazyElementValues.Value, this);
+        public override ImmutableArray<IOperation> ElementValues => SetParentOperation(_lazyElementValues.Value, this);
     }
 
     /// <summary>
@@ -569,8 +569,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public SimpleAssignmentExpression(IOperation target, bool isRef, IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(isRef, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Target = Operation.SetParentOperation(target, this);
-            Value = Operation.SetParentOperation(value, this);
+            Target = SetParentOperation(target, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Target { get; }
         public override IOperation Value { get; }
@@ -590,8 +590,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyTarget = target ?? throw new System.ArgumentNullException(nameof(target));
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Target => Operation.SetParentOperation(_lazyTarget.Value, this);
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -621,8 +621,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public DeconstructionAssignmentExpression(IOperation target, IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Target = Operation.SetParentOperation(target, this);
-            Value = Operation.SetParentOperation(value, this);
+            Target = SetParentOperation(target, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Target { get; }
         public override IOperation Value { get; }
@@ -642,8 +642,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyTarget = target ?? throw new System.ArgumentNullException(nameof(target));
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Target => Operation.SetParentOperation(_lazyTarget.Value, this);
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public DeclarationExpression(IOperation expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Expression = Operation.SetParentOperation(expression, this);
+            Expression = SetParentOperation(expression, this);
         }
         public override IOperation Expression { get; }
     }
@@ -719,7 +719,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyExpression = expression ?? throw new System.ArgumentNullException(nameof(expression));
         }
-        public override IOperation Expression => Operation.SetParentOperation(_lazyExpression.Value, this);
+        public override IOperation Expression => SetParentOperation(_lazyExpression.Value, this);
     }
 
     /// <summary>
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public AwaitExpression(IOperation operation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
+            Operation = SetParentOperation(operation, this);
         }
 
         public override IOperation Operation { get; }
@@ -783,7 +783,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
         }
 
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
     }
 
     /// <summary>
@@ -863,8 +863,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public BinaryOperatorExpression(BinaryOperatorKind operatorKind, IOperation leftOperand, IOperation rightOperand, bool isLifted, bool isChecked, bool isCompareText, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(operatorKind, isLifted, isChecked, isCompareText, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            LeftOperand = Operation.SetParentOperation(leftOperand, this);
-            RightOperand = Operation.SetParentOperation(rightOperand, this);
+            LeftOperand = SetParentOperation(leftOperand, this);
+            RightOperand = SetParentOperation(rightOperand, this);
         }
 
         public override IOperation LeftOperand { get; }
@@ -886,8 +886,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyRightOperand = rightOperand ?? throw new System.ArgumentNullException(nameof(rightOperand));
         }
 
-        public override IOperation LeftOperand => Operation.SetParentOperation(_lazyLeftOperand.Value, this);
-        public override IOperation RightOperand => Operation.SetParentOperation(_lazyRightOperand.Value, this);
+        public override IOperation LeftOperand => SetParentOperation(_lazyLeftOperand.Value, this);
+        public override IOperation RightOperand => SetParentOperation(_lazyRightOperand.Value, this);
     }
 
     /// <summary>
@@ -940,7 +940,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public BlockStatement(ImmutableArray<IOperation> operations, ImmutableArray<ILocalSymbol> locals, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operations = Operation.SetParentOperation(operations, this);
+            Operations = SetParentOperation(operations, this);
         }
 
         public override ImmutableArray<IOperation> Operations { get; }
@@ -959,7 +959,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperations = operations;
         }
 
-        public override ImmutableArray<IOperation> Operations => Operation.SetParentOperation(_lazyOperations.Value, this);
+        public override ImmutableArray<IOperation> Operations => SetParentOperation(_lazyOperations.Value, this);
     }
 
     /// <summary>
@@ -1086,9 +1086,9 @@ namespace Microsoft.CodeAnalysis.Operations
         public CatchClause(IOperation exceptionDeclarationOrExpression, ITypeSymbol exceptionType, ImmutableArray<ILocalSymbol> locals, IOperation filter, IBlockOperation handler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(exceptionType, locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ExceptionDeclarationOrExpression = Operation.SetParentOperation(exceptionDeclarationOrExpression, this);
-            Filter = Operation.SetParentOperation(filter, this);
-            Handler = Operation.SetParentOperation(handler, this);
+            ExceptionDeclarationOrExpression = SetParentOperation(exceptionDeclarationOrExpression, this);
+            Filter = SetParentOperation(filter, this);
+            Handler = SetParentOperation(handler, this);
         }
 
         public override IBlockOperation Handler { get; }
@@ -1113,9 +1113,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyHandler = handler ?? throw new System.ArgumentNullException(nameof(handler));
         }
 
-        public override IOperation ExceptionDeclarationOrExpression => Operation.SetParentOperation(_lazyExceptionDeclarationOrExpression.Value, this);
-        public override IOperation Filter => Operation.SetParentOperation(_lazyFilter.Value, this);
-        public override IBlockOperation Handler => Operation.SetParentOperation(_lazyHandler.Value, this);
+        public override IOperation ExceptionDeclarationOrExpression => SetParentOperation(_lazyExceptionDeclarationOrExpression.Value, this);
+        public override IOperation Filter => SetParentOperation(_lazyFilter.Value, this);
+        public override IBlockOperation Handler => SetParentOperation(_lazyHandler.Value, this);
     }
 
     /// <summary>
@@ -1169,8 +1169,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public CompoundAssignmentOperation(IOperation target, IOperation value, IConvertibleConversion inConversionConvertible, IConvertibleConversion outConversionConvertible, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(inConversionConvertible, outConversionConvertible, operatorKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Target = Operation.SetParentOperation(target, this);
-            Value = Operation.SetParentOperation(value, this);
+            Target = SetParentOperation(target, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Target { get; }
@@ -1189,8 +1189,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value;
         }
 
-        public override IOperation Target => Operation.SetParentOperation(_lazyTarget.Value, this);
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -1243,8 +1243,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public ConditionalAccessExpression(IOperation whenNotNull, IOperation operation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            WhenNotNull = Microsoft.CodeAnalysis.Operation.SetParentOperation(whenNotNull, this);
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
+            WhenNotNull = SetParentOperation(whenNotNull, this);
+            Operation = SetParentOperation(operation, this);
         }
 
         public override IOperation Operation { get; }
@@ -1266,8 +1266,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
         }
 
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
-        public override IOperation WhenNotNull => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyWhenNotNull.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
+        public override IOperation WhenNotNull => SetParentOperation(_lazyWhenNotNull.Value, this);
     }
 
     /// <summary>
@@ -1369,9 +1369,9 @@ namespace Microsoft.CodeAnalysis.Operations
         public ConditionalOperation(IOperation condition, IOperation whenTrue, IOperation whenFalse, bool isRef, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(isRef, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Condition = Operation.SetParentOperation(condition, this);
-            WhenTrue = Operation.SetParentOperation(whenTrue, this);
-            WhenFalse = Operation.SetParentOperation(whenFalse, this);
+            Condition = SetParentOperation(condition, this);
+            WhenTrue = SetParentOperation(whenTrue, this);
+            WhenFalse = SetParentOperation(whenFalse, this);
         }
 
         public override IOperation Condition { get; }
@@ -1401,9 +1401,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyWhenFalse = whenFalse ?? throw new System.ArgumentNullException(nameof(whenFalse));
         }
 
-        public override IOperation Condition => Operation.SetParentOperation(_lazyCondition.Value, this);
-        public override IOperation WhenTrue => Operation.SetParentOperation(_lazyWhenTrue.Value, this);
-        public override IOperation WhenFalse => Operation.SetParentOperation(_lazyWhenFalse.Value, this);
+        public override IOperation Condition => SetParentOperation(_lazyCondition.Value, this);
+        public override IOperation WhenTrue => SetParentOperation(_lazyWhenTrue.Value, this);
+        public override IOperation WhenFalse => SetParentOperation(_lazyWhenFalse.Value, this);
     }
 
     /// <summary>
@@ -1453,7 +1453,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ConversionOperation(IOperation operand, IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(convertibleConversion, isTryCast, isChecked, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operand = Operation.SetParentOperation(operand, this);
+            Operand = SetParentOperation(operand, this);
         }
 
         public override IOperation Operand { get; }
@@ -1469,7 +1469,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperand = lazyOperand;
         }
 
-        public override IOperation Operand => Operation.SetParentOperation(_lazyOperand.Value, this);
+        public override IOperation Operand => SetParentOperation(_lazyOperand.Value, this);
     }
 
     /// <remarks>
@@ -1608,8 +1608,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public EventAssignmentOperation(IEventReferenceOperation eventReference, IOperation handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(adds, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            EventReference = Operation.SetParentOperation(eventReference, this);
-            HandlerValue = Operation.SetParentOperation(handlerValue, this);
+            EventReference = SetParentOperation(eventReference, this);
+            HandlerValue = SetParentOperation(handlerValue, this);
         }
 
         public override IEventReferenceOperation EventReference { get; }
@@ -1631,8 +1631,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyHandlerValue = handlerValue ?? throw new System.ArgumentNullException(nameof(handlerValue));
         }
 
-        public override IEventReferenceOperation EventReference => Operation.SetParentOperation(_lazyEventReference.Value, this);
-        public override IOperation HandlerValue => Operation.SetParentOperation(_lazyHandlerValue.Value, this);
+        public override IEventReferenceOperation EventReference => SetParentOperation(_lazyEventReference.Value, this);
+        public override IOperation HandlerValue => SetParentOperation(_lazyHandlerValue.Value, this);
     }
 
     /// <summary>
@@ -1678,7 +1678,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public EventReferenceExpression(IEventSymbol @event, IOperation instance, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(@event, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
+            Instance = SetParentOperation(instance, this);
         }
         public override IOperation Instance { get; }
     }
@@ -1695,7 +1695,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyInstance = instance ?? throw new System.ArgumentNullException(nameof(instance));
         }
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
     }
 
     /// <summary>
@@ -1740,7 +1740,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ExpressionStatement(IOperation operation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
+            Operation = SetParentOperation(operation, this);
         }
 
         public override IOperation Operation { get; }
@@ -1759,7 +1759,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
         }
 
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
     }
 
     /// <summary>
@@ -1800,7 +1800,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public VariableInitializer(IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Value { get; }
     }
@@ -1817,7 +1817,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -1863,7 +1863,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public FieldInitializer(ImmutableArray<IFieldSymbol> initializedFields, IOperation value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(initializedFields, kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Value { get; }
     }
@@ -1880,7 +1880,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -1927,7 +1927,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public FieldReferenceExpression(IFieldSymbol field, bool isDeclaration, IOperation instance, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(field, isDeclaration, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
+            Instance = SetParentOperation(instance, this);
         }
         public override IOperation Instance { get; }
     }
@@ -1944,7 +1944,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyInstance = instance ?? throw new System.ArgumentNullException(nameof(instance));
         }
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
     }
 
     /// <summary>
@@ -1999,8 +1999,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public FixedStatement(IVariableDeclarationGroupOperation variables, IOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Variables = Operation.SetParentOperation(variables, this);
-            Body = Operation.SetParentOperation(body, this);
+            Variables = SetParentOperation(variables, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IVariableDeclarationGroupOperation Variables { get; }
@@ -2022,8 +2022,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IVariableDeclarationGroupOperation Variables => Operation.SetParentOperation(_lazyVariables.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IVariableDeclarationGroupOperation Variables => SetParentOperation(_lazyVariables.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -2092,10 +2092,10 @@ namespace Microsoft.CodeAnalysis.Operations
         public ForEachLoopStatement(ImmutableArray<ILocalSymbol> locals, IOperation loopControlVariable, IOperation collection, ImmutableArray<IOperation> nextVariables, IOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            LoopControlVariable = Operation.SetParentOperation(loopControlVariable, this);
-            Collection = Operation.SetParentOperation(collection, this);
-            NextVariables = Operation.SetParentOperation(nextVariables, this);
-            Body = Operation.SetParentOperation(body, this);
+            LoopControlVariable = SetParentOperation(loopControlVariable, this);
+            Collection = SetParentOperation(collection, this);
+            NextVariables = SetParentOperation(nextVariables, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IOperation LoopControlVariable { get; }
@@ -2123,10 +2123,10 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IOperation LoopControlVariable => Operation.SetParentOperation(_lazyLoopControlVariable.Value, this);
-        public override IOperation Collection => Operation.SetParentOperation(_lazyCollection.Value, this);
-        public override ImmutableArray<IOperation> NextVariables => Operation.SetParentOperation(_lazyNextVariables.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IOperation LoopControlVariable => SetParentOperation(_lazyLoopControlVariable.Value, this);
+        public override IOperation Collection => SetParentOperation(_lazyCollection.Value, this);
+        public override ImmutableArray<IOperation> NextVariables => SetParentOperation(_lazyNextVariables.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -2198,10 +2198,10 @@ namespace Microsoft.CodeAnalysis.Operations
         public ForLoopStatement(ImmutableArray<IOperation> before, IOperation condition, ImmutableArray<IOperation> atLoopBottom, ImmutableArray<ILocalSymbol> locals, IOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Before = Operation.SetParentOperation(before, this);
-            Condition = Operation.SetParentOperation(condition, this);
-            AtLoopBottom = Operation.SetParentOperation(atLoopBottom, this);
-            Body = Operation.SetParentOperation(body, this);
+            Before = SetParentOperation(before, this);
+            Condition = SetParentOperation(condition, this);
+            AtLoopBottom = SetParentOperation(atLoopBottom, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override ImmutableArray<IOperation> Before { get; }
@@ -2229,10 +2229,10 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override ImmutableArray<IOperation> Before => Operation.SetParentOperation(_lazyBefore.Value, this);
-        public override IOperation Condition => Operation.SetParentOperation(_lazyCondition.Value, this);
-        public override ImmutableArray<IOperation> AtLoopBottom => Operation.SetParentOperation(_lazyAtLoopBottom.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override ImmutableArray<IOperation> Before => SetParentOperation(_lazyBefore.Value, this);
+        public override IOperation Condition => SetParentOperation(_lazyCondition.Value, this);
+        public override ImmutableArray<IOperation> AtLoopBottom => SetParentOperation(_lazyAtLoopBottom.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -2321,12 +2321,12 @@ namespace Microsoft.CodeAnalysis.Operations
         public ForToLoopStatement(ImmutableArray<ILocalSymbol> locals, IOperation loopControlVariable, IOperation initialValue, IOperation limitValue, IOperation stepValue, IOperation body, ImmutableArray<IOperation> nextVariables, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            LoopControlVariable = Operation.SetParentOperation(loopControlVariable, this);
-            InitialValue = Operation.SetParentOperation(initialValue, this);
-            LimitValue = Operation.SetParentOperation(limitValue, this);
-            StepValue = Operation.SetParentOperation(stepValue, this);
-            Body = Operation.SetParentOperation(body, this);
-            NextVariables = Operation.SetParentOperation(nextVariables, this);
+            LoopControlVariable = SetParentOperation(loopControlVariable, this);
+            InitialValue = SetParentOperation(initialValue, this);
+            LimitValue = SetParentOperation(limitValue, this);
+            StepValue = SetParentOperation(stepValue, this);
+            Body = SetParentOperation(body, this);
+            NextVariables = SetParentOperation(nextVariables, this);
         }
 
         public override IOperation LoopControlVariable { get; }
@@ -2360,12 +2360,12 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyNextVariables = nextVariables ?? throw new System.ArgumentNullException(nameof(nextVariables));
         }
 
-        public override IOperation LoopControlVariable => Operation.SetParentOperation(_lazyLoopControlVariable.Value, this);
-        public override IOperation InitialValue => Operation.SetParentOperation(_lazyInitialValue.Value, this);
-        public override IOperation LimitValue => Operation.SetParentOperation(_lazyLimitValue.Value, this);
-        public override IOperation StepValue => Operation.SetParentOperation(_lazyStepValue.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
-        public override ImmutableArray<IOperation> NextVariables => Operation.SetParentOperation(_lazyNextVariables.Value, this);
+        public override IOperation LoopControlVariable => SetParentOperation(_lazyLoopControlVariable.Value, this);
+        public override IOperation InitialValue => SetParentOperation(_lazyInitialValue.Value, this);
+        public override IOperation LimitValue => SetParentOperation(_lazyLimitValue.Value, this);
+        public override IOperation StepValue => SetParentOperation(_lazyStepValue.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
+        public override ImmutableArray<IOperation> NextVariables => SetParentOperation(_lazyNextVariables.Value, this);
     }
 
     /// <summary>
@@ -2434,7 +2434,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public IncrementExpression(bool isDecrement, bool isPostfix, bool isLifted, bool isChecked, IOperation target, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(isDecrement, isPostfix, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Target = Operation.SetParentOperation(target, this);
+            Target = SetParentOperation(target, this);
         }
 
         public override IOperation Target { get; }
@@ -2453,7 +2453,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyTarget = target ?? throw new System.ArgumentNullException(nameof(target));
         }
 
-        public override IOperation Target => Operation.SetParentOperation(_lazyTarget.Value, this);
+        public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
     }
 
     /// <summary>
@@ -2527,7 +2527,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public InterpolatedStringExpression(ImmutableArray<IInterpolatedStringContentOperation> parts, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Parts = Operation.SetParentOperation(parts, this);
+            Parts = SetParentOperation(parts, this);
         }
 
         public override ImmutableArray<IInterpolatedStringContentOperation> Parts { get; }
@@ -2546,7 +2546,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyParts = parts;
         }
 
-        public override ImmutableArray<IInterpolatedStringContentOperation> Parts => Operation.SetParentOperation(_lazyParts.Value, this);
+        public override ImmutableArray<IInterpolatedStringContentOperation> Parts => SetParentOperation(_lazyParts.Value, this);
     }
 
     /// <remarks>
@@ -2591,7 +2591,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public InterpolatedStringText(IOperation text, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Text = Operation.SetParentOperation(text, this);
+            Text = SetParentOperation(text, this);
         }
 
         public override IOperation Text { get; }
@@ -2610,7 +2610,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyText = text;
         }
 
-        public override IOperation Text => Operation.SetParentOperation(_lazyText.Value, this);
+        public override IOperation Text => SetParentOperation(_lazyText.Value, this);
     }
 
     /// <remarks>
@@ -2671,9 +2671,9 @@ namespace Microsoft.CodeAnalysis.Operations
         public Interpolation(IOperation expression, IOperation alignment, IOperation formatString, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Expression = Operation.SetParentOperation(expression, this);
-            Alignment = Operation.SetParentOperation(alignment, this);
-            FormatString = Operation.SetParentOperation(formatString, this);
+            Expression = SetParentOperation(expression, this);
+            Alignment = SetParentOperation(alignment, this);
+            FormatString = SetParentOperation(formatString, this);
         }
 
         public override IOperation Expression { get; }
@@ -2698,9 +2698,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyFormatString = formatString;
         }
 
-        public override IOperation Expression => Operation.SetParentOperation(_lazyExpression.Value, this);
-        public override IOperation Alignment => Operation.SetParentOperation(_lazyAlignment.Value, this);
-        public override IOperation FormatString => Operation.SetParentOperation(_lazyFormatString.Value, this);
+        public override IOperation Expression => SetParentOperation(_lazyExpression.Value, this);
+        public override IOperation Alignment => SetParentOperation(_lazyAlignment.Value, this);
+        public override IOperation FormatString => SetParentOperation(_lazyFormatString.Value, this);
     }
 
     /// <remarks>
@@ -2734,7 +2734,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             // we don't allow null children.
             Debug.Assert(children.All(o => o != null));
-            Children = Operation.SetParentOperation(children, this);
+            Children = SetParentOperation(children, this);
         }
         public override IEnumerable<IOperation> Children { get; }
     }
@@ -2754,7 +2754,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Debug.Assert(children.Value.All(o => o != null));
             _lazyChildren = children;
         }
-        public override IEnumerable<IOperation> Children => Operation.SetParentOperation(_lazyChildren.Value, this);
+        public override IEnumerable<IOperation> Children => SetParentOperation(_lazyChildren.Value, this);
     }
 
     /// <summary>
@@ -2823,8 +2823,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public InvocationExpression(IMethodSymbol targetMethod, IOperation instance, bool isVirtual, ImmutableArray<IArgumentOperation> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(targetMethod, isVirtual, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
-            Arguments = Operation.SetParentOperation(arguments, this);
+            Instance = SetParentOperation(instance, this);
+            Arguments = SetParentOperation(arguments, this);
         }
 
         public override IOperation Instance { get; }
@@ -2846,8 +2846,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArguments = arguments;
         }
 
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
-        public override ImmutableArray<IArgumentOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
+        public override ImmutableArray<IArgumentOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <summary>
@@ -2901,8 +2901,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public RaiseEventStatement(IEventReferenceOperation eventReference, ImmutableArray<IArgumentOperation> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            EventReference = Operation.SetParentOperation(eventReference, this);
-            Arguments = Operation.SetParentOperation(arguments, this);
+            EventReference = SetParentOperation(eventReference, this);
+            Arguments = SetParentOperation(arguments, this);
         }
 
         public override IEventReferenceOperation EventReference { get; }
@@ -2924,8 +2924,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArguments = arguments;
         }
 
-        public override IEventReferenceOperation EventReference => Operation.SetParentOperation(_lazyEventReference.Value, this);
-        public override ImmutableArray<IArgumentOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IEventReferenceOperation EventReference => SetParentOperation(_lazyEventReference.Value, this);
+        public override ImmutableArray<IArgumentOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <summary>
@@ -2981,7 +2981,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public IsTypeExpression(IOperation valueOperand, ITypeSymbol typeOperand, bool isNegated, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(typeOperand, isNegated, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ValueOperand = Operation.SetParentOperation(valueOperand, this);
+            ValueOperand = SetParentOperation(valueOperand, this);
         }
 
         public override IOperation ValueOperand { get; }
@@ -3000,7 +3000,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperand = operand ?? throw new System.ArgumentNullException(nameof(operand));
         }
 
-        public override IOperation ValueOperand => Operation.SetParentOperation(_lazyOperand.Value, this);
+        public override IOperation ValueOperand => SetParentOperation(_lazyOperand.Value, this);
     }
 
     /// <summary>
@@ -3049,7 +3049,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public LabeledStatement(ILabelSymbol label, IOperation operation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(label, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
+            Operation = SetParentOperation(operation, this);
         }
 
         public override IOperation Operation { get; }
@@ -3068,7 +3068,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
         }
 
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
     }
 
     internal abstract partial class BaseAnonymousFunctionExpression : Operation, IAnonymousFunctionOperation
@@ -3105,7 +3105,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public AnonymousFunctionExpression(IMethodSymbol symbol, IBlockOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Body = Operation.SetParentOperation(body, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IBlockOperation Body { get; }
@@ -3121,7 +3121,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IBlockOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IBlockOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     internal abstract partial class BaseDelegateCreationExpression : Operation, IDelegateCreationOperation
@@ -3159,7 +3159,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public DelegateCreationExpression(IOperation target, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Target = Operation.SetParentOperation(target, this);
+            Target = SetParentOperation(target, this);
         }
 
         public override IOperation Target { get; }
@@ -3174,7 +3174,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyTarget = lazyTarget;
         }
 
-        public override IOperation Target => Operation.SetParentOperation(_lazyTarget.Value, this);
+        public override IOperation Target => SetParentOperation(_lazyTarget.Value, this);
     }
 
     /// <summary>
@@ -3236,7 +3236,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public DynamicMemberReferenceExpression(IOperation instance, string memberName, ImmutableArray<ITypeSymbol> typeArguments, ITypeSymbol containingType, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(memberName, typeArguments, containingType, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
+            Instance = SetParentOperation(instance, this);
         }
 
         public override IOperation Instance { get; }
@@ -3255,7 +3255,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInstance = lazyInstance;
         }
 
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
     }
 
     /// <summary>
@@ -3367,8 +3367,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public LockStatement(IOperation lockedValue, IOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            LockedValue = Operation.SetParentOperation(lockedValue, this);
-            Body = Operation.SetParentOperation(body, this);
+            LockedValue = SetParentOperation(lockedValue, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IOperation LockedValue { get; }
@@ -3390,8 +3390,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IOperation LockedValue => Operation.SetParentOperation(_lazyLockedValue.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IOperation LockedValue => SetParentOperation(_lazyLockedValue.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -3489,7 +3489,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public MethodReferenceExpression(IMethodSymbol method, bool isVirtual, IOperation instance, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(method, isVirtual, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
+            Instance = SetParentOperation(instance, this);
         }
         /// <summary>
         /// Instance of the type. Null if the reference is to a static/shared member.
@@ -3509,7 +3509,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyInstance = instance ?? throw new System.ArgumentNullException(nameof(instance));
         }
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
     }
 
     /// <summary>
@@ -3566,8 +3566,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public CoalesceExpression(IOperation value, IOperation whenNull, IConvertibleConversion convertibleValueConversion, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(convertibleValueConversion, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
-            WhenNull = Operation.SetParentOperation(whenNull, this);
+            Value = SetParentOperation(value, this);
+            WhenNull = SetParentOperation(whenNull, this);
         }
 
         public override IOperation Value { get; }
@@ -3589,8 +3589,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyWhenNull = whenNull ?? throw new System.ArgumentNullException(nameof(whenNull));
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
-        public override IOperation WhenNull => Operation.SetParentOperation(_lazyWhenNull.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
+        public override IOperation WhenNull => SetParentOperation(_lazyWhenNull.Value, this);
     }
 
     /// <summary>
@@ -3654,8 +3654,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public ObjectCreationExpression(IMethodSymbol constructor, IObjectOrCollectionInitializerOperation initializer, ImmutableArray<IArgumentOperation> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(constructor, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Initializer = Operation.SetParentOperation(initializer, this);
-            Arguments = Operation.SetParentOperation(arguments, this);
+            Initializer = SetParentOperation(initializer, this);
+            Arguments = SetParentOperation(arguments, this);
         }
 
         public override IObjectOrCollectionInitializerOperation Initializer { get; }
@@ -3677,8 +3677,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArguments = arguments;
         }
 
-        public override IObjectOrCollectionInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
-        public override ImmutableArray<IArgumentOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IObjectOrCollectionInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
+        public override ImmutableArray<IArgumentOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
 
     }
 
@@ -3727,7 +3727,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public AnonymousObjectCreationExpression(ImmutableArray<IOperation> initializers, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Initializers = Operation.SetParentOperation(initializers, this);
+            Initializers = SetParentOperation(initializers, this);
         }
 
         public override ImmutableArray<IOperation> Initializers { get; }
@@ -3746,7 +3746,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInitializers = initializers;
         }
 
-        public override ImmutableArray<IOperation> Initializers => Operation.SetParentOperation(_lazyInitializers.Value, this);
+        public override ImmutableArray<IOperation> Initializers => SetParentOperation(_lazyInitializers.Value, this);
     }
 
     /// <summary>
@@ -3818,7 +3818,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ParameterInitializer(IParameterSymbol parameter, IOperation value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(parameter, kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Value { get; }
     }
@@ -3835,7 +3835,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -3911,7 +3911,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ParenthesizedExpression(IOperation operand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operand = Operation.SetParentOperation(operand, this);
+            Operand = SetParentOperation(operand, this);
         }
 
         public override IOperation Operand { get; }
@@ -3930,7 +3930,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperand = operand ?? throw new System.ArgumentNullException(nameof(operand));
         }
 
-        public override IOperation Operand => Operation.SetParentOperation(_lazyOperand.Value, this);
+        public override IOperation Operand => SetParentOperation(_lazyOperand.Value, this);
     }
 
     /// <summary>
@@ -4006,7 +4006,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public PointerIndirectionReferenceExpression(IOperation pointer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Pointer = Operation.SetParentOperation(pointer, this);
+            Pointer = SetParentOperation(pointer, this);
         }
 
         public override IOperation Pointer { get; }
@@ -4025,7 +4025,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyPointer = pointer ?? throw new System.ArgumentNullException(nameof(pointer));
         }
 
-        public override IOperation Pointer => Operation.SetParentOperation(_lazyPointer.Value, this);
+        public override IOperation Pointer => SetParentOperation(_lazyPointer.Value, this);
     }
 
     /// <summary>
@@ -4071,7 +4071,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public PropertyInitializer(ImmutableArray<IPropertySymbol> initializedProperties, IOperation value, OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(initializedProperties, kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
         public override IOperation Value { get; }
     }
@@ -4088,7 +4088,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -4148,8 +4148,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public PropertyReferenceExpression(IPropertySymbol property, IOperation instance, ImmutableArray<IArgumentOperation> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(property, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Instance = Operation.SetParentOperation(instance, this);
-            Arguments = Operation.SetParentOperation(arguments, this);
+            Instance = SetParentOperation(instance, this);
+            Arguments = SetParentOperation(arguments, this);
         }
         public override IOperation Instance { get; }
         public override ImmutableArray<IArgumentOperation> Arguments { get; }
@@ -4169,8 +4169,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInstance = instance ?? throw new System.ArgumentNullException(nameof(instance));
             _lazyArguments = arguments ?? throw new System.ArgumentNullException(nameof(arguments));
         }
-        public override IOperation Instance => Operation.SetParentOperation(_lazyInstance.Value, this);
-        public override ImmutableArray<IArgumentOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IOperation Instance => SetParentOperation(_lazyInstance.Value, this);
+        public override ImmutableArray<IArgumentOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <summary>
@@ -4223,8 +4223,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public RangeCaseClause(IOperation minimumValue, IOperation maximumValue, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            MinimumValue = Operation.SetParentOperation(minimumValue, this);
-            MaximumValue = Operation.SetParentOperation(maximumValue, this);
+            MinimumValue = SetParentOperation(minimumValue, this);
+            MaximumValue = SetParentOperation(maximumValue, this);
         }
 
         public override IOperation MinimumValue { get; }
@@ -4246,8 +4246,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyMaximumValue = maximumValue ?? throw new System.ArgumentNullException(nameof(maximumValue));
         }
 
-        public override IOperation MinimumValue => Operation.SetParentOperation(_lazyMinimumValue.Value, this);
-        public override IOperation MaximumValue => Operation.SetParentOperation(_lazyMaximumValue.Value, this);
+        public override IOperation MinimumValue => SetParentOperation(_lazyMinimumValue.Value, this);
+        public override IOperation MaximumValue => SetParentOperation(_lazyMaximumValue.Value, this);
     }
 
     /// <summary>
@@ -4298,7 +4298,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public RelationalCaseClause(IOperation value, BinaryOperatorKind relation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(relation, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Value { get; }
@@ -4317,7 +4317,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -4365,7 +4365,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ReturnStatement(OperationKind kind, IOperation returnedValue, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ReturnedValue = Operation.SetParentOperation(returnedValue, this);
+            ReturnedValue = SetParentOperation(returnedValue, this);
         }
 
         public override IOperation ReturnedValue { get; }
@@ -4384,7 +4384,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyReturnedValue = returnedValue ?? throw new System.ArgumentNullException(nameof(returnedValue));
         }
 
-        public override IOperation ReturnedValue => Operation.SetParentOperation(_lazyReturnedValue.Value, this);
+        public override IOperation ReturnedValue => SetParentOperation(_lazyReturnedValue.Value, this);
     }
 
     /// <summary>
@@ -4430,7 +4430,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public SingleValueCaseClause(IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Value { get; }
@@ -4449,7 +4449,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -4591,8 +4591,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public SwitchCase(ImmutableArray<ICaseClauseOperation> clauses, ImmutableArray<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Clauses = Operation.SetParentOperation(clauses, this);
-            Body = Operation.SetParentOperation(body, this);
+            Clauses = SetParentOperation(clauses, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override ImmutableArray<ICaseClauseOperation> Clauses { get; }
@@ -4614,8 +4614,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body;
         }
 
-        public override ImmutableArray<ICaseClauseOperation> Clauses => Operation.SetParentOperation(_lazyClauses.Value, this);
-        public override ImmutableArray<IOperation> Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override ImmutableArray<ICaseClauseOperation> Clauses => SetParentOperation(_lazyClauses.Value, this);
+        public override ImmutableArray<IOperation> Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -4671,8 +4671,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public SwitchStatement(IOperation value, ImmutableArray<ISwitchCaseOperation> cases, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
-            Cases = Operation.SetParentOperation(cases, this);
+            Value = SetParentOperation(value, this);
+            Cases = SetParentOperation(cases, this);
         }
 
         public override IOperation Value { get; }
@@ -4694,8 +4694,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyCases = cases;
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
-        public override ImmutableArray<ISwitchCaseOperation> Cases => Operation.SetParentOperation(_lazyCases.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
+        public override ImmutableArray<ISwitchCaseOperation> Cases => SetParentOperation(_lazyCases.Value, this);
     }
 
     /// <summary>
@@ -4771,9 +4771,9 @@ namespace Microsoft.CodeAnalysis.Operations
         public TryStatement(IBlockOperation body, ImmutableArray<ICatchClauseOperation> catches, IBlockOperation finallyHandler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Body = Operation.SetParentOperation(body, this);
-            Catches = Operation.SetParentOperation(catches, this);
-            Finally = Operation.SetParentOperation(finallyHandler, this);
+            Body = SetParentOperation(body, this);
+            Catches = SetParentOperation(catches, this);
+            Finally = SetParentOperation(finallyHandler, this);
         }
 
         public override IBlockOperation Body { get; }
@@ -4798,9 +4798,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyFinallyHandler = finallyHandler ?? throw new System.ArgumentNullException(nameof(finallyHandler));
         }
 
-        public override IBlockOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
-        public override ImmutableArray<ICatchClauseOperation> Catches => Operation.SetParentOperation(_lazyCatches.Value, this);
-        public override IBlockOperation Finally => Operation.SetParentOperation(_lazyFinallyHandler.Value, this);
+        public override IBlockOperation Body => SetParentOperation(_lazyBody.Value, this);
+        public override ImmutableArray<ICatchClauseOperation> Catches => SetParentOperation(_lazyCatches.Value, this);
+        public override IBlockOperation Finally => SetParentOperation(_lazyFinallyHandler.Value, this);
     }
 
     /// <summary>
@@ -4856,7 +4856,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public TupleExpression(ImmutableArray<IOperation> elements, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ITypeSymbol naturalType, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, naturalType, constantValue, isImplicit)
         {
-            Elements = Operation.SetParentOperation(elements, this);
+            Elements = SetParentOperation(elements, this);
         }
 
         public override ImmutableArray<IOperation> Elements { get; }
@@ -4875,7 +4875,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyElements = elements;
         }
 
-        public override ImmutableArray<IOperation> Elements => Operation.SetParentOperation(_lazyElements.Value, this);
+        public override ImmutableArray<IOperation> Elements => SetParentOperation(_lazyElements.Value, this);
     }
 
     /// <summary>
@@ -4950,7 +4950,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public TypeParameterObjectCreationExpression(IObjectOrCollectionInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Initializer = Operation.SetParentOperation(initializer, this);
+            Initializer = SetParentOperation(initializer, this);
         }
         public override IObjectOrCollectionInitializerOperation Initializer { get; }
     }
@@ -4966,7 +4966,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyInitializer = initializer ?? throw new System.ArgumentNullException(nameof(initializer));
         }
-        public override IObjectOrCollectionInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
+        public override IObjectOrCollectionInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
     }
 
     /// <remarks>
@@ -5043,8 +5043,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public DynamicObjectCreationExpression(ImmutableArray<IOperation> arguments, ImmutableArray<string> argumentNames, ImmutableArray<RefKind> argumentRefKinds, IObjectOrCollectionInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(argumentNames, argumentRefKinds, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Arguments = Operation.SetParentOperation(arguments, this);
-            Initializer = Operation.SetParentOperation(initializer, this);
+            Arguments = SetParentOperation(arguments, this);
+            Initializer = SetParentOperation(initializer, this);
         }
         public override ImmutableArray<IOperation> Arguments { get; }
         public override IObjectOrCollectionInitializerOperation Initializer { get; }
@@ -5063,8 +5063,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArguments = arguments ?? throw new System.ArgumentNullException(nameof(arguments));
             _lazyInitializer = initializer ?? throw new System.ArgumentNullException(nameof(initializer));
         }
-        public override ImmutableArray<IOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
-        public override IObjectOrCollectionInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
+        public override ImmutableArray<IOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
+        public override IObjectOrCollectionInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
     }
 
     /// <remarks>
@@ -5115,8 +5115,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public DynamicInvocationExpression(IOperation operation, ImmutableArray<IOperation> arguments, ImmutableArray<string> argumentNames, ImmutableArray<RefKind> argumentRefKinds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(argumentNames, argumentRefKinds, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
-            Arguments = Microsoft.CodeAnalysis.Operation.SetParentOperation(arguments, this);
+            Operation = SetParentOperation(operation, this);
+            Arguments = SetParentOperation(arguments, this);
         }
         public override IOperation Operation { get; }
         public override ImmutableArray<IOperation> Arguments { get; }
@@ -5135,8 +5135,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
             _lazyArguments = arguments ?? throw new System.ArgumentNullException(nameof(arguments));
         }
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
-        public override ImmutableArray<IOperation> Arguments => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
+        public override ImmutableArray<IOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <remarks>
@@ -5187,8 +5187,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public DynamicIndexerAccessExpression(IOperation operation, ImmutableArray<IOperation> arguments, ImmutableArray<string> argumentNames, ImmutableArray<RefKind> argumentRefKinds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(argumentNames, argumentRefKinds, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
-            Arguments = Microsoft.CodeAnalysis.Operation.SetParentOperation(arguments, this);
+            Operation = SetParentOperation(operation, this);
+            Arguments = SetParentOperation(arguments, this);
         }
         public override IOperation Operation { get; }
         public override ImmutableArray<IOperation> Arguments { get; }
@@ -5207,8 +5207,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
             _lazyArguments = arguments ?? throw new System.ArgumentNullException(nameof(arguments));
         }
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
-        public override ImmutableArray<IOperation> Arguments => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
+        public override ImmutableArray<IOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <summary>
@@ -5275,7 +5275,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public UnaryOperatorExpression(UnaryOperatorKind unaryOperationKind, IOperation operand, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(unaryOperationKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operand = Operation.SetParentOperation(operand, this);
+            Operand = SetParentOperation(operand, this);
         }
 
         public override IOperation Operand { get; }
@@ -5294,7 +5294,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyOperand = operand ?? throw new System.ArgumentNullException(nameof(operand));
         }
 
-        public override IOperation Operand => Operation.SetParentOperation(_lazyOperand.Value, this);
+        public override IOperation Operand => SetParentOperation(_lazyOperand.Value, this);
     }
 
     /// <summary>
@@ -5349,8 +5349,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public UsingStatement(IOperation resources, IOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Resources = Operation.SetParentOperation(resources, this);
-            Body = Operation.SetParentOperation(body, this);
+            Resources = SetParentOperation(resources, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IOperation Resources { get; }
@@ -5372,8 +5372,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IOperation Resources => Operation.SetParentOperation(_lazyResources.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IOperation Resources => SetParentOperation(_lazyResources.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     internal abstract partial class BaseVariableDeclarator : Operation, IVariableDeclaratorOperation
@@ -5425,8 +5425,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public VariableDeclarator(ILocalSymbol symbol, IVariableInitializerOperation initializer, ImmutableArray<IOperation> ignoredArguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Initializer = Operation.SetParentOperation(initializer, this);
-            IgnoredArguments = Operation.SetParentOperation(ignoredArguments, this);
+            Initializer = SetParentOperation(initializer, this);
+            IgnoredArguments = SetParentOperation(ignoredArguments, this);
         }
 
         public override IVariableInitializerOperation Initializer { get; }
@@ -5448,8 +5448,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyIgnoredArguments = ignoredArguments ?? throw new ArgumentNullException(nameof(ignoredArguments));
         }
 
-        public override IVariableInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
-        public override ImmutableArray<IOperation> IgnoredArguments => Operation.SetParentOperation(_lazyIgnoredArguments.Value, this);
+        public override IVariableInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
+        public override ImmutableArray<IOperation> IgnoredArguments => SetParentOperation(_lazyIgnoredArguments.Value, this);
     }
 
     internal abstract partial class BaseVariableDeclaration : Operation, IVariableDeclarationOperation
@@ -5498,8 +5498,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public VariableDeclaration(ImmutableArray<IVariableDeclaratorOperation> declarations, IVariableInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Declarators = Operation.SetParentOperation(declarations, this);
-            Initializer = Operation.SetParentOperation(initializer, this);
+            Declarators = SetParentOperation(declarations, this);
+            Initializer = SetParentOperation(initializer, this);
         }
 
         public override ImmutableArray<IVariableDeclaratorOperation> Declarators { get; }
@@ -5518,8 +5518,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInitializer = initializer;
         }
 
-        public override ImmutableArray<IVariableDeclaratorOperation> Declarators => Operation.SetParentOperation(_lazyDeclarators.Value, this);
-        public override IVariableInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
+        public override ImmutableArray<IVariableDeclaratorOperation> Declarators => SetParentOperation(_lazyDeclarators.Value, this);
+        public override IVariableInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
     }
 
     /// <summary>
@@ -5567,7 +5567,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public VariableDeclarationGroupOperation(ImmutableArray<IVariableDeclarationOperation> declarations, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Declarations = Operation.SetParentOperation(declarations, this);
+            Declarations = SetParentOperation(declarations, this);
         }
 
         public override ImmutableArray<IVariableDeclarationOperation> Declarations { get; }
@@ -5586,7 +5586,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyDeclarations = declarations;
         }
 
-        public override ImmutableArray<IVariableDeclarationOperation> Declarations => Operation.SetParentOperation(_lazyDeclarations.Value, this);
+        public override ImmutableArray<IVariableDeclarationOperation> Declarations => SetParentOperation(_lazyDeclarations.Value, this);
     }
 
     /// <summary>
@@ -5679,9 +5679,9 @@ namespace Microsoft.CodeAnalysis.Operations
         public WhileLoopStatement(IOperation condition, IOperation body, IOperation ignoredCondition, ImmutableArray<ILocalSymbol> locals, bool conditionIsTop, bool conditionIsUntil, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(locals, conditionIsTop, conditionIsUntil, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Condition = Operation.SetParentOperation(condition, this);
-            Body = Operation.SetParentOperation(body, this);
-            IgnoredCondition = Operation.SetParentOperation(ignoredCondition, this);
+            Condition = SetParentOperation(condition, this);
+            Body = SetParentOperation(body, this);
+            IgnoredCondition = SetParentOperation(ignoredCondition, this);
         }
         public override IOperation Condition { get; }
         public override IOperation Body { get; }
@@ -5709,9 +5709,9 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
             _lazyIgnoredCondition = ignoredCondition ?? throw new System.ArgumentNullException(nameof(ignoredCondition));
         }
-        public override IOperation Condition => Operation.SetParentOperation(_lazyCondition.Value, this);
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
-        public override IOperation IgnoredCondition => Operation.SetParentOperation(_lazyIgnoredCondition.Value, this);
+        public override IOperation Condition => SetParentOperation(_lazyCondition.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
+        public override IOperation IgnoredCondition => SetParentOperation(_lazyIgnoredCondition.Value, this);
     }
 
     /// <summary>
@@ -5765,8 +5765,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public WithStatement(IOperation body, IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Body = Operation.SetParentOperation(body, this);
-            Value = Operation.SetParentOperation(value, this);
+            Body = SetParentOperation(body, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Body { get; }
@@ -5788,8 +5788,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
 
-        public override IOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Body => SetParentOperation(_lazyBody.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -5838,7 +5838,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public LocalFunctionStatement(IMethodSymbol symbol, IBlockOperation body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Body = Operation.SetParentOperation(body, this);
+            Body = SetParentOperation(body, this);
         }
 
         public override IBlockOperation Body { get; }
@@ -5857,7 +5857,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
 
-        public override IBlockOperation Body => Operation.SetParentOperation(_lazyBody.Value, this);
+        public override IBlockOperation Body => SetParentOperation(_lazyBody.Value, this);
     }
 
     /// <summary>
@@ -5902,7 +5902,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ConstantPattern(IOperation value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
 
         public override IOperation Value { get; }
@@ -5921,7 +5921,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
     }
 
     /// <summary>
@@ -6009,8 +6009,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public PatternCaseClause(ILabelSymbol label, IPatternOperation pattern, IOperation guardExpression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(label, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Pattern = Operation.SetParentOperation(pattern, this);
-            Guard = Operation.SetParentOperation(guardExpression, this);
+            Pattern = SetParentOperation(pattern, this);
+            Guard = SetParentOperation(guardExpression, this);
         }
 
         public override IPatternOperation Pattern { get; }
@@ -6032,8 +6032,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyGuardExpression = lazyGuardExpression ?? throw new System.ArgumentNullException(nameof(lazyGuardExpression));
         }
 
-        public override IPatternOperation Pattern => Operation.SetParentOperation(_lazyPattern.Value, this);
-        public override IOperation Guard => Operation.SetParentOperation(_lazyGuardExpression.Value, this);
+        public override IPatternOperation Pattern => SetParentOperation(_lazyPattern.Value, this);
+        public override IOperation Guard => SetParentOperation(_lazyGuardExpression.Value, this);
     }
 
     /// <summary>
@@ -6086,8 +6086,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public IsPatternExpression(IOperation value, IPatternOperation pattern, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Value = Operation.SetParentOperation(value, this);
-            Pattern = Operation.SetParentOperation(pattern, this);
+            Value = SetParentOperation(value, this);
+            Pattern = SetParentOperation(pattern, this);
         }
 
         public override IOperation Value { get; }
@@ -6109,8 +6109,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyPattern = lazyPattern ?? throw new System.ArgumentNullException(nameof(lazyPattern));
         }
 
-        public override IOperation Value => Operation.SetParentOperation(_lazyValue.Value, this);
-        public override IPatternOperation Pattern => Operation.SetParentOperation(_lazyPattern.Value, this);
+        public override IOperation Value => SetParentOperation(_lazyValue.Value, this);
+        public override IPatternOperation Pattern => SetParentOperation(_lazyPattern.Value, this);
     }
 
     /// <summary>
@@ -6158,7 +6158,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public ObjectOrCollectionInitializerExpression(ImmutableArray<IOperation> initializers, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Initializers = Operation.SetParentOperation(initializers, this);
+            Initializers = SetParentOperation(initializers, this);
         }
 
         public override ImmutableArray<IOperation> Initializers { get; }
@@ -6177,7 +6177,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInitializers = initializers ?? throw new System.ArgumentNullException(nameof(initializers));
         }
 
-        public override ImmutableArray<IOperation> Initializers => Operation.SetParentOperation(_lazyInitializers.Value, this);
+        public override ImmutableArray<IOperation> Initializers => SetParentOperation(_lazyInitializers.Value, this);
     }
 
     /// <summary>
@@ -6231,8 +6231,8 @@ namespace Microsoft.CodeAnalysis.Operations
         public MemberInitializerExpression(IOperation initializedMember, IObjectOrCollectionInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            InitializedMember = Operation.SetParentOperation(initializedMember, this);
-            Initializer = Operation.SetParentOperation(initializer, this);
+            InitializedMember = SetParentOperation(initializedMember, this);
+            Initializer = SetParentOperation(initializer, this);
         }
 
         public override IOperation InitializedMember { get; }
@@ -6254,8 +6254,8 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyInitializer = initializer ?? throw new System.ArgumentNullException(nameof(initializer));
         }
 
-        public override IOperation InitializedMember => Operation.SetParentOperation(_lazyInitializedMember.Value, this);
-        public override IObjectOrCollectionInitializerOperation Initializer => Operation.SetParentOperation(_lazyInitializer.Value, this);
+        public override IOperation InitializedMember => SetParentOperation(_lazyInitializedMember.Value, this);
+        public override IObjectOrCollectionInitializerOperation Initializer => SetParentOperation(_lazyInitializer.Value, this);
     }
 
     /// <summary>
@@ -6312,7 +6312,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public CollectionElementInitializerExpression(IMethodSymbol addMethod, bool isDynamic, ImmutableArray<IOperation> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(addMethod, isDynamic, semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Arguments = Operation.SetParentOperation(arguments, this);
+            Arguments = SetParentOperation(arguments, this);
         }
 
         public override ImmutableArray<IOperation> Arguments { get; }
@@ -6331,7 +6331,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArguments = arguments ?? throw new System.ArgumentNullException(nameof(arguments));
         }
 
-        public override ImmutableArray<IOperation> Arguments => Operation.SetParentOperation(_lazyArguments.Value, this);
+        public override ImmutableArray<IOperation> Arguments => SetParentOperation(_lazyArguments.Value, this);
     }
 
     /// <summary>
@@ -6385,7 +6385,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public TranslatedQueryExpression(IOperation operation, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            Operation = Microsoft.CodeAnalysis.Operation.SetParentOperation(operation, this);
+            Operation = SetParentOperation(operation, this);
         }
         public override IOperation Operation { get; }
     }
@@ -6407,7 +6407,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             _lazyOperation = operation ?? throw new System.ArgumentNullException(nameof(operation));
         }
-        public override IOperation Operation => Microsoft.CodeAnalysis.Operation.SetParentOperation(_lazyOperation.Value, this);
+        public override IOperation Operation => SetParentOperation(_lazyOperation.Value, this);
     }
 
     internal sealed partial class FlowCaptureReference : Operation, IFlowCaptureReferenceOperation
@@ -6445,7 +6445,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             Debug.Assert(value != null);
             Id = id;
-            Value = Operation.SetParentOperation(value, this);
+            Value = SetParentOperation(value, this);
         }
 
         public int Id { get; }

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -17,8 +17,6 @@ namespace Microsoft.CodeAnalysis.Operations
             base(OperationKind.AddressOf, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
-
-        protected abstract IOperation ReferenceImpl { get; }
         public override IEnumerable<IOperation> Children
         {
             get
@@ -32,7 +30,8 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Addressed reference.
         /// </summary>
-        public IOperation Reference => Operation.SetParentOperation(ReferenceImpl, this);
+        public abstract IOperation Reference { get; }
+
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitAddressOf(this);
@@ -50,10 +49,10 @@ namespace Microsoft.CodeAnalysis.Operations
         public AddressOfExpression(IOperation reference, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ReferenceImpl = reference;
+            Reference = Operation.SetParentOperation(reference, this);
         }
 
-        protected override IOperation ReferenceImpl { get; }
+        public override IOperation Reference { get; }
     }
     /// <summary>
     /// Represents an operation that creates a pointer value by taking the address of a reference.
@@ -62,12 +61,13 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyReference;
 
-        public LazyAddressOfExpression(Lazy<IOperation> reference, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyAddressOfExpression(Lazy<IOperation> reference, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyReference = reference ?? throw new System.ArgumentNullException(nameof(reference));
         }
 
-        protected override IOperation ReferenceImpl => _lazyReference.Value;
+        public override IOperation Reference => Operation.SetParentOperation(_lazyReference.Value, this);
     }
 
     /// <summary>
@@ -76,11 +76,10 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseNameOfExpression : Operation, INameOfOperation
     {
         protected BaseNameOfExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.NameOf, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.NameOf, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
-        protected abstract IOperation ArgumentImpl { get; }
         public override IEnumerable<IOperation> Children
         {
             get
@@ -94,7 +93,8 @@ namespace Microsoft.CodeAnalysis.Operations
         /// <summary>
         /// Argument to name of expression.
         /// </summary>
-        public IOperation Argument => Operation.SetParentOperation(ArgumentImpl, this);
+        public abstract IOperation Argument { get; }
+
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitNameOf(this);
@@ -112,10 +112,10 @@ namespace Microsoft.CodeAnalysis.Operations
         public NameOfExpression(IOperation argument, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
         {
-            ArgumentImpl = argument;
+            Argument = Operation.SetParentOperation(argument, this);
         }
 
-        protected override IOperation ArgumentImpl { get; }
+        public override IOperation Argument { get; }
     }
     /// <summary>
     /// Represents C# nameof and VB NameOf expression.
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Operations
             _lazyArgument = argument ?? throw new System.ArgumentNullException(nameof(argument));
         }
 
-        protected override IOperation ArgumentImpl => _lazyArgument.Value;
+        public override IOperation Argument => Operation.SetParentOperation(_lazyArgument.Value, this);
     }
 
     /// <summary>
@@ -201,8 +201,8 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal abstract partial class BaseArgument : Operation, IArgumentOperation
     {
-        protected BaseArgument(ArgumentKind argumentKind, IParameterSymbol parameter, IConvertibleConversion inConversion, IConvertibleConversion outConversion,  SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Argument, semanticModel, syntax, type: null, constantValue: constantValue, isImplicit: isImplicit)
+        protected BaseArgument(ArgumentKind argumentKind, IParameterSymbol parameter, IConvertibleConversion inConversion, IConvertibleConversion outConversion, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
+            base(OperationKind.Argument, semanticModel, syntax, type: null, constantValue: constantValue, isImplicit: isImplicit)
         {
             ArgumentKind = argumentKind;
             Parameter = parameter;
@@ -248,7 +248,8 @@ namespace Microsoft.CodeAnalysis.Operations
 
     internal sealed partial class ArgumentOperation : BaseArgument
     {
-        public ArgumentOperation(IOperation value, ArgumentKind argumentKind, IParameterSymbol parameter, IConvertibleConversion inConversion, IConvertibleConversion outConversion, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) : base(argumentKind, parameter, inConversion, outConversion, semanticModel, syntax, constantValue, isImplicit)
+        public ArgumentOperation(IOperation value, ArgumentKind argumentKind, IParameterSymbol parameter, IConvertibleConversion inConversion, IConvertibleConversion outConversion, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
+            base(argumentKind, parameter, inConversion, outConversion, semanticModel, syntax, constantValue, isImplicit)
         {
             ValueImpl = value;
         }
@@ -260,7 +261,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyValue;
 
-        public LazyArgumentOperation(Lazy<IOperation> value, ArgumentKind argumentKind, IConvertibleConversion inConversion, IConvertibleConversion outConversion, IParameterSymbol parameter, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) : base(argumentKind, parameter, inConversion, outConversion, semanticModel, syntax, constantValue, isImplicit)
+        public LazyArgumentOperation(Lazy<IOperation> value, ArgumentKind argumentKind, IConvertibleConversion inConversion, IConvertibleConversion outConversion, IParameterSymbol parameter, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
+            base(argumentKind, parameter, inConversion, outConversion, semanticModel, syntax, constantValue, isImplicit)
         {
             _lazyValue = value;
         }
@@ -274,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseArrayCreationExpression : Operation, IArrayCreationOperation
     {
         protected BaseArrayCreationExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ArrayCreation, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ArrayCreation, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
         protected abstract ImmutableArray<IOperation> DimensionSizesImpl { get; }
@@ -338,8 +340,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<ImmutableArray<IOperation>> _lazyDimensionSizes;
         private readonly Lazy<IArrayInitializerOperation> _lazyInitializer;
 
-        public LazyArrayCreationExpression(Lazy<ImmutableArray<IOperation>> dimensionSizes, Lazy<IArrayInitializerOperation> initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyArrayCreationExpression(Lazy<ImmutableArray<IOperation>> dimensionSizes, Lazy<IArrayInitializerOperation> initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyDimensionSizes = dimensionSizes;
             _lazyInitializer = initializer ?? throw new System.ArgumentNullException(nameof(initializer));
@@ -422,7 +424,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyArrayReference;
         private readonly Lazy<ImmutableArray<IOperation>> _lazyIndices;
 
-        public LazyArrayElementReferenceExpression(Lazy<IOperation> arrayReference, Lazy<ImmutableArray<IOperation>> indices, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyArrayElementReferenceExpression(Lazy<IOperation> arrayReference, Lazy<ImmutableArray<IOperation>> indices, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyArrayReference = arrayReference ?? throw new System.ArgumentNullException(nameof(arrayReference));
             _lazyIndices = indices;
@@ -439,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseArrayInitializer : Operation, IArrayInitializerOperation
     {
         protected BaseArrayInitializer(SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ArrayInitializer, semanticModel, syntax, type: null, constantValue: constantValue, isImplicit: isImplicit)
+            base(OperationKind.ArrayInitializer, semanticModel, syntax, type: null, constantValue: constantValue, isImplicit: isImplicit)
         {
         }
 
@@ -492,7 +495,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<ImmutableArray<IOperation>> _lazyElementValues;
 
-        public LazyArrayInitializer(Lazy<ImmutableArray<IOperation>> elementValues, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, constantValue, isImplicit)
+        public LazyArrayInitializer(Lazy<ImmutableArray<IOperation>> elementValues, SemanticModel semanticModel, SyntaxNode syntax, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, constantValue, isImplicit)
         {
             _lazyElementValues = elementValues;
         }
@@ -778,7 +782,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyExpression;
 
-        public LazyAwaitExpression(Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyAwaitExpression(Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyExpression = expression ?? throw new System.ArgumentNullException(nameof(expression));
         }
@@ -792,7 +797,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseBinaryOperatorExpression : Operation, IBinaryOperation
     {
         protected BaseBinaryOperatorExpression(BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, bool isCompareText, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.BinaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.BinaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
         {
             OperatorKind = operatorKind;
             IsLifted = isLifted;
@@ -899,7 +904,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseBlockStatement : Operation, IBlockOperation
     {
         protected BaseBlockStatement(ImmutableArray<ILocalSymbol> locals, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Block, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Block, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Locals = locals;
         }
@@ -957,7 +962,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<ImmutableArray<IOperation>> _lazyStatements;
 
-        public LazyBlockStatement(Lazy<ImmutableArray<IOperation>> statements, ImmutableArray<ILocalSymbol> locals, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(locals, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyBlockStatement(Lazy<ImmutableArray<IOperation>> statements, ImmutableArray<ILocalSymbol> locals, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyStatements = statements;
         }
@@ -1111,8 +1117,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyFilter;
         private readonly Lazy<IBlockOperation> _lazyHandler;
 
-        public LazyCatchClause(Lazy<IOperation> exceptionDeclarationOrExpression, ITypeSymbol exceptionType, ImmutableArray<ILocalSymbol> locals, Lazy<IOperation> filter, Lazy<IBlockOperation> handler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(exceptionType, locals, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyCatchClause(Lazy<IOperation> exceptionDeclarationOrExpression, ITypeSymbol exceptionType, ImmutableArray<ILocalSymbol> locals, Lazy<IOperation> filter, Lazy<IBlockOperation> handler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(exceptionType, locals, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyExceptionDeclarationOrExpression = exceptionDeclarationOrExpression ?? throw new System.ArgumentNullException(nameof(exceptionDeclarationOrExpression));
             _lazyFilter = filter ?? throw new System.ArgumentNullException(nameof(filter));
@@ -1172,7 +1178,8 @@ namespace Microsoft.CodeAnalysis.Operations
 
     internal sealed partial class CompoundAssignmentOperation : BaseCompoundAssignmentExpression
     {
-        public CompoundAssignmentOperation(IOperation target, IOperation value, IConvertibleConversion inConversionConvertible, IConvertibleConversion outConversionConvertible, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(inConversionConvertible, outConversionConvertible, operatorKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
+        public CompoundAssignmentOperation(IOperation target, IOperation value, IConvertibleConversion inConversionConvertible, IConvertibleConversion outConversionConvertible, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(inConversionConvertible, outConversionConvertible, operatorKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
             TargetImpl = target;
             ValueImpl = value;
@@ -1187,7 +1194,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyTarget;
         private readonly Lazy<IOperation> _lazyValue;
 
-        public LazyCompoundAssignmentOperation(Lazy<IOperation> target, Lazy<IOperation> value, IConvertibleConversion inConversionConvertible, IConvertibleConversion outConversionConvertible, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(inConversionConvertible, outConversionConvertible, operatorKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyCompoundAssignmentOperation(Lazy<IOperation> target, Lazy<IOperation> value, IConvertibleConversion inConversionConvertible, IConvertibleConversion outConversionConvertible, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(inConversionConvertible, outConversionConvertible, operatorKind, isLifted, isChecked, operatorMethod, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyTarget = target;
             _lazyValue = value;
@@ -1203,7 +1211,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseConditionalAccessExpression : Operation, IConditionalAccessOperation
     {
         protected BaseConditionalAccessExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ConditionalAccess, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ConditionalAccess, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -1265,7 +1273,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyWhenNotNull;
         private readonly Lazy<IOperation> _lazyExpression;
 
-        public LazyConditionalAccessExpression(Lazy<IOperation> whenNotNull, Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyConditionalAccessExpression(Lazy<IOperation> whenNotNull, Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyWhenNotNull = whenNotNull ?? throw new System.ArgumentNullException(nameof(whenNotNull));
             _lazyExpression = expression ?? throw new System.ArgumentNullException(nameof(expression));
@@ -1312,7 +1321,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseConditionalOperation : Operation, IConditionalOperation
     {
         protected BaseConditionalOperation(bool isRef, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Conditional, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Conditional, semanticModel, syntax, type, constantValue, isImplicit)
         {
             IsRef = isRef;
         }
@@ -1374,9 +1383,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal sealed partial class ConditionalOperation : BaseConditionalOperation, IConditionalOperation
     {
-        public ConditionalOperation(
-            IOperation condition, IOperation whenTrue, IOperation whenFalse, bool isRef, 
-            SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        public ConditionalOperation(IOperation condition, IOperation whenTrue, IOperation whenFalse, bool isRef, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(isRef, semanticModel, syntax, type, constantValue, isImplicit)
         {
             ConditionImpl = condition;
@@ -1403,10 +1410,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyWhenTrue;
         private readonly Lazy<IOperation> _lazyWhenFalse;
 
-        public LazyConditionalOperation(
-            Lazy<IOperation> condition, Lazy<IOperation> whenTrue, Lazy<IOperation> whenFalse, bool isRef, 
-            SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(isRef, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyConditionalOperation(Lazy<IOperation> condition, Lazy<IOperation> whenTrue, Lazy<IOperation> whenFalse, bool isRef, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(isRef, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyCondition = condition ?? throw new System.ArgumentNullException(nameof(condition));
             _lazyWhenTrue = whenTrue ?? throw new System.ArgumentNullException(nameof(whenTrue));
@@ -1426,7 +1431,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseConversionExpression : Operation, IConversionOperation
     {
         protected BaseConversionExpression(IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Conversion, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Conversion, semanticModel, syntax, type, constantValue, isImplicit)
         {
             IsTryCast = isTryCast;
             IsChecked = isChecked;
@@ -1465,7 +1470,8 @@ namespace Microsoft.CodeAnalysis.Operations
 
     internal sealed partial class ConversionOperation : BaseConversionExpression
     {
-        public ConversionOperation(IOperation operand, IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(convertibleConversion, isTryCast, isChecked, semanticModel, syntax, type, constantValue, isImplicit)
+        public ConversionOperation(IOperation operand, IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(convertibleConversion, isTryCast, isChecked, semanticModel, syntax, type, constantValue, isImplicit)
         {
             OperandImpl = operand;
         }
@@ -1477,7 +1483,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyOperand;
 
-        public LazyConversionOperation(Lazy<IOperation> lazyOperand, IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(convertibleConversion, isTryCast, isChecked, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyConversionOperation(Lazy<IOperation> lazyOperand, IConvertibleConversion convertibleConversion, bool isTryCast, bool isChecked, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(convertibleConversion, isTryCast, isChecked, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyOperand = lazyOperand;
         }
@@ -1570,7 +1577,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseEventAssignmentOperation : Operation, IEventAssignmentOperation
     {
         protected BaseEventAssignmentOperation(bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.EventAssignment, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.EventAssignment, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Adds = adds;
         }
@@ -1647,8 +1654,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IEventReferenceOperation> _lazyEventReference;
         private readonly Lazy<IOperation> _lazyHandlerValue;
 
-        public LazyEventAssignmentOperation(Lazy<IEventReferenceOperation> eventReference, Lazy<IOperation> handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(adds, semanticModel, syntax, type, constantValue, isImplicit)
-
+        public LazyEventAssignmentOperation(Lazy<IEventReferenceOperation> eventReference, Lazy<IOperation> handlerValue, bool adds, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(adds, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyEventReference = eventReference ?? throw new System.ArgumentNullException(nameof(eventReference));
             _lazyHandlerValue = handlerValue ?? throw new System.ArgumentNullException(nameof(handlerValue));
@@ -1728,7 +1735,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseExpressionStatement : Operation, IExpressionStatementOperation
     {
         protected BaseExpressionStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ExpressionStatement, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ExpressionStatement, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -1778,7 +1785,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyExpression;
 
-        public LazyExpressionStatement(Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyExpressionStatement(Lazy<IOperation> expression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyExpression = expression ?? throw new System.ArgumentNullException(nameof(expression));
         }
@@ -1977,9 +1985,9 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseFixedStatement : Operation, IFixedOperation
     {
         protected BaseFixedStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    // https://github.com/dotnet/roslyn/issues/21281
-                    // base(OperationKind.Fixed, semanticModel, syntax, type, constantValue)
-                    base(OperationKind.None, semanticModel, syntax, type, constantValue, isImplicit)
+            // https://github.com/dotnet/roslyn/issues/21281
+            // base(OperationKind.Fixed, semanticModel, syntax, type, constantValue)
+            base(OperationKind.None, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -2041,7 +2049,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IVariableDeclarationGroupOperation> _lazyVariables;
         private readonly Lazy<IOperation> _lazyBody;
 
-        public LazyFixedStatement(Lazy<IVariableDeclarationGroupOperation> variables, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyFixedStatement(Lazy<IVariableDeclarationGroupOperation> variables, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyVariables = variables ?? throw new System.ArgumentNullException(nameof(variables));
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
@@ -2526,7 +2535,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseInterpolatedStringExpression : Operation, IInterpolatedStringOperation
     {
         protected BaseInterpolatedStringExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.InterpolatedString, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.InterpolatedString, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -2579,7 +2588,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<ImmutableArray<IInterpolatedStringContentOperation>> _lazyParts;
 
-        public LazyInterpolatedStringExpression(Lazy<ImmutableArray<IInterpolatedStringContentOperation>> parts, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyInterpolatedStringExpression(Lazy<ImmutableArray<IInterpolatedStringContentOperation>> parts, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyParts = parts;
         }
@@ -2593,7 +2603,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseInterpolatedStringText : Operation, IInterpolatedStringTextOperation
     {
         protected BaseInterpolatedStringText(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.InterpolatedStringText, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.InterpolatedStringText, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -2643,7 +2653,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyText;
 
-        public LazyInterpolatedStringText(Lazy<IOperation> text, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyInterpolatedStringText(Lazy<IOperation> text, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyText = text;
         }
@@ -2657,7 +2668,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseInterpolation : Operation, IInterpolationOperation
     {
         protected BaseInterpolation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Interpolation, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Interpolation, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -2795,7 +2806,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<ImmutableArray<IOperation>> _lazyChildren;
 
-        public LazyInvalidOperation(Lazy<ImmutableArray<IOperation>> children, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyInvalidOperation(Lazy<ImmutableArray<IOperation>> children, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             // we don't allow null children.
             Debug.Assert(children.Value.All(o => o != null));
@@ -2810,7 +2822,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseInvocationExpression : Operation, IInvocationOperation
     {
         protected BaseInvocationExpression(IMethodSymbol targetMethod, bool isVirtual, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Invocation, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Invocation, semanticModel, syntax, type, constantValue, isImplicit)
         {
             TargetMethod = targetMethod;
             IsVirtual = isVirtual;
@@ -2888,7 +2900,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyInstance;
         private readonly Lazy<ImmutableArray<IArgumentOperation>> _lazyArguments;
 
-        public LazyInvocationExpression(IMethodSymbol targetMethod, Lazy<IOperation> instance, bool isVirtual, Lazy<ImmutableArray<IArgumentOperation>> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(targetMethod, isVirtual, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyInvocationExpression(IMethodSymbol targetMethod, Lazy<IOperation> instance, bool isVirtual, Lazy<ImmutableArray<IArgumentOperation>> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(targetMethod, isVirtual, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyInstance = instance ?? throw new System.ArgumentNullException(nameof(instance));
             _lazyArguments = arguments;
@@ -2905,7 +2918,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseRaiseEventStatement : Operation, IRaiseEventOperation
     {
         protected BaseRaiseEventStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.RaiseEvent, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.RaiseEvent, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -2989,7 +3002,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseIsTypeExpression : Operation, IIsTypeOperation
     {
         protected BaseIsTypeExpression(ITypeSymbol typeOperand, bool isNegated, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.IsType, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.IsType, semanticModel, syntax, type, constantValue, isImplicit)
         {
             TypeOperand = typeOperand;
             IsNegated = isNegated;
@@ -3051,7 +3064,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyOperand;
 
-        public LazyIsTypeExpression(Lazy<IOperation> operand, ITypeSymbol isType, bool isNotTypeExpression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(isType, isNotTypeExpression, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyIsTypeExpression(Lazy<IOperation> operand, ITypeSymbol isType, bool isNotTypeExpression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(isType, isNotTypeExpression, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyOperand = operand ?? throw new System.ArgumentNullException(nameof(operand));
         }
@@ -3065,7 +3079,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseLabeledStatement : Operation, ILabeledOperation
     {
         protected BaseLabeledStatement(ILabelSymbol label, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Labeled, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Labeled, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Label = label;
         }
@@ -3119,7 +3133,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyStatement;
 
-        public LazyLabeledStatement(ILabelSymbol label, Lazy<IOperation> statement, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(label, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyLabeledStatement(ILabelSymbol label, Lazy<IOperation> statement, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(label, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyStatement = statement ?? throw new System.ArgumentNullException(nameof(statement));
         }
@@ -3130,7 +3145,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseAnonymousFunctionExpression : Operation, IAnonymousFunctionOperation
     {
         protected BaseAnonymousFunctionExpression(IMethodSymbol symbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.AnonymousFunction, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.AnonymousFunction, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Symbol = symbol;
         }
@@ -3172,7 +3187,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IBlockOperation> _lazyBody;
 
-        public LazyAnonymousFunctionExpression(IMethodSymbol symbol, Lazy<IBlockOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyAnonymousFunctionExpression(IMethodSymbol symbol, Lazy<IBlockOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
@@ -3211,7 +3227,7 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal partial class DelegateCreationExpression : BaseDelegateCreationExpression
+    internal sealed partial class DelegateCreationExpression : BaseDelegateCreationExpression
     {
         public DelegateCreationExpression(IOperation target, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(semanticModel, syntax, type, constantValue, isImplicit)
@@ -3222,7 +3238,7 @@ namespace Microsoft.CodeAnalysis.Operations
         protected override IOperation TargetImpl { get; }
     }
 
-    internal partial class LazyDelegateCreationExpression : BaseDelegateCreationExpression
+    internal sealed partial class LazyDelegateCreationExpression : BaseDelegateCreationExpression
     {
         private readonly Lazy<IOperation> _lazyTarget;
         public LazyDelegateCreationExpression(Lazy<IOperation> lazyTarget, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
@@ -3381,7 +3397,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseLockStatement : Operation, ILockOperation
     {
         protected BaseLockStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Lock, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Lock, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -3443,7 +3459,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyExpression;
         private readonly Lazy<IOperation> _lazyBody;
 
-        public LazyLockStatement(Lazy<IOperation> lockedObject, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyLockStatement(Lazy<IOperation> lockedObject, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyExpression = lockedObject ?? throw new System.ArgumentNullException(nameof(lockedObject));
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
@@ -3580,7 +3597,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseCoalesceExpression : Operation, ICoalesceOperation
     {
         protected BaseCoalesceExpression(IConvertibleConversion convertibleValueConversion, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Coalesce, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Coalesce, semanticModel, syntax, type, constantValue, isImplicit)
         {
             ConvertibleValueConversion = convertibleValueConversion;
         }
@@ -3627,8 +3644,7 @@ namespace Microsoft.CodeAnalysis.Operations
     /// </summary>
     internal sealed partial class CoalesceExpression : BaseCoalesceExpression, ICoalesceOperation
     {
-        public CoalesceExpression(IOperation expression, IOperation whenNull, IConvertibleConversion convertibleValueConversion, SemanticModel semanticModel, 
-                                  SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+        public CoalesceExpression(IOperation expression, IOperation whenNull, IConvertibleConversion convertibleValueConversion, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(convertibleValueConversion, semanticModel, syntax, type, constantValue, isImplicit)
         {
             ExpressionImpl = expression;
@@ -3647,8 +3663,7 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyExpression;
         private readonly Lazy<IOperation> _lazyWhenNull;
 
-        public LazyCoalesceExpression(Lazy<IOperation> expression, Lazy<IOperation> whenNull, IConvertibleConversion convertibleValueConversion, 
-                                      SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : 
+        public LazyCoalesceExpression(Lazy<IOperation> expression, Lazy<IOperation> whenNull, IConvertibleConversion convertibleValueConversion, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
             base(convertibleValueConversion, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyExpression = expression ?? throw new System.ArgumentNullException(nameof(expression));
@@ -3666,7 +3681,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseObjectCreationExpression : Operation, IObjectCreationOperation
     {
         protected BaseObjectCreationExpression(IMethodSymbol constructor, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ObjectCreation, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ObjectCreation, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Constructor = constructor;
         }
@@ -3739,7 +3754,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IObjectOrCollectionInitializerOperation> _lazyInitializer;
         private readonly Lazy<ImmutableArray<IArgumentOperation>> _lazyArguments;
 
-        public LazyObjectCreationExpression(IMethodSymbol constructor, Lazy<IObjectOrCollectionInitializerOperation> initializer, Lazy<ImmutableArray<IArgumentOperation>> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(constructor, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyObjectCreationExpression(IMethodSymbol constructor, Lazy<IObjectOrCollectionInitializerOperation> initializer, Lazy<ImmutableArray<IArgumentOperation>> arguments, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(constructor, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyInitializer = initializer;
             _lazyArguments = arguments;
@@ -3945,7 +3961,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseParenthesizedExpression : Operation, IParenthesizedOperation
     {
         protected BaseParenthesizedExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Parenthesized, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Parenthesized, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -3995,7 +4011,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyOperand;
 
-        public LazyParenthesizedExpression(Lazy<IOperation> operand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyParenthesizedExpression(Lazy<IOperation> operand, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyOperand = operand ?? throw new System.ArgumentNullException(nameof(operand));
         }
@@ -4090,7 +4107,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyPointer;
 
-        public LazyPointerIndirectionReferenceExpression(Lazy<IOperation> pointer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyPointerIndirectionReferenceExpression(Lazy<IOperation> pointer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyPointer = pointer ?? throw new System.ArgumentNullException(nameof(pointer));
         }
@@ -4421,7 +4439,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseReturnStatement : Operation, IReturnOperation
     {
         protected BaseReturnStatement(OperationKind kind, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(kind, semanticModel, syntax, type, constantValue, isImplicit)
+            base(kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Debug.Assert(kind == OperationKind.Return
                       || kind == OperationKind.YieldReturn
@@ -4474,7 +4492,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyReturnedValue;
 
-        public LazyReturnStatement(OperationKind kind, Lazy<IOperation> returnedValue, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(kind, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyReturnStatement(OperationKind kind, Lazy<IOperation> returnedValue, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(kind, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyReturnedValue = returnedValue ?? throw new System.ArgumentNullException(nameof(returnedValue));
         }
@@ -4637,7 +4656,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseSwitchCase : Operation, ISwitchCaseOperation
     {
         protected BaseSwitchCase(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.SwitchCase, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.SwitchCase, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -4705,7 +4724,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<ImmutableArray<ICaseClauseOperation>> _lazyClauses;
         private readonly Lazy<ImmutableArray<IOperation>> _lazyBody;
 
-        public LazySwitchCase(Lazy<ImmutableArray<ICaseClauseOperation>> clauses, Lazy<ImmutableArray<IOperation>> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazySwitchCase(Lazy<ImmutableArray<ICaseClauseOperation>> clauses, Lazy<ImmutableArray<IOperation>> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyClauses = clauses;
             _lazyBody = body;
@@ -4722,7 +4742,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseSwitchStatement : Operation, ISwitchOperation
     {
         protected BaseSwitchStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Switch, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Switch, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -4787,7 +4807,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyValue;
         private readonly Lazy<ImmutableArray<ISwitchCaseOperation>> _lazyCases;
 
-        public LazySwitchStatement(Lazy<IOperation> value, Lazy<ImmutableArray<ISwitchCaseOperation>> cases, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazySwitchStatement(Lazy<IOperation> value, Lazy<ImmutableArray<ISwitchCaseOperation>> cases, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
             _lazyCases = cases;
@@ -4894,7 +4915,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<ImmutableArray<ICatchClauseOperation>> _lazyCatches;
         private readonly Lazy<IBlockOperation> _lazyFinallyHandler;
 
-        public LazyTryStatement(Lazy<IBlockOperation> body, Lazy<ImmutableArray<ICatchClauseOperation>> catches, Lazy<IBlockOperation> finallyHandler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyTryStatement(Lazy<IBlockOperation> body, Lazy<ImmutableArray<ICatchClauseOperation>> catches, Lazy<IBlockOperation> finallyHandler, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
             _lazyCatches = catches;
@@ -4914,7 +4936,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseTupleExpression : Operation, ITupleOperation
     {
         protected BaseTupleExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, ITypeSymbol naturalType, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Tuple, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Tuple, semanticModel, syntax, type, constantValue, isImplicit)
         {
             NaturalType = naturalType;
         }
@@ -5332,7 +5354,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseUnaryOperatorExpression : Operation, IUnaryOperation
     {
         protected BaseUnaryOperatorExpression(UnaryOperatorKind unaryOperationKind, bool isLifted, bool isChecked, IMethodSymbol operatorMethod, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.UnaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.UnaryOperator, semanticModel, syntax, type, constantValue, isImplicit)
         {
             OperatorKind = unaryOperationKind;
             IsLifted = isLifted;
@@ -5419,7 +5441,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseUsingStatement : Operation, IUsingOperation
     {
         protected BaseUsingStatement(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.Using, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.Using, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -5484,7 +5506,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyResources;
         private readonly Lazy<IOperation> _lazyBody;
 
-        public LazyUsingStatement(Lazy<IOperation> resources, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyUsingStatement(Lazy<IOperation> resources, Lazy<IOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyResources = resources ?? throw new System.ArgumentNullException(nameof(resources));
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
@@ -5497,7 +5520,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseVariableDeclarator : Operation, IVariableDeclaratorOperation
     {
         protected BaseVariableDeclarator(ILocalSymbol symbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.VariableDeclarator, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.VariableDeclarator, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Symbol = symbol;
         }
@@ -5618,9 +5641,10 @@ namespace Microsoft.CodeAnalysis.Operations
         }
     }
 
-    internal partial class VariableDeclaration : BaseVariableDeclaration
+    internal sealed partial class VariableDeclaration : BaseVariableDeclaration
     {
-        public VariableDeclaration(ImmutableArray<IVariableDeclaratorOperation> declarations, IVariableInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public VariableDeclaration(ImmutableArray<IVariableDeclaratorOperation> declarations, IVariableInitializerOperation initializer, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             DeclarationsImpl = declarations;
             InitializerImpl = initializer;
@@ -5631,7 +5655,7 @@ namespace Microsoft.CodeAnalysis.Operations
         protected override IVariableInitializerOperation InitializerImpl { get; }
     }
 
-    internal partial class LazyVariableDeclaration : BaseVariableDeclaration
+    internal sealed partial class LazyVariableDeclaration : BaseVariableDeclaration
     {
         private readonly Lazy<ImmutableArray<IVariableDeclaratorOperation>> _lazyDeclarations;
         private readonly Lazy<IVariableInitializerOperation> _lazyInitializer;
@@ -5654,7 +5678,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseVariableDeclarationGroupOperation : Operation, IVariableDeclarationGroupOperation
     {
         protected BaseVariableDeclarationGroupOperation(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.VariableDeclarationGroup, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.VariableDeclarationGroup, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -5707,7 +5731,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<ImmutableArray<IVariableDeclarationOperation>> _lazyDeclarations;
 
-        public LazyVariableDeclarationGroupOperation(Lazy<ImmutableArray<IVariableDeclarationOperation>> declarations, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyVariableDeclarationGroupOperation(Lazy<ImmutableArray<IVariableDeclarationOperation>> declarations, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyDeclarations = declarations;
         }
@@ -5912,7 +5937,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IOperation> _lazyBody;
         private readonly Lazy<IOperation> _lazyValue;
 
-        public LazyWithStatement(Lazy<IOperation> body, Lazy<IOperation> value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyWithStatement(Lazy<IOperation> body, Lazy<IOperation> value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
@@ -5929,7 +5955,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseLocalFunctionStatement : Operation, ILocalFunctionOperation
     {
         protected BaseLocalFunctionStatement(IMethodSymbol symbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.LocalFunction, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.LocalFunction, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Symbol = symbol;
         }
@@ -5983,8 +6009,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IBlockOperation> _lazyBody;
 
-        public LazyLocalFunctionStatement(IMethodSymbol symbol, Lazy<IBlockOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyLocalFunctionStatement(IMethodSymbol symbol, Lazy<IBlockOperation> body, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(symbol, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyBody = body ?? throw new System.ArgumentNullException(nameof(body));
         }
@@ -5998,7 +6024,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseConstantPattern : Operation, IConstantPatternOperation
     {
         protected BaseConstantPattern(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ConstantPattern, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ConstantPattern, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -6048,8 +6074,8 @@ namespace Microsoft.CodeAnalysis.Operations
     {
         private readonly Lazy<IOperation> _lazyValue;
 
-        public LazyConstantPattern(Lazy<IOperation> value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyConstantPattern(Lazy<IOperation> value, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyValue = value ?? throw new System.ArgumentNullException(nameof(value));
         }
@@ -6063,7 +6089,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal sealed partial class DeclarationPattern : Operation, IDeclarationPatternOperation
     {
         public DeclarationPattern(ISymbol declaredSymbol, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.DeclarationPattern, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.DeclarationPattern, semanticModel, syntax, type, constantValue, isImplicit)
         {
             DeclaredSymbol = declaredSymbol;
         }
@@ -6094,7 +6120,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BasePatternCaseClause : CaseClause, IPatternCaseClauseOperation
     {
         protected BasePatternCaseClause(ILabelSymbol label, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(CaseKind.Pattern, semanticModel, syntax, type, constantValue, isImplicit)
+            base(CaseKind.Pattern, semanticModel, syntax, type, constantValue, isImplicit)
         {
             Label = label;
         }
@@ -6160,8 +6186,8 @@ namespace Microsoft.CodeAnalysis.Operations
         private readonly Lazy<IPatternOperation> _lazyPattern;
         private readonly Lazy<IOperation> _lazyGuardExpression;
 
-        public LazyPatternCaseClause(ILabelSymbol label, Lazy<IPatternOperation> lazyPattern, Lazy<IOperation> lazyGuardExpression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit)
-            : base(label, semanticModel, syntax, type, constantValue, isImplicit)
+        public LazyPatternCaseClause(ILabelSymbol label, Lazy<IPatternOperation> lazyPattern, Lazy<IOperation> lazyGuardExpression, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
+            base(label, semanticModel, syntax, type, constantValue, isImplicit)
         {
             _lazyPattern = lazyPattern ?? throw new System.ArgumentNullException(nameof(lazyPattern));
             _lazyGuardExpression = lazyGuardExpression ?? throw new System.ArgumentNullException(nameof(lazyGuardExpression));
@@ -6258,7 +6284,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseObjectOrCollectionInitializerExpression : Operation, IObjectOrCollectionInitializerOperation
     {
         protected BaseObjectOrCollectionInitializerExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.ObjectOrCollectionInitializer, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.ObjectOrCollectionInitializer, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -6326,7 +6352,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseMemberInitializerExpression : Operation, IMemberInitializerOperation
     {
         protected BaseMemberInitializerExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.MemberInitializer, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.MemberInitializer, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
 
@@ -6407,7 +6433,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseCollectionElementInitializerExpression : Operation, ICollectionElementInitializerOperation
     {
         protected BaseCollectionElementInitializerExpression(IMethodSymbol addMethod, bool isDynamic, SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.CollectionElementInitializer, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.CollectionElementInitializer, semanticModel, syntax, type, constantValue, isImplicit)
         {
             AddMethod = addMethod;
             IsDynamic = isDynamic;
@@ -6489,7 +6515,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseTranslatedQueryExpression : Operation, ITranslatedQueryOperation
     {
         protected BaseTranslatedQueryExpression(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue, bool isImplicit) :
-                    base(OperationKind.TranslatedQuery, semanticModel, syntax, type, constantValue, isImplicit)
+            base(OperationKind.TranslatedQuery, semanticModel, syntax, type, constantValue, isImplicit)
         {
         }
         protected abstract IOperation ExpressionImpl { get; }
@@ -6558,7 +6584,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal sealed partial class FlowCaptureReference : Operation, IFlowCaptureReferenceOperation
     {
         public FlowCaptureReference(int id, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
-            base(OperationKind.FlowCaptureReference, semanticModel: null, syntax, type, constantValue, isImplicit: true)
+            base(OperationKind.FlowCaptureReference, semanticModel: null, syntax: syntax, type: type, constantValue: constantValue, isImplicit: true)
         {
             Id = id;
         }
@@ -6586,7 +6612,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal sealed partial class FlowCapture : Operation, IFlowCaptureOperation
     {
         public FlowCapture(int id, SyntaxNode syntax, IOperation value) :
-            base(OperationKind.FlowCapture, semanticModel: null, syntax, type: null, constantValue: default, isImplicit: true)
+            base(OperationKind.FlowCapture, semanticModel: null, syntax: syntax, type: null, constantValue: default, isImplicit: true)
         {
             Debug.Assert(value != null);
             Id = id;


### PR DESCRIPTION
we have 2 implementation of IOperation. lazy and non-lazy one. we used to set Parent operation lazily in both case, but now we only set it lazily in lazy implementation. another implementation, we set it right away.