### PR TITLE
added a way to specify ordering of Document/ProjectDiagnosticAnalyzers

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics.EngineV2;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -242,6 +244,43 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             // we should reach here without crashing
         }
 
+        [Fact]
+        public void TestHostAnalyzerOrdering()
+        {
+            var workspace = new AdhocWorkspace(MefV1HostServices.Create(TestExportProvider.ExportProviderWithCSharpAndVisualBasic.AsExportProvider()));
+
+            var project = workspace.AddProject(
+                          ProjectInfo.Create(
+                              ProjectId.CreateNewId(),
+                              VersionStamp.Create(), 
+                              "Dummy",
+                              "Dummy",
+                              LanguageNames.CSharp));
+
+            // create listener/service/analyzer
+            var listener = new AsynchronousOperationListener();
+            var service = new MyDiagnosticAnalyzerService(new DiagnosticAnalyzer[] {
+                new Priority20Analyzer(),
+                new Priority15Analyzer(),
+                new Priority10Analyzer(),
+                new Priority1Analyzer(),
+                new Priority0Analyzer(),
+                new CSharpCompilerDiagnosticAnalyzer(),
+                new Analyzer(),
+            }, listener, project.Language);
+
+            var incrementalAnalyzer = (DiagnosticIncrementalAnalyzer)service.CreateIncrementalAnalyzer(workspace);
+            var analyzers = incrementalAnalyzer.GetAnalyzersTestOnly(project).ToArray();
+
+            Assert.Equal(analyzers[0].GetType(), typeof(CSharpCompilerDiagnosticAnalyzer));
+            Assert.Equal(analyzers[1].GetType(), typeof(Analyzer));
+            Assert.Equal(analyzers[2].GetType(), typeof(Priority0Analyzer));
+            Assert.Equal(analyzers[3].GetType(), typeof(Priority1Analyzer));
+            Assert.Equal(analyzers[4].GetType(), typeof(Priority10Analyzer));
+            Assert.Equal(analyzers[5].GetType(), typeof(Priority15Analyzer));
+            Assert.Equal(analyzers[6].GetType(), typeof(Priority20Analyzer));
+        }
+
         private static Document GetDocumentFromIncompleteProject(AdhocWorkspace workspace)
         {
             var project = workspace.AddProject(
@@ -291,10 +330,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private class MyDiagnosticAnalyzerService : DiagnosticAnalyzerService
         {
             internal MyDiagnosticAnalyzerService(DiagnosticAnalyzer analyzer, IAsynchronousOperationListener listener, string language = LanguageNames.CSharp)
+                : this(SpecializedCollections.SingletonEnumerable(analyzer), listener, language)
+            {
+            }
+
+            internal MyDiagnosticAnalyzerService(IEnumerable<DiagnosticAnalyzer> analyzers, IAsynchronousOperationListener listener, string language = LanguageNames.CSharp)
                 : base(new HostAnalyzerManager(
                             ImmutableArray.Create<AnalyzerReference>(
                                 new TestAnalyzerReferenceByLanguage(
-                                    ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Empty.Add(language, ImmutableArray.Create(analyzer)))),
+                                    ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Empty.Add(language, ImmutableArray.CreateRange(analyzers)))),
                             hostDiagnosticUpdateSource: null),
                       hostDiagnosticUpdateSource: null,
                       registrationService: new MockDiagnosticUpdateSourceRegistrationService(),
@@ -357,6 +401,59 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             {
                 return SpecializedTasks.Default<ImmutableArray<Diagnostic>>();
             }
+        }
+
+        private class Priority20Analyzer : PriorityTestDocumentDiagnosticAnalyzer
+        {
+            public Priority20Analyzer() : base(priority: 20) { }
+        }
+
+        private class Priority15Analyzer : PriorityTestProjectDiagnosticAnalyzer
+        {
+            public Priority15Analyzer() : base(priority: 15) { }
+        }
+
+        private class Priority10Analyzer : PriorityTestDocumentDiagnosticAnalyzer
+        {
+            public Priority10Analyzer() : base(priority: 10) { }
+        }
+
+        private class Priority1Analyzer : PriorityTestProjectDiagnosticAnalyzer
+        {
+            public Priority1Analyzer() : base(priority: 1) { }
+        }
+
+        private class Priority0Analyzer : PriorityTestDocumentDiagnosticAnalyzer
+        {
+            public Priority0Analyzer() : base(priority: -1) { }
+        }
+
+        private class PriorityTestDocumentDiagnosticAnalyzer : DocumentDiagnosticAnalyzer
+        {
+            protected PriorityTestDocumentDiagnosticAnalyzer(int priority)
+            {
+                Priority = priority;
+            }
+
+            public override int Priority { get; }
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<Diagnostic>.Empty);
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<Diagnostic>.Empty);
+        }
+
+        private class PriorityTestProjectDiagnosticAnalyzer : ProjectDiagnosticAnalyzer
+        {
+            protected PriorityTestProjectDiagnosticAnalyzer(int priority)
+            {
+                Priority = priority;
+            }
+
+            public override int Priority { get; }
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
+                => Task.FromResult(ImmutableArray<Diagnostic>.Empty);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
@@ -30,6 +30,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Priority is ascending order and this only works on HostDiagnosticAnalyzer meaning Vsix installed analyzers in VS.
         /// This is to support partner teams (such as typescript and F#) who want to order their analyzer's execution order.
         /// </summary>
-        public virtual int Priority { get; } = DefaultPriority;
+        public virtual int Priority => DefaultPriority;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/DocumentDiagnosticAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal abstract class DocumentDiagnosticAnalyzer : DiagnosticAnalyzer
     {
+        public const int DefaultPriority = 50;
+
         public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken);
 
         public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken);
