### PR TITLE
Implement improved overload candidates, aka "Bestest Betterness".

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -259,6 +259,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ToBadExpression(expr, resultKind);
         }
 
+        internal static bool IsTypeOrValueExpression(BoundExpression expression)
+        {
+            switch (expression?.Kind)
+            {
+                case BoundKind.TypeOrValueExpression:
+                case BoundKind.QueryClause when ((BoundQueryClause)expression).Value.Kind == BoundKind.TypeOrValueExpression:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         /// <summary>
         /// The purpose of this method is to determine if the expression satisfies desired capabilities. 
         /// If it is not then this code gives an appropriate error message.

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 var containingMember = this.ContainingMemberOrLambda;
-                switch (containingMember.Kind)
+                switch (containingMember?.Kind)
                 {
                     case SymbolKind.Method:
                         // global statements

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -807,8 +807,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             MethodSymbol selectedMethod = conversion.Method;
 
-            if (MemberGroupFinalValidation(receiverOpt, selectedMethod, syntax, diagnostics, isExtensionMethod) ||
-                !MethodGroupIsCompatibleWithDelegate(receiverOpt, isExtensionMethod, selectedMethod, delegateType, syntax.Location, diagnostics))
+            if (!MethodGroupIsCompatibleWithDelegate(receiverOpt, isExtensionMethod, selectedMethod, delegateType, syntax.Location, diagnostics) ||
+                MemberGroupFinalValidation(receiverOpt, selectedMethod, syntax, diagnostics, isExtensionMethod))
             {
                 return true;
             }
@@ -863,8 +863,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(delegateMismatchLocation, useSiteDiagnostics);
             if (!conversion.Exists)
             {
-                // No overload for '{0}' matches delegate '{1}'
-                diagnostics.Add(ErrorCode.ERR_MethDelegateMismatch, delegateMismatchLocation, boundMethodGroup.Name, delegateType);
+                if (!Conversions.ReportDelegateMethodGroupDiagnostics(this, boundMethodGroup, delegateType, diagnostics))
+                {
+                    // No overload for '{0}' matches delegate '{1}'
+                    diagnostics.Add(ErrorCode.ERR_MethDelegateMismatch, delegateMismatchLocation, boundMethodGroup.Name, delegateType);
+                }
+
                 return true;
             }
             else

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -455,8 +455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            BoundNode receiverOpt = ((BoundMethodGroup)node).ReceiverOpt;
-            return receiverOpt != null && receiverOpt.Kind == BoundKind.TypeOrValueExpression;
+            return Binder.IsTypeOrValueExpression(((BoundMethodGroup)node).ReceiverOpt);
         }
 
         private BoundMethodGroup FixMethodGroupWithTypeOrValue(BoundMethodGroup group, Conversion conversion, DiagnosticBag diagnostics)
@@ -572,7 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //note that the same assert does not hold for all properties. Some properties and (all indexers) are not referenceable by name, yet
             //their binding brings them through here, perhaps needlessly.
 
-            if (receiverOpt != null && receiverOpt.Kind == BoundKind.TypeOrValueExpression)
+            if (IsTypeOrValueExpression(receiverOpt))
             {
                 // TypeOrValue expression isn't replaced only if the invocation is late bound, in which case it can't be extension method.
                 // None of the checks below apply if the receiver can't be classified as a type or value. 
@@ -678,7 +677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return !IsMemberAccessedThroughType(receiverOpt);
         }
 
-        private static bool IsMemberAccessedThroughType(BoundExpression receiverOpt)
+        internal static bool IsMemberAccessedThroughType(BoundExpression receiverOpt)
         {
             if (receiverOpt == null)
             {
@@ -696,7 +695,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Was the receiver expression compiler-generated?
         /// </summary>
-        private static bool WasImplicitReceiver(BoundExpression receiverOpt)
+        internal static bool WasImplicitReceiver(BoundExpression receiverOpt)
         {
             if (receiverOpt == null) return true;
             if (!receiverOpt.WasCompilerGenerated) return false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4871,9 +4871,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     result.ReportDiagnostics(
-                        binder: this, location: errorLocation, nodeOpt: null, diagnostics: diagnostics,
-                        name: errorName, receiver: null, invokedExpression: null, arguments: analyzedArguments,
-                        memberGroup: candidateConstructors, typeContainingConstructor: typeContainingConstructors, delegateTypeBeingInvoked: null);
+                        binder: this, location: errorLocation, nodeOpt: null, diagnostics,
+                        name: errorName, receiver: null, invokedExpression: null, analyzedArguments,
+                        memberGroup: candidateConstructors, typeContainingConstructors, delegateTypeBeingInvoked: null);
                 }
             }
 
@@ -5836,9 +5836,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression left,
             ImmutableArray<TypeSymbol> typeArguments,
             bool isMethodGroupConversion,
-            RefKind returnRefKind = default,
-            TypeSymbol returnType = null
-)
+            RefKind returnRefKind,
+            TypeSymbol returnType)
         {
             var firstResult = new MethodGroupResolution();
             AnalyzedArguments actualArguments = null;
@@ -6888,6 +6887,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// will either be the methods defined on the receiver class directly (no extension methods)
         /// or the first set of extension methods.
         /// </summary>
+        /// <param name="node">The node associated with the method group</param>
+        /// <param name="analyzedArguments">The arguments of the invocation (or the delegate type, if a method group conversion)</param>
+        /// <param name="isMethodGroupConversion">True if it is a method group conversion</param>
+        /// <param name="useSiteDiagnostics"></param>
+        /// <param name="inferWithDynamic"></param>
+        /// <param name="returnRefKind">If a method group conversion, the desired ref kind of the delegate</param>
+        /// <param name="returnType">If a method group conversion, the desired return type of the delegate.
+        /// May be null during inference if the return type of the delegate needs to be computed.</param>
         internal MethodGroupResolution ResolveMethodGroup(
             BoundMethodGroup node,
             AnalyzedArguments analyzedArguments,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -497,7 +497,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             methodGroup.PopulateWithSingleMethod(boundExpression, delegateType.DelegateInvokeMethod);
             var overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            OverloadResolution.MethodInvocationOverloadResolution(methodGroup.Methods, methodGroup.TypeArguments, analyzedArguments, overloadResolutionResult, ref useSiteDiagnostics);
+            OverloadResolution.MethodInvocationOverloadResolution(
+                methods: methodGroup.Methods,
+                typeArguments: methodGroup.TypeArguments,
+                receiver: methodGroup.Receiver,
+                arguments: analyzedArguments,
+                result: overloadResolutionResult,
+                useSiteDiagnostics: ref useSiteDiagnostics);
             diagnostics.Add(node, useSiteDiagnostics);
 
             // If overload resolution on the "Invoke" method found an applicable candidate, and one of the arguments
@@ -943,8 +949,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Since there were no argument errors to report, we report an error on the invocation itself.
                     string name = (object)delegateTypeOpt == null ? methodName : null;
-                    result.ReportDiagnostics(this, GetLocationForOverloadResolutionDiagnostic(node, expression), diagnostics, name,
-                        methodGroup.Receiver, analyzedArguments, methodGroup.Methods.ToImmutable(),
+                    result.ReportDiagnostics(
+                        binder: this, location: GetLocationForOverloadResolutionDiagnostic(node, expression), nodeOpt: node, diagnostics: diagnostics, name: name,
+                        receiver: methodGroup.Receiver, invokedExpression: expression, arguments: analyzedArguments, memberGroup: methodGroup.Methods.ToImmutable(),
                         typeContainingConstructor: null, delegateTypeBeingInvoked: delegateTypeOpt,
                         queryClause: queryClause);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -807,7 +807,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             OverloadResolutionResult<MethodSymbol> overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            this.OverloadResolution.MethodInvocationOverloadResolution(candidateMethods, typeArguments, arguments, overloadResolutionResult, ref useSiteDiagnostics);
+            // We create a dummy receiver of the invocation so MethodInvocationOverloadResolution knows it was invoked from an instance, not a type
+            var dummyReceiver = new BoundImplicitReceiver(_syntax.Expression, patternType);
+            this.OverloadResolution.MethodInvocationOverloadResolution(
+                methods: candidateMethods,
+                typeArguments: typeArguments,
+                receiver: dummyReceiver,
+                arguments: arguments,
+                result: overloadResolutionResult,
+                useSiteDiagnostics: ref useSiteDiagnostics);
             diagnostics.Add(_syntax.Expression, useSiteDiagnostics);
 
             MethodSymbol result = null;

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -238,12 +238,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool ReportConflictWithParameter(Symbol parameter, Symbol newSymbol, string name, Location newLocation, DiagnosticBag diagnostics)
         {
             var oldLocation = parameter.Locations[0];
-#if PATTERNS_FIXED
             Debug.Assert(oldLocation != newLocation || oldLocation == Location.None || newLocation.SourceTree?.GetRoot().ContainsDiagnostics == true,
                 "same nonempty location refers to different symbols?");
-#else
-            if (oldLocation == newLocation) return false;
-#endif
             SymbolKind parameterKind = parameter.Kind;
 
             // Quirk of the way we represent lambda parameters.                

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -71,7 +71,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var analyzedArguments = AnalyzedArguments.GetInstance();
                 GetDelegateArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
-                var resolution = binder.ResolveMethodGroup(source, analyzedArguments, isMethodGroupConversion: true, ref useSiteDiagnostics, inferWithDynamic: true);
+                var resolution = binder.ResolveMethodGroup(source, analyzedArguments, useSiteDiagnostics: ref useSiteDiagnostics, inferWithDynamic: true,
+                    isMethodGroupConversion: true, returnRefKind: delegateInvokeMethodOpt.RefKind, returnType: delegateInvokeMethodOpt.ReturnType);
                 analyzedArguments.Free();
                 return resolution;
             }
@@ -165,10 +166,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var overloadDiagnostics = DiagnosticBag.GetInstance();
 
-                        result.ReportDiagnostics(binder, expr.Syntax.Location, overloadDiagnostics,
-                            expr.Name,
-                            resolution.MethodGroup.Receiver, resolution.AnalyzedArguments, resolution.MethodGroup.Methods.ToImmutable(),
-                            typeContainingConstructor: null, delegateTypeBeingInvoked: null, isMethodGroupConversion: true);
+                        result.ReportDiagnostics(
+                            binder: binder, location: expr.Syntax.Location, nodeOpt: expr.Syntax, diagnostics: overloadDiagnostics,
+                            name: expr.Name,
+                            receiver: resolution.MethodGroup.Receiver, invokedExpression: expr.Syntax, arguments: resolution.AnalyzedArguments,
+                            memberGroup: resolution.MethodGroup.Methods.ToImmutable(),
+                            typeContainingConstructor: null, delegateTypeBeingInvoked: null,
+                            isMethodGroupConversion: true, returnRefKind: invokeMethodOpt?.RefKind, delegateType: targetType);
 
                         if (!overloadDiagnostics.IsEmptyWithoutResolution)
                         {
@@ -189,12 +193,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var analyzedArguments = AnalyzedArguments.GetInstance();
             var result = OverloadResolutionResult<MethodSymbol>.GetInstance();
+            var delegateInvokeMethod = delegateType.DelegateInvokeMethod;
 
-            Debug.Assert((object)delegateType.DelegateInvokeMethod != null && !delegateType.DelegateInvokeMethod.HasUseSiteError,
+            Debug.Assert((object)delegateInvokeMethod != null && !delegateInvokeMethod.HasUseSiteError,
                          "This method should only be called for valid delegate types");
-            GetDelegateArguments(syntax, analyzedArguments, delegateType.DelegateInvokeMethod.Parameters, Compilation);
+            GetDelegateArguments(syntax, analyzedArguments, delegateInvokeMethod.Parameters, Compilation);
             _binder.OverloadResolution.MethodInvocationOverloadResolution(
-                methodGroup.Methods, methodGroup.TypeArguments, analyzedArguments, result, ref useSiteDiagnostics, isMethodGroupConversion: true);
+                methods: methodGroup.Methods,
+                typeArguments: methodGroup.TypeArguments,
+                receiver: methodGroup.Receiver,
+                arguments: analyzedArguments,
+                result: result,
+                useSiteDiagnostics: ref useSiteDiagnostics,
+                isMethodGroupConversion: true,
+                returnRefKind: delegateInvokeMethod.RefKind,
+                returnType: delegateInvokeMethod.ReturnType);
             var conversion = ToConversion(result, methodGroup, delegateType);
 
             analyzedArguments.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly ImmutableArray<Conversion> ConversionsOpt;
         public readonly ImmutableArray<int> BadArgumentsOpt;
         public readonly ImmutableArray<int> ArgsToParamsOpt;
-        public readonly ImmutableArray<TypeParameterDiagnosticInfo> ConstraintFailureDiagnosticsOpt;
+        public readonly ImmutableArray<TypeParameterDiagnosticInfo> ConstraintFailureDiagnostics;
 
         public readonly int BadParameter;
         public readonly MemberResolutionKind Kind;
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ConversionsOpt = conversionsOpt;
             this.BadParameter = missingParameter;
             this.HasAnyRefOmittedArgument = hasAnyRefOmittedArgument;
-            this.ConstraintFailureDiagnosticsOpt = constraintFailureDiagnosticsOpt.NullToEmpty();
+            this.ConstraintFailureDiagnostics = constraintFailureDiagnosticsOpt.NullToEmpty();
         }
 
         public override bool Equals(object obj)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly ImmutableArray<Conversion> ConversionsOpt;
         public readonly ImmutableArray<int> BadArgumentsOpt;
         public readonly ImmutableArray<int> ArgsToParamsOpt;
-        public readonly ArrayBuilder<TypeParameterDiagnosticInfo> ConstraintFailureDiagnosticsOpt;
+        public readonly ImmutableArray<TypeParameterDiagnosticInfo> ConstraintFailureDiagnosticsOpt;
 
         public readonly int BadParameter;
         public readonly MemberResolutionKind Kind;
@@ -28,11 +28,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public readonly bool HasAnyRefOmittedArgument;
 
-        private MemberAnalysisResult(MemberResolutionKind kind)
-            : this(kind, constraintFailureDiagnosticsOpt: default)
-        {
-        }
-
         private MemberAnalysisResult(
             MemberResolutionKind kind,
             ImmutableArray<int> badArgumentsOpt = default,
@@ -40,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<Conversion> conversionsOpt = default,
             int missingParameter = -1,
             bool hasAnyRefOmittedArgument = false,
-            ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt = null)
+            ImmutableArray<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt = default)
         {
             this.Kind = kind;
             this.BadArgumentsOpt = badArgumentsOpt;
@@ -48,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ConversionsOpt = conversionsOpt;
             this.BadParameter = missingParameter;
             this.HasAnyRefOmittedArgument = hasAnyRefOmittedArgument;
-            this.ConstraintFailureDiagnosticsOpt = constraintFailureDiagnosticsOpt;
+            this.ConstraintFailureDiagnosticsOpt = constraintFailureDiagnosticsOpt.NullToEmpty();
         }
 
         public override bool Equals(object obj)
@@ -284,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new MemberAnalysisResult(MemberResolutionKind.Worst);
         }
 
-        internal static MemberAnalysisResult ConstraintFailure(ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnostics)
+        internal static MemberAnalysisResult ConstraintFailure(ImmutableArray<TypeParameterDiagnosticInfo> constraintFailureDiagnostics)
         {
             return new MemberAnalysisResult(MemberResolutionKind.ConstraintFailure, constraintFailureDiagnosticsOpt: constraintFailureDiagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
@@ -93,9 +93,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         TypeInferenceExtensionInstanceArgument,
 
         /// <summary>
-        /// The candidate member was rejected because it a constraint on a type parameter was not satisfied.
+        /// The candidate member was rejected because a constraint on the type of a parameter was not satisfied.
         /// </summary>
         ConstructedParameterFailedConstraintCheck,
+
+        /// <summary>
+        /// The candidate method's type arguments do not satisfy their constraints.
+        /// </summary>
+        ConstraintFailure,
+
+        /// <summary>
+        /// The candidate member was rejected because it was an instance member accessed from a type,
+        /// or a static member accessed from an instance.
+        /// </summary>
+        StaticInstanceMismatch,
+
+        /// <summary>
+        /// The candidate method in a delegate conversion was rejected because the ref kind of its return does not match the delegate.
+        /// </summary>
+        WrongRefKind,
+
+        /// <summary>
+        /// The candidate method in a delegate conversion was rejected because its return type does not match the return type of the delegate.
+        /// </summary>
+        WrongReturnType,
 
         /// <summary>
         /// The candidate member was rejected because another member further down in the inheritance hierarchy was

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -110,60 +111,77 @@ namespace Microsoft.CodeAnalysis.CSharp
         public void MethodInvocationOverloadResolution(
             ArrayBuilder<MethodSymbol> methods,
             ArrayBuilder<TypeSymbol> typeArguments,
+            BoundExpression receiver,
             AnalyzedArguments arguments,
             OverloadResolutionResult<MethodSymbol> result,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
             bool isMethodGroupConversion = false,
             bool allowRefOmittedArguments = false,
             bool inferWithDynamic = false,
-            bool allowUnexpandedForm = true)
+            bool allowUnexpandedForm = true,
+            RefKind returnRefKind = default,
+            TypeSymbol returnType = null)
         {
             MethodOrPropertyOverloadResolution(
-                methods, typeArguments, arguments, result, isMethodGroupConversion,
+                methods, typeArguments, receiver, arguments, result, isMethodGroupConversion,
                 allowRefOmittedArguments, ref useSiteDiagnostics, inferWithDynamic: inferWithDynamic,
-                allowUnexpandedForm: allowUnexpandedForm);
+                allowUnexpandedForm: allowUnexpandedForm,
+                returnRefKind: returnRefKind,
+                returnType: returnType);
         }
 
         // Perform overload resolution on the given property group, with the given arguments and
         // names. The names can be null if no names were supplied to any arguments.
         public void PropertyOverloadResolution(
             ArrayBuilder<PropertySymbol> indexers,
+            BoundExpression receiverOpt,
             AnalyzedArguments arguments,
             OverloadResolutionResult<PropertySymbol> result,
             bool allowRefOmittedArguments,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             ArrayBuilder<TypeSymbol> typeArguments = ArrayBuilder<TypeSymbol>.GetInstance();
-            MethodOrPropertyOverloadResolution(indexers, typeArguments, arguments, result, isMethodGroupConversion: false, allowRefOmittedArguments: allowRefOmittedArguments, useSiteDiagnostics: ref useSiteDiagnostics);
+            MethodOrPropertyOverloadResolution(
+                indexers, typeArguments, receiverOpt, arguments, result, isMethodGroupConversion: false,
+                allowRefOmittedArguments: allowRefOmittedArguments, useSiteDiagnostics: ref useSiteDiagnostics);
             typeArguments.Free();
         }
 
         internal void MethodOrPropertyOverloadResolution<TMember>(
             ArrayBuilder<TMember> members,
             ArrayBuilder<TypeSymbol> typeArguments,
+            BoundExpression receiver,
             AnalyzedArguments arguments,
             OverloadResolutionResult<TMember> result,
             bool isMethodGroupConversion,
             bool allowRefOmittedArguments,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
             bool inferWithDynamic = false,
-            bool allowUnexpandedForm = true)
+            bool allowUnexpandedForm = true,
+            RefKind returnRefKind = default,
+            TypeSymbol returnType = null)
             where TMember : Symbol
         {
             var results = result.ResultsBuilder;
 
             // First, attempt overload resolution not getting complete results.
             PerformMemberOverloadResolution(
-                results, members, typeArguments, arguments, false, isMethodGroupConversion,
-                allowRefOmittedArguments, ref useSiteDiagnostics, inferWithDynamic: inferWithDynamic,
-                allowUnexpandedForm: allowUnexpandedForm);
+                results: results, members: members, typeArguments: typeArguments,
+                receiver: receiver, arguments: arguments, completeResults: false,
+                isMethodGroupConversion: isMethodGroupConversion, returnRefKind: returnRefKind, returnType: returnType,
+                allowRefOmittedArguments: allowRefOmittedArguments, useSiteDiagnostics: ref useSiteDiagnostics,
+                inferWithDynamic: inferWithDynamic, allowUnexpandedForm: allowUnexpandedForm);
 
             if (!OverloadResolutionResultIsValid(results, arguments.HasDynamicArgument))
             {
                 // We didn't get a single good result. Get full results of overload resolution and return those.
                 result.Clear();
-                PerformMemberOverloadResolution(results, members, typeArguments, arguments, true, isMethodGroupConversion,
-                    allowRefOmittedArguments, ref useSiteDiagnostics, allowUnexpandedForm: allowUnexpandedForm);
+                PerformMemberOverloadResolution(
+                    results: results, members: members, typeArguments: typeArguments,
+                    receiver: receiver, arguments: arguments, completeResults: true,
+                    isMethodGroupConversion: isMethodGroupConversion, returnRefKind: returnRefKind, returnType: returnType,
+                    allowRefOmittedArguments: allowRefOmittedArguments, useSiteDiagnostics: ref useSiteDiagnostics,
+                    allowUnexpandedForm: allowUnexpandedForm);
             }
         }
 
@@ -205,9 +223,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<MemberResolutionResult<TMember>> results,
             ArrayBuilder<TMember> members,
             ArrayBuilder<TypeSymbol> typeArguments,
+            BoundExpression receiver,
             AnalyzedArguments arguments,
             bool completeResults,
             bool isMethodGroupConversion,
+            RefKind returnRefKind,
+            TypeSymbol returnType,
             bool allowRefOmittedArguments,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
             bool inferWithDynamic = false,
@@ -236,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < members.Count; i++)
             {
                 AddMemberToCandidateSet(
-                    members[i], results, members, typeArguments, arguments, completeResults,
+                    members[i], results, members, typeArguments, receiver, arguments, completeResults,
                     isMethodGroupConversion, allowRefOmittedArguments, containingTypeMapOpt, inferWithDynamic: inferWithDynamic,
                     useSiteDiagnostics: ref useSiteDiagnostics, allowUnexpandedForm: allowUnexpandedForm);
             }
