### PR TITLE
fixed a bug on solution crawler progress report.

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -57,22 +57,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
                 }
 
-                public void RemoveCancellationSource(object key)
-                {
-                    lock (_gate)
-                    {
-                        // just remove cancellation token from the map.
-                        // the cancellation token might be passed out to other service
-                        // so don't call cancel on the source only because we are done using it.
-                        _cancellationMap.Remove(key);
-
-                        // every works enqueued by "AddOrReplace" will be processed
-                        // at some point, and when it is processed, this method will be called to mark
-                        // work has been done.
-                        _progressReporter.Stop();
-                    }
-                }
-
                 public virtual Task WaitAsync(CancellationToken cancellationToken)
                 {
                     return _semaphore.WaitAsync(cancellationToken);
@@ -87,6 +71,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             // the item is new item that got added to the queue.
                             // let solution crawler progress report to know about new item enqueued.
                             // progress reporter will take care of nested/overlapped works by itself
+                            // 
+                            // order of events is as follow
+                            // 1. first item added by AddOrReplace which is the point where progress start.
+                            // 2. bunch of other items added or replaced (workitem in the queue > 0)
+                            // 3. items start dequeued to be processed by TryTake or TryTakeAnyWork
+                            // 4. once item is done processed, it is marked as done by MarkWorkItemDoneFor
+                            // 5. all items in the queue are dequeued (workitem in the queue == 0) 
+                            //    but there can be still work in progress
+                            // 6. all works are considered done when last item is marked done by MarkWorkItemDoneFor
+                            //    and at the point, we will set progress to stop.
                             _progressReporter.Start();
 
                             // increase count 
@@ -95,6 +89,22 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
 
                         return false;
+                    }
+                }
+
+                public void MarkWorkItemDoneFor(object key)
+                {
+                    lock (_gate)
+                    {
+                        // just remove cancellation token from the map.
+                        // the cancellation token might be passed out to other service
+                        // so don't call cancel on the source only because we are done using it.
+                        _cancellationMap.Remove(key);
+
+                        // every works enqueued by "AddOrReplace" will be processed
+                        // at some point, and when it is processed, this method will be called to mark
+                        // work has been done.
+                        _progressReporter.Stop();
                     }
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncWorkItemQueue.cs
@@ -66,6 +66,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // so don't call cancel on the source only because we are done using it.
                         _cancellationMap.Remove(key);
 
+                        // every works enqueued by "AddOrReplace" will be processed
+                        // at some point, and when it is processed, this method will be called to mark
+                        // work has been done.
                         _progressReporter.Stop();
                     }
                 }
@@ -81,7 +84,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         if (AddOrReplace_NoLock(item))
                         {
-                            // progress reporter itself has ref counting
+                            // the item is new item that got added to the queue.
+                            // let solution crawler progress report to know about new item enqueued.
+                            // progress reporter will take care of nested/overlapped works by itself
                             _progressReporter.Start();
 
                             // increase count 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             SolutionCrawlerLogger.LogProcessActiveFileDocument(_processor._logAggregator, documentId.Id, processedEverything);
 
                             // remove one that is finished running
-                            _workItemQueue.RemoveCancellationSource(workItem.DocumentId);
+                            _workItemQueue.MarkWorkItemDoneFor(workItem.DocumentId);
                         }
                     }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             SolutionCrawlerLogger.LogProcessProject(this.Processor._logAggregator, projectId.Id, processedEverything);
 
                             // remove one that is finished running
-                            _workItemQueue.RemoveCancellationSource(projectId);
+                            _workItemQueue.MarkWorkItemDoneFor(projectId);
                         }
                     }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -364,7 +364,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                             SolutionCrawlerLogger.LogProcessDocument(this.Processor._logAggregator, documentId.Id, processedEverything);
 
                             // remove one that is finished running
-                            _workItemQueue.RemoveCancellationSource(workItem.DocumentId);
+                            _workItemQueue.MarkWorkItemDoneFor(workItem.DocumentId);
                         }
                     }
 


### PR DESCRIPTION
found case where retry can mess up Start/Stop call pair. instead of trying being smart to reduce Start/Stop call, made it simpler and rely on ref counting on reporter. and the fact that all enqeued work must run at some point.

### Customer scenario

User is working on code and "..." on error list never go away.

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/24707

### Workarounds, if any

No workaround

### Risk

fix is a visible cue on error list that indicates error list has pending update. so this fix won't cause any new crash or perf issue.

### Performance impact

"..." is static indicator, so no perf impact.

### Is this a regression from a previous update?

No

### Root cause analysis

existing code tries to be smart on when to call Start/Stop even though reporter itself has ref count. and that smart had an issue on cancellation/retry of a work. new change just let that ref count do the work and removed complex conditions.

### How was the bug found?

Dogfooding
