### PR TITLE
Keep track of the associated text snapshot when diagnotsics are created.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Common;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -36,6 +38,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
     {
         private readonly IDiagnosticService _diagnosticService;
 
+        /// <summary>
+        /// Keep track of the ITextSnapshot for the open Document that was used when diagnostics were
+        /// produced for it.  We need that because the DiagnoticService does not keep track of this
+        /// snapshot (so as to not hold onto a lot of memory), which means when we query it for 
+        /// diagnostics, we don't know how to map the span of the diagnostic to the current snapshot
+        /// we're tagging.
+        /// </summary>
+        private static readonly ConditionalWeakTable<object, ITextSnapshot> _diagnosticIdToTextSnapshot = 
+            new ConditionalWeakTable<object, ITextSnapshot>();
+
         protected AbstractDiagnosticsTaggerProvider(
             IDiagnosticService diagnosticService,
             IForegroundNotificationService notificationService,
@@ -43,6 +55,40 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             : base(listener, notificationService)
         {
             _diagnosticService = diagnosticService;
+            _diagnosticService.DiagnosticsUpdated += OnDiagnosticsUpdated;
+        }
+
+        private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
+        {
+            if (e.Solution == null || e.DocumentId == null)
+            {
+                return;
+            }
+
+            if (_diagnosticIdToTextSnapshot.TryGetValue(e.Id, out var snapshot))
+            {
+                return;
+            }
+
+            var document = e.Solution.GetDocument(e.DocumentId);
+
+            // Open documents *should* always have their SourceText available, but we cannot guarantee
+            // (i.e. assert) that they do.  That's because we're not on the UI thread here, so there's
+            // a small risk that between calling .IsOpen the file may then close, which then would
+            // cause TryGetText to fail.  However, that's ok.  In that case, if we do need to tag this
+            // document, we'll just use the current editor snapshot.  If that's the same, then the tags
+            // will be hte same.  If it is different, we'll eventually hear about the new diagnostics 
+            // for it and we'll reach our fixed point.
+            if (document != null && document.IsOpen())
+            {
+                // This should always be fast since the document is open.
+                var sourceText = document.State.GetTextSynchronously(cancellationToken: default);
+                snapshot = sourceText.FindCorrespondingEditorTextSnapshot();
+                if (snapshot != null)
+                {
+                    _diagnosticIdToTextSnapshot.GetValue(e.Id, _ => snapshot);
+                }
+            }
         }
 
         protected override TaggerDelay AddedTagNotificationDelay => TaggerDelay.OnIdle;
@@ -93,18 +139,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             var eventArgs = _diagnosticService.GetDiagnosticsUpdatedEventArgs(
                 workspace, document.Project.Id, document.Id, context.CancellationToken);
 
-            var sourceText = editorSnapshot.AsText();
             foreach (var updateArg in eventArgs)
             {
                 ProduceTags(
-                    context, spanToTag, workspace, document, sourceText,
+                    context, spanToTag, workspace, document, 
                     suppressedDiagnosticsSpans, updateArg, cancellationToken);
             }
         }
 
         private void ProduceTags(
             TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag,
-            Workspace workspace, Document document, SourceText sourceText, 
+            Workspace workspace, Document document,
             NormalizedSnapshotSpanCollection suppressedDiagnosticsSpans, 
             UpdatedEventArgs updateArgs, CancellationToken cancellationToken)
         {
@@ -118,6 +163,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 var requestedSpan = spanToTag.SnapshotSpan;
                 var editorSnapshot = requestedSpan.Snapshot;
+
+                // Try to get the text snapshot that these diagnostics were created against.
+                // This may fail if this tagger was created *after* the notification for the
+                // diagnostics was already issued.  That's ok.  We'll take the spans as reported
+                // and apply them directly to the snapshot we have.  Either no new changes will
+                // have happened, and these spans will be accurate, or a change will happen
+                // and we'll hear about and it update the spans shortly to the right position.
+                _diagnosticIdToTextSnapshot.TryGetValue(id, out var diagnosticSnapshot);
+                diagnosticSnapshot = diagnosticSnapshot ?? editorSnapshot;
+
+                var sourceText = diagnosticSnapshot.AsText();
 
                 foreach (var diagnosticData in diagnostics)
                 {
@@ -135,7 +191,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         //    editorSnapshot.
 
                         var diagnosticSpan = diagnosticData.GetExistingOrCalculatedTextSpan(sourceText)
-                                                           .ToSnapshotSpan(editorSnapshot);
+                                                           .ToSnapshotSpan(diagnosticSnapshot)
+                                                           .TranslateTo(editorSnapshot, SpanTrackingMode.EdgeExclusive);
 
                         if (diagnosticSpan.IntersectsWith(requestedSpan) &&
                             !IsSuppressed(suppressedDiagnosticsSpans, diagnosticSpan))

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -170,16 +170,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 // and apply them directly to the snapshot we have.  Either no new changes will
                 // have happened, and these spans will be accurate, or a change will happen
                 // and we'll hear about and it update the spans shortly to the right position.
-                _diagnosticIdToTextSnapshot.TryGetValue(id, out var diagnosticSnapshot);
-                diagnosticSnapshot = diagnosticSnapshot ?? editorSnapshot;
-
-                // This may happen if the file is closed/open.  We can't map these spans forward.
+                //
+                // Also, only use the diagnoticSnapshot if its text buffer matches our.  The text
+                // buffer might be different if the file was closed/reopened.
                 // Note: when this happens, the diagnostic service will reanalyze the file.  So
                 // up to date diagnostic spans will appear shortly after this.
-                if (diagnosticSnapshot.TextBuffer != editorSnapshot.TextBuffer)
-                {
-                    diagnosticSnapshot = editorSnapshot;
-                }
+                _diagnosticIdToTextSnapshot.TryGetValue(id, out var diagnosticSnapshot);
+                diagnosticSnapshot = diagnosticSnapshot?.TextBuffer == editorSnapshot.TextBuffer
+                    ? diagnosticSnapshot
+                    : editorSnapshot;
 
                 var sourceText = diagnosticSnapshot.AsText();
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -173,6 +173,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 _diagnosticIdToTextSnapshot.TryGetValue(id, out var diagnosticSnapshot);
                 diagnosticSnapshot = diagnosticSnapshot ?? editorSnapshot;
 
+                // This may happen if the file is closed/open.  We can't map these spans forward.
+                // Note: when this happens, the diagnostic service will reanalyze the file.  So
+                // up to date diagnostic spans will appear shortly after this.
+                if (diagnosticSnapshot.TextBuffer != editorSnapshot.TextBuffer)
+                {
+                    diagnosticSnapshot = editorSnapshot;
+                }
+
                 var sourceText = diagnosticSnapshot.AsText();
 
                 foreach (var diagnosticData in diagnostics)


### PR DESCRIPTION
This allows us to accurately map the span of a diagnostic returned by the diagnostic service forward to whatever snapshot we currently have.

### Customer scenario

User codes C#/VB/Typscript/F# and squiggles shows up in wrong places and take sometime before it gets corrected.

### Bugs this fixes

Fixes https://github.com/dotnet/roslyn/issues/24714

### Workarounds, if any

N/A

### Risk

I don't see any major risk due to this change.

### Performance impact

we use a map to associates buffer to right events, but it is small map and entries go away once either errors are fixed or files are closed. so no big issue here.

### Is this a regression from a previous update?

Yes. this is due to this change (https://github.com/dotnet/roslyn/pull/23448) which fixed one of biggest memory issue we had. 

### Root cause analysis

when one of diagnostics got updated, our existing tagger updated all diagnostics currently marked on open files. and that is an issue since some of diagnostics are not synced to latest source yet. only one of them has. so except that one, all other diagnostics can point to wrong span which cause the issue above.
the fix make sure when we use diagnostics from old source, we map that to current text correctly.

### How was the bug found?

Dogfooding