@@ -251,6 +272,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // SPEC: The set of candidate methods is reduced to contain only methods from the most derived types.
             RemoveLessDerivedMembers(results, ref useSiteDiagnostics);
+
+            if (Compilation.LanguageVersion.AllowImprovedOverloadCandidates())
+            {
+                RemoveStaticInstanceMismatches(results, arguments, receiver);
+
+                RemoveConstraintViolations(results);
+
+                if (isMethodGroupConversion)
+                {
+                    RemoveDelegateConversionsWithWrongReturnType(results, ref useSiteDiagnostics, returnRefKind, returnType);
+                }
+            }
 
             // NB: As in dev12, we do this AFTER removing less derived members.
             // Also note that less derived members are not actually removed - they are simply flagged.
@@ -271,6 +304,149 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Note, the caller is responsible for "final validation",
             // as that is not part of overload resolution.
+        }
+
+        private void RemoveStaticInstanceMismatches<TMember>(
+            ArrayBuilder<MemberResolutionResult<TMember>> results,
+            AnalyzedArguments arguments,
+            BoundExpression receiverOpt) where TMember : Symbol
+        {
+            // When the feature 'ImprovedOverloadCandidates' is enabled, we do not include instance members when the receiver
+            // is a type, or static members when the receiver is an instance. This does not apply to extension method invocations,
+            // because extension methods are only considered when the receiver is an instance. It also does not apply when the
+            // receiver is a TypeOrValueExpression, which is used to handle the receiver of a Color-Color ambiguity, where either
+            // an instance or a static member would be acceptable.
+            if (arguments.IsExtensionMethodInvocation || Binder.IsTypeOrValueExpression(receiverOpt))
+            {
+                return;
+            }
+
+            bool isImplicitReceiver = Binder.WasImplicitReceiver(receiverOpt);
+            // isStaticContext includes both places where `this` isn't available, and places where it
+            // cannot be used (e.g. a field initializer or a constructor-initializer)
+            bool isStaticContext = !_binder.HasThis(!isImplicitReceiver, out bool inStaticContext) || inStaticContext;
+            if (isImplicitReceiver && !isStaticContext)
+            {
+                return;
+            }
+
+            // We are in a context where only instance (or only static) methods are permitted. We reject the others.
+            bool keepStatic = isImplicitReceiver && isStaticContext || Binder.IsMemberAccessedThroughType(receiverOpt);
+
+            for (int f = 0; f < results.Count; ++f)
+            {
+                var result = results[f];
+                TMember member = result.Member;
+                if (result.Result.IsValid && member.IsStatic != keepStatic)
+                {
+                    results[f] = new MemberResolutionResult<TMember>(member, result.LeastOverriddenMember, MemberAnalysisResult.StaticInstanceMismatch());
+                }
+            }
+        }
+
+        private void RemoveConstraintViolations<TMember>(ArrayBuilder<MemberResolutionResult<TMember>> results) where TMember : Symbol
+        {
+            // When the feature 'ImprovedOverloadCandidates' is enabled, we do not include methods for which the type arguments
+            // violate the constraints of the method's type parameters.
+
+            // Constraint violations apply to method in a method group, not to properties in a "property group".
+            if (typeof(TMember) != typeof(MethodSymbol))
+            {
+                return;
+            }
+
+            for (int f = 0; f < results.Count; ++f)
+            {
+                var result = results[f];
+                var member = (MethodSymbol)(Symbol)result.Member;
+                // a constraint failure on the method trumps (for reporting purposes) a previously-detected
+                // constraint failure on the constructed type of a parameter
+                if ((result.Result.IsValid || result.Result.Kind == MemberResolutionKind.ConstructedParameterFailedConstraintCheck) &&
+                    FailsConstraintChecks(member, out ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt))
+                {
+                    results[f] = new MemberResolutionResult<TMember>(
+                        result.Member, result.LeastOverriddenMember, MemberAnalysisResult.ConstraintFailure(constraintFailureDiagnosticsOpt));
+                }
+            }
+        }
+
+        private bool FailsConstraintChecks(MethodSymbol method, out ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt)
+        {
+            if (method.Arity == 0 || method.OriginalDefinition == (object)method)
+            {
+                constraintFailureDiagnosticsOpt = null;
+                return false;
+            }
+
+            var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
+            ArrayBuilder <TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
+            var constraintsSatisfied = ConstraintsHelper.CheckMethodConstraints(
+                method,
+                this.Conversions,
+                this.Compilation,
+                diagnosticsBuilder,
+                ref useSiteDiagnosticsBuilder);
+
+            if (!constraintsSatisfied)
+            {
+                if (useSiteDiagnosticsBuilder != null)
+                {
+                    diagnosticsBuilder.AddRange(useSiteDiagnosticsBuilder);
+                    useSiteDiagnosticsBuilder.Free();
+                }
+
+                constraintFailureDiagnosticsOpt = diagnosticsBuilder;
+                return true;
+            }
+
+            diagnosticsBuilder.Free();
+            useSiteDiagnosticsBuilder?.Free();
+            constraintFailureDiagnosticsOpt = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Remove candidates to a delegate conversion where the method's return ref kind or return type is wrong.
+        /// </summary>
+        /// <param name="returnRefKind">The ref kind of the delegate's return, if known. This is only unknown in
+        /// error scenarios, such as a delegate type that has no invoke method.</param>
+        /// <param name="returnType">The return type of the delegate, if known. It isn't
+        /// known when we're attempting to infer the return type of a method group for type inference.</param>
+        private void RemoveDelegateConversionsWithWrongReturnType<TMember>(
+            ArrayBuilder<MemberResolutionResult<TMember>> results,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+            RefKind? returnRefKind,
+            TypeSymbol returnType) where TMember : Symbol
+        {
+            // When the feature 'ImprovedOverloadCandidates' is enabled, then a delegate conversion overload resolution
+            // rejects candidates that have the wrong return ref kind or return type.
+
+            // Delegate conversions apply to method in a method group, not to properties in a "property group".
+            Debug.Assert(typeof(TMember) == typeof(MethodSymbol));
+
+            for (int f = 0; f < results.Count; ++f)
+            {
+                var result = results[f];
+                if (!result.Result.IsValid)
+                {
+                    continue;
+                }
+
+                var method = (MethodSymbol)(Symbol)result.Member;
+                bool returnsMatch = returnType == null ||
+                                    method.ReturnType.Equals(returnType, TypeCompareKind.AllIgnoreOptions) ||
+                                    returnRefKind == RefKind.None && Conversions.HasIdentityOrImplicitReferenceConversion(method.ReturnType, returnType, ref useSiteDiagnostics);
+                if (!returnsMatch)
+                {
+                    results[f] = new MemberResolutionResult<TMember>(
+                        result.Member, result.LeastOverriddenMember, MemberAnalysisResult.WrongReturnType());
+                }
+                else if (method.RefKind != returnRefKind)
+                {
+                    results[f] = new MemberResolutionResult<TMember>(
+                        result.Member, result.LeastOverriddenMember, MemberAnalysisResult.WrongRefKind());
+                }
+            }
         }
 
         private static Dictionary<NamedTypeSymbol, ArrayBuilder<TMember>> PartitionMembersByContainingType<TMember>(ArrayBuilder<TMember> members) where TMember : Symbol
@@ -424,6 +600,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<MemberResolutionResult<TMember>> results,
             ArrayBuilder<TMember> members,
             ArrayBuilder<TypeSymbol> typeArguments,
+            BoundExpression receiverOpt,
             AnalyzedArguments arguments,
             bool completeResults,
             bool isMethodGroupConversion,
@@ -2943,7 +3120,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     //
                     // Suppose there is a call M("", null). Type inference infers that T is string.
                     // M<string> is then not an applicable candidate *NOT* because string violates the
-                    // constraint on T. That is not checked until "final validation". Rather, the 
+                    // constraint on T. That is not checked until "final validation" (although when
+                    // feature 'ImprovedOverloadCandidates' is enabled in later language versions
+                    // it is checked on the candidate before overload resolution). Rather, the 
                     // method is not a candidate because string violates the constraint *on U*. 
                     // The constructed method has formal parameter type X<string>, which is not legal.
                     // In the case given, the generic method is eliminated and the object version wins.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -365,7 +365,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     FailsConstraintChecks(member, out ArrayBuilder<TypeParameterDiagnosticInfo> constraintFailureDiagnosticsOpt))
                 {
                     results[f] = new MemberResolutionResult<TMember>(
-                        result.Member, result.LeastOverriddenMember, MemberAnalysisResult.ConstraintFailure(constraintFailureDiagnosticsOpt));
+                        result.Member, result.LeastOverriddenMember,
+                        MemberAnalysisResult.ConstraintFailure(constraintFailureDiagnosticsOpt.ToImmutableAndFree()));
                 }
             }
         }
@@ -379,8 +380,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
-            ArrayBuilder <TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var constraintsSatisfied = ConstraintsHelper.CheckMethodConstraints(
+            ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
+            bool constraintsSatisfied = ConstraintsHelper.CheckMethodConstraints(
                 method,
                 this.Conversions,
                 this.Compilation,
@@ -433,9 +434,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var method = (MethodSymbol)(Symbol)result.Member;
-                bool returnsMatch = returnType == null ||
-                                    method.ReturnType.Equals(returnType, TypeCompareKind.AllIgnoreOptions) ||
-                                    returnRefKind == RefKind.None && Conversions.HasIdentityOrImplicitReferenceConversion(method.ReturnType, returnType, ref useSiteDiagnostics);
+                bool returnsMatch =
+                    (object)returnType == null ||
+                    method.ReturnType.Equals(returnType, TypeCompareKind.AllIgnoreOptions) ||
+                    returnRefKind == RefKind.None && Conversions.HasIdentityOrImplicitReferenceConversion(method.ReturnType, returnType, ref useSiteDiagnostics);
                 if (!returnsMatch)
                 {
                     results[f] = new MemberResolutionResult<TMember>(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            // Otherwise, f there is any such method that has a bad conversion or out/ref mismatch 
+            // Otherwise, if there is any such method that has a bad argument conversion or out/ref mismatch 
             // then the first such method found is the best bad method.
 
             if (HadBadArguments(diagnostics, binder, name, arguments, symbols, location, binder.Flags, isMethodGroupConversion))

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -638,7 +638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            foreach (var pair in constraintFailure.Result.ConstraintFailureDiagnosticsOpt)
+            foreach (var pair in constraintFailure.Result.ConstraintFailureDiagnostics)
             {
                 diagnostics.Add(new CSDiagnostic(pair.DiagnosticInfo, location));
             }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4841,7 +4841,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public definition for &apos;{1}&apos;.
+        ///   Looks up a localized string similar to foreach statement cannot operate on variables of type &apos;{0}&apos; because &apos;{0}&apos; does not contain a public instance definition for &apos;{1}&apos;.
         /// </summary>
         internal static string ERR_ForEachMissingMember {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2604,7 +2604,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>#r is only allowed in scripts</value>
   </data>
   <data name="ERR_ForEachMissingMember" xml:space="preserve">
-    <value>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</value>
+    <value>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</value>
   </data>
   <data name="WRN_BadXMLRefParamType" xml:space="preserve">
     <value>Invalid type for parameter {0} in XML comment cref attribute: '{1}'</value>

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (map.ContainsKey(key))
                     {
-#if DEBUG && PATTERNS_FIXED
+#if DEBUG
                         // It's possible that AddToMap was previously called with a subtree of root.  If this is the case,
                         // then we'll see an entry in the map.  Since the incremental binder should also have seen the
                         // pre-existing map entry, the entry in addition map should be identical.
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     Debug.Assert(
                                         ((BoundTypeExpression)existing[i]).Type == ((BoundTypeOrValueExpression)added[i]).Type,
                                         string.Format(
-                                            CultureInfo.InvariantCulture,
+                                            System.Globalization.CultureInfo.InvariantCulture,
                                             "((BoundTypeExpression)existing[{0}]).Type == ((BoundTypeOrValueExpression)added[{0}]).Type", i));
                                 }
                                 else if (existing[i].Kind == BoundKind.TypeOrValueExpression && added[i].Kind == BoundKind.TypeExpression)
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     Debug.Assert(
                                         ((BoundTypeOrValueExpression)existing[i]).Type == ((BoundTypeExpression)added[i]).Type,
                                         string.Format(
-                                            CultureInfo.InvariantCulture,
+                                            System.Globalization.CultureInfo.InvariantCulture,
                                             "((BoundTypeOrValueExpression)existing[{0}]).Type == ((BoundTypeExpression)added[{0}]).Type", i));
                                 }
                                 else
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 Debug.Assert(
                                     (object)existing[i] == added[i] || !(key is StatementSyntax),
                                     string.Format(
-                                        CultureInfo.InvariantCulture,
+                                        System.Globalization.CultureInfo.InvariantCulture,
                                         "(object)existing[{0}] == added[{0}] || !(key is StatementSyntax)", i));
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -148,6 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         IDS_FeatureRefConditional = MessageBase + 12731,
         IDS_FeatureAttributesOnBackingFields = MessageBase + 12732,
+        IDS_FeatureImprovedOverloadCandidates = MessageBase + 12733,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -189,6 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 7.3 features.
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
+                case MessageID.IDS_FeatureImprovedOverloadCandidates: // semantic check
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -341,5 +341,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return self >= MessageID.IDS_FeatureAttributesOnBackingFields.RequiredVersion();
         }
+
+        internal static bool AllowImprovedOverloadCandidates(this LanguageVersion self)
+        {
+            return self >= MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion();
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -613,8 +613,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ConversionsBase conversions,
             SyntaxNode syntaxNode,
             Compilation currentCompilation,
-            DiagnosticBag diagnostics,
-            BitVector skipParameters = default(BitVector))
+            DiagnosticBag diagnostics)
         {
             if (!RequiresChecking(method))
             {
@@ -623,7 +622,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var result = CheckMethodConstraints(method, conversions, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder, skipParameters);
+            var result = CheckMethodConstraints(method, conversions, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -688,7 +687,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ref useSiteDiagnosticsBuilder);
         }
 
-        private static bool CheckMethodConstraints(
+        public static bool CheckMethodConstraints(
             MethodSymbol method,
             ConversionsBase conversions,
             Compilation currentCompilation,
@@ -774,6 +773,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             HashSet<TypeParameterSymbol> ignoreTypeConstraintsDependentOnTypeParametersOpt)
         {
             Debug.Assert(substitution != null);
+
             // The type parameters must be original definitions of type parameters from the containing symbol.
             Debug.Assert(ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition));
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -4141,8 +4141,8 @@ Blok catch() po bloku catch (System.Exception e) může zachytit výjimky, kter�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">Příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje veřejnou definici pro {1}.</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">Příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje veřejnou definici pro {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -4141,8 +4141,8 @@ Ein catch()-Block nach einem catch (System.Exception e)-Block kann nicht-CLS-Aus
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">Eine foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, da "{0}" keine öffentliche Definition für "{1}" enthält.</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">Eine foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, da "{0}" keine öffentliche Definition für "{1}" enthält.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -4141,8 +4141,8 @@ Un bloque catch() después de un bloque catch (System.Exception e) puede abarcar
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">La instrucción foreach no puede funcionar en variables de tipo '{0}' porque '{0}' no contiene ninguna definición pública para '{1}'</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">La instrucción foreach no puede funcionar en variables de tipo '{0}' porque '{0}' no contiene ninguna definición pública para '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -4141,8 +4141,8 @@ Un bloc catch() après un bloc catch (System.Exception e) peut intercepter des e
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">L'instruction foreach ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient pas de définition publique pour '{1}'</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">L'instruction foreach ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient pas de définition publique pour '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -4141,8 +4141,8 @@ Un blocco catch() dopo un blocco catch (System.Exception e) è in grado di rilev
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">L'istruzione foreach non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione pubblica per '{1}'</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">L'istruzione foreach non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione pubblica per '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -4141,8 +4141,8 @@ AssemblyInfo.cs ファイルで RuntimeCompatibilityAttribute が false に設�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">foreach ステートメントは、'{0}' が '{1}' のパブリック定義を含んでいないため、型 '{0}' の変数に対して使用できません。</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">foreach ステートメントは、'{0}' が '{1}' のパブリック定義を含んでいないため、型 '{0}' の変数に対して使用できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -4141,8 +4141,8 @@ catch (System.Exception e) 블록 뒤의 catch() 블록은 RuntimeCompatibilityA
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">{0}'에는 '{1}'에 대한 공용 정의가 포함되어 있지 않아 '{0}' 형식 변수에서 foreach 문을 수행할 수 없습니다.</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">{0}'에는 '{1}'에 대한 공용 정의가 포함되어 있지 않아 '{0}' 형식 변수에서 foreach 문을 수행할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -4141,8 +4141,8 @@ Blok catch() po bloku catch (System.Exception e) może przechwytywać wyjątki n
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">Instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ „{0}” nie zawiera definicji publicznej elementu „{1}”</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">Instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ „{0}” nie zawiera definicji publicznej elementu „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -4141,8 +4141,8 @@ Um bloco catch() depois de um bloco catch (System.Exception e) poderá capturar 
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">Instrução foreach não pode operar em variáveis do tipo "{0}" porque "{0}" não contém uma definição pública para "{1}"</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">Instrução foreach não pode operar em variáveis do tipo "{0}" porque "{0}" não contém uma definição pública para "{1}"</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -4141,8 +4141,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">Оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит открытого определения для "{1}".</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">Оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит открытого определения для "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -4141,8 +4141,8 @@ RuntimeCompatibilityAttribute AssemblyInfo.cs dosyasında false olarak ayarlanm�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">{0}' bir '{1}' ortak tanım içermediğinden veya erişilemez olduğundan foreach deyimi '{0}' türündeki değişkenlerde çalışamaz</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">{0}' bir '{1}' ortak tanım içermediğinden veya erişilemez olduğundan foreach deyimi '{0}' türündeki değişkenlerde çalışamaz</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -4141,8 +4141,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">“{0}”不包含“{1}”的公共定义，因此 foreach 语句不能作用于“{0}”类型的变量</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">“{0}”不包含“{1}”的公共定义，因此 foreach 语句不能作用于“{0}”类型的变量</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -4141,8 +4141,8 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
         <note />
       </trans-unit>
       <trans-unit id="ERR_ForEachMissingMember">
-        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public definition for '{1}'</source>
-        <target state="translated">foreach 陳述式不可用在類型 '{0}' 的變數上，因為 '{0}' 未包含 '{1}' 的公用定義。</target>
+        <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance definition for '{1}'</source>
+        <target state="needs-review-translation">foreach 陳述式不可用在類型 '{0}' 的變數上，因為 '{0}' 未包含 '{1}' 的公用定義。</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_BadXMLRefParamType">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -4234,19 +4234,19 @@ public class MemberInitializerTest
             CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
                 // (9,105): error CS1525: Invalid expression term 'int'
                 //             genD = (D<int>) GenericMethod<((System.Linq.Expressions.Expression<System.Func<int>>)(() => int)).Compile()()> 
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int"),
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(9, 105),
                 // (9,123): error CS1525: Invalid expression term '}'
                 //             genD = (D<int>) GenericMethod<((System.Linq.Expressions.Expression<System.Func<int>>)(() => int)).Compile()()> 
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("}"),
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("}").WithLocation(9, 123),
                 // (8,9): error CS0246: The type or namespace name 'Goo' could not be found (are you missing a using directive or an assembly reference?)
                 //         Goo f = new Goo {
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Goo").WithArguments("Goo"),
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Goo").WithArguments("Goo").WithLocation(8, 9),
                 // (8,21): error CS0246: The type or namespace name 'Goo' could not be found (are you missing a using directive or an assembly reference?)
                 //         Goo f = new Goo {
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Goo").WithArguments("Goo"),
-                // (9,20): error CS0030: Cannot convert type 'method' to 'MemberInitializerTest.D<int>'
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Goo").WithArguments("Goo").WithLocation(8, 21),
+                // (9,29): error CS0411: The type arguments for method 'MemberInitializerTest.GenericMethod<T>()' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //             genD = (D<int>) GenericMethod<((System.Linq.Expressions.Expression<System.Func<int>>)(() => int)).Compile()()> 
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(D<int>) GenericMethod").WithArguments("method", "MemberInitializerTest.D<int>"));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "GenericMethod").WithArguments("MemberInitializerTest.GenericMethod<T>()").WithLocation(9, 29));
         }
 
         [WorkItem(545191, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545191")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2792,16 +2792,13 @@ class Program
                 //         B.F(new D<int>(o.F), 3);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(26, 24)
                 );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (24,13): error CS1503: Argument 1: cannot convert from 'method group' to 'D<int>'
+                // (24,13): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(o.F, 2);
-                Diagnostic(ErrorCode.ERR_BadArgType, "o.F").WithArguments("1", "method group", "D<int>").WithLocation(24, 13),
-                // (26,13): error CS0123: No overload for 'F' matches delegate 'D<int>'
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(24, 13),
+                // (26,24): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(new D<int>(o.F), 3);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D<int>(o.F)").WithArguments("F", "D<int>").WithLocation(26, 13)
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(26, 24)
                 );
         }
 
@@ -2847,16 +2844,13 @@ class Program
                 //         B.F(new D<int>(o.F), 3);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(25, 24)
                 );
-            // NOTE: we now have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (23,13): error CS1503: Argument 1: cannot convert from 'method group' to 'D<int>'
+                // (23,13): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(o.F, 2);
-                Diagnostic(ErrorCode.ERR_BadArgType, "o.F").WithArguments("1", "method group", "D<int>").WithLocation(23, 13),
-                // (25,13): error CS0123: No overload for 'F' matches delegate 'D<int>'
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(23, 13),
+                // (25,24): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(new D<int>(o.F), 3);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D<int>(o.F)").WithArguments("F", "D<int>").WithLocation(25, 13)
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(25, 24)
                 );
         }
 
@@ -3331,16 +3325,13 @@ class Program
                 //         f = new RefFunc1<object>(M1);
                 Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(13, 34)
             );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
                 // (10,30): error CS0407: 'string Program.M1()' has the wrong return type
                 //         RefFunc1<object> f = M1;
                 Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(10, 30),
