### PR TITLE
Respect current Environment.NewLine in MSBuild task

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        private static readonly string[] s_separators = { "\r\n" };
+        private static readonly string[] s_separators = { Environment.NewLine };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)
         {

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -625,7 +625,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         internal static void LogErrorOutput(string output, TaskLoggingHelper log)
         {
-            string[] lines = output.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] lines = output.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             foreach (string line in lines)
             {
                 string trimmedMessage = line.Trim();

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         #region Tool Members
 
-        private static readonly string[] s_separator = { "\r\n" };
+        private static readonly string[] s_separator = { Environment.NewLine };
 
         internal override void LogMessages(string output, MessageImportance messageImportance)
         {


### PR DESCRIPTION
The compiler server uses `WriteLine` to generate its output stream,
which uses the correct newlines for the current OS. When splitting
the string back into lines in the MSBuild task, though, the split
was done on Windows newlines.

Fixes #24736 by using `Environment.NewLine` instead of `\r\n` to
pass lines to MSBuild's logger, which expects errors one-per-line.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
