### PR TITLE
Run Mono build under Docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,8 @@ binaries_path="${root_path}"/Binaries
 bootstrap_path="${binaries_path}"/Bootstrap
 bootstrap_framework=netcoreapp2.0
 
+args=
+build_in_docker=false
 build_configuration=Debug
 restore=false
 build=false
@@ -53,56 +55,59 @@ do
     opt="$(echo "$1" | awk '{print tolower($0)}')"
     case "$opt" in
         -h|--help)
-        usage
-        exit 1
-        ;;
+            usage
+            exit 1
+            ;;
+        --docker)
+            build_in_docker=true
+            ;;
         --debug)
-        build_configuration=Debug
-        shift 1
-        ;;
+            build_configuration=Debug
+            ;;
         --release)
-        build_configuration=Release
-        shift 1
-        ;;
+            build_configuration=Release
+            ;;
         --restore|-r)
-        restore=true
-        shift 1
-        ;;
+            restore=true
+            ;;
         --build|-b)
-        build=true
-        shift 1
-        ;;
+            build=true
+            ;;
         --test|-t)
-        test_=true
-        shift 1
-        ;;
+            test_=true
+            ;;
         --mono)
-        use_mono=true
-        shift 1
-        ;;
+            use_mono=true
+            ;;
         --build-bootstrap)
-        build_bootstrap=true
-        shift 1
-        ;;
+            build_bootstrap=true
+            ;;
         --use-bootstrap)
-        use_bootstrap=true
-        shift 1
-        ;;
+            use_bootstrap=true
+            ;;
         --bootstrap)
-        build_bootstrap=true
-        use_bootstrap=true
-        shift 1
-        ;;
+            build_bootstrap=true
+            use_bootstrap=true
+            ;;
         --stop-vbcscompiler)
-        stop_vbcscompiler=true
-        shift 1
-        ;;
+            stop_vbcscompiler=true
+            ;;
         *)
-        usage
-        exit 1
+            echo "$1"
+            usage
+            exit 1
         ;;
     esac
+    args="$args $1"
+    shift
 done
+
+if [[ "$build_in_docker" = true ]]
+then
+    echo "Docker exec: $args"
+    BUILD_COMMAND=/opt/code/build.sh "$root_path"/build/scripts/dockerrun.sh $args
+    exit
+fi
 
 source "${root_path}"/build/scripts/obtain_dotnet.sh
 

--- a/build.sh
+++ b/build.sh
@@ -76,7 +76,7 @@ do
         test_=true
         shift 1
         ;;
-        --build-mono)
+        --mono)
         use_mono=true
         shift 1
         ;;

--- a/build.sh
+++ b/build.sh
@@ -76,7 +76,7 @@ do
         test_=true
         shift 1
         ;;
-        --mono)
+        --build-mono)
         use_mono=true
         shift 1
         ;;

--- a/build/scripts/cibuild.sh
+++ b/build/scripts/cibuild.sh
@@ -3,8 +3,9 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set -e
+set -u
 
-root_path="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+root_path="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # $HOME is unset when running the mac unit tests.
 if [[ -z "${HOME+x}" ]]
@@ -23,26 +24,4 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Building this commit:"
 git show --no-patch --pretty=raw HEAD
 
-args=
-
-while [[ $# > 0 ]]; do
-    case $1 in
-        --docker)
-            export BUILD_IN_DOCKER=1
-            ;;
-        *)
-            args="$args $1"
-            ;;
-    esac
-    shift
-done
-
-args="--restore --bootstrap --build --stop-vbcscompiler --test $args"
-
-if [ ! -z "$BUILD_IN_DOCKER" ]
-then
-    echo "Docker exec: $args"
-    BUILD_COMMAND=/opt/code/build.sh "$root_path"/build/scripts/dockerrun.sh $args
-else
-    "$root_path"/build.sh $args
-fi
+"${root_path}"/build.sh --restore --bootstrap --build --stop-vbcscompiler --test "$@"

--- a/build/scripts/cibuild.sh
+++ b/build/scripts/cibuild.sh
@@ -27,10 +27,8 @@ args=
 
 while [[ $# > 0 ]]; do
     case $1 in
-        # FIXME: temp variable
-        --mono)
+        --docker)
             export BUILD_IN_DOCKER=1