-                // (13,13): error CS0123: No overload for 'M1' matches delegate 'Program.RefFunc1<object>'
+                // (13,34): error CS0407: 'string Program.M1()' has the wrong return type
                 //         f = new RefFunc1<object>(M1);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new RefFunc1<object>(M1)").WithArguments("M1", "Program.RefFunc1<object>").WithLocation(13, 13)
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(13, 34)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2784,13 +2784,24 @@ class Program
     }
 }";
 
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (24,13): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(o.F, 2);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(24, 13),
                 // (26,24): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(new D<int>(o.F), 3);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(26, 24)
+                );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateStandardCompilation(source).VerifyDiagnostics(
+                // (24,13): error CS1503: Argument 1: cannot convert from 'method group' to 'D<int>'
+                //         B.F(o.F, 2);
+                Diagnostic(ErrorCode.ERR_BadArgType, "o.F").WithArguments("1", "method group", "D<int>").WithLocation(24, 13),
+                // (26,13): error CS0123: No overload for 'F' matches delegate 'D<int>'
+                //         B.F(new D<int>(o.F), 3);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D<int>(o.F)").WithArguments("F", "D<int>").WithLocation(26, 13)
                 );
         }
 
@@ -2828,13 +2839,24 @@ class Program
     }
 }";
 
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (23,13): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(o.F, 2);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(23, 13),
                 // (25,24): error CS8189: Ref mismatch between 'A<int>.F()' and delegate 'D<int>'
                 //         B.F(new D<int>(o.F), 3);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "o.F").WithArguments("A<int>.F()", "D<int>").WithLocation(25, 24)
+                );
+            // NOTE: we now have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateStandardCompilation(source).VerifyDiagnostics(
+                // (23,13): error CS1503: Argument 1: cannot convert from 'method group' to 'D<int>'
+                //         B.F(o.F, 2);
+                Diagnostic(ErrorCode.ERR_BadArgType, "o.F").WithArguments("1", "method group", "D<int>").WithLocation(23, 13),
+                // (25,13): error CS0123: No overload for 'F' matches delegate 'D<int>'
+                //         B.F(new D<int>(o.F), 3);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D<int>(o.F)").WithArguments("F", "D<int>").WithLocation(25, 13)
                 );
         }
 
@@ -3301,7 +3323,7 @@ class Program
 
 ";
 
-            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+            CreateCompilationWithMscorlib45AndCSruntime(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyEmitDiagnostics(
                 // (10,30): error CS0407: 'string Program.M1()' has the wrong return type
                 //         RefFunc1<object> f = M1;
                 Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string"),
@@ -3309,14 +3331,23 @@ class Program
                 //         f = new RefFunc1<object>(M1);
                 Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(13, 34)
             );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (10,30): error CS0407: 'string Program.M1()' has the wrong return type
+                //         RefFunc1<object> f = M1;
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(10, 30),
+                // (13,13): error CS0123: No overload for 'M1' matches delegate 'Program.RefFunc1<object>'
+                //         f = new RefFunc1<object>(M1);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new RefFunc1<object>(M1)").WithArguments("M1", "Program.RefFunc1<object>").WithLocation(13, 13)
+            );
         }
 
         [Fact]
         public void RefMethodGroupConversionError_WithResolution()
         {
             var source = @"
-using System;
-
 class Base
 {
     public static Base Instance = new Base();
@@ -3347,10 +3378,12 @@ class Program
 
 ";
 
-            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
-                // (24,38): error CS0407: 'Derived1 Program.M1(Derived1)' has the wrong return type
+            CreateCompilationWithMscorlib45AndCSruntime(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyEmitDiagnostics(
+                // (22,38): error CS0407: 'Derived1 Program.M1(Derived1)' has the wrong return type
                 //         RefFunc1<Derived2, Base> f = M1;
-                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1(Derived1)", "Derived1").WithLocation(24, 38)
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1(Derived1)", "Derived1").WithLocation(22, 38)
+            );
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
             );
         }
 
@@ -3433,13 +3466,15 @@ class Program
 
 ";
 
-            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+            CreateCompilationWithMscorlib45AndCSruntime(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyEmitDiagnostics(
                 // (25,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Test(Program.RefFunc1<Derived2, Base>)' and 'Program.Test(Program.RefFunc1<Derived2, Derived1>)'
                 //         Test(M1);
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Test").WithArguments("Program.Test(Program.RefFunc1<Derived2, Base>)", "Program.Test(Program.RefFunc1<Derived2, Derived1>)").WithLocation(25, 9),
                 // (26,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Test(Program.RefFunc1<Derived2, Base>)' and 'Program.Test(Program.RefFunc1<Derived2, Derived1>)'
                 //         Test(M3);
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Test").WithArguments("Program.Test(Program.RefFunc1<Derived2, Base>)", "Program.Test(Program.RefFunc1<Derived2, Derived1>)").WithLocation(26, 9)
+            );
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -15375,7 +15375,7 @@ class M
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (6,16): error CS0236: A field initializer cannot reference the non-static field, method, or property 'M.Test(object)'
                 //     object a = Test((dynamic)2);
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test((dynamic)2)").WithArguments("M.Test(object)").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test").WithArguments("M.Test(object)").WithLocation(6, 16)
             );
         }
 
@@ -15466,7 +15466,7 @@ class M : B
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (16,31): error CS0120: An object reference is required for the non-static field, method, or property 'M.Test(object)'
                 //     public M() : base((object)Test((dynamic)2))
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Test((dynamic)2)").WithArguments("M.Test(object)").WithLocation(16, 31)
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Test").WithArguments("M.Test(object)").WithLocation(16, 31)
             );
         }
 
@@ -15499,7 +15499,7 @@ class M
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (8,31): error CS0120: An object reference is required for the non-static field, method, or property 'M.Test(object)'
                 //         Console.Write((object)Test((dynamic)2));
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Test((dynamic)2)").WithArguments("M.Test(object)").WithLocation(8, 31)
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Test").WithArguments("M.Test(object)").WithLocation(8, 31)
             );
         }
 
@@ -15527,7 +15527,7 @@ class M
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (4,31): error CS0236: A field initializer cannot reference the non-static field, method, or property 'M.Test(object)'
                 //     static object o = (object)Test((dynamic)2);
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test((dynamic)2)").WithArguments("M.Test(object)").WithLocation(4, 31)
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Test").WithArguments("M.Test(object)").WithLocation(4, 31)
             );
         }
 
@@ -15586,22 +15586,22 @@ class M
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (16,29): error CS0236: A field initializer cannot reference the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     static int field = (int)InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
                 // (30,30): error CS0236: A field initializer cannot reference the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     int instanceField = (int)InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(30, 30),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(30, 30),
                 // (21,25): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //             return (int)InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(21, 25),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(21, 25),
                 // (26,21): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //         return (int)InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(26, 21),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(26, 21),
                 // (31,33): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     public C(int x) : base((int)InstanceMethod((dynamic)x))
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod((dynamic)x)").WithArguments("C.InstanceMethod(int)").WithLocation(31, 33),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(31, 33),
                 // (34,28): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     public C() : this((int)InstanceMethod((dynamic)2))
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(34, 28)
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(34, 28)
             );
         }
 
@@ -15665,22 +15665,22 @@ class M
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyDiagnostics(
                 // (16,29): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     static int field = (int)C.InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(16, 29),
                 // (30,30): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     int instanceField = (int)C.InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(30, 30),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(30, 30),
                 // (21,25): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //             return (int)C.InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(21, 25),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(21, 25),
                 // (26,21): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //         return (int)C.InstanceMethod((dynamic)2);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(26, 21),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(26, 21),
                 // (31,33): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     public C(int x) : base((int)C.InstanceMethod((dynamic)x))
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)x)").WithArguments("C.InstanceMethod(int)").WithLocation(31, 33),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(31, 33),
                 // (34,28): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod(int)'
                 //     public C() : this((int)C.InstanceMethod((dynamic)2))
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod((dynamic)2)").WithArguments("C.InstanceMethod(int)").WithLocation(34, 28)
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.InstanceMethod").WithArguments("C.InstanceMethod(int)").WithLocation(34, 28)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -7421,7 +7421,7 @@ class C
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var v1").WithLocation(9, 19),
                 // (9,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'C.G(out int)'
                 //     int F = G(out var v1);    
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "G(out var v1)").WithArguments("C.G(out int)").WithLocation(9, 13),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "G").WithArguments("C.G(out int)").WithLocation(9, 13),
                 // (13,16): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     : base(out var v3)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var v3").WithLocation(13, 16),

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/MethodGroupConversion.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/MethodGroupConversion.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class MethodGroupConversion : CSharpTestBase
+    {
+        [Fact]
+        public void TestAmbiguous()
+        {
+            var source = @"
+partial class Program
+{
+    static void Main()
+    {
+        D d;
+        d = M;
+        d = new D(M);
+        M2(M);
+
+        d = M3;
+        d = new D(M3);
+        M2(M3);
+    }
+    static void M(I1 i1) {}
+    static void M(I2 i2) {}
+    static void M2(D d) {}
+
+    static void M3(int x) {}
+}
+interface I1 {}
+interface I2 {}
+class C : I1, I2 {}
+
+delegate void D(C c);
+";
+            var compilation = CreateStandardCompilation(source);
+            compilation.VerifyDiagnostics(
+                // (7,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(I1)' and 'Program.M(I2)'
+                //         d = M;
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(I1)", "Program.M(I2)").WithLocation(7, 13),
+                // (8,19): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(I1)' and 'Program.M(I2)'
+                //         d = new D(M);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(I1)", "Program.M(I2)").WithLocation(8, 19),
+                // (9,12): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(I1)' and 'Program.M(I2)'
+                //         M2(M);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(I1)", "Program.M(I2)").WithLocation(9, 12),
+                // (11,13): error CS0123: No overload for 'M3' matches delegate 'D'
+                //         d = M3;
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "M3").WithArguments("M3", "D").WithLocation(11, 13),
+                // (12,13): error CS0123: No overload for 'M3' matches delegate 'D'
+                //         d = new D(M3);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D(M3)").WithArguments("M3", "D").WithLocation(12, 13),
+                // (13,12): error CS1503: Argument 1: cannot convert from 'method group' to 'D'
+                //         M2(M3);
+                Diagnostic(ErrorCode.ERR_BadArgType, "M3").WithArguments("1", "method group", "D").WithLocation(13, 12)
+                );
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ArrayCreationAndInitializer.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ArrayCreationAndInitializer.cs
@@ -858,23 +858,26 @@ class C
         var a = /*<bind>*/new string[M()]/*</bind>*/;
     }
 
-    public object M() => null;
+    public static object M() => null;
 }
 ";
             string expectedOperationTree = @"
 IArrayCreationOperation (OperationKind.ArrayCreation, Type: System.String[], IsInvalid) (Syntax: 'new string[M()]')
   Dimension Sizes(1):
-      IInvocationOperation ( System.Object C.M()) (OperationKind.Invocation, Type: System.Object, IsInvalid) (Syntax: 'M()')
-        Instance Receiver: 
-          IInstanceReferenceOperation (OperationKind.InstanceReference, Type: C, IsInvalid, IsImplicit) (Syntax: 'M')
-        Arguments(0)
+      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'M()')
+        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+        Operand: 
+          IInvocationOperation (System.Object C.M()) (OperationKind.Invocation, Type: System.Object, IsInvalid) (Syntax: 'M()')
+            Instance Receiver: 
+              null
+            Arguments(0)
   Initializer: 
     null
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0120: An object reference is required for the non-static field, method, or property 'C.M()'
+                // file.cs(6,27): error CS0266: Cannot implicitly convert type 'object' to 'int'. An explicit conversion exists (are you missing a cast?)
                 //         var a = /*<bind>*/new string[M()]/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "M").WithArguments("C.M()").WithLocation(6, 38)
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "new string[M()]").WithArguments("object", "int").WithLocation(6, 27)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<ArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IDelegateCreationExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IDelegateCreationExpression.cs
@@ -777,13 +777,10 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
       Instance Receiver: 
         ILocalReferenceOperation: p (OperationKind.LocalReference, Type: Program, IsInvalid) (Syntax: 'p')
 ", new DiagnosticDescription[] {
-                // CS0407: 'int Program.M1()' has the wrong return type
+                // file.cs(8,30): error CS0407: 'int Program.M1()' has the wrong return type
                 //         Action a = /*<bind>*/(Action)p.M1/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadRetType, "(Action)p.M1").WithArguments("Program.M1()", "int").WithLocation(8, 30)
             }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, @"
 IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action, IsInvalid) (Syntax: '(Action)p.M1')
   Target: 
@@ -791,9 +788,9 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
       Children(1):
           ILocalReferenceOperation: p (OperationKind.LocalReference, Type: Program, IsInvalid) (Syntax: 'p')
 ", new DiagnosticDescription[] {
-                // file.cs(8,30): error CS0030: Cannot convert type 'method' to 'Action'
+                // file.cs(8,38): error CS0407: 'int Program.M1()' has the wrong return type
                 //         Action a = /*<bind>*/(Action)p.M1/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)p.M1").WithArguments("method", "System.Action").WithLocation(8, 30)
+                Diagnostic(ErrorCode.ERR_BadRetType, "p.M1").WithArguments("Program.M1()", "int").WithLocation(8, 38)
             });
         }
 
@@ -821,9 +818,9 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
 ";
             var expectedDiagnostics = new DiagnosticDescription[]
             {
-                // CS0030: Cannot convert type 'method' to 'Action'
+                // file.cs(7,30): error CS0123: No overload for 'M1' matches delegate 'Action'
                 //         Action a = /*<bind>*/(Action)M1/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)M1").WithArguments("method", "System.Action").WithLocation(7, 30)
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "(Action)M1").WithArguments("M1", "System.Action").WithLocation(7, 30)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
@@ -853,9 +850,9 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
           ILocalReferenceOperation: p (OperationKind.LocalReference, Type: Program, IsInvalid) (Syntax: 'p')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0030: Cannot convert type 'method' to 'Action'
+                // file.cs(8,30): error CS0123: No overload for 'M1' matches delegate 'Action'
                 //         Action a = /*<bind>*/(Action)p.M1/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)p.M1").WithArguments("method", "System.Action").WithLocation(8, 30)
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "(Action)p.M1").WithArguments("M1", "System.Action").WithLocation(8, 30)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
@@ -1074,13 +1071,10 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
       Children(1):
           IInstanceReferenceOperation (OperationKind.InstanceReference, Type: Program, IsInvalid) (Syntax: 'this')
 ";
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // file.cs(7,30): error CS0123: No overload for 'M1' matches delegate 'Action'
+                // file.cs(7,41): error CS0176: Member 'Program.M1()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         Action a = /*<bind>*/new Action(this.M1)/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Action(this.M1)").WithArguments("M1", "System.Action").WithLocation(7, 30)
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "this.M1").WithArguments("Program.M1()").WithLocation(7, 41)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
@@ -1171,9 +1165,6 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
                 //         Action a = /*<bind>*/new Action(M1)/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "int").WithLocation(7, 41)
             }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, @"
 IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action, IsInvalid) (Syntax: 'new Action(M1)')
   Target: 
@@ -1181,9 +1172,9 @@ IDelegateCreationOperation (OperationKind.DelegateCreation, Type: System.Action,
       Children(1):
           IInstanceReferenceOperation (OperationKind.InstanceReference, Type: Program, IsInvalid, IsImplicit) (Syntax: 'M1')
 ", new DiagnosticDescription[] {
-                // file.cs(7,30): error CS0123: No overload for 'M1' matches delegate 'Action'
+                // file.cs(7,41): error CS0407: 'int Program.M1()' has the wrong return type
                 //         Action a = /*<bind>*/new Action(M1)/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Action(M1)").WithArguments("M1", "System.Action").WithLocation(7, 30)
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "int").WithLocation(7, 41)
             });
         }
 
