### PR TITLE
Fix command line build error

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         {
             var kind = ForegroundThreadDataInfo.CreateDefault(defaultKind);
 
-            return new ForegroundThreadData(Thread.CurrentThread, new SynchronizationContextTaskScheduler(SynchronizationContext.Current), kind);
+            return new ForegroundThreadData(Thread.CurrentThread, SynchronizationContext.Current == null ? TaskScheduler.Default : new SynchronizationContextTaskScheduler(SynchronizationContext.Current), kind);
         }
     }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -38,7 +38,7 @@ class Program
             // TODO: Validate build works as expected
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18299"), Trait(Traits.Feature, Traits.Features.Build)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Build)]
         public void BuildWithCommandLine()
         {
             VisualStudio.SolutionExplorer.SaveAll();


### PR DESCRIPTION
### Customer scenario
Create a solution and from command line run:
`devenv <solutionname>.sln /build`

### Bugs this fixes
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/559223
fixes #18204

### Workarounds, if any
build from IDE

### Risk
None, just added a null check on a method call

### Performance impact
None

### Is this a regression from a previous update?

### Root cause analysis
We are re-enabling this test: https://github.com/dotnet/roslyn/issues/18204 to catch this error.

### How was the bug found?
Internal - VS team

### Test documentation updated?
n/a

