### PR TITLE
Don't use inferred member name if that creates duplicates

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -45,6 +45,22 @@ class C
         }
 
         [Fact]
+        [WorkItem(24480, "https://github.com/dotnet/roslyn/issues/24480")]
+        public async Task TestInferredTupleName_WithAmbiguity()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        int alice = 1;
+        (int, int, string) t = ([||]alice: alice, alice, null);
+    }
+}", parameters: new TestParameters(parseOptions: s_parseOptions));
+        }
+
+        [Fact]
         public async Task TestInferredTupleNameAfterCommaWithCSharp6()
         {
             await TestActionCountAsync(
@@ -122,6 +138,22 @@ class C
         var t = new { a, 2 };
     }
 }", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        [WorkItem(24480, "https://github.com/dotnet/roslyn/issues/24480")]
+        public async Task TestInferredAnonymousTypeMemberName_WithAmbiguity()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        int alice = 1;
+        var t = new { [||]alice=alice, alice };
+    }
+}", parameters: new TestParameters(parseOptions: s_parseOptions));
         }
 
         [Fact]

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             using (var workspace = CreateWorkspaceFromOptions(initialMarkup, parameters))
             {
                 var actions = await GetCodeActionsAsync(workspace, parameters);
-                Assert.True(actions.Length == 0);
+                Assert.True(actions.Length == 0, "An action was offered when none was expected");
             }
         }
 

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -40,6 +40,21 @@ End Class
         End Function
 
         <Fact>
+        <WorkItem(24480, "https://github.com/dotnet/roslyn/issues/24480")>
+        Public Async Function TestInferredTupleName_WithAmbiguity() As Task
+            Await TestMissingAsync(
+"
+Class C
+    Sub M()
+        Dim alice As Integer = 1
+        Dim Alice As Integer = 2
+        Dim t = ( [||]alice:= alice, Alice)
+    End Sub
+End Class
+", parameters:=New TestParameters(s_parseOptions))
+        End Function
+
+        <Fact>
         <WorkItem(23659, "https://github.com/dotnet/roslyn/issues/23659")>
         Public Async Function TestMissingForObjectCreation() As Task
             Await TestMissingAsync(
@@ -117,6 +132,20 @@ Class C
     End Sub
 End Class
 ", parseOptions:=s_parseOptions)
+        End Function
+
+        <Fact>
+        <WorkItem(24480, "https://github.com/dotnet/roslyn/issues/24480")>
+        Public Async Function TestInferredAnonymousTypeMemberName_WithAmbiguity() As Task
+            Await TestMissingAsync("
+Class C
+    Sub M()
+        Dim alice As Integer = 1
+        Dim Alice As Integer = 2
+        Dim t = New With {[|.alice =|] alice, Alice}
+    End Sub
+End Class
+", parameters:=New TestParameters(s_parseOptions))
         End Function
 
         <Fact>


### PR DESCRIPTION
### Customer scenario
Use inferred name fixer on `var t = (alice: alice, alice);`. No fix should be offered, as it would result in the name for the first element being lost rather than inferred.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24480

### Workarounds, if any
Don't invoke the fixer in such cases.

### Risk

### Performance impact


### Is this a regression from a previous update?
No

### How was the bug found?
Reported by customer