### PR TITLE
Port fix for duplicate IDEDiagnosticIDs to 15.7

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDUniquenessTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDUniquenessTest.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public void UniqueIDEDiagnosticIds()
         {
             Type type = typeof(IDEDiagnosticIds);
-            List<string> ListOfIDEDiagnosticIds = type.GetFields().Select(x => x.GetValue(null).ToString()).ToList();
-            Assert.Equal(ListOfIDEDiagnosticIds.Count, ListOfIDEDiagnosticIds.Distinct().Count());
+            List<string> listOfIDEDiagnosticIds = type.GetFields().Select(x => x.GetValue(null).ToString()).ToList();
+            Assert.Equal(listOfIDEDiagnosticIds.Count, listOfIDEDiagnosticIds.Distinct().Count());
         }
     }
 }

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDUniquenessTest.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDUniquenessTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
+{
+    public class IDEDiagnosticIDUniquenessTest
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        public void UniqueIDEDiagnosticIds()
+        {
+            Type type = typeof(IDEDiagnosticIds);
+            List<string> ListOfIDEDiagnosticIds = type.GetFields().Select(x => x.GetValue(null).ToString()).ToList();
+            Assert.Equal(ListOfIDEDiagnosticIds.Count, ListOfIDEDiagnosticIds.Distinct().Count());
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string UseExplicitTupleNameDiagnosticId = "IDE0033";
 
         public const string UseDefaultLiteralDiagnosticId = "IDE0034";
-        public const string ValidateFormatStringDiagnosticID = "IDE0035";
 
         public const string RemoveUnreachableCodeDiagnosticId = "IDE0035";
 
@@ -62,6 +61,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string UseIsNullCheckDiagnosticId = "IDE0041";
 
         public const string UseDeconstructionDiagnosticId = "IDE0042";
+
+        public const string ValidateFormatStringDiagnosticID = "IDE0043";
 
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";


### PR DESCRIPTION
Backporting #24590 to 15.7

Original template copied here:
Customer scenario
Both the Validate Format String and Remove Unreachable Code analyzers use the same ID, so a user would see the same code for both of these issues and if they suppress either one it would suppress both.

Bugs this fixes
#23983

Workarounds, if any
none

Risk
No code risk, but it is a breaking change. If a customer previously suppressed the Validate Format String analzyer, it would start firing again because it has a new ID number. @kuhlenh will change it in our documentation and add it to the breaking change log.

Performance impact
none

Is this a regression from a previous update?
no

Root cause analysis
How was the bug found?
Test documentation updated?