### PR TITLE
Remove dependency on Microsoft.VisualStudio.Text.UI.Wpf

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -29,14 +29,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
-    <!-- This package is no longer being consumed by the build, but failure to have this line means the dependency
-         on Microsoft.VisualStudio.Text.Internal will consume a really old version of Microsoft.VisualStudio.Text.UI.Wpf
-         which doesn't have the type forwards to the new Microsoft.VisualStudio.Text.UI. By including this and then
-         saying ExcludeAssets=all, we ensure the package graph is sane but doesn't pull in what we don't want.
-         This line can be deleted once we move off of Microsoft.VisualStudio.Text.Internal. -->
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)">
-      <ExcludeAssets>all</ExcludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="$(MicrosoftCodeAnalysisElfieVersion)" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="$(ICSharpCodeDecompilerVersion)" />
   </ItemGroup>

--- a/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
@@ -32,7 +32,6 @@
     <Reference Include="System.ComponentModel.Composition" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Import Include="Microsoft.CodeAnalysis.Editor.Shared.Extensions" />

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitConnectionListener.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitConnectionListener.vb
@@ -9,11 +9,11 @@ Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
-    <Export(GetType(IWpfTextViewConnectionListener))>
+    <Export(GetType(ITextViewConnectionListener))>
     <ContentType(ContentTypeNames.VisualBasicContentType)>
     <TextViewRole(PredefinedTextViewRoles.Editable)>
     Friend Class CommitConnectionListener
-        Implements IWpfTextViewConnectionListener
+        Implements ITextViewConnectionListener
 
         Private ReadOnly _commitBufferManagerFactory As CommitBufferManagerFactory
         Private ReadOnly _textBufferAssociatedViewService As ITextBufferAssociatedViewService
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             _waitIndicator = waitIndicator
         End Sub
 
-        Public Sub SubjectBuffersConnected(view As IWpfTextView, reason As ConnectionReason, subjectBuffers As Collection(Of ITextBuffer)) Implements IWpfTextViewConnectionListener.SubjectBuffersConnected
+        Public Sub SubjectBuffersConnected(view As ITextView, reason As ConnectionReason, subjectBuffers As IReadOnlyCollection(Of ITextBuffer)) Implements ITextViewConnectionListener.SubjectBuffersConnected
             ' Make sure we have a view manager
             view.Properties.GetOrCreateSingletonProperty(
                 Function() New CommitViewManager(view, _commitBufferManagerFactory, _textBufferAssociatedViewService, _textUndoHistoryRegistry, _waitIndicator))
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Next
         End Sub
 
-        Public Sub SubjectBuffersDisconnected(view As IWpfTextView, reason As ConnectionReason, subjectBuffers As Collection(Of ITextBuffer)) Implements IWpfTextViewConnectionListener.SubjectBuffersDisconnected
+        Public Sub SubjectBuffersDisconnected(view As ITextView, reason As ConnectionReason, subjectBuffers As IReadOnlyCollection(Of ITextBuffer)) Implements ITextViewConnectionListener.SubjectBuffersDisconnected
             For Each buffer In subjectBuffers
                 _commitBufferManagerFactory.CreateForBuffer(buffer).RemoveReferencingView()
             Next


### PR DESCRIPTION
Microsoft.CodeAnalysis.VisualBasic.EditorFeatures was depending on Microsoft.VisualStudio.Text.UI.Wpf but there are now new APIs to fix this problem.

Fixes dotnet/roslyn#23182