### PR TITLE
Move to xunit.console for CoreClr tests

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -393,7 +393,7 @@ function Test-XUnitCoreClr() {
     $tf = "netcoreapp2.0"
     $logDir = Join-Path $unitDir "xUnitResults"
     Create-Directory $logDir 
-    $xunitConsole = Join-Path (Get-PackageDir "dotnet-xunit") "tools\$tf\xunit.console.dll"
+    $xunitConsole = Join-Path (Get-PackageDir "xunit.runner.console") "tools\$tf\xunit.console.dll"
 
     $dlls = @()
     $allGood = $true

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -20,11 +20,11 @@ xunit_console_version="$(get_package_version dotnet-xunit)"
 
 if [[ "${runtime}" == "dotnet" ]]; then
     target_framework=netcoreapp2.0
-    xunit_console="${nuget_dir}"/dotnet-xunit/"${xunit_console_version}"/tools/${target_framework}/xunit.console.dll
+    xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/${target_framework}/xunit.console.dll
 elif [[ "${runtime}" == "mono" ]]; then
     source ${root_path}/build/scripts/obtain_mono.sh
     target_framework=net461
-    xunit_console="${nuget_dir}"/dotnet-xunit/"${xunit_console_version}"/tools/net452/xunit.console.exe
+    xunit_console="${nuget_dir}"/xunit.runner.console/"${xunit_console_version}"/tools/net452/xunit.console.exe
 else
     echo "Unknown runtime: ${runtime}"
     exit 1

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -84,9 +84,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
             string workingDirectory = null)
         {
             var io = new TestConsoleIO(input);
+            var clientDir = Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(CommandLineRunnerTests)));
             var buildPaths = new BuildPaths(
-                clientDir: AppContext.BaseDirectory,
-                workingDir: workingDirectory ?? AppContext.BaseDirectory,
+                clientDir: clientDir,
+                workingDir: workingDirectory ?? clientDir,
                 sdkDir: null,
                 tempDir: Path.GetTempPath());
 

--- a/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
+++ b/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using Roslyn.Test.Utilities;
@@ -48,6 +49,20 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return new DesktopAnalyzerAssemblyLoader();
 #else 
             return new ThrowingAnalyzerAssemblyLoader();
+#endif
+        }
+
+        /// <summary>
+        /// Get the location of the assembly that contains this type
+        /// </summary>
+        internal static string GetAssemblyLocation(Type type)
+        {
+#if NET461 || NET46 || NETCOREAPP2_0
+            return type.GetTypeInfo().Assembly.Location;
+#elif NETSTANDARD1_3
+            throw new NotSupportedException();
+#else
+#error Unsupported configuration
 #endif
         }
     }

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -24,14 +24,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             if (CoreClrShim.AssemblyLoadContext.Type == null)
             {
                 return Path.Combine(
-                    Path.GetDirectoryName(CorLightup.Desktop.GetAssemblyLocation(typeof(object).GetTypeInfo().Assembly)),
+                    RuntimeUtilities.GetAssemblyLocation(typeof(object)),
                     "ilasm.exe");
             }
             else
             {
                 var ilasmExeName = PlatformInformation.IsWindows ? "ilasm.exe" : "ilasm";
 
-                var directory = AppContext.BaseDirectory;
+                var directory = RuntimeUtilities.GetAssemblyLocation(typeof(RuntimeUtilities));
                 string path = null;
                 while (directory != null && !File.Exists(path = Path.Combine(directory, "Binaries", "Tools", "ILAsm", ilasmExeName)))
                 {

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             if (CoreClrShim.AssemblyLoadContext.Type == null)
             {
                 return Path.Combine(
-                    RuntimeUtilities.GetAssemblyLocation(typeof(object)),
+                    Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(object))),
                     "ilasm.exe");
             }
             else

--- a/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
+++ b/src/Test/Utilities/Portable/Metadata/IlasmUtilities.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             {
                 var ilasmExeName = PlatformInformation.IsWindows ? "ilasm.exe" : "ilasm";
 
-                var directory = RuntimeUtilities.GetAssemblyLocation(typeof(RuntimeUtilities));
+                var directory = Path.GetDirectoryName(RuntimeUtilities.GetAssemblyLocation(typeof(RuntimeUtilities)));
                 string path = null;
                 while (directory != null && !File.Exists(path = Path.Combine(directory, "Binaries", "Tools", "ILAsm", ilasmExeName)))
                 {


### PR DESCRIPTION
Previously we were using xunit.console for desktop tests and dotnet-xunit for our
CoreClr tests. This change unifies us on top of xunit.console (now that it has a
netcoreapp2.0 version available).

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