-            args="$args --build-mono"
             ;;
         *)
             args="$args $1"

--- a/build/scripts/cibuild.sh
+++ b/build/scripts/cibuild.sh
@@ -3,9 +3,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set -e
-set -u
 
-root_path="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+root_path="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 # $HOME is unset when running the mac unit tests.
 if [[ -z "${HOME+x}" ]]
@@ -24,4 +23,28 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "Building this commit:"
 git show --no-patch --pretty=raw HEAD
 
-"${root_path}"/build.sh --restore --bootstrap --build --stop-vbcscompiler --test "$@"
+args=
+
+while [[ $# > 0 ]]; do
+    case $1 in
+        # FIXME: temp variable
+        --mono)
+            export BUILD_IN_DOCKER=1
+            args="$args --build-mono"
+            ;;
+        *)
+            args="$args $1"
+            ;;
+    esac
+    shift
+done
+
+args="--restore --bootstrap --build --stop-vbcscompiler --test $args"
+
+if [ ! -z "$BUILD_IN_DOCKER" ]
+then
+    echo "Docker exec: $args"
+    BUILD_COMMAND=/opt/code/build.sh "$root_path"/build/scripts/dockerrun.sh $args
+else
+    "$root_path"/build.sh $args
+fi

--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -1,0 +1,47 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+FROM ubuntu:16.04
+
+# Install the base toolchain we need to build anything
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN rm -rf rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    apt-get update && \
+    apt-get install -y make \
+            git \
+            curl \
+            tar \
+            sudo && \
+    apt-get clean
+
+# Dependencies for CoreCLR and CoreFX
+RUN apt-get install -y  libunwind8 \
+            libkrb5-3 \
+            libicu55 \
+            liblttng-ust0 \
+            libssl1.0.0 \
+            zlib1g \
+            libuuid1 \
+            liblldb-3.6 \
+            libcurl4-openssl-dev && \
+    apt-get clean
+
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=0
+RUN useradd -m code_executor -u ${USER_ID} -g sudo
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permissions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+RUN chmod -R 755 /usr/lib/sudo
+
+# Set user to the one we just created
+USER ${USER_ID}
+
+# Set working directory
+WORKDIR /opt/code

--- a/build/scripts/dockerrun.sh
+++ b/build/scripts/dockerrun.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+dockerfile="$dir"/docker/
+
+[ -z "$CONTAINER_TAG" ] && CONTAINER_TAG="roslyn-build"
+[ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="roslyn-build-container"
+[ -z "$DOCKER_HOST_SHARE_dir" ] && DOCKER_HOST_SHARE_DIR="$dir"/../..
+
+# Make container names CI-specific if we're running in CI
+#  Jenkins
+[ ! -z "$BUILD_TAG" ] && CONTAINER_NAME="$BUILD_TAG"
+
+# Build the docker container (will be fast if it is already built)
+echo "Building Docker Container using Dockerfile: $dockerfile"
+docker build --build-arg USER_ID=$(id -u) -t $CONTAINER_TAG $dockerfile
+
+# Run the build in the container
+echo "Launching build in Docker Container"
+echo "Running command: $BUILD_COMMAND"
+echo "Using code from: $DOCKER_HOST_SHARE_DIR"
+
+# Note: passwords/keys should not be passed in the environment
+docker run -t --rm --sig-proxy=true \
+    --name $CONTAINER_NAME \
+    -v $DOCKER_HOST_SHARE_DIR:/opt/code \
+    $CONTAINER_TAG \
+    $BUILD_COMMAND "$@"

--- a/netci.groovy
+++ b/netci.groovy
@@ -122,7 +122,7 @@ commitPullList.each { isPr ->
   def myJob = job(jobName) {
     description("Ubuntu 16.04 mono tests")
                   steps {
-                    shell("./build/scripts/cibuild.sh --debug --mono")
+                    shell("./build/scripts/cibuild.sh --debug --docker --mono")
                   }
                 }
 


### PR DESCRIPTION
Mono only provides nightlies in .deb format and it's not easy to produce the zip we're using right now. This change runs our Mono builds in a docker container instead. This PR will be followed up by a change to use a mono .deb instead of our zip.