### PR TITLE
Allow replacement in !expr if it doesn't affect type

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4537,6 +4537,30 @@ class C
 }");
         }
 
+        [Fact]
+        [WorkItem(24791, "https://github.com/dotnet/roslyn/issues/24791")]
+        public async Task InlineVariableDoesNotAddUnnecessaryCast()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    bool M()
+    {
+        var [||]o = M();
+        if (!o) throw null;
+        throw null;
+    }
+}",
+@"class C
+{
+    bool M()
+    {
+        if (!M()) throw null;
+        throw null;
+    }
+}");
+        }
+
         [WorkItem(16819, "https://github.com/dotnet/roslyn/issues/16819")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
         public async Task InlineVariableDoesNotAddsDuplicateCast()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3790,6 +3790,29 @@ class Program
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [WorkItem(24791, "https://github.com/dotnet/roslyn/issues/24791")]
+        public async Task SimpleBoolCast()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    bool M()
+    {
+        if (![|(bool)|]M()) throw null;
+        throw null;
+    }
+}",
+@"class C
+{
+    bool M()
+    {
+        if (!M()) throw null;
+        throw null;
+    }
+}");
+        }
+
         [WorkItem(12572, "https://github.com/dotnet/roslyn/issues/12572")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
         public async Task DontRemoveCastThatUnboxes()

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             }
             else if (currentOriginalNode.Kind() == SyntaxKind.LogicalNotExpression)
             {
-                return !SymbolsAreCompatible(((PrefixUnaryExpressionSyntax)currentOriginalNode).Operand, ((PrefixUnaryExpressionSyntax)currentReplacedNode).Operand);
+                return !TypesAreCompatible(((PrefixUnaryExpressionSyntax)currentOriginalNode).Operand, ((PrefixUnaryExpressionSyntax)currentReplacedNode).Operand);
             }
             else if (currentOriginalNode.Kind() == SyntaxKind.ConditionalAccessExpression)
             {


### PR DESCRIPTION
### Customer scenario
Inlining `var x = Bool();` into `if (!x) ...` results in a superfluous cast: `if (!(bool)Bool()) ...`.
That cast also does not trigger the RemoveUnnecessaryCast analyzer.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24791

### Workarounds, if any
Remove the cast manually.

### Risk
Low. The change is very localized.

### Performance impact
None. Replaced a comparison of symbols with a comparison of types.

### Is this a regression from a previous update?
I don't think so.
A user reported this was a regression from 15.5, but I do not think so. I tried on 15.5 preview 1 and got the same behavior. Also, I cannot find a code change that would explain a regression.

### Root cause analysis
The logic that determines whether a cast is unnecessary checks whether a replacement would affect semantics. 
That includes a number of cases for different syntaxes. 
For instance, to see if `if (Bool()) ...` changes semantics from `if ((bool)Bool()) ...`, it checks that `Bool()` and `(bool)Bool()` have the same type.
But the same logic for `!Bool()` and `!(bool)Bool()` was comparing the symbols for `Bool()` (ie method `Bool`) and for `(bool)Bool()` (ie nothing). I'm not sure why things were coded that way.

### How was the bug found?
While working on Roslyn.

Tagging @CyrusNajmabadi @dotnet/roslyn-ide for review. Thanks