### PR TITLE
Skipping PasteCommandWithInteractiveFormatAsBoxCopy test

### DIFF
--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -127,7 +127,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
             End Using
         End Sub
 
-        <WpfFact>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/24749")>
         <Trait(Traits.Feature, Traits.Features.Interactive)>
         Public Sub PasteCommandWithInteractiveFormatAsBoxCopy()
             Using workspace = TestWorkspace.Create(


### PR DESCRIPTION
This skips a flakey test reported here: https://github.com/dotnet/roslyn/issues/24749