@@ -21,5 +23,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public sealed override void Initialize(AnalysisContext context)
         {
         }
+
+        /// <summary>
+        /// This lets vsix installed <see cref="DocumentDiagnosticAnalyzer"/> or <see cref="ProjectDiagnosticAnalyzer"/> to
+        /// specify priority of the analyzer. Regular <see cref="DiagnosticAnalyzer"/> always comes before those 2 different types.
+        /// Priority is ascending order and this only works on HostDiagnosticAnalyzer meaning Vsix installed analyzers in VS.
+        /// This is to support partner teams (such as typescript and F#) who want to order their analyzer's execution order.
+        /// </summary>
+        public virtual int Priority { get; } = DefaultPriority;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
@@ -28,6 +28,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Priority is ascending order and this only works on HostDiagnosticAnalyzer meaning Vsix installed analyzers in VS.
         /// This is to support partner teams (such as typescript and F#) who want to order their analyzer's execution order.
         /// </summary>
-        public virtual int Priority { get; } = DefaultPriority;
+        public virtual int Priority => DefaultPriority;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/ProjectDiagnosticAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal abstract class ProjectDiagnosticAnalyzer : DiagnosticAnalyzer
     {
+        public const int DefaultPriority = 50;
+
         public abstract Task<ImmutableArray<Diagnostic>> AnalyzeProjectAsync(Project project, CancellationToken cancellationToken);
 
         /// <summary>
@@ -19,5 +21,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public sealed override void Initialize(AnalysisContext context)
         {
         }
+
+        /// <summary>
+        /// This lets vsix installed <see cref="DocumentDiagnosticAnalyzer"/> or <see cref="ProjectDiagnosticAnalyzer"/> to
+        /// specify priority of the analyzer. Regular <see cref="DiagnosticAnalyzer"/> always comes before those 2 different types.
+        /// Priority is ascending order and this only works on HostDiagnosticAnalyzer meaning Vsix installed analyzers in VS.
+        /// This is to support partner teams (such as typescript and F#) who want to order their analyzer's execution order.
+        /// </summary>
+        public virtual int Priority { get; } = DefaultPriority;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -36,12 +36,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return GetAnalyzerMap(language).GetStateSets();
                 }
 
-                public IEnumerable<DiagnosticAnalyzer> GetAnalyzers(string language)
-                {
-                    var map = GetAnalyzerMap(language);
-                    return map.GetAnalyzers();
-                }
-
                 public StateSet GetOrCreateStateSet(string language, DiagnosticAnalyzer analyzer)
                 {
                     return GetAnalyzerMap(language).GetStateSet(analyzer);
@@ -85,21 +79,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                         // hold rest of analyzers
                         _map = analyzerMap.Remove(_compilerAnalyzer);
-                    }
-
-                    public IEnumerable<DiagnosticAnalyzer> GetAnalyzers()
-                    {
-                        // always return compiler one first if it exists.
-                        // it might not exist in test environment.
-                        if (_compilerAnalyzer != null)
-                        {
-                            yield return _compilerAnalyzer;
-                        }
-
-                        foreach (var (analyzer, _) in _map)
-                        {
-                            yield return analyzer;
-                        }
                     }
 
                     public IEnumerable<StateSet> GetStateSets()

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -59,6 +59,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 private class DiagnosticAnalyzerMap
                 {
+                    private const int BuiltInCompilerPriority = -2;
+                    private const int RegularDiagnosticAnalyzerPriority = -1;
+
                     private readonly StateSet _compilerStateSet;
 
                     private readonly ImmutableArray<StateSet> _orderedSet;
@@ -78,6 +81,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         }
 
                         // order statesets
