### PR TITLE
Do not suggest var when it change static type of the variable in foreach statement

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2212,55 +2212,85 @@ class Program
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
-        public async Task DoNotSuggestVarForExplicitInterfaceImplementationForeachStatement()
+        public async Task DoNotSuggestVarForInterfaceVariableInForeachStatement()
         {
             await TestMissingInRegularAndScriptAsync(@"
-        public interface ITest
+public interface ITest
+{
+    string Value { get; }
+}
+public class TestInstance : ITest
+{
+    string ITest.Value => ""Hi"";
+}
+
+public class Test
+{
+    public TestInstance[] Instances { get; }
+
+    public void TestIt()
+    {
+        foreach ([|ITest|] test in Instances)
         {
-            string Value { get; }
+            Console.WriteLine(test.Value);
         }
-        public class TestInstance : ITest
-        {
-            string ITest.Value => ""Hi"";
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
         }
 
-        public class Test
-        {
-            public TestInstance[] Instances { get; }
-
-            public void TestIt()
-            {
-                foreach ([|ITest|] test in Instances)
-                {
-                    Console.WriteLine(test.Value);
-                }
-            }
-        }
-        ", new TestParameters(options: ImplicitTypeEverywhere()));
-        }
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
-        public async Task DoNotSuggestVarForExplicitInterfaceImplementationDeclarationStatement()
+        public async Task DoNotSuggestVarForInterfaceVariableInDeclarationStatement()
         {
-            await TestMissingInRegularAndScriptAsync(@"
-        public interface ITest
-        {
-            string Value { get; }
-        }
-        public class TestInstance : ITest
-        {
-            string ITest.Value => ""Hi"";
+    await TestMissingInRegularAndScriptAsync(@"
+public interface ITest
+{
+    string Value { get; }
+}
+public class TestInstance : ITest
+{
+    string ITest.Value => ""Hi"";
+}
+
+public class Test
+{
+    public void TestIt()
+    {
+        [|ITest|] test = new TestInstance();
+        Console.WriteLine(test.Value);
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
         }
 
-        public class Test
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
+        public async Task DoNotSuggestVarForAbstractClassVariable()
         {
-            public void TestIt()
-            {
-                [|ITest|] test = new TestInstance();
-                Console.WriteLine(test.Value);          
-            }
+            await TestMissingInRegularAndScriptAsync(@"
+public abstract class MyAbClass
+{
+    string Value { get; }
+}
+
+public class TestInstance : MyAbClass
+{
+    public string Value => ""Hi"";
+}
+
+public class Test
+{
+    public TestInstance[] Instances { get; }
+
+    public void TestIt()
+    {
+        [|MyAbClass|]  test = new TestInstance();
+
+        foreach ([|MyAbClass|]  instance in Instances)
+        {
+            Console.WriteLine(instance);
         }
-        ", new TestParameters(options: ImplicitTypeEverywhere()));
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2212,31 +2212,55 @@ class Program
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
-        public async Task DoNotSuggestVarForExplicitInterfaceImplementations()
+        public async Task DoNotSuggestVarForExplicitInterfaceImplementationForeachStatement()
         {
             await TestMissingInRegularAndScriptAsync(@"
-public interface ITest
-{
-    string Value { get; }
-}
-public class TestInstance : ITest
-{
-    string ITest.Value => ""Hi"";
-}
-
-public class Test
-{
-    public TestInstance[] Instances { get; }
-
-    public void TestIt()
-    {
-        foreach ([|ITest|] test in Instances)
+        public interface ITest
         {
-            Console.WriteLine(test.Value);
+            string Value { get; }
         }
-    }
-}
-", new TestParameters(options: ImplicitTypeEverywhere()));
+        public class TestInstance : ITest
+        {
+            string ITest.Value => ""Hi"";
+        }
+
+        public class Test
+        {
+            public TestInstance[] Instances { get; }
+
+            public void TestIt()
+            {
+                foreach ([|ITest|] test in Instances)
+                {
+                    Console.WriteLine(test.Value);
+                }
+            }
+        }
+        ", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
+        public async Task DoNotSuggestVarForExplicitInterfaceImplementationDeclarationStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+        public interface ITest
+        {
+            string Value { get; }
+        }
+        public class TestInstance : ITest
+        {
+            string ITest.Value => ""Hi"";
+        }
+
+        public class Test
+        {
+            public void TestIt()
+            {
+                [|ITest|] test = new TestInstance();
+                Console.WriteLine(test.Value);          
+            }
+        }
+        ", new TestParameters(options: ImplicitTypeEverywhere()));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2209,5 +2209,34 @@ class Program
     delegate object GetHandler();
 }", new TestParameters(options: ImplicitTypeEverywhere()));
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
+        public async Task DoNotSuggestVarForExplicitInterfaceImplementations()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+public interface ITest
+{
+    string Value { get; }
+}
+public class TestInstance : ITest
+{
+    string ITest.Value => ""Hi"";
+}
+
+public class Test
+{
+    public TestInstance[] Instances { get; }
+
+    public void TestIt()
+    {
+        foreach ([|ITest|] test in Instances)
+        {
+            Console.WriteLine(test.Value);
+        }
+    }
+}
+", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -2264,7 +2264,36 @@ public class Test
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
-        public async Task DoNotSuggestVarForAbstractClassVariable()
+        public async Task DoNotSuggestVarForAbstractClassVariableInForeachStatement()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+public abstract class MyAbClass
+{
+    string Value { get; }
+}
+
+public class TestInstance : MyAbClass
+{
+    public string Value => ""Hi"";
+}
+
+public class Test
+{
+    public TestInstance[] Instances { get; }
+
+    public void TestIt()
+    {
+        foreach ([|MyAbClass|] instance in Instances)
+        {
+            Console.WriteLine(instance);
+        }
+    }
+}", new TestParameters(options: ImplicitTypeEverywhere()));
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(24262, "https://github.com/dotnet/roslyn/issues/24262")]
+        public async Task DoNotSuggestVarForAbstractClassVariableInDeclarationStatement()
         {
             await TestMissingInRegularAndScriptAsync(@"
 public abstract class MyAbClass
@@ -2284,11 +2313,6 @@ public class Test
     public void TestIt()
     {
         [|MyAbClass|]  test = new TestInstance();
-
-        foreach ([|MyAbClass|]  instance in Instances)
-        {
-            Console.WriteLine(instance);
-        }
     }
 }", new TestParameters(options: ImplicitTypeEverywhere()));
         }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -135,10 +135,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 }
             }
             else if (typeName.Parent is ForEachStatementSyntax foreachStatement &&
-                IsExpressionSameAfterVarConversion(foreachStatement.Expression, semanticModel, cancellationToken))
+                IsExpressionSyntaxSameAfterVarConversion(foreachStatement.Expression, semanticModel, cancellationToken))
             {
-                issueSpan = candidateIssueSpan;
-                return true;
+                // Semantic check to see if the conversion changes expression
+                var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatement);
+                if (foreachStatementInfo.ElementConversion.IsIdentityOrImplicitReference())
+                {
+                    issueSpan = candidateIssueSpan;
+                    return true;
+                }
             }
             else if (typeName.Parent is DeclarationExpressionSyntax declarationExpression &&
                      TryAnalyzeDeclarationExpression(declarationExpression, semanticModel, optionSet, cancellationToken))
@@ -244,7 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 return false;
             }
 
-            if (!IsExpressionSameAfterVarConversion(expression, semanticModel, cancellationToken))
+            if (!IsExpressionSyntaxSameAfterVarConversion(expression, semanticModel, cancellationToken))
             {
                 return false;
             }
@@ -254,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return declaredType.Equals(initializerType);
         }
 
-        private static bool IsExpressionSameAfterVarConversion(
+        private static bool IsExpressionSyntaxSameAfterVarConversion(
             ExpressionSyntax expression,
             SemanticModel semanticModel,
             CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -134,21 +134,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                     return true;
                 }
             }
-            else if (typeName.Parent is ForEachStatementSyntax foreachStatement)
+            else if (typeName.Parent is ForEachStatementSyntax foreachStatement &&
+                IsExpressionSameAfterVarConversion(foreachStatement.Expression, semanticModel, cancellationToken))
             {
-                if (IsExpressionSameAfterVarConversion(foreachStatement.Expression, semanticModel, cancellationToken))
+                var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatement);
+                if (foreachStatementInfo.ElementConversion.IsIdentityOrImplicitReference())
                 {
-                    var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatement);
-                    if (foreachStatementInfo.ElementConversion.IsIdentityOrImplicitReference())
-                    {
-                        issueSpan = candidateIssueSpan;
-                        return true;
-                    }
-                }
-                else
-                {
-                    issueSpan = default;
-                    return false;
+                    issueSpan = candidateIssueSpan;
+                    return true;
                 }
             }
             else if (typeName.Parent is DeclarationExpressionSyntax declarationExpression &&
@@ -265,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return declaredType.Equals(initializerType);
         }
 
-        private bool IsExpressionSameAfterVarConversion(
+        private static bool IsExpressionSameAfterVarConversion(
             ExpressionSyntax expression,
             SemanticModel semanticModel,
             CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -252,14 +252,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             // and if we're replacing the declaration with 'var' we'd be changing the semantics by inferring type of
             // initializer expression and thereby losing the conversion.
             var conversion = semanticModel.GetConversion(expression, cancellationToken);
-            if (conversion.Exists && conversion.IsImplicit && !conversion.IsIdentity)
+            if (conversion.IsIdentity)
             {
-                return false;
+                // final check to compare type information on both sides of assignment.
+                var initializerType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
+                return declaredType.Equals(initializerType);
             }
 
-            // final check to compare type information on both sides of assignment.
-            var initializerType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
-            return declaredType.Equals(initializerType);
+            return false;
         }
 
         protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -137,12 +137,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             else if (typeName.Parent is ForEachStatementSyntax foreachStatement &&
                 IsExpressionSameAfterVarConversion(foreachStatement.Expression, semanticModel, cancellationToken))
             {
-                var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatement);
-                if (foreachStatementInfo.ElementConversion.IsIdentityOrImplicitReference())
-                {
-                    issueSpan = candidateIssueSpan;
-                    return true;
-                }
+                issueSpan = candidateIssueSpan;
+                return true;
             }
             else if (typeName.Parent is DeclarationExpressionSyntax declarationExpression &&
                      TryAnalyzeDeclarationExpression(declarationExpression, semanticModel, optionSet, cancellationToken))
@@ -268,7 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             // and if we're replacing the declaration with 'var' we'd be changing the semantics by inferring type of
             // initializer expression and thereby losing the conversion.
             var conversion = semanticModel.GetConversion(expression, cancellationToken);
-            return conversion.Exists && conversion.IsImplicit && conversion.IsIdentity;
+            return conversion.IsIdentity;
         }
 
         protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)


### PR DESCRIPTION
<details><summary>Do not suggest var when it change static type of the variable in foreach statement</summary>

### Customer scenario
Do not suggest var when it change static type of the variable in foreach statement

### Bugs this fixes
https://github.com/dotnet/roslyn/issues/24262

### Workarounds, if any
No

### Risk
Low risk as it only add another check in the code analytic in foreach statement.

### Performance impact
low perf impact because no extra allocations/no complexity changes

### Is this a regression from a previous update?
not sure

### Root cause analysis
not sure

### How was the bug found?
customer reported it

### Test documentation updated?
Unit tests added

</details>
