### PR TITLE
Create missing binder for local function with both block and expression bodies

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -195,7 +195,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
         {
-            var body = (CSharpSyntaxNode)node.Body ?? node.ExpressionBody;
+            if (node.Body != null)
+            {
+                VisitLocalFunctionBody(node, node.Body);
+            }
+            if (node.ExpressionBody != null)
+            {
+                VisitLocalFunctionBody(node, node.ExpressionBody);
+            }
+        }
+
+        private void VisitLocalFunctionBody(LocalFunctionStatementSyntax node, CSharpSyntaxNode body)
+        {
             LocalFunctionSymbol match = null;
             // Don't use LookupLocalFunction because it recurses up the tree, as it
             // should be defined in the directly enclosing block (see note below)

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -196,13 +196,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
         {
             bool oldSawYield = _sawYield;
+            Symbol oldMethod = _containingMemberOrLambda;
             Binder binder = _enclosing;
-            Symbol oldMethod = null;
             LocalFunctionSymbol match = FindLocalFunction(node, _enclosing);
 
             if ((object)match != null)
             {
-                oldMethod = _containingMemberOrLambda;
                 _containingMemberOrLambda = match;
 
                 binder = match.IsGenericMethod
@@ -233,11 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(!_sawYield);
             }
 
-            if ((object)oldMethod != null)
-            {
-                _containingMemberOrLambda = oldMethod;
-            }
-
+            _containingMemberOrLambda = oldMethod;
             _sawYield = oldSawYield;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -84,7 +84,7 @@ class Program
 {
     static void Main(string[] args)
     {
-        void Func() { } => new object();
+        void local() { } => new object();
     }
 }");
             var tree = comp.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
@@ -71,6 +73,30 @@ public class E
 }", references: new[] { LinqAssemblyRef }, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: @"1
 0");
+        }
+
+        [Fact]
+        [WorkItem(24647, "https://github.com/dotnet/roslyn/issues/24647")]
+        public void Repro24647()
+        {
+            var comp = CreateStandardCompilation(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        void Func() { } => new object();
+    }
+}");
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            var creation = tree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().Single();
+
+            var operation = model.GetOperation(creation);
+            Assert.Null(operation); // we didn't bind the expression body, but should. See issue https://github.com/dotnet/roslyn/issues/24650
+
+            var info = model.GetTypeInfo(creation);
+            Assert.Equal("System.Object", info.Type.ToTestDisplayString());
+            Assert.Equal("System.Object", info.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]


### PR DESCRIPTION
### Customer scenario
Typing a local function with both a block and an expression body crashes the IDE.
For example: `void local() { } => new object();`

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24647

### Risk
### Performance impact
Low. Instead of creating a binder just for the block body or the just for the expression body, we create both binders.

### Is this a regression from a previous update?

### Root cause analysis
The crash occurred when using the semantic model's `GetTypeInfo` which tries to get bound nodes for the expression `new object()`. But we didn't create a binder for the expression body.

### How was the bug found?
Reported by customer.