### PR TITLE
System.Runtime.CompilerServices.SkipLocalsInitAttribute recognized as…

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -8507,6 +8507,17 @@ namespace System.Runtime.CompilerServices
             Assert.True(wellKnownType.IsErrorType());
         }
 
+        [Fact]
+        public void SkipLocalsInitAttributeMissingWhenNotDeclared()
+        {
+            var comp = CreateStandardCompilation("");
+            comp.VerifyDiagnostics();
+
+            var wellKnownType = comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+
+            Assert.True(wellKnownType.IsErrorType());
+        }
+
         #endregion
 
         [Fact, WorkItem(807, "https://github.com/dotnet/roslyn/issues/807")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -8411,6 +8411,104 @@ public class C
 
         #endregion
 
+        #region SkipLocalsInitAttribute
+
+        [Fact]
+        public void SkipLocalsInitAttributeRecognizedAsWellKnownTypeWhenDeclaredInSource()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+";
+
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var wellKnownType = comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+            var typeMember = comp.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.SkipLocalsInitAttribute");
+
+            Assert.Equal(wellKnownType, typeMember);
+        }
+
+        [Fact]
+        public void SkipLocalsInitAttributeRecognizedAsWellKnownTypeWhenDeclaredInMetadata()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+";
+
+            var metadataComp = CreateStandardCompilation(source);
+            metadataComp.VerifyDiagnostics();
+
+            var comp = CreateStandardCompilation("", references: new[] { metadataComp.EmitToImageReference() });
+            comp.VerifyDiagnostics();
+
+            var wellKnownType = comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+            var typeMember = comp.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.SkipLocalsInitAttribute");
+
+            Assert.Equal(wellKnownType, typeMember);
+        }
+
+        [Fact]
+        public void SkipLocalsInitAttributeFromSourceRecognizedAsWellKnownTypeWhenDeclaredInSourceAndMetadata()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+";
+
+            var metadataComp = CreateStandardCompilation(source);
+            metadataComp.VerifyDiagnostics();
+
+            var comp = CreateStandardCompilation(source, references: new[] { metadataComp.EmitToImageReference() });
+            comp.VerifyDiagnostics();
+
+            var wellKnownType = comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+            
+            Assert.IsType<SourceNamedTypeSymbol>(wellKnownType);
+        }
+
+        [Fact]
+        public void SkipLocalsInitAttributeMissingWhenDeclaredMoreThanOnceInOtherAssemblies()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    public class SkipLocalsInitAttribute : System.Attribute
+    {
+    }
+}
+";
+
+            var metadataComp1 = CreateStandardCompilation(source);
+            metadataComp1.VerifyDiagnostics();
+
+            var metadataComp2 = CreateStandardCompilation(source);
+            metadataComp2.VerifyDiagnostics();
+
+            var comp = CreateStandardCompilation("", references: new[] { metadataComp1.EmitToImageReference(), metadataComp2.EmitToImageReference() });
+            comp.VerifyDiagnostics();
+
+            var wellKnownType = comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+
+            Assert.True(wellKnownType.IsErrorType());
+        }
+
+        #endregion
+
         [Fact, WorkItem(807, "https://github.com/dotnet/roslyn/issues/807")]
         public void TestAttributePropagationForAsyncAndIterators_01()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -560,6 +560,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory:
                     case WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute:
                     case WellKnownType.System_Span_T:
                     case WellKnownType.System_ReadOnlySpan_T:
                     // Not yet in the platform.

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -272,6 +272,8 @@ namespace Microsoft.CodeAnalysis
         System_Span_T,
         System_ReadOnlySpan_T,
 
+        System_Runtime_CompilerServices_SkipLocalsInitAttribute,
+
         NextAvailable,
     }
 
@@ -537,6 +539,8 @@ namespace Microsoft.CodeAnalysis
             "System.ObsoleteAttribute",
             "System.Span`1",
             "System.ReadOnlySpan`1",
+
+            "System.Runtime.CompilerServices.SkipLocalsInitAttribute",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -267,12 +267,11 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_CompilerServices_IsReadOnlyAttribute,
         System_Runtime_CompilerServices_IsByRefLikeAttribute,
+        System_Runtime_CompilerServices_SkipLocalsInitAttribute,
         System_Runtime_InteropServices_InAttribute,
         System_ObsoleteAttribute,
         System_Span_T,
         System_ReadOnlySpan_T,
-
-        System_Runtime_CompilerServices_SkipLocalsInitAttribute,
 
         NextAvailable,
     }
@@ -535,12 +534,11 @@ namespace Microsoft.CodeAnalysis
 
             "System.Runtime.CompilerServices.IsReadOnlyAttribute",
             "System.Runtime.CompilerServices.IsByRefLikeAttribute",
+            "System.Runtime.CompilerServices.SkipLocalsInitAttribute",
             "System.Runtime.InteropServices.InAttribute",
             "System.ObsoleteAttribute",
             "System.Span`1",
             "System.ReadOnlySpan`1",
-
-            "System.Runtime.CompilerServices.SkipLocalsInitAttribute",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -502,6 +502,7 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
+                         WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute,
                          WellKnownType.System_Span_T,
                          WellKnownType.System_ReadOnlySpan_T
                         ' Not available on all platforms.
@@ -541,6 +542,7 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
+                         WellKnownType.System_Runtime_CompilerServices_SkipLocalsInitAttribute,
                          WellKnownType.System_Span_T,
                          WellKnownType.System_ReadOnlySpan_T
                         ' Not available on all platforms.


### PR DESCRIPTION
… a WellKnownType

System_Runtime_CompilerServices_SkipLocalsInitAttribute entry was added to the WellKnownType enum, and its corresponding metadata name was added to the s_metadataNames array in WellKnownTypes class.

The implemented tests contemplate four possible scenarios:

- SkipLocalsInitAttribute declared in source code: GetWellKnownType must return the requested type without further ado.

- SkipLocalsInitAttribute declared in metadata: same as above.

- SkipLocalsInitAttribute declared both in source code and in metadata: GetWellKnownType must return the one from source code.

- SkipLocalsInitAttribute declared in metadata in two different assemblies: GetWellKnownType must return an error type symbol.

That's the expected behavior for types after C# 7.