+                        // order will be in this order
+                        // BuiltIn Compiler Analyzer (C#/VB) < Regular DiagnosticAnalyzers < Document/ProjectDiagnosticAnalyzers
                         _orderedSet = _map.Values.OrderBy(PriorityComparison).ToImmutableArray();
                     }
 
@@ -103,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         // compiler gets highest priority
                         if (state == _compilerStateSet)
                         {
-                            return -2;
+                            return BuiltInCompilerPriority;
                         }
 
                         switch (state.Analyzer)
@@ -113,8 +118,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             case ProjectDiagnosticAnalyzer analyzer:
                                 return Math.Max(0, analyzer.Priority);
                             default:
-                                // regular analyzer get next priority
-                                return -1;
+                                // regular analyzer get next priority after compiler analyzer
+                                return RegularDiagnosticAnalyzerPriority;
                         }
                     }
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -40,14 +40,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             public event EventHandler<ProjectAnalyzerReferenceChangedEventArgs> ProjectAnalyzerReferenceChanged;
 
             /// <summary>
-            /// Return existing or new <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>.
-            /// </summary>
-            public IEnumerable<DiagnosticAnalyzer> GetOrCreateAnalyzers(Project project)
-            {
-                return _hostStates.GetAnalyzers(project.Language).Concat(_projectStates.GetOrCreateAnalyzers(project));
-            }
-
-            /// <summary>
             /// Return all <see cref="StateSet"/>.
             /// This will never create new <see cref="StateSet"/> but will return ones already created.
             /// </summary>

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -282,6 +282,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             return Owner.GetOnAnalyzerException(projectId, DiagnosticLogAggregator);
         }
 
+        internal IEnumerable<DiagnosticAnalyzer> GetAnalyzersTestOnly(Project project)
+        {
+            return _stateManager.GetOrCreateStateSets(project).Select(s => s.Analyzer);
+        }
+
         private static string GetDocumentLogMessage(string title, Document document, DiagnosticAnalyzer analyzer)
         {
             return $"{title}: ({document.FilePath ?? document.Name}), ({analyzer.ToString()})";

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -222,15 +222,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         /// <summary>
-        /// Create <see cref="DiagnosticAnalyzer"/>s collection for given <paramref name="project"/>
-        /// </summary>
-        public ImmutableArray<DiagnosticAnalyzer> CreateDiagnosticAnalyzers(Project project)
-        {
-            var analyzersPerReferences = CreateDiagnosticAnalyzersPerReference(project);
-            return analyzersPerReferences.SelectMany(kv => kv.Value).ToImmutableArray();
-        }
-
-        /// <summary>
         /// Check whether given <see cref="DiagnosticData"/> belong to compiler diagnostic analyzer
         /// </summary>
         public bool IsCompilerDiagnostic(string language, DiagnosticData diagnostic)


### PR DESCRIPTION
### Customer scenario

Users that use F# or Typescript should see errors that are considered cheaper to calculate much faster than before.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/20390 (for F#)

### Workarounds, if any

each have put their own workaround for it which they want to remove.

### Risk

I don't see any risk

### Performance impact

time to run all analyzers are same. just order of they run can be changed. but for users, since they will see the first error faster than before if there is one, perception-wise, it could feel faster.

### Is this a regression from a previous update?

No

### Root cause analysis

Roslyn analyzer engine doesn't allow diagnostic author to specific order of analyzers since it is open platform (third party analyzers). otherwise, there can be an abuser that think theirs are most important and put theirs at the head. so we don't give this control to author. for built in analyzers, we do have control over the order. for example, we run compiler analyzers first so not a problem.

Issue occurred once partner team start to adapt Roslyn for diagnostics (typescript, F#). they want to control order of their builtin analyzers (like running their compiler analyzers run first), but to us, they are still not first party, so they don't have such control. this expose a way for them to control their analyzers order. but for now, this is specific to vsix installed analyzers and only for partner team (Document/ProjectDiagnosticAnalyzers). we still don't give it to pure third party.

### How was the bug found?

Dogfooding
