### PR TITLE
Updates link to .NET SDK in an error message

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -431,7 +431,7 @@
          set though we need to error out and provide a link to get the correct SDK installed.
       -->
     <Error 
-      Text="The $(ShortSdkVersion) SDK is required to build this repo. It can be install here https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.0-preview1-007622/dotnet-sdk-2.2.0-preview1-007622-win-x64.exe"
+      Text="The $(ShortSdkVersion) SDK is required to build this repo. It can be installed here https://www.microsoft.com/net/download"
       Condition="'$(UsingMicrosoftNETSdk)' == ''" />
   </Target> 
 


### PR DESCRIPTION
The hard link in the error message points to a specific version of .NET SDK installer which causes user's machine to end up in a bad state: see dotnet/cli/issues/8531 and [this](https://github.com/dotnet/designs/pull/29#issuecomment-363553995)

This PR changes the link to the general download page, where user may get a correct and supported version of the SDK

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
