### PR TITLE
Don't compute project data for the remote workspace's WorkspaceHost

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/NeverPushProjectsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/NeverPushProjectsTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
+{
+    public class NeverPushProjectsTests
+    {
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void NeverPushProjectsDoesNotPushProjects()
+        {
+            using (var environment = new TestEnvironment(neverPushProjects: true))
+            {
+                var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
+
+                // This should be empty since we opted out
+                Assert.Empty(environment.Workspace.CurrentSolution.Projects);
+
+                // Mutate the project so we don't crash when not pushing projects
+                project.OnImportAdded("Z:\\Reference.dll", "Reference");
+
+                project.Disconnect();
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private readonly IVisualStudioWorkspaceHost _workspaceHost;
             private readonly VisualStudioProjectTracker _tracker;
             private readonly HashSet<AbstractProject> _pushedProjects;
+            private readonly bool _neverPushProjects;
 
             /// <summary>
             /// Set to true if we've already called <see cref="IVisualStudioWorkspaceHost.OnSolutionAdded(Microsoft.CodeAnalysis.SolutionInfo)"/>
@@ -25,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             /// </summary>
             private bool _solutionAdded;
 
-            public WorkspaceHostState(VisualStudioProjectTracker tracker, IVisualStudioWorkspaceHost workspaceHost)
+            public WorkspaceHostState(VisualStudioProjectTracker tracker, IVisualStudioWorkspaceHost workspaceHost, bool neverPushProjects)
                 : base(assertIsForeground: true)
             {
                 _tracker = tracker;
@@ -33,6 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _pushedProjects = new HashSet<AbstractProject>();
 
                 this.HostReadyForEvents = false;
+                _neverPushProjects = neverPushProjects;
                 _solutionAdded = false;
             }
 
@@ -89,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // Also, if the solution is closing we shouldn't do anything either, because all of our state is
                 // in the process of going away. This can happen if we receive notification that a document has
                 // opened in the middle of the solution close operation.
-                if (!this.HostReadyForEvents || _tracker._solutionIsClosing)
+                if (!this.HostReadyForEvents || _tracker._solutionIsClosing || _neverPushProjects)
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -167,6 +167,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void RegisterWorkspaceHost(IVisualStudioWorkspaceHost host)
         {
+            RegisterWorkspaceHost(host, neverPushProjects: false);
+        }
+
+        internal void RegisterWorkspaceHost(IVisualStudioWorkspaceHost host, bool neverPushProjects)
+        {
             this.AssertIsForeground();
 
             if (_workspaceHosts.Any(hostState => hostState.Host == host))
@@ -174,7 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 throw new ArgumentException("The workspace host is already registered.", nameof(host));
             }
 
-            _workspaceHosts.Add(new WorkspaceHostState(this, host));
+            _workspaceHosts.Add(new WorkspaceHostState(this, host, neverPushProjects));
         }
 
         public void StartSendingEventsToWorkspaceHost(IVisualStudioWorkspaceHost host)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 var projectTracker = vsWorkspace.GetProjectTrackerAndInitializeIfNecessary(Shell.ServiceProvider.GlobalProvider);
 
-                projectTracker.RegisterWorkspaceHost(host);
+                projectTracker.RegisterWorkspaceHost(host, neverPushProjects: true);
                 projectTracker.StartSendingEventsToWorkspaceHost(host);
             }, CancellationToken.None, ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.TaskScheduler).ConfigureAwait(false);
         }

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         Private ReadOnly _workspace As TestWorkspace
         Private ReadOnly _projectFilePaths As New List(Of String)
 
-        Public Sub New(Optional solutionIsFullyLoaded As Boolean = True)
+        Public Sub New(Optional solutionIsFullyLoaded As Boolean = True, Optional neverPushProjects As Boolean = False)
             ' As a policy, if anything goes wrong don't use exception filters, just throw exceptions for the
             ' test harness to catch normally. Otherwise debugging things can be annoying when your test process
             ' goes away
@@ -55,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             _projectTracker.InitializeProviders(documentProvider, metadataReferenceProvider, ruleSetFileProvider)
 
             Dim workspaceHost = New WorkspaceHost(_workspace)
-            _projectTracker.RegisterWorkspaceHost(workspaceHost)
+            _projectTracker.RegisterWorkspaceHost(workspaceHost, neverPushProjects)
             _projectTracker.StartSendingEventsToWorkspaceHost(workspaceHost)
         End Sub
 


### PR DESCRIPTION
When we are initializing the remote workspace, we connect an IVisualStudioWorkspaceHost as a way to get notifications about the solution being added and information being changed. The implementation of this for most methods is a no-op, but we were still spending a lot of time computing data to push to those methods that then ignored it. This PR adds an opt-out flag to save some processing time.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