@@ -1541,9 +1532,9 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Action, IsInvalid) (Synta
                 IInstanceReferenceOperation (OperationKind.InstanceReference, Type: Program, IsInvalid, IsImplicit) (Syntax: 'M1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0030: Cannot convert type 'method' to 'Action'
+                // file.cs(7,41): error CS0123: No overload for 'M1' matches delegate 'Action'
                 //         Action a = /*<bind>*/new Action((Action)M1)/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)M1").WithArguments("method", "System.Action").WithLocation(7, 41)
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "(Action)M1").WithArguments("M1", "System.Action").WithLocation(7, 41)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
@@ -1643,9 +1634,9 @@ IInvalidOperation (OperationKind.Invalid, Type: System.Action<System.Int32>, IsI
               IInstanceReferenceOperation (OperationKind.InstanceReference, Type: Program, IsInvalid, IsImplicit) (Syntax: 'M1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0123: No overload for 'Action' matches delegate 'Action<int>'
+                // file.cs(7,35): error CS0123: No overload for 'Action.Invoke()' matches delegate 'Action<int>'
                 //         Action<int> a = /*<bind>*/new Action<int>((Action)M1)/*</bind>*/;
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Action<int>((Action)M1)").WithArguments("Action", "System.Action<int>").WithLocation(7, 35)
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Action<int>((Action)M1)").WithArguments("System.Action.Invoke()", "System.Action<int>").WithLocation(7, 35)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IInvocationOperation.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IInvocationOperation.cs
@@ -25,13 +25,12 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IInvocationOperation ( void C.M1()) (OperationKind.Invocation, Type: System.Void, IsInvalid) (Syntax: 'c.M1()')
-  Instance Receiver: 
-    ILocalReferenceOperation: c (OperationKind.LocalReference, Type: C, IsInvalid) (Syntax: 'c')
-  Arguments(0)
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'c.M1()')
+  Children(1):
+      ILocalReferenceOperation: c (OperationKind.LocalReference, Type: C, IsInvalid) (Syntax: 'c')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0176: Member 'C.M1()' cannot be accessed with an instance reference; qualify it with a type name instead
+                // file.cs(9,19): error CS0176: Member 'C.M1()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         /*<bind>*/c.M1()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_ObjectProhibited, "c.M1").WithArguments("C.M1()").WithLocation(9, 19)
             };
@@ -81,13 +80,12 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IInvocationOperation (void C.M1()) (OperationKind.Invocation, Type: System.Void, IsInvalid) (Syntax: 'C.M1()')
-  Instance Receiver: 
-    null
-  Arguments(0)
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'C.M1()')
+  Children(1):
+      IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0120: An object reference is required for the non-static field, method, or property 'C.M1()'
+                // file.cs(8,19): error CS0120: An object reference is required for the non-static field, method, or property 'C.M1()'
                 //         /*<bind>*/C.M1()/*</bind>*/;
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "C.M1").WithArguments("C.M1()").WithLocation(8, 19)
             };

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BetterCandidates.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BetterCandidates.cs
@@ -1,0 +1,433 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    /// <summary>
+    /// Tests for improved overload candidate selection.
+    /// See also https://github.com/dotnet/csharplang/issues/98.
+    /// </summary>
+    public class BetterCandidates : CompilingTestBase
+    {
+        private CSharpCompilation CreateCompilationWithoutBetterCandidates(string source, CSharpCompilationOptions options = null)
+        {
+            return CreateStandardCompilation(source, options: options, parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
+        }
+        private CSharpCompilation CreateCompilationWithBetterCandidates(string source, CSharpCompilationOptions options = null)
+        {
+            Debug.Assert(TestOptions.Regular.LanguageVersion >= MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion());
+            return CreateStandardCompilation(source, options: options, parseOptions: TestOptions.Regular);
+        }
+
+        //When a method group contains both instance and static members, we discard the instance members if invoked with a static receiver.
+        [Fact]
+        public void TestStaticReceiver01()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        Program.M(null);
+    }
+    public static void M(A a) { System.Console.WriteLine(1); }
+    public void M(B b) { System.Console.WriteLine(2); }
+}
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,17): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //         Program.M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(5, 17)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "1");
+        }
+
+        //When a method group contains both instance and static members, we discard the static members if invoked with an instance receiver.
+        [Fact]
+        public void TestInstanceReceiver01()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        Program p = new Program();
+        p.M(null);
+    }
+    public static void M(A a) { System.Console.WriteLine(1); }
+    public void M(B b) { System.Console.WriteLine(2); }
+}
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (6,11): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //         p.M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(6, 11)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "2");
+        }
+
+        //When a method group contains no receiver in a static context, we include only static members.
+        // Type 1: in a static method
+        [Fact]
+        public void TestStaticContext01()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        M(null);
+    }
+    public static void M(A a) { System.Console.WriteLine(1); }
+    public void M(B b) { System.Console.WriteLine(2); }
+}
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //         M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(5, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "1");
+        }
+
+        //When a method group contains no receiver in a static context, we include only static members.
+        // Type 2: in a field initializer
+        [Fact]
+        public void TestStaticContext02()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        new Program();
+    }
+    public static int M(A a) { System.Console.WriteLine(1); return 1; }
+    public int M(B b) { System.Console.WriteLine(2); return 2; }
+    int X = M(null);
+}
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (9,13): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //     int X = M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(9, 13)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "1");
+        }
+
+        //When a method group contains no receiver in a static context, we include only static members.
+        // Type 4: in a constructor-initializer
+        [Fact]
+        public void TestStaticContext04()
+        {
+            var source =
+@"class Program
+{
+    public static void Main()
+    {
+        new Program();
+    }
+    public Program() : this(M(null)) {}
+    public Program(int x) {}
+    public static int M(A a) { System.Console.WriteLine(1); return 1; }
+    public int M(B b) { System.Console.WriteLine(2); return 2; }
+}
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (7,29): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //     public Program() : this(M(null)) {}
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(7, 29)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "1");
+        }
+
+        //When a method group contains no receiver in a static context, we include only static members.
+        // Type 5: in an attribute argument
+        [Fact]
+        public void TestStaticContext05()
+        {
+            var source =
+@"public class Program
+{
+    public static int M(A a) { System.Console.WriteLine(1); return 1; }
+    public int M(B b) { System.Console.WriteLine(2); return 2; }
+
+    [My(M(null))]
+    public int x;
+}
+public class A {}
+public class B {}
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int value) {}
+}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //     [My(M(null))]
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(6, 9)
+                );
+            CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,9): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                //     [My(M(null))]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "M(null)").WithLocation(6, 9)
+                );
+        }
+
+        //When a method group contains no receiver, we include both static and instance members in an other-than-static context. i.e. discard nothing.
+        [Fact]
+        public void TestInstanceContext01()
+        {
+            var source =
+@"public class Program
+{
+    public void M()
+    {
+        M(null);
+    }
+
+    public static int M(A a) => 1;
+    public int M(B b) => 2;
+}
+public class A {}
+public class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //         M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(5, 9)
+                );
+            CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(A)' and 'Program.M(B)'
+                //         M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(A)", "Program.M(B)").WithLocation(5, 9)
+                );
+        }
+
+        //When a method group receiver is ambiguously an instance or type due to a color-color situation, we include both instance and static candidates.
+        [Fact]
+        public void TestAmbiguousContext01()
+        {
+            var source =
+@"public class Color
+{
+    public void M()
+    {
+        Color Color = null;
+        Color.M(null);
+    }
+
+    public static int M(A a) => 1;
+    public int M(B b) => 2;
+}
+public class A {}
+public class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,15): error CS0121: The call is ambiguous between the following methods or properties: 'Color.M(A)' and 'Color.M(B)'
+                //         Color.M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Color.M(A)", "Color.M(B)").WithLocation(6, 15)
+                );
+            CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseDll).VerifyDiagnostics(
+                // (6,15): error CS0121: The call is ambiguous between the following methods or properties: 'Color.M(A)' and 'Color.M(B)'
+                //         Color.M(null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Color.M(A)", "Color.M(B)").WithLocation(6, 15)
+                );
+        }
+
+        //When a method group contains some generic methods whose type parameters do not satisfy their constraints, these members are removed from the candidate set.
+        [Fact]
+        public void TestConstraintFailed01()
+        {
+            var source =
+@"public class Program
+{
+    static void Main()
+    {
+        M(new A(), 0);
+    }
+
+    static void M<T>(T t1, int i) where T: B { System.Console.WriteLine(1); }
+    static void M<T>(T t1, short s) { System.Console.WriteLine(2); }
+}
+public class A {}
+public class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,9): error CS0311: The type 'A' cannot be used as type parameter 'T' in the generic type or method 'Program.M<T>(T, int)'. There is no implicit reference conversion from 'A' to 'B'.
+                //         M(new A(), 0);
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M").WithArguments("Program.M<T>(T, int)", "B", "T", "A").WithLocation(5, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "2");
+        }
+
+        //When a method group contains some generic methods whose type parameters do not satisfy their constraints, these members are removed from the candidate set.
+        // Test that this permits overload resolution to use type parameter constraints "as a tie-breaker" to guide overload resolution.
+        [Fact]
+        public void TestConstraintFailed02()
+        {
+            var source =
+@"public class Program
+{
+    static void Main()
+    {
+        M(new A(), null);
+        M(new B(), null);
+    }
+
+    static void M<T>(T t1, B b) where T: struct { System.Console.Write(""struct ""); }
+    static void M<T>(T t1, X s) where T : class { System.Console.Write(""class ""); }
+}
+public struct A {}
+public class B {}
+public class X {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M<T>(T, B)' and 'Program.M<T>(T, X)'
+                //         M(new A(), null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M<T>(T, B)", "Program.M<T>(T, X)").WithLocation(5, 9),
+                // (6,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M<T>(T, B)' and 'Program.M<T>(T, X)'
+                //         M(new B(), null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M<T>(T, B)", "Program.M<T>(T, X)").WithLocation(6, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "struct class ");
+        }
+
+        //For a method group conversion, candidate methods whose return type doesn't match up with the delegate's return type are removed from the set.
+        [Fact]
+        public void TestReturnTypeMismatch01()
+        {
+            var source =
+@"public class Program
+{
+    static void Main()
+    {
+        M(Program.Q);
+    }
+
+    static void M(D1 d) { System.Console.WriteLine(1); }
+    static void M(D2 d) { System.Console.WriteLine(2); }
+
+    static void Q(A a) { }
+    static void Q(B b) { }
+}
+delegate int D1(A a);
+delegate void D2(B b);
+
+class A {}
+class B {}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(D1)' and 'Program.M(D2)'
+                //         M(Q);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(D1)", "Program.M(D2)").WithLocation(5, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "2");
+        }
+
+        //For a method group conversion, candidate methods whose return ref kind doesn't match up with the delegate's return ref kind are removed from the set.
+        [Fact]
+        public void TestReturnRefMismatch01()
+        {
+            var source =
+@"public class Program
+{
+    static int tmp;
+    static void Main()
+    {
+        M(Q);
+    }
+
+    static void M(D1 d) { System.Console.WriteLine(1); }
+    static void M(D2 d) { System.Console.WriteLine(2); }
+
+    static ref int Q() { return ref tmp; }
+}
+delegate int D1();
+delegate ref int D2();
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (6,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(D1)' and 'Program.M(D2)'
+                //         M(Q);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(D1)", "Program.M(D2)").WithLocation(6, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "2");
+        }
+
+        //For a method group conversion, candidate methods whose return type doesn't match up with the delegate's return type are removed from the set.
+        [Fact]
+        public void TestReturnTypeMismatch02()
+        {
+            var source =
+@"public class Program
+{
+    static void Main()
+    {
+        M(new Z().Q);
+    }
+
+    static void M(D1 d) { System.Console.WriteLine(1); }
+    static void M(D2 d) { System.Console.WriteLine(2); }
+}
+delegate int D1(A a);
+delegate void D2(B b);
+
+public class A {}
+public class B {}
+public class Z {}
+public static class X
+{
+    public static void Q(this Z z, A a) {}
+    public static void Q(this Z z, B b) {}
+}
+namespace System.Runtime.CompilerServices
+{
+    public class ExtensionAttribute : System.Attribute {}
+}
+";
+            CreateCompilationWithoutBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                // (5,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.M(D1)' and 'Program.M(D2)'
+                //         M(new Z().Q);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("Program.M(D1)", "Program.M(D2)").WithLocation(5, 9)
+                );
+            var compilation = CreateCompilationWithBetterCandidates(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+                );
+            CompileAndVerify(compilation, expectedOutput: "2");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2400,10 +2400,18 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (15,15): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
                 //         new D(M)();
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(15, 15)
+                );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+                // (15,9): error CS0123: No overload for 'M' matches delegate 'D'
+                //         new D(M)();
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D(M)").WithArguments("M", "D").WithLocation(15, 9)
                 );
         }
 
@@ -2462,10 +2470,18 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (19,11): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
                 //         M(M);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(19, 11)
+                );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+                // (19,11): error CS1503: Argument 1: cannot convert from 'method group' to 'D'
+                //         M(M);
+                Diagnostic(ErrorCode.ERR_BadArgType, "M").WithArguments("1", "method group", "D").WithLocation(19, 11)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2405,13 +2405,10 @@ class C
                 //         new D(M)();
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(15, 15)
                 );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
-                // (15,9): error CS0123: No overload for 'M' matches delegate 'D'
+                // (15,15): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
                 //         new D(M)();
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D(M)").WithArguments("M", "D").WithLocation(15, 9)
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(15, 15)
                 );
         }
 
@@ -2475,13 +2472,10 @@ class C
                 //         M(M);
                 Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(19, 11)
                 );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
-                // (19,11): error CS1503: Argument 1: cannot convert from 'method group' to 'D'
+                // (19,11): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
                 //         M(M);
-                Diagnostic(ErrorCode.ERR_BadArgType, "M").WithArguments("1", "method group", "D").WithLocation(19, 11)
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(19, 11)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConditionalOperatorTests.cs
@@ -96,8 +96,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             TestConditional("true ? GetInt() : null", null,
                 Diagnostic(ErrorCode.ERR_InvalidQM, "true ? GetInt() : null").WithArguments("int", "<null>"));
-            TestConditional("false ? GetString : (System.Func<int>)null", null,
+            TestConditional("false ? GetString : (System.Func<int>)null", null, TestOptions.WithoutImprovedOverloadCandidates,
                 Diagnostic(ErrorCode.ERR_BadRetType, "GetString").WithArguments("C.GetString()", "string"));
+            TestConditional("false ? GetString : (System.Func<int>)null", null,
+                // (6,34): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between 'method group' and 'Func<int>'
+                //         System.Console.WriteLine(false ? GetString : (System.Func<int>)null);
+                Diagnostic(ErrorCode.ERR_InvalidQM, "false ? GetString : (System.Func<int>)null").WithArguments("method group", "System.Func<int>").WithLocation(6, 34));
             TestConditional("true ? (System.Func<int, short>)null : x => x", null,
                 Diagnostic(ErrorCode.ERR_InvalidQM, "true ? (System.Func<int, short>)null : x => x").WithArguments("System.Func<int, short>", "lambda expression"));
         }
@@ -1188,6 +1192,11 @@ System.Collections.Generic.List`1[System.Int32]
 
         private static void TestConditional(string conditionalExpression, string expectedType, params DiagnosticDescription[] expectedDiagnostics)
         {
+            TestConditional(conditionalExpression, expectedType, null, expectedDiagnostics);
+        }
+
+        private static void TestConditional(string conditionalExpression, string expectedType, CSharpParseOptions parseOptions, params DiagnosticDescription[] expectedDiagnostics)
+        {
             string sourceTemplate = @"
 class C
 {{
@@ -1215,7 +1224,7 @@ public enum color {{ Red, Blue, Green }};
 interface I<in T, out U> {{ }}";
 
             var source = string.Format(sourceTemplate, conditionalExpression);
-            var tree = Parse(source);
+            var tree = Parse(source, options: parseOptions);
 
             var comp = CreateStandardCompilation(tree);
             comp.VerifyDiagnostics(expectedDiagnostics);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -1335,7 +1335,7 @@ class C
     }
 }
 ";
-            string expectedOperationTree = @"
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, @"
 IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'c.Goo<short>(d, d)')
   Children(3):
       IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'c.Goo<short>')
@@ -1343,14 +1343,22 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'c.Goo<sh
             IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C, IsInvalid) (Syntax: 'c')
       IParameterReferenceOperation: d (OperationKind.ParameterReference, Type: dynamic, IsInvalid) (Syntax: 'd')
       IParameterReferenceOperation: d (OperationKind.ParameterReference, Type: dynamic, IsInvalid) (Syntax: 'd')
-";
-            var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS0452: The type 'short' must be a reference type in order to use it as parameter 'T' in the generic type or method 'C.Goo<T>(int, int)'
-                //         /*<bind>*/c.Goo<short>(d, d)/*</bind>*/;
+", new DiagnosticDescription[] {
+                // file.cs(15,19): error CS0452: The type 'short' must be a reference type in order to use it as parameter 'T' in the generic type or method 'C.Goo<T>(int, int)'
+                //         /*<bind>*/c.Goo<short>(d, d)/*</bind>*/; // Doesn't constraints of generic overloads.
                 Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "c.Goo<short>(d, d)").WithArguments("C.Goo<T>(int, int)", "T", "short").WithLocation(15, 19)
-            };
-
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, @"
+IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'c.Goo<short>(d, d)')
+  Children(3):
+      IParameterReferenceOperation: c (OperationKind.ParameterReference, Type: C) (Syntax: 'c')
+      IParameterReferenceOperation: d (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd')
+      IParameterReferenceOperation: d (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd')
+", new DiagnosticDescription[] {
+                // file.cs(15,21): error CS0452: The type 'short' must be a reference type in order to use it as parameter 'T' in the generic type or method 'C.Goo<T>(int, int)'
+                //         /*<bind>*/c.Goo<short>(d, d)/*</bind>*/; // Doesn't constraints of generic overloads.
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "Goo<short>").WithArguments("C.Goo<T>(int, int)", "T", "short").WithLocation(15, 21)
+            });
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1638,9 +1646,9 @@ class Program
 }
 ";
             CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
-                // (8,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Program.Goo<T>(int, T)'. 
-                // There is no boxing conversion from 'int' to 'System.Collections.IEnumerable'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "Goo<int>((dynamic)1, 1)").WithArguments("Program.Goo<T>(int, T)", "System.Collections.IEnumerable", "T", "int"));
+                // (8,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Program.Goo<T>(int, T)'. There is no boxing conversion from 'int' to 'System.Collections.IEnumerable'.
+                //         Goo<int>((dynamic)1, 1);
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "Goo<int>").WithArguments("Program.Goo<T>(int, T)", "System.Collections.IEnumerable", "T", "int").WithLocation(8, 9));
         }
 
         [Fact]
@@ -1713,7 +1721,8 @@ class C
 ";
             CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
                 // (13,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.F<T>(T, X<T>)'
-                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "F<string>(d, null)").WithArguments("C.F<T>(T, X<T>)", "T", "string"));
+                //         F<string>(d, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "F<string>").WithArguments("C.F<T>(T, X<T>)", "T", "string").WithLocation(13, 9));
         }
 
         [Fact]
@@ -1732,7 +1741,8 @@ public class C
 }";
             CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
                 // (9,3): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'C.F<T>(string, params T[])'. There is no boxing conversion from 'int' to 'C'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "F<int>(d, 1, 2)").WithArguments("C.F<T>(string, params T[])", "C", "T", "int"));
+                // 		F<int>(d, 1, 2);
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "F<int>").WithArguments("C.F<T>(string, params T[])", "C", "T", "int").WithLocation(9, 3));
         }
 
         [Fact]
@@ -3758,7 +3768,7 @@ class Test
             compilation1.VerifyDiagnostics(
                 // (11,18): error CS0120: An object reference is required for the non-static field, method, or property '_Worksheet.MRange(object, object)'
                 //         var z2 = Worksheet.MRange(x, y);
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Worksheet.MRange(x, y)").WithArguments("Microsoft.Office.Interop.Excel._Worksheet.MRange(object, object)").WithLocation(11, 18)
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Worksheet.MRange").WithArguments("Microsoft.Office.Interop.Excel._Worksheet.MRange(object, object)").WithLocation(11, 18)
                 );
 
             string consumer2 = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -276,10 +276,13 @@ class Enumerator
 }
 ";
 
-            CreateStandardCompilation(text).VerifyDiagnostics(
+            CreateStandardCompilation(text, parseOptions: TestOptions.Regular7).VerifyDiagnostics(
                 // (6,27): warning CS0279: 'Enumerable' does not implement the 'collection' pattern. 'Enumerable.GetEnumerator()' is either static or not public.
                 Diagnostic(ErrorCode.WRN_PatternStaticOrInaccessible, "new Enumerable()").WithArguments("Enumerable", "collection", "Enumerable.GetEnumerator()"),
                 // (6,27): error CS1579: foreach statement cannot operate on variables of type 'Enumerable' because 'Enumerable' does not contain a public definition for 'GetEnumerator'
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "new Enumerable()").WithArguments("Enumerable", "GetEnumerator"));
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (6,27): error CS1579: foreach statement cannot operate on variables of type 'Enumerable' because 'Enumerable' does not contain a public instance definition for 'GetEnumerator'
                 Diagnostic(ErrorCode.ERR_ForEachMissingMember, "new Enumerable()").WithArguments("Enumerable", "GetEnumerator"));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -375,21 +375,29 @@ class Class : Interface
 
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (13,9): error CS0120: An object reference is required for the non-static field, method, or property 'Interface.Method(int, long)'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Method").WithArguments("Interface.Method(int, long)"),
+                //         Interface.Method(1, 2);
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Method").WithArguments("Interface.Method(int, long)").WithLocation(13, 9),
                 // (18,9): error CS0120: An object reference is required for the non-static field, method, or property 'Interface.Method<T>()'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Method<T>").WithArguments("Interface.Method<T>()"),
+                //         Interface.Method<T>();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Method<T>").WithArguments("Interface.Method<T>()").WithLocation(18, 9),
                 // (27,9): error CS0120: An object reference is required for the non-static field, method, or property 'Interface.Property'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Property").WithArguments("Interface.Property"),
+                //         Interface.Property = 2;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Property").WithArguments("Interface.Property").WithLocation(27, 9),
                 // (28,9): error CS0120: An object reference is required for the non-static field, method, or property 'Interface.Event'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Event").WithArguments("Interface.Event"),
+                //         Interface.Event += null;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Interface.Event").WithArguments("Interface.Event").WithLocation(28, 9),
                 // (31,11): error CS1061: 'Class' does not contain a definition for 'Interface' and no extension method 'Interface' accepting a first argument of type 'Class' could be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface"),
+                //         c.Interface.Method(1, 2);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface").WithLocation(31, 11),
                 // (32,11): error CS1061: 'Class' does not contain a definition for 'Interface' and no extension method 'Interface' accepting a first argument of type 'Class' could be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface"),
+                //         c.Interface.Method<string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface").WithLocation(32, 11),
                 // (33,11): error CS1061: 'Class' does not contain a definition for 'Interface' and no extension method 'Interface' accepting a first argument of type 'Class' could be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface"),
+                //         c.Interface.Property = 2;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface").WithLocation(33, 11),
                 // (34,11): error CS1061: 'Class' does not contain a definition for 'Interface' and no extension method 'Interface' accepting a first argument of type 'Class' could be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface"));
+                //         c.Interface.Event += null;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Interface").WithArguments("Class", "Interface").WithLocation(34, 11));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ObjectAndCollectionInitializerTests.cs
@@ -1572,10 +1572,8 @@ IObjectCreationOperation (Constructor: MemberInitializerTest..ctor()) (Operation
               ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
           ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo() = new ... lizerTest()')
             Left: 
-              IInvocationOperation ( MemberInitializerTest MemberInitializerTest.Goo()) (OperationKind.Invocation, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo()')
-                Instance Receiver: 
-                  IInstanceReferenceOperation (OperationKind.InstanceReference, Type: MemberInitializerTest, IsInvalid, IsImplicit) (Syntax: 'Goo')
-                Arguments(0)
+              IInvalidOperation (OperationKind.Invalid, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo()')
+                Children(0)
             Right: 
               IObjectCreationOperation (Constructor: MemberInitializerTest..ctor()) (OperationKind.ObjectCreation, Type: MemberInitializerTest, IsInvalid) (Syntax: 'new MemberI ... lizerTest()')
                 Arguments(0)
@@ -2071,8 +2069,8 @@ IObjectCreationOperation (Constructor: Test..ctor()) (OperationKind.ObjectCreati
   Initializer: 
     IObjectOrCollectionInitializerOperation (OperationKind.ObjectOrCollectionInitializer, Type: Test, IsInvalid) (Syntax: '{ 1 }')
       Initializers(1):
-          ICollectionElementInitializerOperation (AddMethod: void Test.Add(System.Int32 i)) (IsDynamic: False) (OperationKind.CollectionElementInitializer, Type: System.Void, IsInvalid, IsImplicit) (Syntax: '1')
-            Arguments(1):
+          IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid, IsImplicit) (Syntax: '1')
+            Children(1):
                 ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
@@ -2281,10 +2279,8 @@ IObjectCreationOperation (Constructor: MemberInitializerTest..ctor()) (Operation
             Children(1):
                 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo() = new ... lizerTest()')
                   Left: 
-                    IInvocationOperation ( MemberInitializerTest MemberInitializerTest.Goo()) (OperationKind.Invocation, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo()')
-                      Instance Receiver: 
-                        IInstanceReferenceOperation (OperationKind.InstanceReference, Type: MemberInitializerTest, IsInvalid, IsImplicit) (Syntax: 'Goo')
-                      Arguments(0)
+                    IInvalidOperation (OperationKind.Invalid, Type: MemberInitializerTest, IsInvalid) (Syntax: 'Goo()')
+                      Children(0)
                   Right: 
                     IObjectCreationOperation (Constructor: MemberInitializerTest..ctor()) (OperationKind.ObjectCreation, Type: MemberInitializerTest, IsInvalid) (Syntax: 'new MemberI ... lizerTest()')
                       Arguments(0)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -1368,7 +1368,7 @@ class C
     static void Test5<Y>(Y y, N<Y> ny) { }
     static void Test6<Z>(N<Z> nz) where Z : struct {}
 }";
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (67,36): error CS0453: The type 'Y' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
                 //     static void Test5<Y>(Y y, N<Y> ny) { }
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "ny").WithArguments("C.N<T>", "T", "Y").WithLocation(67, 36),
@@ -1381,6 +1381,25 @@ class C
                 // (36,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'X' in the generic type or method 'C.Test4<X>(X)'
                 //         Test4(s);
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test4").WithArguments("C.Test4<X>(X)", "X", "string").WithLocation(36, 9),
+                // (47,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
+                //         Test5(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test5").WithArguments("C.N<T>", "T", "string").WithLocation(47, 9),
+                // (58,17): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'
+                //         Test6<L<string>>(null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("C.L<S>", "S", "string").WithLocation(58, 17),
+                // (58,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'
+                //         Test6<L<string>>(null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test6<L<string>>").WithArguments("C.L<S>", "S", "string").WithLocation(58, 9));
+            CreateStandardCompilation(source).VerifyDiagnostics(
+                // (67,36): error CS0453: The type 'Y' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
+                //     static void Test5<Y>(Y y, N<Y> ny) { }
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "ny").WithArguments("C.N<T>", "T", "Y").WithLocation(67, 36),
+                // (17,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'U' in the generic type or method 'C.Test1<U>(U, C.N<U>)'
+                //         Test1<string>(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test1<string>").WithArguments("C.Test1<U>(U, C.N<U>)", "U", "string").WithLocation(17, 9),
+                // (21,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'V' in the generic type or method 'C.Test2<V>(V, C.N<V>)'
+                //         Test2(s, null);
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test2").WithArguments("C.Test2<V>(V, C.N<V>)", "V", "string").WithLocation(21, 9),
                 // (47,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
                 //         Test5(s, null);
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test5").WithArguments("C.N<T>", "T", "string").WithLocation(47, 9),
@@ -7796,12 +7815,12 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateStandardCompilation(source1, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
     // (25,38): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Bar<T, V>.Create(Func<T, bool>)' and 'Program.Bar<T, V>.Create(Func<T, V>, params Func<T, bool>[])'
     //             var x = Bar<Goo, double>.Create(Goo.IsThing);
     Diagnostic(ErrorCode.ERR_AmbigCall, "Create").WithArguments("ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, bool>)", "ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, V>, params System.Func<T, bool>[])").WithLocation(25, 38)
+                );
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe).VerifyDiagnostics(
                 );
         }
 
@@ -7876,12 +7895,12 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateStandardCompilation(source1, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
     // (25,38): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Bar<T, V>.Create(Func<T, bool>, params int[])' and 'Program.Bar<T, V>.Create(Func<T, V>)'
     //             var x = Bar<Goo, double>.Create(Goo.IsThing);
     Diagnostic(ErrorCode.ERR_AmbigCall, "Create").WithArguments("ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, bool>, params int[])", "ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, V>)").WithLocation(25, 38)
+                );
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe).VerifyDiagnostics(
                 );
         }
 
@@ -7918,12 +7937,12 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateStandardCompilation(source1, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
     // (25,38): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Bar<T, V>.Create(Func<T, V>)' and 'Program.Bar<T, V>.Create(Func<T, bool>, params int[])'
     //             var x = Bar<Goo, double>.Create(Goo.IsThing);
     Diagnostic(ErrorCode.ERR_AmbigCall, "Create").WithArguments("ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, V>)", "ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, bool>, params int[])").WithLocation(25, 38)
+                );
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe).VerifyDiagnostics(
                 );
         }
 
@@ -7960,12 +7979,12 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateStandardCompilation(source1, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
     // (25,38): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Bar<T, V>.Create(Func<T, V>, params Func<T, bool>[])' and 'Program.Bar<T, V>.Create(Func<T, bool>)'
     //             var x = Bar<Goo, double>.Create(Goo.IsThing);
     Diagnostic(ErrorCode.ERR_AmbigCall, "Create").WithArguments("ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, V>, params System.Func<T, bool>[])", "ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, bool>)").WithLocation(25, 38)
+                );
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe).VerifyDiagnostics(
                 );
         }
 
@@ -8000,12 +8019,12 @@ namespace ConsoleApplication2
 }
 ";
 
-            var compilation = CreateStandardCompilation(source1, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
     // (23,38): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Bar<T, V>.Create(Func<T, bool>, params int[])' and 'Program.Bar<T, V>.Create(Func<T, V>, params int[])'
     //             var x = Bar<Goo, double>.Create(Goo.IsThing);
     Diagnostic(ErrorCode.ERR_AmbigCall, "Create").WithArguments("ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, bool>, params int[])", "ConsoleApplication2.Program.Bar<T, V>.Create(System.Func<T, V>, params int[])").WithLocation(23, 38)
+                );
+            CreateStandardCompilation(source1, options: TestOptions.DebugExe).VerifyDiagnostics(
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -1390,6 +1390,7 @@ class C
                 // (58,9): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'S' in the generic type or method 'C.L<S>'
                 //         Test6<L<string>>(null);
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "Test6<L<string>>").WithArguments("C.L<S>", "S", "string").WithLocation(58, 9));
+
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (67,36): error CS0453: The type 'Y' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.N<T>'
                 //     static void Test5<Y>(Y y, N<Y> ny) { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -1372,9 +1372,9 @@ goto Label;");
                 // (1,27): error CS0822: Implicitly-typed variables cannot be constant
                 // string F() => null; const var x = F();
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableCannotBeConst, "var").WithLocation(1, 27),
-                // (1,35): error CS0120: An object reference is required for the non-static field, method, or property 'F()'
+                // (1,35): error CS0236: A field initializer cannot reference the non-static field, method, or property 'F()'
                 // string F() => null; const var x = F();
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("F()").WithLocation(1, 35)
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "F").WithArguments("F()").WithLocation(1, 35)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
@@ -448,12 +448,12 @@ class C
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (84,29): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
-                //     public static void PExt(this P p) {}
-                Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(84, 29),
                 // (69,28): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
                 //     public static P Select(this P p, Func<P, P> projection)
                 Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(69, 28),
+                // (84,29): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
+                //     public static void PExt(this P p) {}
+                Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(84, 29),
                 // (80,33): error CS1110: Cannot define a new extension method because the compiler required type 'System.Runtime.CompilerServices.ExtensionAttribute' cannot be found. Are you missing a reference to System.Core.dll?
                 //     public static object Select(this Q q, object projection)
                 Diagnostic(ErrorCode.ERR_ExtensionAttrNotFound, "this").WithArguments("System.Runtime.CompilerServices.ExtensionAttribute").WithLocation(80, 33),
@@ -505,7 +505,7 @@ class C
                 // (190,24): error CS1620: Argument 1 must be passed with the 'ref' keyword
                 //         p.RefParameter(456);
                 Diagnostic(ErrorCode.ERR_BadArgRef, "456").WithArguments("1", "ref").WithLocation(190, 24),
-                // (195,28): error CS1615: Argument 1 should not be passed with the 'out' keyword
+                // (195,28): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //         p.OneParameter(out local);  
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "local").WithArguments("1", "out").WithLocation(195, 28),
                 // (199,28): error CS1620: Argument 1 must be passed with the 'ref' keyword
@@ -519,7 +519,8 @@ class C
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "P.NoParameter").WithArguments("P.NoParameter()").WithLocation(219, 9),
                 // (223,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod()'
                 //         InstanceMethod(); // Verify that use of 'implicit this' is not legal in a static method.
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod()").WithLocation(223, 9));
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod()").WithLocation(223, 9)
+                );
         }
 
         [WorkItem(538651, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538651")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1340,17 +1340,19 @@ class A : Attribute
             string text = @"
 int a;
 int b = a;
-int c = this.a;
-this.c = this.a;
-int prop { get { return 1; } set { this.a = 1;} }
+int c = this.a; // 1
+this.c = // 2
+    this.a; // 3
+int prop { get { return 1; } set { this.a = 1;} } // 4
 
 void goo() {
-    this.goo();
-    this.a = this.b;
-    object c = this;
+    this.goo(); // 5
+    this.a =    // 6
+        this.b; // 7
+    object c = this; // 8
 }
 
-this.prop = 1;
+this.prop = 1; // 9
 
 class C
 {
@@ -1360,30 +1362,40 @@ class C
 
     void goo()
     {
-        this.goo();
+        this.goo(); // OK
     }
 }";
             var comp = CreateCompilationWithMscorlib45(
                 new[] { SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Script) });
             comp.VerifyDiagnostics(
                 // (4,9): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                // int c = this.a; // 1
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(4, 9),
                 // (5,1): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (5,10): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (14,1): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (6,36): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (9,5): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                // this.c = // 2
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(5, 1),
+                // (6,5): error CS0027: Keyword 'this' is not available in the current context
+                //     this.a; // 3
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(6, 5),
+                // (16,1): error CS0027: Keyword 'this' is not available in the current context
+                // this.prop = 1; // 9
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(16, 1),
+                // (7,36): error CS0027: Keyword 'this' is not available in the current context
+                // int prop { get { return 1; } set { this.a = 1;} } // 4
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(7, 36),
                 // (10,5): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (10,14): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
-                // (11,16): error CS0027: Keyword 'this' is not available in the current context
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"));
+                //     this.goo(); // 5
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(10, 5),
+                // (11,5): error CS0027: Keyword 'this' is not available in the current context
+                //     this.a =    // 6
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(11, 5),
+                // (12,9): error CS0027: Keyword 'this' is not available in the current context
+                //         this.b; // 7
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(12, 9),
+                // (13,16): error CS0027: Keyword 'this' is not available in the current context
+                //     object c = this; // 8
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(13, 16)
+                );
         }
 
         [Fact]
@@ -2661,17 +2673,23 @@ class C
 ")
             .VerifyDiagnostics(
                 // (8,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.field'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "field").WithArguments("C.field"),
+                //         field = Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "field").WithArguments("C.field").WithLocation(8, 9),
                 // (8,17): error CS0120: An object reference is required for the non-static field, method, or property 'C.Property'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Property").WithArguments("C.Property"),
+                //         field = Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Property").WithArguments("C.Property").WithLocation(8, 17),
                 // (9,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.field'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.field").WithArguments("C.field"),
+                //         C.field = C.Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.field").WithArguments("C.field").WithLocation(9, 9),
                 // (9,19): error CS0120: An object reference is required for the non-static field, method, or property 'C.Property'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Property").WithArguments("C.Property"),
+                //         C.field = C.Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Property").WithArguments("C.Property").WithLocation(9, 19),
                 // (10,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.Method()'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Method").WithArguments("C.Method()"),
+                //         Method();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Method").WithArguments("C.Method()").WithLocation(10, 9),
                 // (11,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.Method()'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Method").WithArguments("C.Method()"));
+                //         C.Method();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Method").WithArguments("C.Method()").WithLocation(11, 9));
         }
 
         [Fact]
@@ -2698,7 +2716,7 @@ class Program
         [Fact]
         public void CS0120ERR_ObjectRequired03()
         {
-            CreateStandardCompilation(
+            var source =
 @"delegate int boo();
 interface I
 {
@@ -2717,14 +2735,25 @@ class C
         goo += new boo(I.bar);
         goo();
     }
-}")
-            .VerifyDiagnostics(
+}";
+            CreateStandardCompilation(source, parseOptions: TestOptions.Regular7).VerifyDiagnostics(
                 // (16,24): error CS0120: An object reference is required for the non-static field, method, or property 'I.bar()'
                 //         goo += new boo(I.bar);
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "I.bar").WithArguments("I.bar()"),
                 // (14,13): warning CS0219: The variable 'p' is assigned but its value is never used
                 //         abc p = new abc();
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p")
+            );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateStandardCompilation(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
+                // (16,16): error CS0123: No overload for 'bar' matches delegate 'boo'
+                //         goo += new boo(I.bar);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new boo(I.bar)").WithArguments("bar", "boo").WithLocation(16, 16),
+                // (14,13): warning CS0219: The variable 'p' is assigned but its value is never used
+                //         abc p = new abc();
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(14, 13)
             );
         }
 
@@ -2794,28 +2823,28 @@ class C : B
             .VerifyDiagnostics(
                 // (19,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.instanceField'
                 //         instanceField, //CS0120
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "instanceField").WithArguments("C.instanceField"),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "instanceField").WithArguments("C.instanceField").WithLocation(19, 9),
                 // (21,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceProperty'
                 //         InstanceProperty, //CS0120
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceProperty").WithArguments("C.InstanceProperty"),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceProperty").WithArguments("C.InstanceProperty").WithLocation(21, 9),
                 // (23,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.InstanceMethod()'
                 //         InstanceMethod(), //CS0120
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod()").WithArguments("C.InstanceMethod()"),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "InstanceMethod").WithArguments("C.InstanceMethod()").WithLocation(23, 9),
                 // (25,9): error CS0027: Keyword 'this' is not available in the current context
                 //         this.instanceField, //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(25, 9),
                 // (27,9): error CS0027: Keyword 'this' is not available in the current context
                 //         this.InstanceProperty, //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(27, 9),
                 // (29,9): error CS0027: Keyword 'this' is not available in the current context
                 //         this.InstanceMethod(), //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(29, 9),
                 // (8,9): warning CS0649: Field 'C.instanceField' is never assigned to, and will always have its default value 0
                 //     int instanceField;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "instanceField").WithArguments("C.instanceField", "0"),
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "instanceField").WithArguments("C.instanceField", "0").WithLocation(8, 9),
                 // (9,16): warning CS0649: Field 'C.staticField' is never assigned to, and will always have its default value 0
                 //     static int staticField;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "staticField").WithArguments("C.staticField", "0"));
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "staticField").WithArguments("C.staticField", "0").WithLocation(9, 16));
         }
 
         [Fact]
@@ -2838,17 +2867,23 @@ class C : B
 ")
             .VerifyDiagnostics(
                 // (8,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.field'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "field").WithArguments("C.field"),
+                //         field = Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "field").WithArguments("C.field").WithLocation(8, 9),
                 // (8,17): error CS0120: An object reference is required for the non-static field, method, or property 'C.Property'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Property").WithArguments("C.Property"),
+                //         field = Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Property").WithArguments("C.Property").WithLocation(8, 17),
                 // (9,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.field'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.field").WithArguments("C.field"),
+                //         C.field = C.Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.field").WithArguments("C.field").WithLocation(9, 9),
                 // (9,19): error CS0120: An object reference is required for the non-static field, method, or property 'C.Property'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Property").WithArguments("C.Property"),
+                //         C.field = C.Property;
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Property").WithArguments("C.Property").WithLocation(9, 19),
                 // (10,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.Method()'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "Method").WithArguments("C.Method()"),
+                //         Method();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "Method").WithArguments("C.Method()").WithLocation(10, 9),
                 // (11,9): error CS0120: An object reference is required for the non-static field, method, or property 'C.Method()'
-                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Method").WithArguments("C.Method()"));
+                //         C.Method();
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "C.Method").WithArguments("C.Method()").WithLocation(11, 9));
         }
 
         [Fact]
@@ -6439,7 +6474,7 @@ class A
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (9,13): error CS0176: Member 'A.B.Method()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //             this.Method();
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "this.Method").WithArguments("A.B.Method()")
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "this.Method").WithArguments("A.B.Method()").WithLocation(9, 13)
                 );
         }
 
@@ -6488,19 +6523,20 @@ class B<T> where T : A
 {
     static void M(T t)
     {
-        t.ReferenceEquals(t.F, null);
+        object q = t.F;
+        t.ReferenceEquals(q, null);
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (9,27): error CS0176: Member 'A.F' cannot be accessed with an instance reference; qualify it with a type name instead
-                //         t.ReferenceEquals(t.F, null);
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "t.F").WithArguments("A.F"),
-                // (9,9): error CS0176: Member 'object.ReferenceEquals(object, object)' cannot be accessed with an instance reference; qualify it with a type name instead
-                //         t.ReferenceEquals(t.F, null);
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "t.ReferenceEquals").WithArguments("object.ReferenceEquals(object, object)"),
+                // (9,20): error CS0176: Member 'A.F' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         object q = t.F;
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "t.F").WithArguments("A.F").WithLocation(9, 20),
+                // (10,9): error CS0176: Member 'object.ReferenceEquals(object, object)' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         t.ReferenceEquals(q, null);
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "t.ReferenceEquals").WithArguments("object.ReferenceEquals(object, object)").WithLocation(10, 9),
                 // (3,28): warning CS0649: Field 'A.F' is never assigned to, and will always have its default value null
                 //     internal static object F;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F").WithArguments("A.F", "null"));
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "F").WithArguments("A.F", "null").WithLocation(3, 28));
         }
 
         [WorkItem(543361, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543361")]
@@ -6520,9 +6556,9 @@ class Test
 }
 ";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (9,9): error CS0176: Member Member 'System.Delegate.CreateDelegate(System.Type, System.Type, string)' cannot be accessed with an instance reference; qualify it with a type name instead
-                //             this.Method();
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "D.CreateDelegate").WithArguments("System.Delegate.CreateDelegate(System.Type, System.Type, string)")
+                // (9,9): error CS0176: Member 'Delegate.CreateDelegate(Type, object, string)' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         D.CreateDelegate(null, null, null); // CS0176
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "D.CreateDelegate").WithArguments("System.Delegate.CreateDelegate(System.Type, object, string)").WithLocation(9, 9)
                 );
         }
 
@@ -8327,46 +8363,47 @@ public class MyClass
             comp.VerifyDiagnostics(
                 // (12,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'MyClass.b'
                 //     int c = b; //CS0236
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "b").WithArguments("MyClass.b"),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "b").WithArguments("MyClass.b").WithLocation(12, 13),
                 // (13,13): error CS0027: Keyword 'this' is not available in the current context
                 //     int d = this.b; //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(13, 13),
                 // (14,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'MyClass.InstanceMethod()'
                 //     int e = InstanceMethod(); //CS0236
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod()").WithArguments("MyClass.InstanceMethod()"),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceMethod").WithArguments("MyClass.InstanceMethod()").WithLocation(14, 13),
                 // (15,13): error CS0027: Keyword 'this' is not available in the current context
                 //     int f = this.InstanceMethod(); //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(15, 13),
                 // (18,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'MyClass.GenericInstanceMethod<int>(int)'
                 //     int i = GenericInstanceMethod<int>(1); //CS0236
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "GenericInstanceMethod<int>(1)").WithArguments("MyClass.GenericInstanceMethod<int>(int)"),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "GenericInstanceMethod<int>").WithArguments("MyClass.GenericInstanceMethod<int>(int)").WithLocation(18, 13),
                 // (19,13): error CS0027: Keyword 'this' is not available in the current context
                 //     int j = this.GenericInstanceMethod<int>(1); //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(19, 13),
                 // (22,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'MyClass.InstanceProperty'
                 //     int m = InstanceProperty; //CS0236
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceProperty").WithArguments("MyClass.InstanceProperty"),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "InstanceProperty").WithArguments("MyClass.InstanceProperty").WithLocation(22, 13),
                 // (23,13): error CS0027: Keyword 'this' is not available in the current context
                 //     int n = this.InstanceProperty; //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(23, 13),
                 // (26,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'MyClass.instanceArray'
                 //     int q = instanceArray[0]; //CS0236
-                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "instanceArray").WithArguments("MyClass.instanceArray"),
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "instanceArray").WithArguments("MyClass.instanceArray").WithLocation(26, 13),
                 // (27,13): error CS0027: Keyword 'this' is not available in the current context
                 //     int r = this.instanceArray[0]; //CS0027
-                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this"),
+                Diagnostic(ErrorCode.ERR_ThisInBadContext, "this").WithLocation(27, 13),
                 // (4,11): warning CS0649: Field 'MyClass.instanceArray' is never assigned to, and will always have its default value null
                 //     int[] instanceArray;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "instanceArray").WithArguments("MyClass.instanceArray", "null"),
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "instanceArray").WithArguments("MyClass.instanceArray", "null").WithLocation(4, 11),
                 // (5,18): warning CS0649: Field 'MyClass.staticArray' is never assigned to, and will always have its default value null
                 //     static int[] staticArray;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "staticArray").WithArguments("MyClass.staticArray", "null"),
-                // (32,9): warning CS0414: The field 'MyClass.w' is assigned but its value is never used
-                //     int w = constField;
-                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "w").WithArguments("MyClass.w"),
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "staticArray").WithArguments("MyClass.staticArray", "null").WithLocation(5, 18),
                 // (33,9): warning CS0414: The field 'MyClass.x' is assigned but its value is never used
                 //     int x = MyClass.constField;
-                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("MyClass.x"));
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("MyClass.x").WithLocation(33, 9),
+                // (32,9): warning CS0414: The field 'MyClass.w' is assigned but its value is never used
+                //     int w = constField;
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "w").WithArguments("MyClass.w").WithLocation(32, 9)
+            );
         }
 
         [Fact]
@@ -9544,24 +9581,34 @@ struct S
 
             CreateStandardCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
                 // (9,36): error CS0310: 'U' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'D<T>'
+                //     internal static void E<U>(D<U> d) { } // Error: missing constraint on E<U> to satisfy constraint on D<U>
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "d").WithArguments("D<T>", "T", "U").WithLocation(9, 36),
-                // (29,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<A>.M<B>").WithArguments("C<A>.M<U>()", "U", "B").WithLocation(29, 9),
+                // (29,14): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.M<U>()'
+                //         C<A>.M<B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<B>").WithArguments("C<A>.M<U>()", "U", "B").WithLocation(29, 14),
                 // (30,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //         C<B>.M<A>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "B").WithArguments("C<T>", "T", "B").WithLocation(30, 11),
                 // (31,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //         C<B>.M<B>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "B").WithArguments("C<T>", "T", "B").WithLocation(31, 11),
-                // (31,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<B>.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<B>.M<B>").WithArguments("C<B>.M<U>()", "U", "B").WithLocation(31, 9),
+                // (31,14): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<B>.M<U>()'
+                //         C<B>.M<B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<B>").WithArguments("C<B>.M<U>()", "U", "B").WithLocation(31, 14),
                 // (32,11): error CS0310: 'G' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //         C<G>.M<H>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "G").WithArguments("C<T>", "T", "G").WithLocation(32, 11),
-                // (33,9): error CS0310: 'G' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<H>.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<H>.M<G>").WithArguments("C<H>.M<U>()", "U", "G").WithLocation(33, 9),
+                // (33,14): error CS0310: 'G' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<H>.M<U>()'
+                //         C<H>.M<G>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<G>").WithArguments("C<H>.M<U>()", "U", "G").WithLocation(33, 14),
                 // (34,11): error CS0310: 'I' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //         C<I>.M<S>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "I").WithArguments("C<T>", "T", "I").WithLocation(34, 11),
-                // (36,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'E.F<T>(D<T>)'
+                // (36,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'E.F<T>(D<T>)'
+                //         E.F(S.F<B>);
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "F").WithArguments("E.F<T>(D<T>)", "T", "B").WithLocation(36, 11),
                 // (38,19): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //         E.F(S.F<C<B>>);
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "B").WithArguments("C<T>", "T", "B").WithLocation(38, 19),
 
                 // This invocation of E.F(S.F<C<B>>) is an extremely interesting one. 
@@ -9595,13 +9642,15 @@ struct S
                 // We might want to put some gear in place to suppress this cascading error. It is not
                 // entirely clear what that machinery might look like.
 
-                // (38,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                // (38,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
                 //         E.F(S.F<C<B>>);
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "F").WithArguments("C<T>", "T", "B"),
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "F").WithArguments("C<T>", "T", "B").WithLocation(38, 11),
 
-                // (41,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'E.M<T>(object)'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "o.M<B>").WithArguments("E.M<T>(object)", "T", "B").WithLocation(41, 9),
+                // (41,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'E.M<T>(object)'
+                //         o.M<B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<B>").WithArguments("E.M<T>(object)", "T", "B").WithLocation(41, 11),
                 // (42,22): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'F<T, U>'
+                //         o = new F<A, B>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "B").WithArguments("F<T, U>", "U", "B").WithLocation(42, 22));
         }
 
@@ -9642,13 +9691,18 @@ static class S
 }";
             CreateStandardCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
                 // (15,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'V' in the generic type or method 'C<T, U>.M<V>(V)'
+                //         M(b);
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M").WithArguments("C<T, U>.M<V>(V)", "V", "B").WithLocation(15, 9),
-                // (16,9): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'S.E<T>(T)'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "b.E").WithArguments("S.E<T>(T)", "T", "B").WithLocation(16, 9),
+                // (16,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'S.E<T>(T)'
+                //         b.E();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "E").WithArguments("S.E<T>(T)", "T", "B").WithLocation(16, 11),
                 // (18,9): error CS0310: 'T' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'V' in the generic type or method 'C<T, U>.M<V>(V)'
+                //         M(t);
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M").WithArguments("C<T, U>.M<V>(V)", "V", "T").WithLocation(18, 9),
-                // (19,9): error CS0310: 'T' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'S.E<T>(T)'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "t.E").WithArguments("S.E<T>(T)", "T", "T").WithLocation(19, 9));
+                // (19,11): error CS0310: 'T' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'S.E<T>(T)'
+                //         t.E();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "E").WithArguments("S.E<T>(T)", "T", "T").WithLocation(19, 11)
+);
         }
 
         /// <summary>
@@ -9696,27 +9750,38 @@ namespace N
     }
 }";
             CreateStandardCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
-                // (4,7): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (4,7): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                // using CB = N.C<N.B>;
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CB").WithArguments("N.C<T>", "T", "N.B").WithLocation(4, 7),
-                // (8,11): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (8,11): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //     using CBD = C<N.B>.D;
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CBD").WithArguments("N.C<T>", "T", "N.B").WithLocation(8, 11),
-                // (24,13): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'N.C<N.A>.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<N.A>.M<N.B>").WithArguments("N.C<N.A>.M<U>()", "U", "N.B").WithLocation(24, 13),
-                // (25,15): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (24,20): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.M<U>()'
+                //             C<N.A>.M<N.B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<N.B>").WithArguments("N.C<N.A>.M<U>()", "U", "N.B").WithLocation(24, 20),
+                // (25,15): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //             C<NB>.M<NA>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "NB").WithArguments("N.C<T>", "T", "N.B").WithLocation(25, 15),
-                // (26,15): error CS0310: 'N.C<N.A>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (26,15): error CS0310: 'C<A>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //             C<C<N.A>.D>.M<N.A>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<N.A>.D").WithArguments("N.C<T>", "T", "N.C<N.A>.D").WithLocation(26, 15),
-                // (27,13): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'N.C<N.A>.D.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "C<N.A>.D.M<N.B>").WithArguments("N.C<N.A>.D.M<U>()", "U", "N.B").WithLocation(27, 13),
-                // (28,15): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (27,22): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.D.M<U>()'
+                //             C<N.A>.D.M<N.B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<N.B>").WithArguments("N.C<N.A>.D.M<U>()", "U", "N.B").WithLocation(27, 22),
+                // (28,15): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //             C<N.B>.D.M<N.A>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "N.B").WithArguments("N.C<T>", "T", "N.B").WithLocation(28, 15),
-                // (29,13): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'N.C<N.A>.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CA.M<N.B>").WithArguments("N.C<N.A>.M<U>()", "U", "N.B").WithLocation(29, 13),
-                // (31,13): error CS0310: 'N.B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'N.C<N.A>.D.M<U>()'
-                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CAD.M<N.B>").WithArguments("N.C<N.A>.D.M<U>()", "U", "N.B").WithLocation(31, 13),
-                // (33,15): error CS0310: 'N.C<N.A>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (29,16): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.M<U>()'
+                //             CA.M<N.B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<N.B>").WithArguments("N.C<N.A>.M<U>()", "U", "N.B").WithLocation(29, 16),
+                // (31,17): error CS0310: 'B' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'U' in the generic type or method 'C<A>.D.M<U>()'
+                //             CAD.M<N.B>();
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "M<N.B>").WithArguments("N.C<N.A>.D.M<U>()", "U", "N.B").WithLocation(31, 17),
+                // (33,15): error CS0310: 'C<A>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //             C<CAD>.M<N.A>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CAD").WithArguments("N.C<T>", "T", "N.C<N.A>.D").WithLocation(33, 15),
-                // (34,15): error CS0310: 'N.C<N.B>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'N.C<T>'
+                // (34,15): error CS0310: 'C<B>.D' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C<T>'
+                //             C<CBD>.M<N.A>();
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "CBD").WithArguments("N.C<T>", "T", "N.C<N.B>.D").WithLocation(34, 15));
         }
 
@@ -9848,10 +9913,12 @@ class C<T1, T2, T3>
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (16,24): error CS0311: The type 'object' cannot be used as type parameter 'U' in the generic type or method 'N.C<T, U>'. There is no implicit reference conversion from 'object' to 'int'.
+                // (16,24): error CS0311: The type 'object' cannot be used as type parameter 'U' in the generic type or method 'C<T, U>'. There is no implicit reference conversion from 'object' to 'int'.
+                //             o = C<int, object>.F();
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "object").WithArguments("N.C<T, U>", "int", "U", "object").WithLocation(16, 24),
-                // (17,17): error CS0311: The type 'string' cannot be used as type parameter 'V' in the generic type or method 'N.C<int, int>.G<V>()'. There is no implicit reference conversion from 'string' to 'int'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "N.C<int, int>.G<string>").WithArguments("N.C<int, int>.G<V>()", "int", "V", "string").WithLocation(17, 17));
+                // (17,31): error CS0311: The type 'string' cannot be used as type parameter 'V' in the generic type or method 'C<int, int>.G<V>()'. There is no implicit reference conversion from 'string' to 'int'.
+                //             o = N.C<int, int>.G<string>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "G<string>").WithArguments("N.C<int, int>.G<V>()", "int", "V", "string").WithLocation(17, 31));
         }
 
         [Fact]
@@ -9870,9 +9937,11 @@ class B<T>
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (7,26): error CS0312: The type 'int?' cannot be used as type parameter 'T' in the generic type or method 'A<T, U>'. The nullable type 'int?' does not satisfy the constraint of 'int'.
+                //         object o = new A<int?, int>();
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedNullableEnum, "int?").WithArguments("A<T, U>", "int", "T", "int?").WithLocation(7, 26),
-                // (8,9): error CS0312: The type 'int?' cannot be used as type parameter 'U' in the generic type or method 'B<T>.M<U>()'. The nullable type 'int?' does not satisfy the constraint of 'int'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedNullableEnum, "B<int>.M<int?>").WithArguments("B<int>.M<U>()", "int", "U", "int?").WithLocation(8, 9));
+                // (8,16): error CS0312: The type 'int?' cannot be used as type parameter 'U' in the generic type or method 'B<int>.M<U>()'. The nullable type 'int?' does not satisfy the constraint of 'int'.
+                //         B<int>.M<int?>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedNullableEnum, "M<int?>").WithArguments("B<int>.M<U>()", "int", "U", "int?").WithLocation(8, 16));
         }
 
         [Fact]
@@ -10106,9 +10175,19 @@ class C
     }
 }
 ";
-            CreateStandardCompilation(text).VerifyDiagnostics(
+            CreateStandardCompilation(text, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (11,28): error CS0407: 'void C.G()' has the wrong return type
-                Diagnostic(ErrorCode.ERR_BadRetType, "G").WithArguments("C.G()", "void"));
+                //         d = new MyDelegate(G);  // CS0407 - G doesn't return int
+                Diagnostic(ErrorCode.ERR_BadRetType, "G").WithArguments("C.G()", "void").WithLocation(11, 28)
+                );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,13): error CS0123: No overload for 'G' matches delegate 'MyDelegate'
+                //         d = new MyDelegate(G);  // CS0407 - G doesn't return int
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new MyDelegate(G)").WithArguments("G", "MyDelegate").WithLocation(11, 13)
+                );
         }
 
         [WorkItem(925899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/925899")]
@@ -10129,13 +10208,24 @@ class C
     }
 }
 ";
+            CreateStandardCompilation(text, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
+                // (10,43): error CS0407: 'object System.Func<object, object>.Invoke(object)' has the wrong return type
+                //         var os = new Func<object, string>(oo);
+                Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(10, 43),
+                // (11,43): error CS0407: 'object System.Func<object, object>.Invoke(object)' has the wrong return type
+                //         var ss = new Func<string, string>(oo);
+                Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(11, 43)
+                );
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
+            // because we don't report *why* a delegate conversion failed.
+            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,43): error CS0407: 'object System.Func<object, object>.Invoke(object)' has the wrong return type
-    //         var os = new Func<object, string>(oo);
-    Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(10, 43),
-    // (11,43): error CS0407: 'object System.Func<object, object>.Invoke(object)' has the wrong return type
-    //         var ss = new Func<string, string>(oo);
-    Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(11, 43)
+                // (10,18): error CS0123: No overload for 'Func' matches delegate 'Func<object, string>'
+                //         var os = new Func<object, string>(oo);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Func<object, string>(oo)").WithArguments("Func", "System.Func<object, string>").WithLocation(10, 18),
+                // (11,18): error CS0123: No overload for 'Func' matches delegate 'Func<string, string>'
+                //         var ss = new Func<string, string>(oo);
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Func<string, string>(oo)").WithArguments("Func", "System.Func<string, string>").WithLocation(11, 18)
                 );
         }
 
@@ -17821,9 +17911,12 @@ unsafe  class C : IEnumerable<object>
             { d, delegate() { } },
             { d, 1, p },
             { d, __arglist },
-            { d, GetEnumerator }
+            { d, GetEnumerator },
+            { d, SomeStaticMethod },
         };
     }
+
+    public static void SomeStaticMethod() {}
 
     public void Add(dynamic d, int x, int* ptr)
     {
@@ -17854,13 +17947,23 @@ unsafe  class C : IEnumerable<object>
             var comp = CreateCompilationWithMscorlibAndSystemCore(source, new[] { CSharpRef }, options: TestOptions.UnsafeReleaseDll);
             comp.VerifyDiagnostics(
                 // (16,18): error CS1977: Cannot use a lambda expression as an argument to a dynamically dispatched operation without first casting it to a delegate or expression tree type.
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgLambda, "delegate() { }"),
+                //             { d, delegate() { } },
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgLambda, "delegate() { }").WithLocation(16, 18),
                 // (17,21): error CS1978: Cannot use an expression of type 'int*' as an argument to a dynamically dispatched operation.
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "p").WithArguments("int*"),
-                // (18,18): error CS1978: Cannot use an expression of type 'System.RuntimeArgumentHandle' as an argument to a dynamically dispatched operation.
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "__arglist").WithArguments("System.RuntimeArgumentHandle"),
-                // (19,18): error CS1976: Cannot use a method group as an argument to a dynamically dispatched operation. Did you intend to invoke the method?
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgMemgrp, "GetEnumerator"));
+                //             { d, 1, p },
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "p").WithArguments("int*").WithLocation(17, 21),
+                // (18,18): error CS1978: Cannot use an expression of type 'RuntimeArgumentHandle' as an argument to a dynamically dispatched operation.
+                //             { d, __arglist },
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(18, 18),
+                // (19,13): error CS1950: The best overloaded Add method 'C.Add(dynamic, RuntimeArgumentHandle)' for the collection initializer has some invalid arguments
+                //             { d, GetEnumerator },
+                Diagnostic(ErrorCode.ERR_BadArgTypesForCollectionAdd, "{ d, GetEnumerator }").WithArguments("C.Add(dynamic, System.RuntimeArgumentHandle)").WithLocation(19, 13),
+                // (19,18): error CS1503: Argument 2: cannot convert from 'method group' to 'RuntimeArgumentHandle'
+                //             { d, GetEnumerator },
+                Diagnostic(ErrorCode.ERR_BadArgType, "GetEnumerator").WithArguments("2", "method group", "System.RuntimeArgumentHandle").WithLocation(19, 18),
+                // (20,18): error CS1976: Cannot use a method group as an argument to a dynamically dispatched operation. Did you intend to invoke the method?
+                //             { d, SomeStaticMethod },
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgMemgrp, "SomeStaticMethod").WithLocation(20, 18));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -2744,13 +2744,10 @@ class C
                 //         abc p = new abc();
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p")
             );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
-                // (16,16): error CS0123: No overload for 'bar' matches delegate 'boo'
+                // (16,24): error CS0120: An object reference is required for the non-static field, method, or property 'I.bar()'
                 //         goo += new boo(I.bar);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new boo(I.bar)").WithArguments("bar", "boo").WithLocation(16, 16),
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "I.bar").WithArguments("I.bar()").WithLocation(16, 24),
                 // (14,13): warning CS0219: The variable 'p' is assigned but its value is never used
                 //         abc p = new abc();
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(14, 13)
@@ -10180,13 +10177,10 @@ class C
                 //         d = new MyDelegate(G);  // CS0407 - G doesn't return int
                 Diagnostic(ErrorCode.ERR_BadRetType, "G").WithArguments("C.G()", "void").WithLocation(11, 28)
                 );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,13): error CS0123: No overload for 'G' matches delegate 'MyDelegate'
+                // (11,28): error CS0407: 'void C.G()' has the wrong return type
                 //         d = new MyDelegate(G);  // CS0407 - G doesn't return int
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new MyDelegate(G)").WithArguments("G", "MyDelegate").WithLocation(11, 13)
+                Diagnostic(ErrorCode.ERR_BadRetType, "G").WithArguments("C.G()", "void").WithLocation(11, 28)
                 );
         }
 
@@ -10216,16 +10210,13 @@ class C
                 //         var ss = new Func<string, string>(oo);
                 Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(11, 43)
                 );
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (10,18): error CS0123: No overload for 'Func' matches delegate 'Func<object, string>'
+                // (10,43): error CS0407: 'object Func<object, object>.Invoke(object)' has the wrong return type
                 //         var os = new Func<object, string>(oo);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Func<object, string>(oo)").WithArguments("Func", "System.Func<object, string>").WithLocation(10, 18),
-                // (11,18): error CS0123: No overload for 'Func' matches delegate 'Func<string, string>'
+                Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(10, 43),
+                // (11,43): error CS0407: 'object Func<object, object>.Invoke(object)' has the wrong return type
                 //         var ss = new Func<string, string>(oo);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Func<string, string>(oo)").WithArguments("Func", "System.Func<string, string>").WithLocation(11, 18)
+                Diagnostic(ErrorCode.ERR_BadRetType, "oo").WithArguments("System.Func<object, object>.Invoke(object)", "object").WithLocation(11, 43)
                 );
         }
 
@@ -22137,25 +22128,25 @@ namespace CSSample
             comp.VerifyDiagnostics(
                 // (28,25): error CS0149: Method name expected
                 //             d1 = new D1(2 + 2);
-                Diagnostic(ErrorCode.ERR_MethodNameExpected, "2 + 2"),
-                // (29,18): error CS0123: No overload for 'D3' matches delegate 'CSSample.Program.D1'
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "2 + 2").WithLocation(28, 25),
+                // (29,18): error CS0123: No overload for 'Program.D3.Invoke(int)' matches delegate 'Program.D1'
                 //             d1 = new D1(d3);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D1(d3)").WithArguments("D3", "CSSample.Program.D1"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D1(d3)").WithArguments("CSSample.Program.D3.Invoke(int)", "CSSample.Program.D1").WithLocation(29, 18),
                 // (30,25): error CS0149: Method name expected
                 //             d1 = new D1(2, 3);
-                Diagnostic(ErrorCode.ERR_MethodNameExpected, "2, 3"),
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "2, 3").WithLocation(30, 25),
                 // (31,28): error CS0149: Method name expected
                 //             d1 = new D1(x: 3);
-                Diagnostic(ErrorCode.ERR_MethodNameExpected, "3"),
-                // (32,18): error CS0123: No overload for 'M2' matches delegate 'CSSample.Program.D1'
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "3").WithLocation(31, 28),
+                // (32,18): error CS0123: No overload for 'M2' matches delegate 'Program.D1'
                 //             d1 = new D1(M2);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D1(M2)").WithArguments("M2", "CSSample.Program.D1"),
-                // (16,19): warning CS0169: The field 'CSSample.Program.d2' is never used
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new D1(M2)").WithArguments("M2", "CSSample.Program.D1").WithLocation(32, 18),
+                // (16,19): warning CS0169: The field 'Program.d2' is never used
                 //         static D2 d2;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "d2").WithArguments("CSSample.Program.d2"),
-                // (17,19): warning CS0649: Field 'CSSample.Program.d3' is never assigned to, and will always have its default value null
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "d2").WithArguments("CSSample.Program.d2").WithLocation(16, 19),
+                // (17,19): warning CS0649: Field 'Program.d3' is never assigned to, and will always have its default value null
                 //         static D3 d3;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "d3").WithArguments("CSSample.Program.d3", "null"));
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "d3").WithArguments("CSSample.Program.d3", "null").WithLocation(17, 19));
         }
 
         [Fact, WorkItem(7359, "https://github.com/dotnet/roslyn/issues/7359")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -4370,19 +4370,19 @@ static class Extensions
             CreateCompilationWithMscorlibAndSystemCore(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (26,9): error CS0176: Member 'S.StaticField' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         p->StaticField = 1; //CS0176
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticField").WithArguments("S.StaticField"),
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticField").WithArguments("S.StaticField").WithLocation(26, 9),
                 // (29,9): error CS0176: Member 'S.StaticProperty' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         p->StaticProperty = 2; //CS0176
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticProperty").WithArguments("S.StaticProperty"),
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticProperty").WithArguments("S.StaticProperty").WithLocation(29, 9),
                 // (32,9): error CS0176: Member 'S.StaticMethod()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         p->StaticMethod(); //CS0176
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticMethod").WithArguments("S.StaticMethod()"),
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticMethod").WithArguments("S.StaticMethod()").WithLocation(32, 9),
                 // (38,13): error CS0176: Member 'S.StaticMethod()' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         a = p->StaticMethod; //CS0176
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticMethod").WithArguments("S.StaticMethod()"),
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticMethod").WithArguments("S.StaticMethod()").WithLocation(38, 13),
                 // (39,13): error CS1113: Extension method 'Extensions.ExtensionMethod(S)' defined on value type 'S' cannot be used to create delegates
                 //         a = p->ExtensionMethod; //CS1113
-                Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "p->ExtensionMethod").WithArguments("Extensions.ExtensionMethod(S)", "S")
+                Diagnostic(ErrorCode.ERR_ValueTypeExtDelegate, "p->ExtensionMethod").WithArguments("Extensions.ExtensionMethod(S)", "S").WithLocation(39, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
+++ b/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
@@ -313,6 +313,9 @@ interface I1<T>
                 // (151,9): error CS0012: The type 'CL2_C1' is defined in an assembly that is not referenced. You must add a reference to assembly 'CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         CL3_C2.Test1();
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "CL3_C2.Test1").WithArguments("CL2_C1", "CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(151, 9),
+                // (156,9): error CS0012: The type 'CL2_C1' is defined in an assembly that is not referenced. You must add a reference to assembly 'CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //         CL3_C2.Test1(1);
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "CL3_C2.Test1").WithArguments("CL2_C1", "CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(156, 9),
                 // (156,9): error CS0120: An object reference is required for the non-static field, method, or property 'CL3_C2.Test1(int)'
                 //         CL3_C2.Test1(1);
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "CL3_C2.Test1").WithArguments("CL3_C2.Test1(int)").WithLocation(156, 9),
@@ -500,6 +503,9 @@ public interface CL3_I1 : CL2_I1
                 // (151,9): error CS0246: The type or namespace name 'CL2_C1' could not be found (are you missing a using directive or an assembly reference?)
                 //         CL3_C2.Test1();
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "CL3_C2.Test1").WithArguments("CL2_C1").WithLocation(151, 9),
+                // (156,9): error CS0246: The type or namespace name 'CL2_C1' could not be found (are you missing a using directive or an assembly reference?)
+                //         CL3_C2.Test1(1);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "CL3_C2.Test1").WithArguments("CL2_C1").WithLocation(156, 9),
                 // (156,9): error CS0120: An object reference is required for the non-static field, method, or property 'CL3_C2.Test1(int)'
                 //         CL3_C2.Test1(1);
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "CL3_C2.Test1").WithArguments("CL3_C2.Test1(int)").WithLocation(156, 9),

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -5714,7 +5714,7 @@ class C { }
             Assert.Equal(ConversionKind.MethodGroup, conversionB.Kind);
 
             var conversionC = model.ClassifyConversion(methodGroupSyntax, typeFuncC);
-            Assert.Equal(ConversionKind.MethodGroup, conversionC.Kind);
+            Assert.Equal(ConversionKind.NoConversion, conversionC.Kind);
         }
 
         [WorkItem(872064, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/872064")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1871,8 +1871,10 @@ static class E
 }";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source);
             compilation.VerifyDiagnostics(
-                // (8,9): error CS0311: The type 'B' cannot be used as type parameter 'T' in the generic type or method 'E.F<T>(T)'. There is no implicit reference conversion from 'B' to 'A'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "b.F").WithArguments("E.F<T>(T)", "A", "T", "B").WithLocation(8, 9));
+                // (8,11): error CS0311: The type 'B' cannot be used as type parameter 'T' in the generic type or method 'E.F<T>(T)'. There is no implicit reference conversion from 'B' to 'A'.
+                //         b.F();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "F").WithArguments("E.F<T>(T)", "A", "T", "B").WithLocation(8, 11)
+);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1910,8 +1912,9 @@ static class E
 }";
             compilation = CreateCompilationWithMscorlibAndSystemCore(source);
             compilation.VerifyDiagnostics(
-                // (8,9): error CS0311: The type 'B' cannot be used as type parameter 'T' in the generic type or method 'E.F<T>(T)'. There is no implicit reference conversion from 'B' to 'A'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "b.F").WithArguments("E.F<T>(T)", "A", "T", "B").WithLocation(8, 9));
+                // (8,11): error CS0311: The type 'B' cannot be used as type parameter 'T' in the generic type or method 'E.F<T>(T)'. There is no implicit reference conversion from 'B' to 'A'.
+                //         b.F();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "F").WithArguments("E.F<T>(T)", "A", "T", "B").WithLocation(8, 11));
 
             tree = compilation.SyntaxTrees.Single();
             model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -7960,28 +7960,47 @@ class Program
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+            {
+                var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode,
+                    parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
 
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
+                Assert.Null(semanticInfo.Type);
+                Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal("System.Int32 Program.f()", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
-            Assert.Empty(semanticInfo.CandidateSymbols);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.Symbol.ToTestDisplayString());
+                Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
+                Assert.Empty(semanticInfo.CandidateSymbols);
 
-            Assert.Equal(1, semanticInfo.MethodGroup.Length);
-            Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
+                Assert.Equal(1, semanticInfo.MethodGroup.Length);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
 
-            Assert.False(semanticInfo.IsCompileTimeConstant);
+                Assert.False(semanticInfo.IsCompileTimeConstant);
+            }
+            {
+                var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+
+
+                Assert.Null(semanticInfo.Type);
+                Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
+
+                Assert.Null(semanticInfo.Symbol);
+                Assert.Equal(CandidateReason.OverloadResolutionFailure, semanticInfo.CandidateReason);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.CandidateSymbols[0].ToTestDisplayString());
+                Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+
+                Assert.Equal(1, semanticInfo.MethodGroup.Length);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
+
+                Assert.False(semanticInfo.IsCompileTimeConstant);
+            }
         }
 
         [Fact]
         public void DelegateSignatureMismatch4()
         {
-            // This test and the DelgateSignatureMismatch3 should have identical results, as they are semantically identical
-
             string sourceCode = @"
 using System;
 using System.Collections.Generic;
@@ -7996,20 +8015,42 @@ class Program
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+            {
+                var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode,
+                    parseOptions: TestOptions.WithoutImprovedOverloadCandidates);
 
-            Assert.Null(semanticInfo.Type);
-            Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
-            Assert.Equal(ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal("System.Int32 Program.f()", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
-            Assert.Empty(semanticInfo.CandidateSymbols);
+                Assert.Null(semanticInfo.Type);
+                Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.MethodGroup, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal(1, semanticInfo.MethodGroup.Length);
-            Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.Symbol.ToTestDisplayString());
+                Assert.Equal(CandidateReason.None, semanticInfo.CandidateReason);
+                Assert.Empty(semanticInfo.CandidateSymbols);
 
-            Assert.False(semanticInfo.IsCompileTimeConstant);
+                Assert.Equal(1, semanticInfo.MethodGroup.Length);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
+
+                Assert.False(semanticInfo.IsCompileTimeConstant);
+            }
+            {
+                var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+
+
+                Assert.Null(semanticInfo.Type);
+                Assert.Equal("System.Action", semanticInfo.ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.NoConversion, semanticInfo.ImplicitConversion.Kind);
+
+                Assert.Null(semanticInfo.Symbol);
+                Assert.Equal(CandidateReason.OverloadResolutionFailure, semanticInfo.CandidateReason);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.CandidateSymbols[0].ToTestDisplayString());
+                Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+
+                Assert.Equal(1, semanticInfo.MethodGroup.Length);
+                Assert.Equal("System.Int32 Program.f()", semanticInfo.MethodGroup[0].ToTestDisplayString());
+
+                Assert.False(semanticInfo.IsCompileTimeConstant);
+            }
         }
 
         [WorkItem(541802, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541802")]
@@ -13006,9 +13047,12 @@ public class MemberInitializerTest
             Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal("MemberInitializerTest MemberInitializerTest.Goo()", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
-            Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
+            Assert.Null(semanticInfo.Symbol);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, semanticInfo.CandidateReason);
+            Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+            var symbol = semanticInfo.CandidateSymbols[0];
+            Assert.Equal("MemberInitializerTest MemberInitializerTest.Goo()", symbol.ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, symbol.Kind);
 
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
@@ -13016,7 +13060,7 @@ public class MemberInitializerTest
         }
 
         [Fact]
-        public void ObjectInitializer_BadNamedAssignmentLeft_InvocationExpressionSyntax()
+        public void ObjectInitializer_BadNamedAssignmentLeft_InvocationExpressionSyntax_01()
         {
             string sourceCode = @"
 public class MemberInitializerTest
@@ -13037,9 +13081,46 @@ public class MemberInitializerTest
             Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
-            Assert.Equal("MemberInitializerTest MemberInitializerTest.Goo()", semanticInfo.Symbol.ToTestDisplayString());
-            Assert.Equal(SymbolKind.Method, semanticInfo.Symbol.Kind);
-            Assert.Equal(0, semanticInfo.CandidateSymbols.Length);
+            Assert.Null(semanticInfo.Symbol);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, semanticInfo.CandidateReason);
+            Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+            var symbol = semanticInfo.CandidateSymbols[0];
+            Assert.Equal("MemberInitializerTest MemberInitializerTest.Goo()", symbol.ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, symbol.Kind);
+
+            Assert.Equal(0, semanticInfo.MethodGroup.Length);
+
+            Assert.False(semanticInfo.IsCompileTimeConstant);
+        }
+
+        [Fact]
+        public void ObjectInitializer_BadNamedAssignmentLeft_InvocationExpressionSyntax_02()
+        {
+            string sourceCode = @"
+public class MemberInitializerTest
+{
+    public int x;
+    public static MemberInitializerTest Goo() { return new MemberInitializerTest(); }
+    public static void Main()
+    {
+        var i = new MemberInitializerTest() { x = 0, /*<bind>*/Goo()/*</bind>*/ = new MemberInitializerTest() };
+    }
+}
+";
+            var semanticInfo = GetSemanticInfoForTest<InvocationExpressionSyntax>(sourceCode);
+
+            Assert.Equal("MemberInitializerTest", semanticInfo.Type.ToTestDisplayString());
+            Assert.Equal(TypeKind.Class, semanticInfo.Type.TypeKind);
+            Assert.Equal("MemberInitializerTest", semanticInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal(TypeKind.Class, semanticInfo.ConvertedType.TypeKind);
+            Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
+
+            Assert.Null(semanticInfo.Symbol);
+            Assert.Equal(CandidateReason.NotAVariable, semanticInfo.CandidateReason);
+            Assert.Equal(1, semanticInfo.CandidateSymbols.Length);
+            var symbol = semanticInfo.CandidateSymbols[0];
+            Assert.Equal("MemberInitializerTest MemberInitializerTest.Goo()", symbol.ToTestDisplayString());
+            Assert.Equal(SymbolKind.Method, symbol.Kind);
 
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -1888,10 +1888,12 @@ public class C
             // The return type of F isn't considered until the delegate compatibility check,
             // which happens AFTER determining that the method group conversion exists.  As
             // a result, both methods are considered applicable and the "wrong" one is chosen.
-            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (8,11): error CS0407: 'dynamic C.F()' has the wrong return type
                 //         M(F);
                 Diagnostic(ErrorCode.ERR_BadRetType, "F").WithArguments("C.F()", "dynamic"));
+            // However, we later added a feature that takes the return type into account.
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics();
         }
 
         [WorkItem(737971, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/737971")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -1003,15 +1003,26 @@ static class S3
             CreateStandardCompilation(source, references: new[] { SystemCoreRef },
                     parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (10,16): error CS0407: 'void S2.F1(object, object)' has the wrong return type
+                //             M1(c.F1); // wrong return type
                 Diagnostic(ErrorCode.ERR_BadRetType, "c.F1").WithArguments("S2.F1(object, object)", "void").WithLocation(10, 16),
-                // (13,16): error CS0407: 'object S2.F2(N.C, object)' has the wrong return type
+                // (13,16): error CS0407: 'object S2.F2(C, object)' has the wrong return type
+                //             M2(c.F2); // wrong return type
                 Diagnostic(ErrorCode.ERR_BadRetType, "c.F2").WithArguments("S2.F2(N.C, object)", "object").WithLocation(13, 16),
-                // (14,16): error CS1503: Argument 1: cannot convert from 'method group' to 'System.Func<object, object>'
+                // (14,16): error CS0121: The call is ambiguous between the following methods or properties: 'S2.F3(C, object)' and 'S3.F3(C, object)'
                 //             M1(c.F3); // ambiguous
-                Diagnostic(ErrorCode.ERR_BadArgType, "c.F3").WithArguments("1", "method group", "System.Func<object, object>"));
-            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this failure case
-            // because we don't report *why* a delegate conversion failed.
-            // See https://github.com/dotnet/roslyn/issues/24675 for a proposal to restore the quality of this diagnostic.
+                Diagnostic(ErrorCode.ERR_AmbigCall, "c.F3").WithArguments("S2.F3(N.C, object)", "S3.F3(N.C, object)").WithLocation(14, 16));
+            // NOTE: we have a degradation in the quality of diagnostics for a delegate conversion in this particular failure case.
+            // See https://github.com/dotnet/roslyn/issues/24787
+            // It is caused by a combination of two shortcomings  in the computation of diagnostics. First, in `BindExtensionMethod`
+            // when we fail to find an applicable extension method, we only report a diagnostic for the first extension method group
+            // that failed, even if some other extension method group contains a much better candidate. In the case of this test the first
+            // extension method group contains a method with the wrong number of parameters, while the second one has an extension method
+            // that fails only because of its return type mismatch.  Second, in
+            // `OverloadResolutionResult<TMember>.ReportDiagnostics<T>`, we do not report a diagnostic for the failure
+            // `MemberResolutionKind.NoCorrespondingParameter`, leaving it to the caller to notice that we failed to produce a
+            // diagnostic (the caller has to grub through the diagnostic bag to see that there is no error there) and then the caller
+            // has to produce a generic error message, which we see below. It does not appear that all callers have that test, though,
+            // suggesting there may be a latent bug of missing diagnostics.
             CreateStandardCompilation(source, references: new[] { SystemCoreRef }).VerifyDiagnostics(
                 // (10,16): error CS1503: Argument 1: cannot convert from 'method group' to 'Func<object, object>'
                 //             M1(c.F1); // wrong return type
@@ -1019,9 +1030,9 @@ static class S3
                 // (13,16): error CS1503: Argument 1: cannot convert from 'method group' to 'Action<object>'
                 //             M2(c.F2); // wrong return type
                 Diagnostic(ErrorCode.ERR_BadArgType, "c.F2").WithArguments("1", "method group", "System.Action<object>").WithLocation(13, 16),
-                // (14,16): error CS1503: Argument 1: cannot convert from 'method group' to 'Func<object, object>'
+                // (14,16): error CS0121: The call is ambiguous between the following methods or properties: 'S2.F3(C, object)' and 'S3.F3(C, object)'
                 //             M1(c.F3); // ambiguous
-                Diagnostic(ErrorCode.ERR_BadArgType, "c.F3").WithArguments("1", "method group", "System.Func<object, object>").WithLocation(14, 16));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "c.F3").WithArguments("S2.F3(N.C, object)", "S3.F3(N.C, object)").WithLocation(14, 16));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -1078,11 +1078,12 @@ static class C
     static void F(this object o) { }
     static void F<T>(this T t) where T : struct { }
 }";
-            CreateStandardCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics(
+            CreateStandardCompilation(text, references: new[] { SystemCoreRef }, parseOptions: TestOptions.WithoutImprovedOverloadCandidates).VerifyDiagnostics(
                 // (7,9): error CS0310: 'I' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'C.E<T>(T)'
                 Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "i.E").WithArguments("C.E<T>(T)", "T", "I").WithLocation(7, 9),
                 // (9,9): error CS0453: The type 'I' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'C.F<T>(T)'
                 Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "i.F").WithArguments("C.F<T>(T)", "T", "I").WithLocation(9, 9));
+            CreateStandardCompilation(text, references: new[] { SystemCoreRef }).VerifyDiagnostics();
         }
 
         [ClrOnlyFact]
@@ -2701,9 +2702,9 @@ class C<T> where T : IA, IB
                 // (3,29): error CS0454: Circular constraint dependency involving 'T' and 'T'
                 //     static void M(A<object> a) { }
                 Diagnostic(ErrorCode.ERR_CircularConstraint, "a").WithArguments("T", "T").WithLocation(3, 29),
-                // (6,9): error CS0454: Circular constraint dependency involving 'T' and 'U'
+                // (6,11): error CS0454: Circular constraint dependency involving 'T' and 'U'
                 //         B.M<string, string>();
-                Diagnostic(ErrorCode.ERR_CircularConstraint, "B.M<string, string>").WithArguments("T", "U").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_CircularConstraint, "M<string, string>").WithArguments("T", "U").WithLocation(6, 11));
         }
 
         /// <summary>
@@ -2733,18 +2734,18 @@ class C<T> where T : IA, IB
             // Note: for method overload resolution, methods with use-site errors
             // are ignored so there is no constraint error for B.M<string>().
             CreateCompilationWithCustomILSource(csharpSource, ilSource).VerifyDiagnostics(
-                // (3,29): error CS0012: The type 'C' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //     static void M(A<object> a) { }
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("C", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 29),
                 // (3,29): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A<T>'. There is no implicit reference conversion from 'object' to 'C'.
                 //     static void M(A<object> a) { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A<T>", "C", "T", "object").WithLocation(3, 29),
-                // (6,9): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B.M<U>()'. There is no implicit reference conversion from 'string' to 'C'.
+                // (3,29): error CS0012: The type 'C' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static void M(A<object> a) { }
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("C", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 29),
+                // (6,11): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B.M<U>()'. There is no implicit reference conversion from 'string' to 'C'.
                 //         B.M<string>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "B.M<string>").WithArguments("B.M<U>()", "C", "U", "string").WithLocation(6, 9),
-                // (6,9): error CS0012: The type 'C' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<string>").WithArguments("B.M<U>()", "C", "U", "string").WithLocation(6, 11),
+                // (6,11): error CS0012: The type 'C' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         B.M<string>();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "B.M<string>").WithArguments("C", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "M<string>").WithArguments("C", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(6, 11));
         }
 
         [Fact]
@@ -2894,36 +2895,36 @@ class C5B : B5
     }
 }";
             CreateCompilationWithCustomILSource(csharpSource, ilSource).VerifyDiagnostics(
-                // (3,30): error CS0012: The type 'B1' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //     static void M(A1<object> a) { }
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B1", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 30),
-                // (4,30): error CS0012: The type 'B2' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //     static void M(A2<object> a) { }
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B2", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
-                // (3,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A1<T>'. There is no implicit reference conversion from 'object' to 'B1'.
-                //     static void M(A1<object> a) { }
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A1<T>", "B1", "T", "object").WithLocation(3, 30),
                 // (4,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A2<T>'. There is no implicit reference conversion from 'object' to 'B2'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A2<T>", "B2", "T", "object").WithLocation(4, 30),
                 // (4,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A2<T>'. There is no implicit reference conversion from 'object' to 'I'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A2<T>", "I", "T", "object").WithLocation(4, 30),
+                // (4,30): error CS0012: The type 'B2' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static void M(A2<object> a) { }
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B2", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
                 // (4,30): error CS0012: The type 'I' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("I", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
+                // (3,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A1<T>'. There is no implicit reference conversion from 'object' to 'B1'.
+                //     static void M(A1<object> a) { }
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A1<T>", "B1", "T", "object").WithLocation(3, 30),
                 // (3,30): error CS0454: Circular constraint dependency involving 'T' and 'T'
                 //     static void M(A1<object> a) { }
                 Diagnostic(ErrorCode.ERR_CircularConstraint, "a").WithArguments("T", "T").WithLocation(3, 30),
-                // (7,9): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A3.M<T>()'. There is no implicit reference conversion from 'object' to 'B3'.
+                // (3,30): error CS0012: The type 'B1' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static void M(A1<object> a) { }
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B1", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 30),
+                // (7,12): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A3.M<T>()'. There is no implicit reference conversion from 'object' to 'B3'.
                 //         A3.M<object>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "A3.M<object>").WithArguments("A3.M<T>()", "B3", "T", "object").WithLocation(7, 9),
-                // (7,9): error CS0454: Circular constraint dependency involving 'T' and 'T'
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<object>").WithArguments("A3.M<T>()", "B3", "T", "object").WithLocation(7, 12),
+                // (7,12): error CS0454: Circular constraint dependency involving 'T' and 'T'
                 //         A3.M<object>();
-                Diagnostic(ErrorCode.ERR_CircularConstraint, "A3.M<object>").WithArguments("T", "T").WithLocation(7, 9),
-                // (7,9): error CS0012: The type 'B3' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_CircularConstraint, "M<object>").WithArguments("T", "T").WithLocation(7, 12),
+                // (7,12): error CS0012: The type 'B3' is defined in an assembly that is not referenced. You must add a reference to assembly 'other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         A3.M<object>();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "A3.M<object>").WithArguments("B3", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "M<object>").WithArguments("B3", "other, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(7, 12));
         }
 
         // Same as UseSiteErrorMissingConstraintTypeAndCircularConstraint but
@@ -2963,30 +2964,30 @@ public class A3
 }";
             var compilation3 = CreateStandardCompilation(source3, references: new MetadataReference[] { new CSharpCompilationReference(compilation2) });
             compilation3.VerifyDiagnostics(
-                // (3,30): error CS0012: The type 'B1' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //     static void M(A1<object> a) { }
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B1", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 30),
-                // (4,30): error CS0012: The type 'B2' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //     static void M(A2<object> a) { }
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B2", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
-                // (3,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A1<T>'. There is no implicit reference conversion from 'object' to 'B1'.
-                //     static void M(A1<object> a) { }
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A1<T>", "B1", "T", "object").WithLocation(3, 30),
                 // (4,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A2<T>'. There is no implicit reference conversion from 'object' to 'B2'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A2<T>", "B2", "T", "object").WithLocation(4, 30),
                 // (4,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A2<T>'. There is no implicit reference conversion from 'object' to 'I'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A2<T>", "I", "T", "object").WithLocation(4, 30),
+                // (4,30): error CS0012: The type 'B2' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static void M(A2<object> a) { }
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B2", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
                 // (4,30): error CS0012: The type 'I' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     static void M(A2<object> a) { }
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("I", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(4, 30),
-                // (7,9): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A3.M<T>()'. There is no implicit reference conversion from 'object' to 'B3'.
+                // (3,30): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A1<T>'. There is no implicit reference conversion from 'object' to 'B1'.
+                //     static void M(A1<object> a) { }
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "a").WithArguments("A1<T>", "B1", "T", "object").WithLocation(3, 30),
+                // (3,30): error CS0012: The type 'B1' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static void M(A1<object> a) { }
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "a").WithArguments("B1", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(3, 30),
+                // (7,12): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'A3.M<T>()'. There is no implicit reference conversion from 'object' to 'B3'.
                 //         A3.M<object>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "A3.M<object>").WithArguments("A3.M<T>()", "B3", "T", "object").WithLocation(7, 9),
-                // (7,9): error CS0012: The type 'B3' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<object>").WithArguments("A3.M<T>()", "B3", "T", "object").WithLocation(7, 12),
+                // (7,12): error CS0012: The type 'B3' is defined in an assembly that is not referenced. You must add a reference to assembly 'd521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         A3.M<object>();
-                Diagnostic(ErrorCode.ERR_NoTypeDef, "A3.M<object>").WithArguments("B3", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "M<object>").WithArguments("B3", "d521fe98-c881-45cf-8870-249e00ae400d, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(7, 12));
         }
 
         [WorkItem(542753, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542753")]
@@ -3320,24 +3321,24 @@ class P
                 // (7,17): error CS0648: '' is a type not supported by the language
                 //     void I<A>.M<T>() { }
                 Diagnostic(ErrorCode.ERR_BogusType, "T").WithArguments("").WithLocation(7, 17),
-                // (13,9): error CS0311: The type 'A' cannot be used as type parameter 'T' in the generic type or method 'A.M<T>()'. There is no implicit reference conversion from 'A' to '?'.
+                // (13,17): error CS0311: The type 'A' cannot be used as type parameter 'T' in the generic type or method 'A.M<T>()'. There is no implicit reference conversion from 'A' to '?'.
                 //         new A().M<A>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "new A().M<A>").WithArguments("A.M<T>()", "?", "T", "A").WithLocation(13, 9),
-                // (13,9): error CS0648: '' is a type not supported by the language
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<A>").WithArguments("A.M<T>()", "?", "T", "A").WithLocation(13, 17),
+                // (13,17): error CS0648: '' is a type not supported by the language
                 //         new A().M<A>();
-                Diagnostic(ErrorCode.ERR_BogusType, "new A().M<A>").WithArguments("").WithLocation(13, 9),
+                Diagnostic(ErrorCode.ERR_BogusType, "M<A>").WithArguments("").WithLocation(13, 17),
                 // (15,13): error CS0311: The type 'A' cannot be used as type parameter 'T' in the generic type or method 'I<T>'. There is no implicit reference conversion from 'A' to '?'.
                 //         ((I<A>)new C()).M<A>();
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "A").WithArguments("I<T>", "?", "T", "A").WithLocation(15, 13),
                 // (15,13): error CS0648: '' is a type not supported by the language
                 //         ((I<A>)new C()).M<A>();
                 Diagnostic(ErrorCode.ERR_BogusType, "A").WithArguments("").WithLocation(15, 13),
-                // (15,9): error CS0311: The type 'A' cannot be used as type parameter 'U' in the generic type or method 'I<A>.M<U>()'. There is no implicit reference conversion from 'A' to '?'.
+                // (15,25): error CS0311: The type 'A' cannot be used as type parameter 'U' in the generic type or method 'I<A>.M<U>()'. There is no implicit reference conversion from 'A' to '?'.
                 //         ((I<A>)new C()).M<A>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "((I<A>)new C()).M<A>").WithArguments("I<A>.M<U>()", "?", "U", "A").WithLocation(15, 9),
-                // (15,9): error CS0648: '' is a type not supported by the language
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<A>").WithArguments("I<A>.M<U>()", "?", "U", "A").WithLocation(15, 25),
+                // (15,25): error CS0648: '' is a type not supported by the language
                 //         ((I<A>)new C()).M<A>();
-                Diagnostic(ErrorCode.ERR_BogusType, "((I<A>)new C()).M<A>").WithArguments("").WithLocation(15, 9));
+                Diagnostic(ErrorCode.ERR_BogusType, "M<A>").WithArguments("").WithLocation(15, 25));
         }
 
         /// <summary>
@@ -5039,12 +5040,16 @@ class C
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (11,26): error CS0311: The type 'object' cannot be used as type parameter 'U' in the generic type or method 'A<T, U>'. There is no implicit reference conversion from 'object' to 'I<object>'.
+                //         new A<I<object>, object>();
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "object").WithArguments("A<T, U>", "I<object>", "U", "object").WithLocation(11, 26),
-                // (12,9): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B<I<object>>.M<U>()'. There is no implicit reference conversion from 'string' to 'I<object>'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "B<I<object>>.M<string>").WithArguments("B<I<object>>.M<U>()", "I<object>", "U", "string").WithLocation(12, 9),
-                // (12,9): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B<I<object>>.M<U>()'. There is no implicit reference conversion from 'string' to 'I<string>'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "B<I<object>>.M<string>").WithArguments("B<I<object>>.M<U>()", "I<string>", "U", "string").WithLocation(12, 9),
+                // (12,22): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B<I<object>>.M<U>()'. There is no implicit reference conversion from 'string' to 'I<object>'.
+                //         B<I<object>>.M<string>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<string>").WithArguments("B<I<object>>.M<U>()", "I<object>", "U", "string").WithLocation(12, 22),
+                // (12,22): error CS0311: The type 'string' cannot be used as type parameter 'U' in the generic type or method 'B<I<object>>.M<U>()'. There is no implicit reference conversion from 'string' to 'I<string>'.
+                //         B<I<object>>.M<string>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<string>").WithArguments("B<I<object>>.M<U>()", "I<string>", "U", "string").WithLocation(12, 22),
                 // (13,9): error CS0311: The type 'object' cannot be used as type parameter 'T2' in the generic type or method 'C.M<T1, T2>()'. There is no implicit reference conversion from 'object' to 'I<object>'.
+                //         M<object, object>();
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<object, object>").WithArguments("C.M<T1, T2>()", "I<object>", "T2", "object").WithLocation(13, 9));
         }
 
@@ -5763,10 +5768,12 @@ class B : A<int, object>
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (23,9): error CS0314: The type 'U' cannot be used as type parameter 'U' in the generic type or method 'A<int, object>.M0<U>()'. There is no boxing conversion or type parameter conversion from 'U' to 'int'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "base.M0<U>").WithArguments("A<int, object>.M0<U>()", "int", "U", "U").WithLocation(23, 9),
-                // (24,9): error CS0314: The type 'U' cannot be used as type parameter 'U' in the generic type or method 'A<int, object>.M1<U>()'. There is no boxing conversion or type parameter conversion from 'U' to 'int'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "base.M1<U>").WithArguments("A<int, object>.M1<U>()", "int", "U", "U").WithLocation(24, 9));
+                // (23,14): error CS0314: The type 'U' cannot be used as type parameter 'U' in the generic type or method 'A<int, object>.M0<U>()'. There is no boxing conversion or type parameter conversion from 'U' to 'int'.
+                //         base.M0<U>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "M0<U>").WithArguments("A<int, object>.M0<U>()", "int", "U", "U").WithLocation(23, 14),
+                // (24,14): error CS0314: The type 'U' cannot be used as type parameter 'U' in the generic type or method 'A<int, object>.M1<U>()'. There is no boxing conversion or type parameter conversion from 'U' to 'int'.
+                //         base.M1<U>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "M1<U>").WithArguments("A<int, object>.M1<U>()", "int", "U", "U").WithLocation(24, 14));
         }
 
         [WorkItem(545588, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545588")]
@@ -5792,8 +5799,9 @@ class B : A<object[]>
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (12,9): error CS0311: The type 'U' cannot be used as type parameter 'V' in the generic type or method 'A<object[]>.M1<U, V>()'. There is no implicit reference conversion from 'U' to 'V'.
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "base.M1<V, U>").WithArguments("A<object[]>.M1<U, V>()", "V", "V", "U").WithLocation(12, 9));
+                // (12,14): error CS0311: The type 'U' cannot be used as type parameter 'V' in the generic type or method 'A<object[]>.M1<U, V>()'. There is no implicit reference conversion from 'U' to 'V'.
+                //         base.M1<V, U>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M1<V, U>").WithArguments("A<object[]>.M1<U, V>()", "V", "V", "U").WithLocation(12, 14));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -589,95 +589,90 @@ public class DelegateTest
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // These match Dev10.
-
                 // (44,14): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Da'
                 //         da = new Da(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Da(FTT)").WithArguments("FTT", "DelegateTest.Da"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Da(FTT)").WithArguments("FTT", "DelegateTest.Da").WithLocation(44, 14),
+                // (45,21): error CS0411: The type arguments for method 'DelegateTest.FCT<T>(C<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         da = new Da(FCT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FCT").WithArguments("DelegateTest.FCT<T>(C<T>)").WithLocation(45, 21),
+                // (46,21): error CS0411: The type arguments for method 'DelegateTest.PT<T>(params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         da = new Da(PT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PT").WithArguments("DelegateTest.PT<T>(params T[])").WithLocation(46, 21),
                 // (48,15): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Daa'
                 //         daa = new Daa(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(FT)").WithArguments("FT", "DelegateTest.Daa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(FT)").WithArguments("FT", "DelegateTest.Daa").WithLocation(48, 15),
                 // (49,15): error CS0123: No overload for 'FTi' matches delegate 'DelegateTest.Daa'
                 //         daa = new Daa(FTi);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(FTi)").WithArguments("FTi", "DelegateTest.Daa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(FTi)").WithArguments("FTi", "DelegateTest.Daa").WithLocation(49, 15),
                 // (50,15): error CS0123: No overload for 'PTT' matches delegate 'DelegateTest.Daa'
                 //         daa = new Daa(PTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(PTT)").WithArguments("PTT", "DelegateTest.Daa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(PTT)").WithArguments("PTT", "DelegateTest.Daa").WithLocation(50, 15),
+                // (51,23): error CS0411: The type arguments for method 'DelegateTest.PST<S, T>(S, params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         daa = new Daa(PST);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PST").WithArguments("DelegateTest.PST<S, T>(S, params T[])").WithLocation(51, 23),
                 // (53,15): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Dai'
                 //         dai = new Dai(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(FT)").WithArguments("FT", "DelegateTest.Dai"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(FT)").WithArguments("FT", "DelegateTest.Dai").WithLocation(53, 15),
+                // (54,23): error CS0411: The type arguments for method 'DelegateTest.FTT<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dai = new Dai(FTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FTT").WithArguments("DelegateTest.FTT<T>(T, T)").WithLocation(54, 23),
                 // (55,15): error CS0123: No overload for 'PTT' matches delegate 'DelegateTest.Dai'
                 //         dai = new Dai(PTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(PTT)").WithArguments("PTT", "DelegateTest.Dai"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(PTT)").WithArguments("PTT", "DelegateTest.Dai").WithLocation(55, 15),
+                // (56,23): error CS0411: The type arguments for method 'DelegateTest.PST<S, T>(S, params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dai = new Dai(PST);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PST").WithArguments("DelegateTest.PST<S, T>(S, params T[])").WithLocation(56, 23),
                 // (58,15): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Dab'
                 //         dab = new Dab(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(FT)").WithArguments("FT", "DelegateTest.Dab"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(FT)").WithArguments("FT", "DelegateTest.Dab").WithLocation(58, 15),
+                // (59,23): error CS0411: The type arguments for method 'DelegateTest.FTT<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dab = new Dab(FTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FTT").WithArguments("DelegateTest.FTT<T>(T, T)").WithLocation(59, 23),
                 // (60,15): error CS0123: No overload for 'FTi' matches delegate 'DelegateTest.Dab'
                 //         dab = new Dab(FTi);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(FTi)").WithArguments("FTi", "DelegateTest.Dab"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(FTi)").WithArguments("FTi", "DelegateTest.Dab").WithLocation(60, 15),
                 // (61,15): error CS0123: No overload for 'PTT' matches delegate 'DelegateTest.Dab'
                 //         dab = new Dab(PTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(PTT)").WithArguments("PTT", "DelegateTest.Dab"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(PTT)").WithArguments("PTT", "DelegateTest.Dab").WithLocation(61, 15),
+                // (62,23): error CS0411: The type arguments for method 'DelegateTest.PST<S, T>(S, params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dab = new Dab(PST);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PST").WithArguments("DelegateTest.PST<S, T>(S, params T[])").WithLocation(62, 23),
                 // (64,15): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dpa'
                 //         dpa = new Dpa(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpa(FTT)").WithArguments("FTT", "DelegateTest.Dpa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpa(FTT)").WithArguments("FTT", "DelegateTest.Dpa").WithLocation(64, 15),
+                // (65,23): error CS0411: The type arguments for method 'DelegateTest.FCT<T>(C<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dpa = new Dpa(FCT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FCT").WithArguments("DelegateTest.FCT<T>(C<T>)").WithLocation(65, 23),
                 // (67,16): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Dapa'
                 //         dapa = new Dapa(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapa(FT)").WithArguments("FT", "DelegateTest.Dapa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapa(FT)").WithArguments("FT", "DelegateTest.Dapa").WithLocation(67, 16),
+                // (68,25): error CS0411: The type arguments for method 'DelegateTest.FTT<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dapa = new Dapa(FTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FTT").WithArguments("DelegateTest.FTT<T>(T, T)").WithLocation(68, 25),
                 // (70,16): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Dapb'
                 //         dapb = new Dapb(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapb(FT)").WithArguments("FT", "DelegateTest.Dapb"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapb(FT)").WithArguments("FT", "DelegateTest.Dapb").WithLocation(70, 16),
+                // (71,25): error CS0411: The type arguments for method 'DelegateTest.FTT<T>(T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dapb = new Dapb(FTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "FTT").WithArguments("DelegateTest.FTT<T>(T, T)").WithLocation(71, 25),
+                // (72,25): error CS0411: The type arguments for method 'DelegateTest.PTT<T>(T, params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dapb = new Dapb(PTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PTT").WithArguments("DelegateTest.PTT<T>(T, params T[])").WithLocation(72, 25),
                 // (74,17): error CS0123: No overload for 'FT' matches delegate 'DelegateTest.Dpapa'
                 //         dpapa = new Dpapa(FT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpapa(FT)").WithArguments("FT", "DelegateTest.Dpapa"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpapa(FT)").WithArguments("FT", "DelegateTest.Dpapa").WithLocation(74, 17),
+                // (75,27): error CS0411: The type arguments for method 'DelegateTest.PTT<T>(T, params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dpapa = new Dpapa(PTT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PTT").WithArguments("DelegateTest.PTT<T>(T, params T[])").WithLocation(75, 27),
                 // (77,15): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dca'
                 //         dca = new Dca(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dca(FTT)").WithArguments("FTT", "DelegateTest.Dca"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dca(FTT)").WithArguments("FTT", "DelegateTest.Dca").WithLocation(77, 15),
+                // (78,23): error CS0411: The type arguments for method 'DelegateTest.PT<T>(params T[])' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         dca = new Dca(PT);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "PT").WithArguments("DelegateTest.PT<T>(params T[])").WithLocation(78, 23),
                 // (80,9): error CS0411: The type arguments for method 'DelegateTest.RunG<T>(T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         RunG(null);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "RunG").WithArguments("DelegateTest.RunG<T>(T)"),
-
-                // Dev10 reports CS0411 (ERR_CantInferMethTypeArgs) for these.
-
-                // (45,14): error CS0123: No overload for 'FCT' matches delegate 'DelegateTest.Da'
-                //         da = new Da(FCT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Da(FCT)").WithArguments("FCT", "DelegateTest.Da"),
-                // (46,14): error CS0123: No overload for 'PT' matches delegate 'DelegateTest.Da'
-                //         da = new Da(PT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Da(PT)").WithArguments("PT", "DelegateTest.Da"),
-                // (51,15): error CS0123: No overload for 'PST' matches delegate 'DelegateTest.Daa'
-                //         daa = new Daa(PST);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Daa(PST)").WithArguments("PST", "DelegateTest.Daa"),
-                // (54,15): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dai'
-                //         dai = new Dai(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(FTT)").WithArguments("FTT", "DelegateTest.Dai"),
-                // (56,15): error CS0123: No overload for 'PST' matches delegate 'DelegateTest.Dai'
-                //         dai = new Dai(PST);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dai(PST)").WithArguments("PST", "DelegateTest.Dai"),
-                // (59,15): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dab'
-                //         dab = new Dab(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(FTT)").WithArguments("FTT", "DelegateTest.Dab"),
-                // (62,15): error CS0123: No overload for 'PST' matches delegate 'DelegateTest.Dab'
-                //         dab = new Dab(PST);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dab(PST)").WithArguments("PST", "DelegateTest.Dab"),
-                // (65,15): error CS0123: No overload for 'FCT' matches delegate 'DelegateTest.Dpa'
-                //         dpa = new Dpa(FCT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpa(FCT)").WithArguments("FCT", "DelegateTest.Dpa"),
-                // (68,16): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dapa'
-                //         dapa = new Dapa(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapa(FTT)").WithArguments("FTT", "DelegateTest.Dapa"),
-                // (71,16): error CS0123: No overload for 'FTT' matches delegate 'DelegateTest.Dapb'
-                //         dapb = new Dapb(FTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapb(FTT)").WithArguments("FTT", "DelegateTest.Dapb"),
-                // (72,16): error CS0123: No overload for 'PTT' matches delegate 'DelegateTest.Dapb'
-                //         dapb = new Dapb(PTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dapb(PTT)").WithArguments("PTT", "DelegateTest.Dapb"),
-                // (75,17): error CS0123: No overload for 'PTT' matches delegate 'DelegateTest.Dpapa'
-                //         dpapa = new Dpapa(PTT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dpapa(PTT)").WithArguments("PTT", "DelegateTest.Dpapa"),
-                // (78,15): error CS0123: No overload for 'PT' matches delegate 'DelegateTest.Dca'
-                //         dca = new Dca(PT);
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "new Dca(PT)").WithArguments("PT", "DelegateTest.Dca"));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "RunG").WithArguments("DelegateTest.RunG<T>(T)").WithLocation(80, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
@@ -609,9 +609,9 @@ public class C
                 // file.cs(6,15): warning CS0436: The type 'C' in 'file.cs' conflicts with the imported type 'C' in 'Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'file.cs'.
                 //         Lib.M<C>();
                 Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "C").WithArguments("file.cs", "C", "Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C").WithLocation(6, 15),
-                // file.cs(6,9): error CS0311: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no implicit reference conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
+                // file.cs(6,13): error CS0311: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no implicit reference conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
                 //         Lib.M<C>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "Lib.M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(6, 13));
         }
 
         // Not relevant: will always have one nullable and one non-nullable.
@@ -643,9 +643,9 @@ public class Test<C> where C : struct
 
             var libRef = CreateStandardCompilation(libSource, assemblyName: "Metadata").EmitToImageReference();
             CreateStandardCompilation(Parse(source, "file.cs"), new[] { libRef }, assemblyName: "Source").VerifyDiagnostics(
-                // file.cs(6,9): error CS0314: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no boxing conversion or type parameter conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
+                // file.cs(6,13): error CS0314: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no boxing conversion or type parameter conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
                 //         Lib.M<C>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "Lib.M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(6, 9));
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedTyVar, "M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(6, 13));
         }
 
         [Fact]
@@ -677,9 +677,9 @@ public class Test
                 // file.cs(8,15): warning CS0436: The type 'C' in 'file.cs' conflicts with the imported type 'C' in 'Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'file.cs'.
                 //         Lib.M<C>();
                 Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "C").WithArguments("file.cs", "C", "Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C").WithLocation(8, 15),
-                // file.cs(8,9): error CS0315: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no boxing conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
+                // file.cs(8,13): error CS0315: The type 'C [file.cs(2)]' cannot be used as type parameter 'T' in the generic type or method 'Lib.M<T>()'. There is no boxing conversion from 'C [file.cs(2)]' to 'C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]'.
                 //         Lib.M<C>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "Lib.M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(8, 9));
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "M<C>").WithArguments("Lib.M<T>()", "C [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", "T", "C [file.cs(2)]").WithLocation(8, 13));
         }
 
         [WorkItem(6262, "https://github.com/dotnet/roslyn/issues/6262")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -4125,36 +4125,36 @@ static class S
 }
 ";
             CreateCompilationWithMscorlib46(source).VerifyDiagnostics(
-// (7,15): error CS0306: The type 'int*' may not be used as a type argument
-//         new C<int*>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "int*").WithArguments("int*"),
-// (8,15): error CS0306: The type 'System.ArgIterator' may not be used as a type argument
-//         new C<ArgIterator>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "ArgIterator").WithArguments("System.ArgIterator"),
-// (9,15): error CS0306: The type 'System.RuntimeArgumentHandle' may not be used as a type argument
-//         new C<RuntimeArgumentHandle>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle"),
-// (10,15): error CS0306: The type 'System.TypedReference' may not be used as a type argument
-//         new C<TypedReference>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference"),
-// (11,9): error CS0306: The type 'int*' may not be used as a type argument
-//         F<int*>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "F<int*>").WithArguments("int*"),
-// (12,9): error CS0306: The type 'System.ArgIterator' may not be used as a type argument
-//         o.E<object, ArgIterator>();
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "o.E<object, ArgIterator>").WithArguments("System.ArgIterator"),
-// (14,13): error CS0306: The type 'System.RuntimeArgumentHandle' may not be used as a type argument
-//         a = F<RuntimeArgumentHandle>;
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "F<RuntimeArgumentHandle>").WithArguments("System.RuntimeArgumentHandle"),
-// (15,13): error CS0306: The type 'System.TypedReference' may not be used as a type argument
-//         a = o.E<T, TypedReference>;
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "o.E<T, TypedReference>").WithArguments("System.TypedReference"),
-// (16,34): error CS0306: The type 'System.TypedReference' may not be used as a type argument
-//         Console.WriteLine(typeof(TypedReference?));
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference?").WithArguments("System.TypedReference"),
-// (17,43): error CS0306: The type 'System.TypedReference' may not be used as a type argument
-//         Console.WriteLine(typeof(Nullable<TypedReference>));
-Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference"));
+                // (7,15): error CS0306: The type 'int*' may not be used as a type argument
+                //         new C<int*>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "int*").WithArguments("int*").WithLocation(7, 15),
+                // (8,15): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                //         new C<ArgIterator>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(8, 15),
+                // (9,15): error CS0306: The type 'RuntimeArgumentHandle' may not be used as a type argument
+                //         new C<RuntimeArgumentHandle>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "RuntimeArgumentHandle").WithArguments("System.RuntimeArgumentHandle").WithLocation(9, 15),
+                // (10,15): error CS0306: The type 'TypedReference' may not be used as a type argument
+                //         new C<TypedReference>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference").WithLocation(10, 15),
+                // (11,9): error CS0306: The type 'int*' may not be used as a type argument
+                //         F<int*>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "F<int*>").WithArguments("int*").WithLocation(11, 9),
+                // (12,11): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                //         o.E<object, ArgIterator>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "E<object, ArgIterator>").WithArguments("System.ArgIterator").WithLocation(12, 11),
+                // (14,13): error CS0306: The type 'RuntimeArgumentHandle' may not be used as a type argument
+                //         a = F<RuntimeArgumentHandle>;
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "F<RuntimeArgumentHandle>").WithArguments("System.RuntimeArgumentHandle").WithLocation(14, 13),
+                // (15,13): error CS0306: The type 'TypedReference' may not be used as a type argument
+                //         a = o.E<T, TypedReference>;
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "o.E<T, TypedReference>").WithArguments("System.TypedReference").WithLocation(15, 13),
+                // (16,34): error CS0306: The type 'TypedReference' may not be used as a type argument
+                //         Console.WriteLine(typeof(TypedReference?));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference?").WithArguments("System.TypedReference").WithLocation(16, 34),
+                // (17,43): error CS0306: The type 'TypedReference' may not be used as a type argument
+                //         Console.WriteLine(typeof(Nullable<TypedReference>));
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "TypedReference").WithArguments("System.TypedReference").WithLocation(17, 43));
         }
 
         /// <summary>
@@ -4181,13 +4181,16 @@ class C<T>
     }
 }";
             CreateCompilationWithMscorlib46(source).VerifyDiagnostics(
-                // (2,7): error CS0306: The type 'int*' may not be used as a type argument
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "COfIntPtr").WithArguments("int*").WithLocation(2, 7),
-                // (3,7): error CS0306: The type 'System.ArgIterator' may not be used as a type argument
+                // (3,7): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                // using COfArgIterator = C<System.ArgIterator>; // unused
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "COfArgIterator").WithArguments("System.ArgIterator").WithLocation(3, 7),
-                // (10,9): error CS0306: The type 'int*' may not be used as a type argument
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "COfObject.F<int*>").WithArguments("int*").WithLocation(10, 9),
-                // (3,1): info CS8019: Unnecessary using directive.
+                // (2,7): error CS0306: The type 'int*' may not be used as a type argument
+                // using COfIntPtr = C<int*>;
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "COfIntPtr").WithArguments("int*").WithLocation(2, 7),
+                // (10,19): error CS0306: The type 'int*' may not be used as a type argument
+                //         COfObject.F<int*>();
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "F<int*>").WithArguments("int*").WithLocation(10, 19),
+                // (3,1): hidden CS8019: Unnecessary using directive.
                 // using COfArgIterator = C<System.ArgIterator>; // unused
                 Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using COfArgIterator = C<System.ArgIterator>;").WithLocation(3, 1));
         }

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular7_1 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_1);
         public static readonly CSharpParseOptions Regular7_2 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_2);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = Regular.WithDocumentationMode(DocumentationMode.Diagnose);
+        public static readonly CSharpParseOptions WithoutImprovedOverloadCandidates = Regular.WithLanguageVersion(MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion() - 1);
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string> { };
         public static readonly CSharpParseOptions ExperimentalParseOptions =


### PR DESCRIPTION
- Refine candidate set based on static/instance receiver, or static context
- Refine candidate methods whose type parameter constraints are violated.
- For a method group conversion, remove methods with the wrong return type or ref mode.

Implements https://github.com/dotnet/csharplang/issues/98
Also fixes https://github.com/dotnet/roslyn/issues/24675
