### PR TITLE
Support unmanaged constraint

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -135,7 +135,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             var typeConstraintSyntax = (TypeConstraintSyntax)syntax;
                             var typeSyntax = typeConstraintSyntax.Type;
-                            if (typeSyntax.Kind() != SyntaxKind.PredefinedType && !SyntaxFacts.IsName(typeSyntax.Kind()))
+                            var typeSyntaxKind = typeSyntax.Kind();
+                            if (typeSyntaxKind != SyntaxKind.PredefinedType && typeSyntaxKind != SyntaxKind.PointerType && !SyntaxFacts.IsName(typeSyntax.Kind()))
                             {
                                 diagnostics.Add(ErrorCode.ERR_BadConstraintType, typeSyntax.GetLocation());
                             }
@@ -153,8 +154,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // This should produce diagnostics if the types are missing
                                 GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType, diagnostics, typeSyntax);
                                 GetSpecialType(SpecialType.System_ValueType, diagnostics, typeSyntax);
-
-                                Compilation.EnsureIsUnmanagedAttributeExists(diagnostics, typeSyntax.Location, modifyCompilationForIsUnmanaged: true);
 
                                 constraints |= TypeParameterConstraintKind.Unmanaged;
                                 continue;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -149,6 +149,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
                                 }
 
+                                // This should produce diagnostics if the types are missing
+                                GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType, diagnostics, typeSyntax);
+                                GetSpecialType(SpecialType.System_ValueType, diagnostics, typeSyntax);
+
                                 constraints |= TypeParameterConstraintKind.Unmanaged;
                                 continue;
                             }
@@ -167,6 +171,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     // "Duplicate constraint '{0}' for type parameter '{1}'"
                                     Error(diagnostics, ErrorCode.ERR_DuplicateBound, syntax, type, name);
+                                    continue;
+                                }
+
+                                if ((constraints & TypeParameterConstraintKind.Unmanaged) != 0)
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
                                     continue;
                                 }
 
@@ -197,10 +207,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                 Error(diagnostics, ErrorCode.ERR_RefValBoundWithClass, syntax, type);
                                                 continue;
                                         }
-                                    }
-                                    else if ((constraints & TypeParameterConstraintKind.Unmanaged) != 0)
-                                    {
-                                        diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
                                     }
                                 }
                             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -147,11 +147,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (constraints != 0 || constraintTypes.Any())
                                 {
                                     diagnostics.Add(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, typeSyntax.GetLocation());
+                                    continue;
                                 }
 
                                 // This should produce diagnostics if the types are missing
                                 GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType, diagnostics, typeSyntax);
                                 GetSpecialType(SpecialType.System_ValueType, diagnostics, typeSyntax);
+
+                                Compilation.EnsureIsUnmanagedAttributeExists(diagnostics, typeSyntax.Location, modifyCompilationForIsUnmanaged: true);
 
                                 constraints |= TypeParameterConstraintKind.Unmanaged;
                                 continue;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2340,7 +2340,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (typeSyntax.IsVar)
             {
                 var ignored = DiagnosticBag.GetInstance();
-                BindTypeOrAlias(typeSyntax, ignored, out isVar);
+                BindTypeOrAliasOrVarKeyword(typeSyntax, ignored, out isVar);
                 ignored.Free();
 
                 if (isVar)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool isVar;
             AliasSymbol aliasOpt;
-            TypeSymbol declType = BindType(typeSyntax, diagnostics, out isVar, out aliasOpt);
+            TypeSymbol declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out aliasOpt);
             if (isVar)
             {
                 declType = operandType;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -641,7 +641,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we want to treat the declaration as an explicitly typed declaration.
 
             RefKind refKind;
-            TypeSymbol declType = BindType(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
+            TypeSymbol declType = BindTypeOrVarKeyword(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
             Debug.Assert((object)declType != null || isVar);
 
             if (isVar)
@@ -2153,7 +2153,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             AliasSymbol alias;
             bool isVar;
-            TypeSymbol declType = BindType(typeSyntax, diagnostics, out isVar, out alias);
+            TypeSymbol declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
             Debug.Assert((object)declType != null || isVar);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -29,11 +28,31 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bound type if syntax binds to a type in the current context and
         /// null if syntax binds to "var" keyword in the current context.
         /// </returns>
-        internal TypeSymbol BindType(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
+        internal TypeSymbol BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
         {
-            var symbol = BindTypeOrAlias(syntax, diagnostics, out isVar);
+            var symbol = BindTypeOrAliasOrVarKeyword(syntax, diagnostics, out isVar);
             Debug.Assert(isVar == ((object)symbol == null));
             return isVar ? null : (TypeSymbol)UnwrapAlias(symbol, diagnostics, syntax);
+        }
+
+        /// <summary>
+        /// Binds the type for the syntax taking into account possibility of "unmanaged" type.
+        /// </summary>
+        /// <param name="syntax">Type syntax to bind.</param>
+        /// <param name="diagnostics">Diagnostics.</param>
+        /// <param name="isUnmanaged">
+        /// Set to false if syntax binds to a type in the current context and true if
+        /// syntax is "unmanaged" and it binds to "unmanaged" keyword in the current context.
+        /// </param>
+        /// <returns>
+        /// Bound type if syntax binds to a type in the current context and
+        /// null if syntax binds to "unmanaged" keyword in the current context.
+        /// </returns>
+        internal TypeSymbol BindTypeOrUnmanagedKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isUnmanaged)
+        {
+            var symbol = BindTypeOrAliasOrUnmanagedKeyword(syntax, diagnostics, out isUnmanaged);
+            Debug.Assert(isUnmanaged == ((object)symbol == null));
+            return isUnmanaged ? null : (TypeSymbol)UnwrapAlias(symbol, diagnostics, syntax);
         }
 
         /// <summary>
@@ -50,9 +69,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bound type if syntax binds to a type in the current context and
         /// null if syntax binds to "var" keyword in the current context.
         /// </returns>
-        internal TypeSymbol BindType(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar, out AliasSymbol alias)
+        internal TypeSymbol BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar, out AliasSymbol alias)
         {
-            var symbol = BindTypeOrAlias(syntax, diagnostics, out isVar);
+            var symbol = BindTypeOrAliasOrVarKeyword(syntax, diagnostics, out isVar);
             Debug.Assert(isVar == ((object)symbol == null));
             if (isVar)
             {
@@ -64,129 +83,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (TypeSymbol)UnwrapAlias(symbol, out alias, diagnostics, syntax);
             }
         }
-
-        /// <summary>
-        /// Binds the type for the syntax taking into account possibility of "var" type.
-        /// If the syntax binds to an alias symbol to a type, it returns the alias symbol.
-        /// </summary>
-        /// <param name="syntax">Type syntax to bind.</param>
-        /// <param name="diagnostics">Diagnostics.</param>
-        /// <param name="isVar">
-        /// Set to false if syntax binds to a type or alias to a type in the current context and true if
-        /// syntax is "var" and it binds to "var" keyword in the current context.
-        /// </param>
-        /// <returns>
-        /// Bound type or alias if syntax binds to a type or alias to a type in the current context and
-        /// null if syntax binds to "var" keyword in the current context.
-        /// </returns>
-        private Symbol BindTypeOrAlias(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
+           
+        private Symbol BindTypeOrAliasOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
         {
-            ConsList<Symbol> basesBeingResolved = null;
-            if (!syntax.IsVar)
+            if (syntax.IsVar)
             {
-                isVar = false;
-                return BindTypeOrAlias(syntax, diagnostics, basesBeingResolved);
-            }
-            else
-            {
-                // Only IdentifierNameSyntax instances may be 'var'.
-                var identifierValueText = ((IdentifierNameSyntax)syntax).Identifier.ValueText;
-
-                Symbol symbol = null;
-
-                // Perform name lookup without generating diagnostics as it could possibly be 
-                // "var" keyword in the current context.
-                var lookupResult = LookupResult.GetInstance();
-                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                this.LookupSymbolsInternal(lookupResult, identifierValueText, arity: 0, useSiteDiagnostics: ref useSiteDiagnostics, basesBeingResolved: basesBeingResolved,
-                    options: LookupOptions.NamespacesOrTypesOnly, diagnose: false);
-                diagnostics.Add(syntax, useSiteDiagnostics);
-
-                // We have following possible cases for lookup:
-
-                //  1) LookupResultKind.Empty: isVar = true
-
-                //  2) LookupResultKind.Viable:
-                //      a) Single viable result that corresponds to 1) a non-error type: isVar = false
-                //                                                  2) an error type: isVar = true
-                //      b) Single viable result that corresponds to namespace: isVar = true
-                //      c) Multi viable result (ambiguous result), we must return an error type: isVar = false
-
-                // 3) Non viable, non empty lookup result: isVar = true
-
-                // BREAKING CHANGE:     Case (2)(c) is a breaking change from the native compiler.
-                // BREAKING CHANGE:     Native compiler interprets lookup with ambiguous result to correspond to bind
-                // BREAKING CHANGE:     to "var" keyword (isVar = true), rather than reporting an error.
-                // BREAKING CHANGE:     See test SemanticErrorTests.ErrorMeansSuccess_var() for an example.
-
-                switch (lookupResult.Kind)
-                {
-                    case LookupResultKind.Empty:
-                        // Case (1)
-                        isVar = true;
-                        symbol = null;
-                        break;
-
-                    case LookupResultKind.Viable:
-                        // Case (2)
-                        DiagnosticBag resultDiagnostics = DiagnosticBag.GetInstance();
-                        bool wasError;
-                        symbol = ResultSymbol(
-                            lookupResult,
-                            identifierValueText,
-                            arity: 0,
-                            where: syntax,
-                            diagnostics: resultDiagnostics,
-                            suppressUseSiteDiagnostics: false,
-                            wasError: out wasError);
-
-                        // Here, we're mimicking behavior of dev10.  If "var" fails to bind
-                        // as a type, even if the reason is (e.g.) a type/alias conflict, then treat
-                        // it as the contextual keyword.
-                        if (wasError && lookupResult.IsSingleViable)
-                        {
-                            // NOTE: don't report diagnostics - we're not going to use the lookup result.
-                            resultDiagnostics.Free();
-                            // Case (2)(a)(2)
-                            goto default;
-                        }
-
-                        diagnostics.AddRange(resultDiagnostics);
-                        resultDiagnostics.Free();
-
-                        if (lookupResult.IsSingleViable)
-                        {
-                            var type = UnwrapAlias(symbol, diagnostics, syntax) as TypeSymbol;
-
-                            if ((object)type != null)
-                            {
-                                // Case (2)(a)(1)
-                                isVar = false;
-                            }
-                            else
-                            {
-                                // Case (2)(b)
-                                Debug.Assert(UnwrapAliasNoDiagnostics(symbol) is NamespaceSymbol);
-                                isVar = true;
-                                symbol = null;
-                            }
-                        }
-                        else
-                        {
-                            // Case (2)(c)
-                            isVar = false;
-                        }
-
-                        break;
-
-                    default:
-                        // Case (3)
-                        isVar = true;
-                        symbol = null;
-                        break;
-                }
-
-                lookupResult.Free();
+                var symbol = BindTypeOrAliasOrKeyword(syntax, diagnostics, out isVar);
 
                 if (isVar)
                 {
@@ -195,6 +97,136 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return symbol;
             }
+            else
+            {
+                isVar = false;
+                return BindTypeOrAlias(syntax, diagnostics, basesBeingResolved: null);
+            }
+        }
+
+        private Symbol BindTypeOrAliasOrUnmanagedKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isUnmanaged)
+        {
+            if (syntax.IsUnmanaged)
+            {
+                var symbol = BindTypeOrAliasOrKeyword(syntax, diagnostics, out isUnmanaged);
+
+                if (isUnmanaged)
+                {
+                    CheckFeatureAvailability(syntax, MessageID.IDS_FeatureUnmanagedGenericTypeConstraint, diagnostics);
+                }
+
+                return symbol;
+            }
+            else
+            {
+                isUnmanaged = false;
+                return BindTypeOrAlias(syntax, diagnostics, basesBeingResolved: null);
+            }
+        }
+
+        /// <summary>
+        /// Binds the type for the syntax taking into account possibility of the type being a keyword.
+        /// If the syntax binds to an alias symbol to a type, it returns the alias symbol.
+        /// PREREQUISITE: syntax should be checked to match the keyword, like <see cref="TypeSyntax.IsVar"/> or <see cref="TypeSyntax.IsUnmanaged"/>.
+        /// Otherwise, call <see cref="Binder.BindTypeOrAlias(ExpressionSyntax, DiagnosticBag, ConsList{Symbol})"/> instead.
+        /// </summary>
+        private Symbol BindTypeOrAliasOrKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isKeyword)
+        {
+            // Keywords can only be IdentifierNameSyntax
+            var identifierValueText = ((IdentifierNameSyntax)syntax).Identifier.ValueText;
+            Symbol symbol = null;
+
+            // Perform name lookup without generating diagnostics as it could possibly be a keyword in the current context.
+            var lookupResult = LookupResult.GetInstance();
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            this.LookupSymbolsInternal(lookupResult, identifierValueText, arity: 0, useSiteDiagnostics: ref useSiteDiagnostics, basesBeingResolved: null, options: LookupOptions.NamespacesOrTypesOnly, diagnose: false);
+
+            // We have following possible cases for lookup:
+
+            //  1) LookupResultKind.Empty: must be a keyword
+
+            //  2) LookupResultKind.Viable:
+            //      a) Single viable result that corresponds to 1) a non-error type: cannot be a keyword
+            //                                                  2) an error type: must be a keyword
+            //      b) Single viable result that corresponds to namespace: must be a keyword
+            //      c) Multi viable result (ambiguous result), we must return an error type: cannot be a keyword
+
+            // 3) Non viable, non empty lookup result: must be a keyword
+
+            // BREAKING CHANGE:     Case (2)(c) is a breaking change from the native compiler.
+            // BREAKING CHANGE:     Native compiler interprets lookup with ambiguous result to correspond to bind
+            // BREAKING CHANGE:     to "var" keyword (isVar = true), rather than reporting an error.
+            // BREAKING CHANGE:     See test SemanticErrorTests.ErrorMeansSuccess_var() for an example.
+
+            switch (lookupResult.Kind)
+            {
+                case LookupResultKind.Empty:
+                    // Case (1)
+                    isKeyword = true;
+                    symbol = null;
+                    break;
+
+                case LookupResultKind.Viable:
+                    // Case (2)
+                    DiagnosticBag resultDiagnostics = DiagnosticBag.GetInstance();
+                    bool wasError;
+                    symbol = ResultSymbol(
+                        lookupResult,
+                        identifierValueText,
+                        arity: 0,
+                        where: syntax,
+                        diagnostics: resultDiagnostics,
+                        suppressUseSiteDiagnostics: false,
+                        wasError: out wasError);
+
+                    // Here, we're mimicking behavior of dev10.  If the identifier fails to bind
+                    // as a type, even if the reason is (e.g.) a type/alias conflict, then treat
+                    // it as the contextual keyword.
+                    if (wasError && lookupResult.IsSingleViable)
+                    {
+                        // NOTE: don't report diagnostics - we're not going to use the lookup result.
+                        resultDiagnostics.Free();
+                        // Case (2)(a)(2)
+                        goto default;
+                    }
+
+                    diagnostics.AddRange(resultDiagnostics);
+                    resultDiagnostics.Free();
+
+                    if (lookupResult.IsSingleViable)
+                    {
+                        var type = UnwrapAlias(symbol, diagnostics, syntax) as TypeSymbol;
+
+                        if ((object)type != null)
+                        {
+                            // Case (2)(a)(1)
+                            isKeyword = false;
+                        }
+                        else
+                        {
+                            // Case (2)(b)
+                            Debug.Assert(UnwrapAliasNoDiagnostics(symbol) is NamespaceSymbol);
+                            isKeyword = true;
+                            symbol = null;
+                        }
+                    }
+                    else
+                    {
+                        // Case (2)(c)
+                        isKeyword = false;
+                    }
+
+                    break;
+
+                default:
+                    // Case (3)
+                    isKeyword = true;
+                    symbol = null;
+                    break;
+            }
+
+            lookupResult.Free();
+            return symbol;
         }
 
         // Binds the given expression syntax as Type.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -403,7 +403,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var elementType = BindType(node.ElementType, diagnostics, basesBeingResolved);
                         ReportUnsafeIfNotAllowed(node, diagnostics);
 
-                        if (elementType.IsManagedType)
+                        // Checking BinderFlags.GenericConstraintsClause to prevent cycles in binding
+                        if (Flags.HasFlag(BinderFlags.GenericConstraintsClause) && elementType.TypeKind == TypeKind.TypeParameter)
+                        {
+                            // Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                            Error(diagnostics, ErrorCode.ERR_BadConstraintType, node);
+                        }
+                        else if (elementType.IsManagedType)
                         {
                             // "Cannot take the address of, get the size of, or declare a pointer to a managed type ('{0}')"
                             Error(diagnostics, ErrorCode.ERR_ManagedAddr, node, elementType);

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         bool isVar;
                         AliasSymbol alias;
-                        TypeSymbol declType = BindType(typeSyntax, diagnostics, out isVar, out alias);
+                        TypeSymbol declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
                         if (isVar)
                         {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3176,6 +3176,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type parameter &apos;{1}&apos; has the &apos;unmanaged&apos; constraint so &apos;{1}&apos; cannot be used as a constraint for &apos;{0}&apos;.
+        /// </summary>
+        internal static string ERR_ConWithUnmanagedCon {
+            get {
+                return ResourceManager.GetString("ERR_ConWithUnmanagedCon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type parameter &apos;{1}&apos; has the &apos;struct&apos; constraint so &apos;{1}&apos; cannot be used as a constraint for &apos;{0}&apos;.
         /// </summary>
         internal static string ERR_ConWithValCon {
@@ -9733,6 +9742,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_UnmanagedConstraintNotSatisfied {
             get {
                 return ResourceManager.GetString("ERR_UnmanagedConstraintNotSatisfied", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using unmanaged constraint on local functions type parameters is not supported..
+        /// </summary>
+        internal static string ERR_UnmanagedConstraintWithLocalFunctions {
+            get {
+                return ResourceManager.GetString("ERR_UnmanagedConstraintWithLocalFunctions", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6758,6 +6758,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;new()&apos; constraint cannot be used with the &apos;unmanaged&apos; constraint.
+        /// </summary>
+        internal static string ERR_NewBoundWithUnmanaged {
+            get {
+                return ResourceManager.GetString("ERR_NewBoundWithUnmanaged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;new()&apos; constraint cannot be used with the &apos;struct&apos; constraint.
         /// </summary>
         internal static string ERR_NewBoundWithVal {
@@ -9710,6 +9719,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;unmanaged&apos; constraint cannot be specified with other constraints..
+        /// </summary>
+        internal static string ERR_UnmanagedConstraintMustBeAlone {
+            get {
+                return ResourceManager.GetString("ERR_UnmanagedConstraintMustBeAlone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type &apos;{2}&apos; cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter &apos;{1}&apos; in the generic type or method &apos;{0}&apos;.
+        /// </summary>
+        internal static string ERR_UnmanagedConstraintNotSatisfied {
+            get {
+                return ResourceManager.GetString("ERR_UnmanagedConstraintNotSatisfied", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A previous catch clause already catches all exceptions of this or of a super type (&apos;{0}&apos;).
         /// </summary>
         internal static string ERR_UnreachableCatch {
@@ -10787,6 +10814,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_FeatureTypeVariance {
             get {
                 return ResourceManager.GetString("IDS_FeatureTypeVariance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unmanaged generic type constraints.
+        /// </summary>
+        internal static string IDS_FeatureUnmanagedGenericTypeConstraint {
+            get {
+                return ResourceManager.GetString("IDS_FeatureUnmanagedGenericTypeConstraint", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9746,7 +9746,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using unmanaged constraint on local functions type parameters is not supported..
+        ///   Looks up a localized string similar to Using &apos;unmanaged&apos; constraint on local functions type parameters is not supported..
         /// </summary>
         internal static string ERR_UnmanagedConstraintWithLocalFunctions {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5265,7 +5265,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</value>
   </data>
   <data name="ERR_UnmanagedConstraintWithLocalFunctions" xml:space="preserve">
-    <value>Using unmanaged constraint on local functions type parameters is not supported.</value>
+    <value>Using 'unmanaged' constraint on local functions type parameters is not supported.</value>
   </data>
   <data name="ERR_ConWithUnmanagedCon" xml:space="preserve">
     <value>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5264,4 +5264,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_UnmanagedConstraintNotSatisfied" xml:space="preserve">
     <value>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</value>
   </data>
+  <data name="ERR_UnmanagedConstraintWithLocalFunctions" xml:space="preserve">
+    <value>Using unmanaged constraint on local functions type parameters is not supported.</value>
+  </data>
+  <data name="ERR_ConWithUnmanagedCon" xml:space="preserve">
+    <value>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5252,4 +5252,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureDelegateGenericTypeConstraint" xml:space="preserve">
     <value>delegate generic type constraints</value>
   </data>
+  <data name="IDS_FeatureUnmanagedGenericTypeConstraint" xml:space="preserve">
+    <value>unmanaged generic type constraints</value>
+  </data>
+  <data name="ERR_NewBoundWithUnmanaged" xml:space="preserve">
+    <value>The 'new()' constraint cannot be used with the 'unmanaged' constraint</value>
+  </data>
+  <data name="ERR_UnmanagedConstraintMustBeAlone" xml:space="preserve">
+    <value>The 'unmanaged' constraint cannot be specified with other constraints.</value>
+  </data>
+  <data name="ERR_UnmanagedConstraintNotSatisfied" xml:space="preserve">
+    <value>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private SynthesizedEmbeddedAttributeSymbol _lazyEmbeddedAttribute;
         private SynthesizedEmbeddedAttributeSymbol _lazyIsReadOnlyAttribute;
         private SynthesizedEmbeddedAttributeSymbol _lazyIsByRefLikeAttribute;
+        private SynthesizedEmbeddedAttributeSymbol _lazyIsUnmanagedAttribute;
 
         /// <summary>
         /// The behavior of the C# command-line compiler is as follows:
@@ -79,6 +80,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if ((object)_lazyIsReadOnlyAttribute != null)
             {
                 builder.Add(_lazyIsReadOnlyAttribute);
+            }
+
+            if ((object)_lazyIsUnmanagedAttribute != null)
+            {
+                builder.Add(_lazyIsUnmanagedAttribute);
             }
 
             if ((object)_lazyIsByRefLikeAttribute != null)
@@ -182,6 +188,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return base.TrySynthesizeIsReadOnlyAttribute();
         }
 
+        protected override SynthesizedAttributeData TrySynthesizeIsUnmanagedAttribute()
+        {
+            if ((object)_lazyIsUnmanagedAttribute != null)
+            {
+                return new SynthesizedAttributeData(
+                    _lazyIsUnmanagedAttribute.Constructor,
+                    ImmutableArray<TypedConstant>.Empty,
+                    ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
+            }
+
+            return base.TrySynthesizeIsUnmanagedAttribute();
+        }
+
         protected override SynthesizedAttributeData TrySynthesizeIsByRefLikeAttribute()
         {
             if ((object)_lazyIsByRefLikeAttribute != null)
@@ -215,6 +234,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     ref _lazyIsByRefLikeAttribute,
                     diagnostics,
                     AttributeDescription.IsByRefLikeAttribute);
+            }
+
+            if (this.NeedsGeneratedIsUnmanagedAttribute)
+            {
+                CreateEmbeddedAttributeItselfIfNeeded(diagnostics);
+
+                CreateEmbeddedAttributeIfNeeded(
+                    ref _lazyIsUnmanagedAttribute,
+                    diagnostics,
+                    AttributeDescription.IsUnmanagedAttribute);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -42,9 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private Dictionary<FieldSymbol, NamedTypeSymbol> _fixedImplementationTypes;
 
         private bool _needsGeneratedIsReadOnlyAttribute_Value;
-
-        private bool _needsGeneratedIsUnmanagedAttribute_Value;
-
+        
         private bool _needsGeneratedAttributes_IsFrozen;
 
         /// <summary>
@@ -77,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get
             {
                 _needsGeneratedAttributes_IsFrozen = true;
-                return Compilation.NeedsGeneratedIsUnmanagedAttribute || _needsGeneratedIsUnmanagedAttribute_Value;
+                return Compilation.NeedsGeneratedIsUnmanagedAttribute;
             }
         }
 
@@ -1504,22 +1502,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if (Compilation.CheckIfIsReadOnlyAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
             {
                 _needsGeneratedIsReadOnlyAttribute_Value = true;
-            }
-        }
-
-        internal void EnsureIsUnmanagedAttributeExists()
-        {
-            Debug.Assert(!_needsGeneratedAttributes_IsFrozen);
-
-            if (_needsGeneratedIsUnmanagedAttribute_Value || Compilation.NeedsGeneratedIsUnmanagedAttribute)
-            {
-                return;
-            }
-
-            // Don't report any errors. They should be reported during binding.
-            if (Compilation.CheckIfIsUnmanagedAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
-            {
-                _needsGeneratedIsUnmanagedAttribute_Value = true;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -43,6 +43,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
         private bool _needsGeneratedIsReadOnlyAttribute_Value;
 
+        private bool _needsGeneratedIsUnmanagedAttribute_Value;
+
         private bool _needsGeneratedAttributes_IsFrozen;
 
         /// <summary>
@@ -67,6 +69,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             get
             {
                 return Compilation.NeedsGeneratedIsByRefLikeAttribute;
+            }
+        }
+
+        internal bool NeedsGeneratedIsUnmanagedAttribute
+        {
+            get
+            {
+                _needsGeneratedAttributes_IsFrozen = true;
+                return Compilation.NeedsGeneratedIsUnmanagedAttribute || _needsGeneratedIsUnmanagedAttribute_Value;
             }
         }
 
@@ -1440,6 +1451,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return TrySynthesizeIsReadOnlyAttribute();
         }
 
+        internal SynthesizedAttributeData SynthesizeIsUnmanagedAttribute(Symbol symbol)
+        {
+            if ((object)Compilation.SourceModule != symbol.ContainingModule)
+            {
+                // For symbols that are not defined in the same compilation (like NoPia), don't synthesize this attribute.
+                return null;
+            }
+
+            return TrySynthesizeIsUnmanagedAttribute();
+        }
+
         internal SynthesizedAttributeData SynthesizeIsByRefLikeAttribute(Symbol symbol)
         {
             if ((object)Compilation.SourceModule != symbol.ContainingModule)
@@ -1455,6 +1477,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             // For modules, this attribute should be present. Only assemblies generate and embed this type.
             return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsReadOnlyAttribute__ctor);
+        }
+
+        protected virtual SynthesizedAttributeData TrySynthesizeIsUnmanagedAttribute()
+        {
+            // For modules, this attribute should be present. Only assemblies generate and embed this type.
+            return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor);
         }
 
         protected virtual SynthesizedAttributeData TrySynthesizeIsByRefLikeAttribute()
@@ -1476,6 +1504,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if (Compilation.CheckIfIsReadOnlyAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
             {
                 _needsGeneratedIsReadOnlyAttribute_Value = true;
+            }
+        }
+
+        internal void EnsureIsUnmanagedAttributeExists()
+        {
+            Debug.Assert(!_needsGeneratedAttributes_IsFrozen);
+
+            if (_needsGeneratedIsUnmanagedAttribute_Value || Compilation.NeedsGeneratedIsUnmanagedAttribute)
+            {
+                return;
+            }
+
+            // Don't report any errors. They should be reported during binding.
+            if (Compilation.CheckIfIsUnmanagedAttributeShouldBeEmbedded(diagnosticsOpt: null, locationOpt: null))
+            {
+                _needsGeneratedIsUnmanagedAttribute_Value = true;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -226,13 +226,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (this.HasUnmanagedTypeConstraint)
             {
-                Debug.Assert(
-                    !this.HasReferenceTypeConstraint &&
-                    !this.HasConstructorConstraint &&
-                    !this.HasValueTypeConstraint
-                    && this.ConstraintTypesNoUseSiteDiagnostics.IsEmpty,
-                    "This constraint can only exist alone");
-
                 var typeRef = moduleBeingBuilt.Translate(
                     typeSymbol: moduleBeingBuilt.Compilation.GetSpecialType(SpecialType.System_ValueType),
                     syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -223,33 +223,57 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         IEnumerable<Cci.TypeReferenceWithAttributes> Cci.IGenericParameter.GetConstraints(EmitContext context)
         {
             var moduleBeingBuilt = (PEModuleBuilder)context.Module;
-            var seenValueType = false;
-            foreach (var type in this.ConstraintTypesNoUseSiteDiagnostics)
-            {
-                switch (type.SpecialType)
-                {
-                    case SpecialType.System_Object:
-                        // Avoid emitting unnecessary object constraint.
-                        continue;
-                    case SpecialType.System_ValueType:
-                        seenValueType = true;
-                        break;
-                }
-                var typeRef = moduleBeingBuilt.Translate(type,
-                                                         syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                         diagnostics: context.Diagnostics);
 
-                yield return type.GetTypeRefWithAttributes(this.DeclaringCompilation,
-                                                           typeRef);
+            if (this.HasUnmanagedTypeConstraint)
+            {
+                Debug.Assert(
+                    !this.HasReferenceTypeConstraint &&
+                    !this.HasConstructorConstraint &&
+                    !this.HasValueTypeConstraint
+                    && this.ConstraintTypesNoUseSiteDiagnostics.IsEmpty,
+                    "This constraint can only exist alone");
+
+                var typeRef = moduleBeingBuilt.Translate(
+                    typeSymbol: moduleBeingBuilt.Compilation.GetSpecialType(SpecialType.System_ValueType),
+                    syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                    diagnostics: context.Diagnostics);
+
+                var modifier = CSharpCustomModifier.CreateRequired(
+                    moduleBeingBuilt.Compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_UnmanagedType));
+
+                yield return new Cci.TypeReferenceWithAttributes(new Cci.ModifiedTypeReference(typeRef, ImmutableArray.Create<Cci.ICustomModifier>(modifier)));
             }
-            if (this.HasValueTypeConstraint && !seenValueType)
+            else
             {
-                // Add System.ValueType constraint to comply with Dev11 output
-                var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
-                                                              syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                              diagnostics: context.Diagnostics);
+                var seenValueType = false;
+                foreach (var type in this.ConstraintTypesNoUseSiteDiagnostics)
+                {
+                    switch (type.SpecialType)
+                    {
+                        case SpecialType.System_Object:
+                            // Avoid emitting unnecessary object constraint.
+                            continue;
+                        case SpecialType.System_ValueType:
+                            seenValueType = true;
+                            break;
+                    }
+                    var typeRef = moduleBeingBuilt.Translate(type,
+                                                             syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                             diagnostics: context.Diagnostics);
 
-                yield return new Cci.TypeReferenceWithAttributes(typeRef);
+                    yield return type.GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                                               typeRef);
+                }
+
+                if (this.HasValueTypeConstraint && !seenValueType)
+                {
+                    // Add System.ValueType constraint to comply with Dev11 output
+                    var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
+                                                                  syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                                  diagnostics: context.Diagnostics);
+
+                    yield return new Cci.TypeReferenceWithAttributes(typeRef);
+                }
             }
         }
 
@@ -265,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return this.HasValueTypeConstraint;
+                return this.HasValueTypeConstraint || this.HasUnmanagedTypeConstraint;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1559,6 +1559,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NewBoundWithUnmanaged = 8373,
         ERR_UnmanagedConstraintMustBeAlone = 8374,
         ERR_UnmanagedConstraintNotSatisfied = 8375,
+        ERR_UnmanagedConstraintWithLocalFunctions = 8376,
+        ERR_ConWithUnmanagedCon = 8377,
 
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1556,6 +1556,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_AttributesOnBackingFieldsNotAvailable = 8371,
         ERR_DoNotUseFixedBufferAttrOnProperty = 8372,
 
+        ERR_NewBoundWithUnmanaged = 8373,
+        ERR_UnmanagedConstraintMustBeAlone = 8374,
+        ERR_UnmanagedConstraintNotSatisfied = 8375,
+
         // Note: you will need to re-generate compiler code after adding warnings (build\scripts\generate-compiler-code.cmd)
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -149,6 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureAttributesOnBackingFields = MessageBase + 12731,
         IDS_FeatureEnumGenericTypeConstraint = MessageBase + 12732,
         IDS_FeatureDelegateGenericTypeConstraint = MessageBase + 12733,
+        IDS_FeatureUnmanagedGenericTypeConstraint = MessageBase + 12734,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -192,6 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureAttributesOnBackingFields: // semantic check
                 case MessageID.IDS_FeatureEnumGenericTypeConstraint: // semantic check
                 case MessageID.IDS_FeatureDelegateGenericTypeConstraint: // semantic check
+                case MessageID.IDS_FeatureUnmanagedGenericTypeConstraint: // semantic check
                     return LanguageVersion.CSharp7_3;
 
                 // C# 7.2 features.

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -15,6 +15,7 @@ Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax.IsUnmanaged.get -> bool
 static Microsoft.CodeAnalysis.CSharp.CSharpCommandLineParser.Script.get -> Microsoft.CodeAnalysis.CSharp.CSharpCommandLineParser
 static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Argument(Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax nameColon, Microsoft.CodeAnalysis.SyntaxToken refKindKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -73,6 +73,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
+            public override bool HasUnmanagedTypeConstraint
+            {
+                get { return false; }
+            }
+
             public override bool IsImplicitlyDeclared
             {
                 get { return true; }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool _needsGeneratedIsReadOnlyAttribute_Value;
         private bool _needsGeneratedIsByRefLikeAttribute_Value;
+        private bool _needsGeneratedIsUnmanagedAttribute_Value;
 
         private bool _needsGeneratedAttributes_IsFrozen;
 
@@ -62,6 +63,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _needsGeneratedAttributes_IsFrozen = true;
                 return _needsGeneratedIsByRefLikeAttribute_Value;
+            }
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this compilation has a member that needs IsUnmanagedAttribute to be generated during emit phase.
+        /// The value is set during binding the symbols that need that attribute, and is frozen on first trial to get it.
+        /// Freezing is needed to make sure that nothing tries to modify the value after the value is read.
+        /// </summary>
+        internal bool NeedsGeneratedIsUnmanagedAttribute
+        {
+            get
+            {
+                _needsGeneratedAttributes_IsFrozen = true;
+                return _needsGeneratedIsUnmanagedAttribute_Value;
             }
         }
 
@@ -484,6 +499,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal void EnsureIsUnmanagedAttributeExists(DiagnosticBag diagnostics, Location location, bool modifyCompilationForIsUnmanaged)
+        {
+            Debug.Assert(!modifyCompilationForIsUnmanaged || !_needsGeneratedAttributes_IsFrozen);
+
+            var isNeeded = CheckIfIsUnmanagedAttributeShouldBeEmbedded(diagnostics, location);
+
+            if (isNeeded && modifyCompilationForIsUnmanaged)
+            {
+                _needsGeneratedIsUnmanagedAttribute_Value = true;
+            }
+        }
+
         internal bool CheckIfIsReadOnlyAttributeShouldBeEmbedded(DiagnosticBag diagnosticsOpt, Location locationOpt)
         {
             return CheckIfAttributeShouldBeEmbedded(
@@ -496,10 +523,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool CheckIfIsByRefLikeAttributeShouldBeEmbedded(DiagnosticBag diagnosticsOpt, Location locationOpt)
         {
             return CheckIfAttributeShouldBeEmbedded(
-                diagnosticsOpt, 
-                locationOpt, 
-                WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, 
+                diagnosticsOpt,
+                locationOpt,
+                WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute,
                 WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor);
+        }
+
+        internal bool CheckIfIsUnmanagedAttributeShouldBeEmbedded(DiagnosticBag diagnosticsOpt, Location locationOpt)
+        {
+            return CheckIfAttributeShouldBeEmbedded(
+                diagnosticsOpt,
+                locationOpt,
+                WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute,
+                WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor);
         }
 
         private bool CheckIfAttributeShouldBeEmbedded(DiagnosticBag diagnosticsOpt, Location locationOpt, WellKnownType attributeType, WellKnownMember attributeCtor)

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -810,6 +810,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
+            if(typeParameter.HasUnmanagedTypeConstraint && typeArgument.IsManagedType)
+            {
+                // "The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'"
+                diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, containingSymbol.ConstructedFrom(), typeParameter, typeArgument)));
+                return false;
+            }
+
             // The type parameters for a constructed type/method are the type parameters of
             // the ConstructedFrom type/method, so the constraint types are not substituted.
             // For instance with "class C<T, U> where T : U", the type parameter for T in "C<object, int>"

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -803,17 +803,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
+            if (typeParameter.HasUnmanagedTypeConstraint && (typeArgument.IsManagedType || !typeArgument.IsNonNullableValueType()))
+            {
+                // "The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'"
+                diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, containingSymbol.ConstructedFrom(), typeParameter, typeArgument)));
+                return false;
+            }
+
             if (typeParameter.HasValueTypeConstraint && !typeArgument.IsNonNullableValueType())
             {
                 // "The type '{2}' must be a non-nullable value type in order to use it as parameter '{1}' in the generic type or method '{0}'"
                 diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_ValConstraintNotSatisfied, containingSymbol.ConstructedFrom(), typeParameter, typeArgument)));
-                return false;
-            }
-
-            if(typeParameter.HasUnmanagedTypeConstraint && typeArgument.IsManagedType)
-            {
-                // "The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'"
-                diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, containingSymbol.ConstructedFrom(), typeParameter, typeArgument)));
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -163,10 +163,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 constraintDeducedBase = constraintTypeParameter.GetDeducedBaseType(constraintsInProgress);
                                 AddInterfaces(interfacesBuilder, constraintTypeParameter.GetInterfaces(constraintsInProgress));
 
-                                if (constraintTypeParameter.HasValueTypeConstraint && !inherited && currentCompilation != null && constraintTypeParameter.IsFromCompilation(currentCompilation))
+                                if (!inherited && currentCompilation != null && constraintTypeParameter.IsFromCompilation(currentCompilation))
                                 {
-                                    // "Type parameter '{1}' has the 'struct' constraint so '{1}' cannot be used as a constraint for '{0}'"
-                                    diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(ErrorCode.ERR_ConWithValCon, typeParameter, constraintTypeParameter)));
+                                    ErrorCode errorCode;
+                                    if (constraintTypeParameter.HasUnmanagedTypeConstraint)
+                                    {
+                                        errorCode = ErrorCode.ERR_ConWithUnmanagedCon;
+                                    }
+                                    else if (constraintTypeParameter.HasValueTypeConstraint)
+                                    {
+                                        errorCode = ErrorCode.ERR_ConWithValCon;
+                                    }
+                                    else
+                                    {
+                                        break;
+                                    }
+
+                                    // "Type parameter '{1}' has the '?' constraint so '{1}' cannot be used as a constraint for '{0}'"
+                                    diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter, new CSDiagnosticInfo(errorCode, typeParameter, constraintTypeParameter)));
                                     continue;
                                 }
                             }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -71,6 +71,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            public override bool HasUnmanagedTypeConstraint
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
             public override int Ordinal
             {
                 get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -254,6 +254,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get
+            {
+                // PROTOTYPE: handle PE symbols
+                return false;
+            }
+        }
+
         public override VarianceKind Variance
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -25,17 +25,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         #region Metadata
         private readonly string _name;
         private readonly ushort _ordinal; // 0 for first, 1 for second, ...
-        private readonly GenericParameterAttributes _flags;
-        private readonly bool _hasIsUnmanagedAttribute;
         #endregion
-
-        private TypeParameterBounds _lazyBounds = TypeParameterBounds.Unset;
 
         /// <summary>
         /// First error calculating bounds.
         /// </summary>
         private DiagnosticInfo _lazyConstraintsUseSiteErrorInfo = CSDiagnosticInfo.EmptyErrorInfo; // Indicates unknown state.
 
+        private GenericParameterAttributes _lazyFlags;
+        private ThreeState _lazyHasIsUnmanagedAttribute;
+        private TypeParameterBounds _lazyBounds = TypeParameterBounds.Unset;
+        private ImmutableArray<TypeSymbol> _lazyDeclaredConstraintTypes;
         private ImmutableArray<CSharpAttributeData> _lazyCustomAttributes;
 
         internal PETypeParameterSymbol(
@@ -87,15 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             // Clear the '.ctor' flag if both '.ctor' and 'valuetype' are
             // set since '.ctor' is redundant in that case.
-            _flags = ((flags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) ? flags : (flags & ~GenericParameterAttributes.DefaultConstructorConstraint);
-            _hasIsUnmanagedAttribute = moduleSymbol.Module.HasIsUnmanagedAttribute(handle);
-
-            if (_hasIsUnmanagedAttribute && (_flags & (GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)) != 0)
-            {
-                // Unmanaged constraint cannot be combined with new() or class constraints
-                _flags = _flags & ~(GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint);
-                _lazyConstraintsUseSiteErrorInfo = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
-            }
+            _lazyFlags = ((flags & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) ? flags : (flags & ~GenericParameterAttributes.DefaultConstructorConstraint);
 
             _ordinal = ordinal;
             _handle = handle;
@@ -147,83 +139,99 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private ImmutableArray<TypeSymbol> GetDeclaredConstraintTypes()
         {
-            PEMethodSymbol containingMethod = null;
-            PENamedTypeSymbol containingType;
-
-            if (_containingSymbol.Kind == SymbolKind.Method)
+            if (_lazyDeclaredConstraintTypes.IsDefault)
             {
-                containingMethod = (PEMethodSymbol)_containingSymbol;
-                containingType = (PENamedTypeSymbol)containingMethod.ContainingSymbol;
-            }
-            else
-            {
-                containingType = (PENamedTypeSymbol)_containingSymbol;
-            }
+                ImmutableArray<TypeSymbol> declaredConstraintTypes;
 
-            var moduleSymbol = containingType.ContainingPEModule;
-            var metadataReader = moduleSymbol.Module.MetadataReader;
-            GenericParameterConstraintHandleCollection constraints;
+                PEMethodSymbol containingMethod = null;
+                PENamedTypeSymbol containingType;
 
-            try
-            {
-                constraints = metadataReader.GetGenericParameter(_handle).GetConstraints();
-            }
-            catch (BadImageFormatException)
-            {
-                constraints = default(GenericParameterConstraintHandleCollection);
-                Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
-            }
-
-            if (constraints.Count > 0)
-            {
-                var symbolsBuilder = ArrayBuilder<TypeSymbol>.GetInstance();
-                MetadataDecoder tokenDecoder;
-
-                if ((object)containingMethod != null)
+                if (_containingSymbol.Kind == SymbolKind.Method)
                 {
-                    tokenDecoder = new MetadataDecoder(moduleSymbol, containingMethod);
+                    containingMethod = (PEMethodSymbol)_containingSymbol;
+                    containingType = (PENamedTypeSymbol)containingMethod.ContainingSymbol;
                 }
                 else
                 {
-                    tokenDecoder = new MetadataDecoder(moduleSymbol, containingType);
+                    containingType = (PENamedTypeSymbol)_containingSymbol;
                 }
 
-                foreach (var constraintHandle in constraints)
+                var moduleSymbol = containingType.ContainingPEModule;
+                var metadataReader = moduleSymbol.Module.MetadataReader;
+                GenericParameterConstraintHandleCollection constraints;
+
+                try
                 {
-                    var constraint = metadataReader.GetGenericParameterConstraint(constraintHandle);
-                    var typeSymbol = tokenDecoder.DecodeGenericParameterConstraint(constraint.Type, out bool hasUnmanagedModreq);
-
-                    if (hasUnmanagedModreq != this._hasIsUnmanagedAttribute)
-                    {
-                        // The presence of UnmanagedType modreq has to match the presence of the IsUnmanagedAttribute
-                        Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
-                        continue;
-                    }
-
-                    // Drop 'System.Object' constraint type.
-                    if (typeSymbol.SpecialType == SpecialType.System_Object)
-                    {
-                        continue;
-                    }
-
-                    // Drop 'System.ValueType' constraint type if the 'valuetype' constraint was also specified.
-                    if (((_flags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0) &&
-                        (typeSymbol.SpecialType == SpecialType.System_ValueType))
-                    {
-                        continue;
-                    }
-
-                    typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, constraintHandle, moduleSymbol);
-
-                    symbolsBuilder.Add(typeSymbol);
+                    constraints = metadataReader.GetGenericParameter(_handle).GetConstraints();
+                }
+                catch (BadImageFormatException)
+                {
+                    constraints = default(GenericParameterConstraintHandleCollection);
+                    Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
                 }
 
-                return symbolsBuilder.ToImmutableAndFree();
+                this.GetAttributes();
+                if (_lazyHasIsUnmanagedAttribute.Value() && (_lazyFlags & (GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint)) != 0)
+                {
+                    _lazyFlags = _lazyFlags & ~(GenericParameterAttributes.ReferenceTypeConstraint | GenericParameterAttributes.DefaultConstructorConstraint);
+                    _lazyConstraintsUseSiteErrorInfo = new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this);
+                }
+
+                if (constraints.Count > 0)
+                {
+                    var symbolsBuilder = ArrayBuilder<TypeSymbol>.GetInstance();
+                    MetadataDecoder tokenDecoder;
+
+                    if ((object)containingMethod != null)
+                    {
+                        tokenDecoder = new MetadataDecoder(moduleSymbol, containingMethod);
+                    }
+                    else
+                    {
+                        tokenDecoder = new MetadataDecoder(moduleSymbol, containingType);
+                    }
+
+                    foreach (var constraintHandle in constraints)
+                    {
+                        var constraint = metadataReader.GetGenericParameterConstraint(constraintHandle);
+                        var typeSymbol = tokenDecoder.DecodeGenericParameterConstraint(constraint.Type, out bool hasUnmanagedModreq);
+
+                        if (hasUnmanagedModreq != this._lazyHasIsUnmanagedAttribute.Value())
+                        {
+                            // The presence of UnmanagedType modreq has to match the presence of the IsUnmanagedAttribute
+                            Interlocked.CompareExchange(ref _lazyConstraintsUseSiteErrorInfo, new CSDiagnosticInfo(ErrorCode.ERR_BindToBogus, this), CSDiagnosticInfo.EmptyErrorInfo);
+                            continue;
+                        }
+
+                        // Drop 'System.Object' constraint type.
+                        if (typeSymbol.SpecialType == SpecialType.System_Object)
+                        {
+                            continue;
+                        }
+
+                        // Drop 'System.ValueType' constraint type if the 'valuetype' constraint was also specified.
+                        if (((_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0) &&
+                            (typeSymbol.SpecialType == SpecialType.System_ValueType))
+                        {
+                            continue;
+                        }
+
+                        typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, constraintHandle, moduleSymbol);
+
+                        symbolsBuilder.Add(typeSymbol);
+                    }
+
+                    declaredConstraintTypes = symbolsBuilder.ToImmutableAndFree();
+                }
+                else
+                {
+                    declaredConstraintTypes = ImmutableArray<TypeSymbol>.Empty;
+                }
+
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyDeclaredConstraintTypes, declaredConstraintTypes);
             }
-            else
-            {
-                return ImmutableArray<TypeSymbol>.Empty;
-            }
+
+            return _lazyDeclaredConstraintTypes;
         }
 
         public override ImmutableArray<Location> Locations
@@ -246,7 +254,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_flags & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+                GetDeclaredConstraintTypes();
+                return (_lazyFlags & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
             }
         }
 
@@ -254,7 +263,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_flags & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+                GetDeclaredConstraintTypes();
+                return (_lazyFlags & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
             }
         }
 
@@ -262,7 +272,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (_flags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0 || HasUnmanagedTypeConstraint;
+                GetDeclaredConstraintTypes();
+                return (_lazyFlags & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0 || HasUnmanagedTypeConstraint;
             }
         }
 
@@ -270,7 +281,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return this._hasIsUnmanagedAttribute;
+                GetDeclaredConstraintTypes();
+                return this._lazyHasIsUnmanagedAttribute.Value();
             }
         }
 
@@ -278,7 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                return (VarianceKind)(_flags & GenericParameterAttributes.VarianceMask);
+                GetDeclaredConstraintTypes();
+                return (VarianceKind)(_lazyFlags & GenericParameterAttributes.VarianceMask);
             }
         }
 
@@ -321,9 +334,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (_lazyCustomAttributes.IsDefault)
             {
-                var containingPEModuleSymbol = (PEModuleSymbol)this.ContainingModule;
-                containingPEModuleSymbol.LoadCustomAttributes(this.Handle, ref _lazyCustomAttributes);
+                var loadedCustomAttributes = ((PEModuleSymbol)this.ContainingModule).GetCustomAttributesForToken(
+                    this.Handle,
+                    out CustomAttributeHandle isUnmanagedAttribute,
+                    AttributeDescription.IsUnmanagedAttribute,
+                    out _,
+                    default);
+
+                this._lazyHasIsUnmanagedAttribute = (!isUnmanagedAttribute.IsNil).ToThreeState();
+
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, loadedCustomAttributes);
             }
+
             return _lazyCustomAttributes;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -62,6 +62,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return type.IsWellKnownTypeInAttribute();
         }
 
+        internal override bool IsAcceptedUnmanagedTypeModifierType(TypeSymbol type)
+        {
+            return type.IsWellKnownTypeUnmanagedType();
+        }
+
         internal override TypeSymbol GetSZArrayTypeSymbol(PEModuleSymbol moduleSymbol, TypeSymbol elementType, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
         {
             if (elementType is UnsupportedMetadataTypeSymbol)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -126,6 +126,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get { return false; }
+        }
+
         public override bool HasConstructorConstraint
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -206,6 +206,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // IsReadOnlyAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
             {
                 // IsByRefLikeAttribute should not be set explicitly.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var binder = binderFactory.GetBinder(typeSyntax);
 
             bool isVar;
-            type = binder.BindType(typeSyntax, diagnostics, out isVar);
+            type = binder.BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar);
 
             Debug.Assert((object)type != null || isVar);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -125,6 +125,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get { return false; }
+        }
+
         public override bool HasConstructorConstraint
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -108,6 +108,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var typeParam in _typeParameters)
             {
                 typeParam.ForceComplete(null, default(CancellationToken));
+
+                if (typeParam.HasUnmanagedTypeConstraint)
+                {
+                    addTo.Add(ErrorCode.ERR_UnmanagedConstraintWithLocalFunctions, typeParam.GetNonNullSyntaxNode().Location);
+                }
             }
 
             // force lazy init

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -561,6 +561,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // IsReadOnlyAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
             {
                 // IsByRefLikeAttribute should not be set explicitly.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_typeSyntax.IsVar)
                 {
                     bool isVar;
-                    TypeSymbol declType = this.TypeSyntaxBinder.BindType(_typeSyntax, new DiagnosticBag(), out isVar);
+                    TypeSymbol declType = this.TypeSyntaxBinder.BindTypeOrVarKeyword(_typeSyntax, new DiagnosticBag(), out isVar);
                     return isVar;
                 }
 
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool isVar;
             RefKind refKind;
-            TypeSymbol declType = typeBinder.BindType(_typeSyntax.SkipRef(out refKind), diagnostics, out isVar);
+            TypeSymbol declType = typeBinder.BindTypeOrVarKeyword(_typeSyntax.SkipRef(out refKind), diagnostics, out isVar);
 
             if (isVar)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -482,6 +482,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         foreach (var typeParameter in this.TypeParameters)
                         {
                             typeParameter.ForceComplete(locationOpt, cancellationToken);
+                            var diagnostics = DiagnosticBag.GetInstance();
+
+                            if (typeParameter.HasUnmanagedTypeConstraint)
+                            {
+                                this.DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, typeParameter.GetNonNullSyntaxNode().Location, modifyCompilationForIsUnmanaged: true);
+                            }
+
+                            AddDeclarationDiagnostics(diagnostics);
+                            diagnostics.Free();
                         }
 
                         state.NotePartComplete(CompletionPart.TypeParameters);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else
                 {
                     bool isVar;
-                    type = binder.BindType(typeSyntax, diagnostics, out isVar);
+                    type = binder.BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar);
 
                     Debug.Assert((object)type != null || isVar);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1110,6 +1110,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // IsReadOnlyAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
             {
                 // IsByRefLikeAttribute should not be set explicitly.
@@ -1234,6 +1239,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // DynamicAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -723,6 +723,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // IsReadOnlyAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
             {
                 // IsByRefLikeAttribute should not be set explicitly.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -141,15 +141,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             CheckForBlockAndExpressionBody(
                 syntax.Body, syntax.ExpressionBody, syntax, diagnostics);
-
-            foreach (var typeParameter in _typeParameters)
-            {
-                if (typeParameter.HasUnmanagedTypeConstraint)
-                {
-                    // This check has to come last, after all relevants fields of this symbol (including overriden symbols) are set.
-                    DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, syntax.Location, modifyCompilationForIsUnmanaged: true);
-                }
-            }
         }
 
         public override bool ReturnsVoid
@@ -377,6 +368,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             CheckModifiers(location, diagnostics);
+
+            foreach (var typeParameter in _typeParameters)
+            {
+                if (typeParameter.HasUnmanagedTypeConstraint)
+                {
+                    DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, syntax.Location, modifyCompilationForIsUnmanaged: true);
+                }
+            }
         }
 
         // This is also used for async lambdas.  Probably not the best place to locate this method, but where else could it go?

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -141,6 +141,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             CheckForBlockAndExpressionBody(
                 syntax.Body, syntax.ExpressionBody, syntax, diagnostics);
+
+            foreach (var typeParameter in _typeParameters)
+            {
+                if (typeParameter.HasUnmanagedTypeConstraint)
+                {
+                    // This check has to come last, after all relevants fields of this symbol (including overriden symbols) are set.
+                    DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, syntax.Location, modifyCompilationForIsUnmanaged: true);
+                }
+            }
         }
 
         public override bool ReturnsVoid

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (typeParameter.HasUnmanagedTypeConstraint)
                 {
-                    DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, syntax.Location, modifyCompilationForIsUnmanaged: true);
+                    DeclaringCompilation.EnsureIsUnmanagedAttributeExists(diagnostics, typeParameter.GetNonNullSyntaxNode().Location, modifyCompilationForIsUnmanaged: true);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1263,6 +1263,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // IsReadOnlyAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
+            {
+                // IsUnmanagedAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
             {
                 // IsByRefLikeAttribute should not be set explicitly.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -304,6 +305,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _state.SpinWaitComplete(incompletePart, cancellationToken);
             }
         }
+
+        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+            if (this.HasUnmanagedTypeConstraint)
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsUnmanagedAttribute(this));
+            }
+        }
     }
 
     internal sealed class SourceTypeParameterSymbol : SourceTypeParameterSymbolBase
@@ -350,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var constraints = this.GetDeclaredConstraints();
-                return (constraints & TypeParameterConstraintKind.ValueType) != 0;
+                return (constraints & (TypeParameterConstraintKind.ValueType | TypeParameterConstraintKind.Unmanaged)) != 0;
             }
         }
 
@@ -429,7 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var constraints = this.GetDeclaredConstraints();
-                return (constraints & TypeParameterConstraintKind.ValueType) != 0;
+                return (constraints & (TypeParameterConstraintKind.ValueType | TypeParameterConstraintKind.Unmanaged)) != 0;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -363,6 +363,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get
+            {
+                var constraints = this.GetDeclaredConstraints();
+                return (constraints & TypeParameterConstraintKind.Unmanaged) != 0;
+            }
+        }
+
         protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
         {
             get { return _owner.TypeParameters; }
@@ -430,6 +439,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var constraints = this.GetDeclaredConstraints();
                 return (constraints & TypeParameterConstraintKind.ReferenceType) != 0;
+            }
+        }
+
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get
+            {
+                var constraints = this.GetDeclaredConstraints();
+                return (constraints & TypeParameterConstraintKind.Unmanaged) != 0;
             }
         }
 
@@ -624,6 +642,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 var typeParameter = this.OverriddenTypeParameter;
                 return ((object)typeParameter != null) && typeParameter.HasReferenceTypeConstraint;
+            }
+        }
+
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get
+            {
+                var typeParameter = this.OverriddenTypeParameter;
+                return ((object)typeParameter != null) && typeParameter.HasUnmanagedTypeConstraint;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/TypeParameterConstraintClause.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         ReferenceType = 0x01,
         ValueType = 0x02,
         Constructor = 0x04,
+        Unmanaged = 0x08,
     }
 
     /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
+
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
@@ -15,6 +18,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsImplicitlyDeclared
         {
             get { return true; }
+        }
+
+        internal override void AddSynthesizedAttributes(PEModuleBuilder moduleBuilder, ref ArrayBuilder<SynthesizedAttributeData> attributes)
+        {
+            base.AddSynthesizedAttributes(moduleBuilder, ref attributes);
+
+            if (this.HasUnmanagedTypeConstraint)
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsUnmanagedAttribute(this));
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -445,18 +445,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal static bool IsManagedTypeFromConstraintTypes(ImmutableArray<TypeSymbol> constraintTypes)
-        {
-            foreach (var constraintType in constraintTypes)
-            {
-                if (constraintType.IsManagedType)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
         public sealed override bool IsReferenceType
         {
             get
@@ -477,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return !this.HasUnmanagedTypeConstraint && IsManagedTypeFromConstraintTypes(this.ConstraintTypesNoUseSiteDiagnostics);
+                return !this.HasUnmanagedTypeConstraint;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -445,6 +445,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
+        internal static bool IsManagedTypeFromConstraintTypes(ImmutableArray<TypeSymbol> constraintTypes)
+        {
+            foreach (var constraintType in constraintTypes)
+            {
+                if (constraintType.IsManagedType)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public sealed override bool IsReferenceType
         {
             get
@@ -465,7 +477,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return true;
+                return !this.HasUnmanagedTypeConstraint && IsManagedTypeFromConstraintTypes(this.ConstraintTypesNoUseSiteDiagnostics);
             }
         }
 
@@ -495,6 +507,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract bool HasReferenceTypeConstraint { get; }
 
         public abstract bool HasValueTypeConstraint { get; }
+
+        public abstract bool HasUnmanagedTypeConstraint { get; }
 
         public abstract VarianceKind Variance { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1528,9 +1528,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return new Cci.TypeReferenceWithAttributes(typeRef);
         }
 
-        internal static bool IsWellKnownTypeInAttribute(this ITypeSymbol typeSymbol)
+        internal static bool IsWellKnownTypeInAttribute(this ITypeSymbol typeSymbol) => typeSymbol.IsWellKnownInteropServicesTopLevelType("InAttribute");
+
+        internal static bool IsWellKnownTypeUnmanagedType(this ITypeSymbol typeSymbol) => typeSymbol.IsWellKnownInteropServicesTopLevelType("UnmanagedType");
+
+        private static bool IsWellKnownInteropServicesTopLevelType(this ITypeSymbol typeSymbol, string name)
         {
-            if (typeSymbol.Name != "InAttribute" || typeSymbol.ContainingType != null)
+            if (typeSymbol.Name != name || typeSymbol.ContainingType != null)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -73,6 +73,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get
+            {
+                return _underlyingTypeParameter.HasUnmanagedTypeConstraint;
+            }
+        }
+
         public override bool HasValueTypeConstraint
         {
             get

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
@@ -4,13 +4,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal abstract partial class TypeSyntax
     {
-        public bool IsVar
-        {
-            get
-            {
-                var ts = this as IdentifierNameSyntax;
-                return ts != null && ts.Identifier.ToString() == "var";
-            }
-        }
+        public bool IsVar => this is IdentifierNameSyntax name && name.Identifier.ToString() == "var";
+
+        public bool IsUnmanaged => this is IdentifierNameSyntax name && name.Identifier.ToString() == "unmanaged";
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/TypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TypeSyntax.cs
@@ -4,12 +4,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     public abstract partial class TypeSyntax
     {
-        public bool IsVar
-        {
-            get
-            {
-                return ((InternalSyntax.TypeSyntax)this.Green).IsVar;
-            }
-        }
+        public bool IsVar => ((InternalSyntax.TypeSyntax)this.Green).IsVar;
+
+        public bool IsUnmanaged => ((InternalSyntax.TypeSyntax)this.Green).IsUnmanaged;
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8630,6 +8630,16 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8631,8 +8631,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8610,6 +8610,26 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8630,6 +8630,16 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8631,8 +8631,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8610,6 +8610,26 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8630,6 +8630,16 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8610,6 +8610,26 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8631,8 +8631,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8630,6 +8630,16 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8631,8 +8631,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8610,6 +8610,26 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8610,6 +8610,26 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8630,6 +8630,16 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8631,8 +8631,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8610,6 +8610,26 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8630,6 +8630,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8610,6 +8610,26 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8630,6 +8630,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8610,6 +8610,26 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8630,6 +8630,16 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8631,8 +8631,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8631,8 +8631,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8630,6 +8630,16 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8610,6 +8610,26 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8610,6 +8610,26 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8630,6 +8630,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8630,6 +8630,16 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8610,6 +8610,26 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8631,8 +8631,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8610,6 +8610,26 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8630,6 +8630,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8610,6 +8610,26 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">delegate generic type constraints</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureUnmanagedGenericTypeConstraint">
+        <source>unmanaged generic type constraints</source>
+        <target state="new">unmanaged generic type constraints</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NewBoundWithUnmanaged">
+        <source>The 'new()' constraint cannot be used with the 'unmanaged' constraint</source>
+        <target state="new">The 'new()' constraint cannot be used with the 'unmanaged' constraint</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintMustBeAlone">
+        <source>The 'unmanaged' constraint cannot be specified with other constraints.</source>
+        <target state="new">The 'unmanaged' constraint cannot be specified with other constraints.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintNotSatisfied">
+        <source>The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</source>
+        <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8630,6 +8630,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <target state="new">The type '{2}' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter '{1}' in the generic type or method '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
+        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ConWithUnmanagedCon">
+        <source>Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</source>
+        <target state="new">Type parameter '{1}' has the 'unmanaged' constraint so '{1}' cannot be used as a constraint for '{0}'</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8631,8 +8631,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnmanagedConstraintWithLocalFunctions">
-        <source>Using unmanaged constraint on local functions type parameters is not supported.</source>
-        <target state="new">Using unmanaged constraint on local functions type parameters is not supported.</target>
+        <source>Using 'unmanaged' constraint on local functions type parameters is not supported.</source>
+        <target state="new">Using 'unmanaged' constraint on local functions type parameters is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConWithUnmanagedCon">

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsUnmanaged.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsUnmanaged.cs
@@ -1,0 +1,591 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class AttributeTests_IsUnmanaged : CSharpTestBase
+    {
+        [Fact]
+        public void AttributeUsedIfExists_FromSource_Method()
+        {
+            var text = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+public class Test
+{
+    public void M<T>() where T : unmanaged { }
+}
+";
+
+            CompileAndVerify(text, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Fact]
+        public void AttributeUsedIfExists_FromSource_Class()
+        {
+            var text = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+public class Test<T> where T : unmanaged
+{
+}
+";
+
+            CompileAndVerify(text, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Fact]
+        public void AttributeUsedIfExists_FromReference_Method_Dll()
+        {
+            var reference = CreateStandardCompilation(@"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}").EmitToImageReference();
+
+            var text = @"
+public class Test
+{
+    public void M<T>() where T : unmanaged { }
+}
+";
+
+            CompileAndVerify(text, additionalRefs: new[] { reference }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), reference.Display);
+                AssertNoIsUnmanagedAttributeExists(module.ContainingAssembly);
+            });
+        }
+
+        [Fact]
+        public void AttributeUsedIfExists_FromReference_Class_Dll()
+        {
+            var reference = CreateStandardCompilation(@"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}").EmitToImageReference();
+
+            var text = @"
+public class Test<T> where T : unmanaged
+{
+}
+";
+
+            CompileAndVerify(text, additionalRefs: new[] { reference }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), reference.Display);
+                AssertNoIsUnmanagedAttributeExists(module.ContainingAssembly);
+            });
+        }
+
+        [Fact]
+        public void AttributeUsedIfExists_FromReference_Method_Module()
+        {
+            var reference = CreateStandardCompilation(@"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}").EmitToImageReference();
+
+            var text = @"
+public class Test
+{
+    public void M<T>() where T : unmanaged { }
+}
+";
+
+            CompileAndVerify(text, verify: Verification.Fails, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), reference.Display);
+                AssertNoIsUnmanagedAttributeExists(module.ContainingAssembly);
+            });
+        }
+
+        [Fact]
+        public void AttributeUsedIfExists_FromReference_Class_Module()
+        {
+            var reference = CreateStandardCompilation(@"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}").EmitToImageReference();
+
+            var text = @"
+public class Test<T> where T : unmanaged
+{
+}
+";
+
+            CompileAndVerify(text, verify: Verification.Fails, additionalRefs: new[] { reference }, options: TestOptions.ReleaseModule, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Public, typeParameter.GetAttributes(), reference.Display);
+                AssertNoIsUnmanagedAttributeExists(module.ContainingAssembly);
+            });
+        }
+
+        [Fact]
+        public void AttributeGeneratedIfNotExists_FromSource_Method()
+        {
+            var text = @"
+public class Test
+{
+    public void M<T>() where T : unmanaged { }
+}
+";
+
+            CompileAndVerify(text, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Fact]
+        public void AttributeGeneratedIfNotExists_FromSource_Class()
+        {
+            var text = @"
+public class Test<T> where T : unmanaged
+{
+}
+";
+
+            CompileAndVerify(text, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Delegates()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+[IsUnmanaged]
+public delegate void D([IsUnmanaged]int x);
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (9,2): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                // [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(9, 2),
+                // (10,25): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                // public delegate void D([IsUnmanaged]int x);
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(10, 25));
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Types()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+[IsUnmanaged]
+public class Test
+{
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (9,2): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                // [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(9, 2));
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Fields()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+public class Test
+{
+    [IsUnmanaged]
+    public int x = 0;
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (11,6): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(11, 6));
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Properties()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+public class Test
+{
+    [IsUnmanaged]
+    public int Property => 0;
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (11,6): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(11, 6));
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Methods()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+public class Test
+{
+    [IsUnmanaged]
+    [return: IsUnmanaged]
+    public int Method([IsUnmanaged]int x)
+    {
+        return x;
+    }
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (11,6): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(11, 6),
+                // (12,14): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     [return: IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(12, 14),
+                // (13,24): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     public int Method([IsUnmanaged]int x)
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(13, 24));
+        }
+
+        [Fact]
+        public void IsUnmanagedAttributeIsDisallowedEverywhereInSource_Indexers()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+
+public class Test
+{
+    [IsUnmanaged]
+    public int this[[IsUnmanaged]int x] => x;
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (11,6): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(11, 6),
+                // (12,22): error CS8335: Do not use 'System.Runtime.CompilerServices.IsUnmanagedAttribute'. This is reserved for compiler usage.
+                //     public int this[[IsUnmanaged]int x] => x;
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "IsUnmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(12, 22));
+        }
+
+        [Fact]
+        public void UserReferencingIsUnmanagedAttributeShouldResultInAnError()
+        {
+            var code = @"
+[IsUnmanaged]
+public class Test
+{
+}
+";
+
+            CreateStandardCompilation(code).VerifyDiagnostics(
+                // (2,2): error CS0246: The type or namespace name 'IsUnmanagedAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "IsUnmanaged").WithArguments("IsUnmanagedAttribute").WithLocation(2, 2),
+                // (2,2): error CS0246: The type or namespace name 'IsUnmanaged' could not be found (are you missing a using directive or an assembly reference?)
+                // [IsUnmanaged]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "IsUnmanaged").WithArguments("IsUnmanaged").WithLocation(2, 2));
+        }
+
+        [Fact]
+        public void TypeReferencingAnotherTypeThatUsesAPublicAttributeFromAThirdNotReferencedAssemblyShouldGenerateItsOwn()
+        {
+            var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
+
+            var code1 = CreateStandardCompilation(@"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute { }
+}");
+
+            var code2 = CreateStandardCompilation(@"
+public class Test1<T> where T : unmanaged { }
+", references: new[] { code1.ToMetadataReference() }, options: options);
+
+            CompileAndVerify(code2, symbolValidator: module =>
+            {
+                AssertNoIsUnmanagedAttributeExists(module.ContainingAssembly);
+            });
+
+            var code3 = CreateStandardCompilation(@"
+public class Test2<T> : Test1<T> where T : unmanaged { }
+", references: new[] { code2.ToMetadataReference() }, options: options);
+
+            CompileAndVerify(code3, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test2`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Fact]
+        public void BuildingAModuleRequiresIsUnmanagedAttributeToBeThere_Missing_Type()
+        {
+            var code = @"
+public class Test<T> where T : unmanaged
+{
+}";
+
+            CreateStandardCompilation(code, options: TestOptions.ReleaseModule).VerifyDiagnostics(
+                // (2,32): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
+                // public class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(2, 32));
+        }
+
+        [Fact]
+        public void BuildingAModuleRequiresIsUnmanagedAttributeToBeThere_Missing_Method()
+        {
+            var code = @"
+public class Test
+{
+    public void M<T>() where T : unmanaged {}
+}";
+
+            CreateStandardCompilation(code, options: TestOptions.ReleaseModule).VerifyDiagnostics(
+                // (4,34): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
+                //     public void M<T>() where T : unmanaged {}
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(4, 34));
+        }
+
+        [Fact]
+        public void ReferencingAnEmbeddedIsUnmanagedAttributeDoesNotUseIt_InternalsVisible()
+        {
+            var options = TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All);
+
+            var code1 = @"
+[assembly:System.Runtime.CompilerServices.InternalsVisibleToAttribute(""Assembly2"")]
+public class Test1<T> where T : unmanaged
+{
+}";
+
+            var comp1 = CompileAndVerify(code1, options: options, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test1`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+
+            var code2 = @"
+public class Test2<T> : Test1<T> where T : unmanaged
+{
+}";
+
+            CompileAndVerify(code2, options: options.WithModuleName("Assembly2"), additionalRefs: new[] { comp1.Compilation.ToMetadataReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Test2`1").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter.GetAttributes(), module.ContainingAssembly.Name);
+            });
+        }
+
+        [Theory]
+        [InlineData(OutputKind.DynamicallyLinkedLibrary)]
+        [InlineData(OutputKind.NetModule)]
+        public void IsUnmanagedAttributeExistsWithWrongConstructorSignature(OutputKind outputKind)
+        {
+            var text = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute
+    {
+        public IsUnmanagedAttribute(int p) { }
+    }
+}
+class Test<T> where T : unmanaged
+{
+}";
+
+            CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
+                // (9,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 25));
+        }
+
+        [Theory]
+        [InlineData(OutputKind.DynamicallyLinkedLibrary)]
+        [InlineData(OutputKind.NetModule)]
+        public void IsUnmanagedAttributeExistsWithPrivateConstructor(OutputKind outputKind)
+        {
+            var text = @"
+namespace System.Runtime.CompilerServices
+{
+    public class IsUnmanagedAttribute : System.Attribute
+    {
+        private IsUnmanagedAttribute() { }
+    }
+}
+class Test<T> where T : unmanaged
+{
+}";
+
+            CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
+                // (9,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 25));
+        }
+
+        [Theory]
+        [InlineData(OutputKind.DynamicallyLinkedLibrary)]
+        [InlineData(OutputKind.NetModule)]
+        public void IsUnmanagedAttributeExistsAsInterface(OutputKind outputKind)
+        {
+            var text = @"
+namespace System.Runtime.CompilerServices
+{
+    public interface IsUnmanagedAttribute { }
+}
+class Test<T> where T : unmanaged
+{
+}";
+
+            CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
+                // (6,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(6, 25));
+        }
+
+        private void AssertReferencedIsUnmanagedAttribute(Accessibility accessibility, ImmutableArray<CSharpAttributeData> attributes, string assemblyName)
+        {
+            var attributeType = attributes.Single().AttributeClass;
+            Assert.Equal("IsUnmanagedAttribute", attributeType.Name);
+            Assert.Equal(assemblyName, attributeType.ContainingAssembly.Name);
+            Assert.Equal(accessibility, attributeType.DeclaredAccessibility);
+
+            switch (accessibility)
+            {
+                case Accessibility.Internal:
+                    {
+                        var isUnmanagedTypeAttributes = attributeType.GetAttributes().OrderBy(attribute => attribute.AttributeClass.Name).ToArray();
+                        Assert.Equal(2, isUnmanagedTypeAttributes.Length);
+
+                        Assert.Equal(WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_CompilerGeneratedAttribute), isUnmanagedTypeAttributes[0].AttributeClass.ToDisplayString());
+                        Assert.Equal(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName, isUnmanagedTypeAttributes[1].AttributeClass.ToDisplayString());
+                        break;
+                    }
+
+                case Accessibility.Public:
+                    {
+                        Assert.Null(attributeType.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
+
+                        break;
+                    }
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(accessibility);
+            }
+
+        }
+
+        private void AssertNoIsUnmanagedAttributeExists(AssemblySymbol assembly)
+        {
+            var isUnmanagedAttributeTypeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute);
+            Assert.Null(assembly.GetTypeByMetadataName(isUnmanagedAttributeTypeName));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsUnmanaged.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsUnmanaged.cs
@@ -429,9 +429,9 @@ public class Test<T> where T : unmanaged
 }";
 
             CreateStandardCompilation(code, options: TestOptions.ReleaseModule).VerifyDiagnostics(
-                // (2,32): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
+                // (2,19): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
                 // public class Test<T> where T : unmanaged
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(2, 32));
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "T").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(2, 19));
         }
 
         [Fact]
@@ -444,9 +444,9 @@ public class Test
 }";
 
             CreateStandardCompilation(code, options: TestOptions.ReleaseModule).VerifyDiagnostics(
-                // (4,34): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
+                // (4,19): error CS0518: Predefined type 'System.Runtime.CompilerServices.IsUnmanagedAttribute' is not defined or imported
                 //     public void M<T>() where T : unmanaged {}
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(4, 34));
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "T").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute").WithLocation(4, 19));
         }
 
         [Fact]
@@ -502,9 +502,9 @@ class Test<T> where T : unmanaged
 }";
 
             CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
-                // (9,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // (9,12): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
                 // class Test<T> where T : unmanaged
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 25));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "T").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 12));
         }
 
         [Theory]
@@ -525,9 +525,9 @@ class Test<T> where T : unmanaged
 }";
 
             CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
-                // (9,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // (9,12): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
                 // class Test<T> where T : unmanaged
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 25));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "T").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(9, 12));
         }
 
         [Theory]
@@ -545,9 +545,9 @@ class Test<T> where T : unmanaged
 }";
 
             CreateStandardCompilation(text, options: new CSharpCompilationOptions(outputKind)).VerifyDiagnostics(
-                // (6,25): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
+                // (6,12): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IsUnmanagedAttribute..ctor'
                 // class Test<T> where T : unmanaged
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "unmanaged").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(6, 25));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "T").WithArguments("System.Runtime.CompilerServices.IsUnmanagedAttribute", ".ctor").WithLocation(6, 12));
         }
 
         private void AssertReferencedIsUnmanagedAttribute(Accessibility accessibility, ImmutableArray<CSharpAttributeData> attributes, string assemblyName)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -13,6 +13,8 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
+    // PROTOTYPE: check tests here
+
     public class AttributeTests_RefReadOnly : CSharpTestBase
     {
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_RefReadOnly.cs
@@ -13,8 +13,6 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    // PROTOTYPE: check tests here
-
     public class AttributeTests_RefReadOnly : CSharpTestBase
     {
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
@@ -10,8 +10,6 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 {
-    // PROTOTYPE: check tests here
-
     public class InAttributeModifierTests : CSharpTestBase
     {
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/InAttributeModifierTests.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 {
+    // PROTOTYPE: check tests here
+
     public class InAttributeModifierTests : CSharpTestBase
     {
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
@@ -1,0 +1,640 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
+{
+    public class UnmanagedTypeModifierTests : CSharpTestBase
+    {
+        [Fact]
+        public void LoadingADifferentModifierTypeForUnmanagedConstraint()
+        {
+            var ilSource = IsUnmanagedAttributeIL + @"
+.class public auto ansi beforefieldinit TestRef
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig instance void
+          M1<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M1
+
+  .method public hidebysig instance void
+          M2<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.InAttribute)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M2
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method TestRef::.ctor
+
+}";
+
+            var reference = CompileIL(ilSource, prependDefaultHeader: false);
+
+            var code = @"
+public class Test
+{
+    public static void Main()
+    {
+        var obj = new TestRef();
+
+        obj.M1<int>();      // valid
+        obj.M2<int>();      // invalid
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'TestRef.M2<T>()'. There is no boxing conversion from 'int' to '?'.
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "obj.M2<int>").WithArguments("TestRef.M2<T>()", "?", "T", "int").WithLocation(9, 9),
+                // (9,9): error CS0570: 'T' is not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BindToBogus, "obj.M2<int>").WithArguments("T").WithLocation(9, 9),
+                // (9,9): error CS0648: '' is a type not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BogusType, "obj.M2<int>").WithArguments("").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void LoadingUnmanagedTypeModifier_OptionalIsError()
+        {
+            var ilSource = IsUnmanagedAttributeIL + @"
+.class public auto ansi beforefieldinit TestRef
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig instance void
+          M1<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M1
+
+  .method public hidebysig instance void
+          M2<valuetype .ctor (class [mscorlib]System.ValueType modopt([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M2
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method TestRef::.ctor
+
+}";
+
+            var reference = CompileIL(ilSource, prependDefaultHeader: false);
+
+            var code = @"
+public class Test
+{
+    public static void Main()
+    {
+        var obj = new TestRef();
+
+        obj.M1<int>();      // valid
+        obj.M2<int>();      // invalid
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,9): error CS0570: 'T' is not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BindToBogus, "obj.M2<int>").WithArguments("T").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void LoadingUnmanagedTypeModifier_ModreqWithoutAttribute()
+        {
+            var ilSource = IsUnmanagedAttributeIL + @"
+.class public auto ansi beforefieldinit TestRef
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig instance void
+          M1<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M1
+
+  .method public hidebysig instance void
+          M2<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M2
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method TestRef::.ctor
+
+}";
+
+            var reference = CompileIL(ilSource, prependDefaultHeader: false);
+
+            var code = @"
+public class Test
+{
+    public static void Main()
+    {
+        var obj = new TestRef();
+
+        obj.M1<int>();      // valid
+        obj.M2<int>();      // invalid
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,9): error CS0570: 'T' is not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BindToBogus, "obj.M2<int>").WithArguments("T").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void LoadingUnmanagedTypeModifier_AttributeWithoutModreq()
+        {
+            var ilSource = IsUnmanagedAttributeIL + @"
+.class public auto ansi beforefieldinit TestRef
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig instance void
+          M1<valuetype .ctor (class [mscorlib]System.ValueType modreq([mscorlib]System.Runtime.InteropServices.UnmanagedType)) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M1
+
+  .method public hidebysig instance void
+          M2<valuetype .ctor (class [mscorlib]System.ValueType) T>() cil managed
+  {
+    .param type T
+    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor() = ( 01 00 00 00 )
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method TestRef::M2
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method TestRef::.ctor
+
+}";
+
+            var reference = CompileIL(ilSource, prependDefaultHeader: false);
+
+            var code = @"
+public class Test
+{
+    public static void Main()
+    {
+        var obj = new TestRef();
+
+        obj.M1<int>();      // valid
+        obj.M2<int>();      // invalid
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (9,9): error CS0570: 'T' is not supported by the language
+                //         obj.M2<int>();      // invalid
+                Diagnostic(ErrorCode.ERR_BindToBogus, "obj.M2<int>").WithArguments("T").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void ProperErrorsArePropagatedIfModreqTypeIsNotAvailable_Class()
+        {
+            var code = @"
+namespace System
+{
+    public class Object {}
+    public class Void {}
+    public class ValueType {}
+}
+class Test<T> where T : unmanaged
+{
+}";
+
+            CreateCompilation(code).VerifyDiagnostics(
+                // (8,25): error CS0518: Predefined type 'System.Runtime.InteropServices.UnmanagedType' is not defined or imported
+                // class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.InteropServices.UnmanagedType").WithLocation(8, 25));
+        }
+
+        [Fact]
+        public void ProperErrorsArePropagatedIfModreqTypeIsNotAvailable_Method()
+        {
+            var code = @"
+namespace System
+{
+    public class Object {}
+    public class Void {}
+    public class ValueType {}
+}
+class Test
+{
+    public void M<T>() where T : unmanaged {}
+}";
+
+            CreateCompilation(code).VerifyDiagnostics(
+                // (10,34): error CS0518: Predefined type 'System.Runtime.InteropServices.UnmanagedType' is not defined or imported
+                //     public void M<T>() where T : unmanaged {}
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.InteropServices.UnmanagedType").WithLocation(10, 34));
+        }
+
+        [Fact]
+        public void ProperErrorsArePropagatedIfValueTypeIsNotAvailable_Class()
+        {
+            var code = @"
+namespace System
+{
+    public class Object {}
+    public class Void {}
+
+    namespace Runtime
+    {
+        namespace InteropServices
+        {
+            public class UnmanagedType {}
+        }
+    }
+}
+class Test<T> where T : unmanaged
+{
+}";
+
+            CreateCompilation(code).VerifyDiagnostics(
+                // (15,25): error CS0518: Predefined type 'System.ValueType' is not defined or imported
+                // class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.ValueType").WithLocation(15, 25));
+        }
+
+        [Fact]
+        public void ProperErrorsArePropagatedIfValueTypeIsNotAvailable_Method()
+        {
+            var code = @"
+namespace System
+{
+    public class Object {}
+    public class Void {}
+
+    namespace Runtime
+    {
+        namespace InteropServices
+        {
+            public class UnmanagedType {}
+        }
+    }
+}
+class Test
+{
+    public void M<T>() where T : unmanaged {}
+}";
+
+            CreateCompilation(code).VerifyDiagnostics(
+                // (17,34): error CS0518: Predefined type 'System.ValueType' is not defined or imported
+                //     public void M<T>() where T : unmanaged {}
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.ValueType").WithLocation(17, 34));
+        }
+
+        [Fact]
+        public void UnmanagedTypeModreqIsCopiedToOverrides_Virtual()
+        {
+            var parent = CompileAndVerify(@"
+public class Parent
+{
+    public virtual string M<T>() where T : unmanaged => ""Parent"";
+}", symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+
+            var child = CompileAndVerify(@"
+public class Child : Parent
+{
+    public override string M<T>() => ""Child"";
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+            CompileAndVerify(@"
+class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(new Parent().M<int>());
+        System.Console.WriteLine(new Child().M<int>());
+    }
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference(), child.Compilation.EmitToImageReference() }, expectedOutput: @"
+Parent
+Child");
+        }
+
+        [Fact]
+        public void UnmanagedTypeModreqIsCopiedToOverrides_Abstract()
+        {
+            var parent = CompileAndVerify(@"
+public abstract class Parent
+{
+    public abstract string M<T>() where T : unmanaged;
+}", symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+
+            var child = CompileAndVerify(@"
+public class Child : Parent
+{
+    public override string M<T>() => ""Child"";
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+            CompileAndVerify(@"
+class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(new Child().M<int>());
+    }
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference(), child.Compilation.EmitToImageReference() }, expectedOutput: "Child");
+        }
+
+        [Fact]
+        public void UnmanagedTypeModreqIsCopiedToOverrides_Interface_Implicit_Nonvirtual()
+        {
+            var parent = CompileAndVerify(@"
+public interface Parent
+{
+    string M<T>() where T : unmanaged;
+}", symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+
+            var child = CompileAndVerify(@"
+public class Child : Parent
+{
+    public string M<T>() where T : unmanaged => ""Child"";
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+            CompileAndVerify(@"
+class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(new Child().M<int>());
+    }
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference(), child.Compilation.EmitToImageReference() }, expectedOutput: "Child");
+        }
+
+        [Fact]
+        public void UnmanagedTypeModreqIsCopiedToOverrides_Interface_Implicit_Virtual()
+        {
+            var parent = CompileAndVerify(@"
+public interface Parent
+{
+    string M<T>() where T : unmanaged;
+}", symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+
+            var child = CompileAndVerify(@"
+public class Child : Parent
+{
+    public virtual string M<T>() where T : unmanaged => ""Child"";
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+            CompileAndVerify(@"
+class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(new Child().M<int>());
+    }
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference(), child.Compilation.EmitToImageReference() }, expectedOutput: "Child");
+        }
+
+        [Fact]
+        public void UnmanagedTypeModreqIsCopiedToOverrides_Interface_Explicit()
+        {
+            var parent = CompileAndVerify(@"
+public interface Parent
+{
+    string M<T>() where T : unmanaged;
+}", symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Parent").GetMethod("M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+
+            var child = CompileAndVerify(@"
+public class Child : Parent
+{
+    string Parent.M<T>() => ""Child"";
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference() }, symbolValidator: module =>
+            {
+                var typeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("Parent.M").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasUnmanagedTypeConstraint);
+
+                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+            });
+
+            CompileAndVerify(@"
+class Program
+{
+    public static void Main()
+    {
+        Parent obj = new Child();
+        System.Console.WriteLine(obj.M<int>());
+    }
+}", additionalRefs: new[] { parent.Compilation.EmitToImageReference(), child.Compilation.EmitToImageReference() }, expectedOutput: "Child");
+        }
+
+        [Fact]
+        public void DuplicateUnmanagedTypeInReferences()
+        {
+            var refCode = @"
+namespace System.Runtime.InteropServices
+{
+    public class UnmanagedType {}
+}";
+
+            var ref1 = CreateStandardCompilation(refCode).EmitToImageReference();
+            var ref2 = CreateStandardCompilation(refCode).EmitToImageReference();
+
+            var user = @"
+public class Test<T> where T : unmanaged
+{
+}";
+
+            CreateStandardCompilation(user, references: new[] { ref1, ref2 }).VerifyDiagnostics(
+                // (2,32): error CS0518: Predefined type 'System.Runtime.InteropServices.UnmanagedType' is not defined or imported
+                // public class Test<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "unmanaged").WithArguments("System.Runtime.InteropServices.UnmanagedType").WithLocation(2, 32));
+        }
+        
+        private const string IsUnmanagedAttributeIL = @"
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly Test
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78 63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module Test.dll
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003
+.corflags 0x00000001
+
+.class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
+       extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  }
+}
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.IsUnmanagedAttribute
+       extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  }
+}
+";
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/UnmanagedTypeModifierTests.cs
@@ -415,13 +415,13 @@ public class Child : Parent
                 Assert.True(parentTypeParameter.HasValueTypeConstraint);
                 Assert.True(parentTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", parentTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, parentTypeParameter, module.ContainingAssembly.Name);
 
                 var childTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
                 Assert.True(childTypeParameter.HasValueTypeConstraint);
                 Assert.True(childTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", childTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, childTypeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -450,7 +450,7 @@ public class Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -464,7 +464,7 @@ public class Child : Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -497,13 +497,13 @@ public class Child : Parent
                 Assert.True(parentTypeParameter.HasValueTypeConstraint);
                 Assert.True(parentTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", parentTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, parentTypeParameter, module.ContainingAssembly.Name);
 
                 var childTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
                 Assert.True(childTypeParameter.HasValueTypeConstraint);
                 Assert.True(childTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", childTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, childTypeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -529,7 +529,7 @@ public abstract class Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -543,7 +543,7 @@ public class Child : Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -573,13 +573,13 @@ public class Child : Parent
                 Assert.True(parentTypeParameter.HasValueTypeConstraint);
                 Assert.True(parentTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", parentTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, parentTypeParameter, module.ContainingAssembly.Name);
 
                 var childTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
                 Assert.True(childTypeParameter.HasValueTypeConstraint);
                 Assert.True(childTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", childTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, childTypeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -605,7 +605,7 @@ public interface Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -619,7 +619,7 @@ public class Child : Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -649,13 +649,13 @@ public class Child : Parent
                 Assert.True(parentTypeParameter.HasValueTypeConstraint);
                 Assert.True(parentTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", parentTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, parentTypeParameter, module.ContainingAssembly.Name);
 
                 var childTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("M").TypeParameters.Single();
                 Assert.True(childTypeParameter.HasValueTypeConstraint);
                 Assert.True(childTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", childTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, childTypeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -681,7 +681,7 @@ public interface Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -695,7 +695,7 @@ public class Child : Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -725,13 +725,13 @@ public class Child : Parent
                 Assert.True(parentTypeParameter.HasValueTypeConstraint);
                 Assert.True(parentTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", parentTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, parentTypeParameter, module.ContainingAssembly.Name);
 
                 var childTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Child").GetMethod("Parent.M").TypeParameters.Single();
                 Assert.True(childTypeParameter.HasValueTypeConstraint);
                 Assert.True(childTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", childTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, childTypeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -758,7 +758,7 @@ public interface Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -772,7 +772,7 @@ public class Child : Parent
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
             CompileAndVerify(@"
@@ -818,13 +818,13 @@ public class Program
                 Assert.True(delegateTypeParameter.HasValueTypeConstraint);
                 Assert.True(delegateTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", delegateTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, delegateTypeParameter, module.ContainingAssembly.Name);
 
                 var lambdaTypeParameter = module.ContainingAssembly.GetTypeByMetadataName("Program").GetTypeMember("<>c__DisplayClass0_0").TypeParameters.Single();
                 Assert.True(lambdaTypeParameter.HasValueTypeConstraint);
                 Assert.True(lambdaTypeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", lambdaTypeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, lambdaTypeParameter, module.ContainingAssembly.Name);
             });
         }
 
@@ -845,7 +845,7 @@ public class TestRef
                 Assert.True(typeParameter.HasValueTypeConstraint);
                 Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
             });
 
 
@@ -871,7 +871,7 @@ public class Program
                     Assert.True(typeParameter.HasValueTypeConstraint);
                     Assert.True(typeParameter.HasUnmanagedTypeConstraint);
 
-                    Assert.Equal("IsUnmanagedAttribute", typeParameter.GetAttributes().Single().AttributeClass.Name);
+                    AttributeTests_IsUnmanaged.AssertReferencedIsUnmanagedAttribute(Accessibility.Internal, typeParameter, module.ContainingAssembly.Name);
                 });
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/GenericConstraintsTests.cs
@@ -1539,5 +1539,540 @@ class B<T> : A<T> where T : System.Delegate { }";
                 // class B<T> : A<T> where T : System.Delegate { }
                 Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "B").WithArguments("A<T>", "System.MulticastDelegate", "T", "T").WithLocation(3, 7));
         }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_Alone()
+        {
+            CreateStandardCompilation(@"
+public class Test<T> where T : unmanaged
+{
+}
+public struct GoodType { public int I; }
+public struct BadType { public string S; }
+public class Test2
+{
+    public void M<U>() where U : unmanaged
+    {
+        var a = new Test<GoodType>();           // unmanaged struct
+        var b = new Test<BadType>();            // managed struct
+        var c = new Test<string>();             // reference type
+        var d = new Test<int>();                // value type
+        var e = new Test<U>();                  // generic type constrained to unmanaged
+    }
+}").VerifyDiagnostics(
+                // (12,26): error CS8375: The type 'BadType' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var b = new Test<BadType>();            // managed struct
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, "BadType").WithArguments("Test<T>", "T", "BadType").WithLocation(12, 26),
+                // (13,26): error CS8375: The type 'string' cannot be a reference type, or contain reference type fields at any level of nesting, in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var c = new Test<string>();             // reference type
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintNotSatisfied, "string").WithArguments("Test<T>", "T", "string").WithLocation(13, 26));
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_ReferenceType()
+        {
+            CreateStandardCompilation("public class Test<T> where T : class, unmanaged {}").VerifyDiagnostics(
+                // (1,39): error CS8374: The 'unmanaged' constraint cannot be specified with other constraints.
+                // public class Test<T> where T : class, unmanaged {}
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, "unmanaged").WithLocation(1, 39));
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_ValueType()
+        {
+            CreateStandardCompilation("public class Test<T> where T : struct, unmanaged {}").VerifyDiagnostics(
+                // (1,40): error CS8374: The 'unmanaged' constraint cannot be specified with other constraints.
+                // public class Test<T> where T : struct, unmanaged {}
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, "unmanaged").WithLocation(1, 40));
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_Constructor()
+        {
+            CreateStandardCompilation("public class Test<T> where T : unmanaged, new() {}").VerifyDiagnostics(
+                // (1,43): error CS8373: The 'new()' constraint cannot be used with the 'unmanaged' constraint
+                // public class Test<T> where T : unmanaged, new() {}
+                Diagnostic(ErrorCode.ERR_NewBoundWithUnmanaged, "new").WithLocation(1, 43));
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_AnotherType_Before()
+        {
+            CreateStandardCompilation("public class Test<T> where T : unmanaged, System.Exception { }").VerifyDiagnostics(
+                // (1,43): error CS8374: The 'unmanaged' constraint cannot be specified with other constraints.
+                // public class Test<T> where T : unmanaged, System.Exception { }
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, "System.Exception").WithLocation(1, 43));
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Compilation_AnotherType_After()
+        {
+            CreateStandardCompilation("public class Test<T> where T : System.Exception, unmanaged { }").VerifyDiagnostics(
+                // (1,50): error CS8374: The 'unmanaged' constraint cannot be specified with other constraints.
+                // public class Test<T> where T : System.Exception, unmanaged { }
+                Diagnostic(ErrorCode.ERR_UnmanagedConstraintMustBeAlone, "unmanaged").WithLocation(1, 50));
+        }
+
+        /*
+        [Fact]
+        public void EnumConstraint_Reference_Alone()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test<T> where T : System.Enum
+{
+}"
+                ).EmitToImageReference();
+
+            var code = @"
+public enum E1
+{
+    A
+}
+
+public class Test2
+{
+    public void M<U>() where U : System.Enum
+    {
+        var a = new Test<E1>();             // enum
+        var b = new Test<int>();            // value type
+        var c = new Test<string>();         // reference type
+        var d = new Test<System.Enum>();    // Enum type
+        var e = new Test<U>();              // Generic type constrained to enum
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (12,26): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         var b = new Test<int>();            // value type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "int").WithArguments("Test<T>", "System.Enum", "T", "int").WithLocation(12, 26),
+                // (13,26): error CS0311: The type 'string' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no implicit reference conversion from 'string' to 'System.Enum'.
+                //         var c = new Test<string>();         // reference type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "string").WithArguments("Test<T>", "System.Enum", "T", "string").WithLocation(13, 26));
+        }
+
+        [Fact]
+        public void EnumConstraint_Reference_ReferenceType()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test<T> where T : class, System.Enum
+{
+}"
+                ).EmitToImageReference();
+
+            var code = @"
+public enum E1
+{
+    A
+}
+
+public class Test2
+{
+    public void M<U>() where U : class, System.Enum
+    {
+        var a = new Test<E1>();             // enum
+        var b = new Test<int>();            // value type
+        var c = new Test<string>();         // reference type
+        var d = new Test<System.Enum>();    // Enum type
+        var e = new Test<U>();              // Generic type constrained to enum
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (11,26): error CS0452: The type 'E1' must be a reference type in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var a = new Test<E1>();             // enum
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "E1").WithArguments("Test<T>", "T", "E1").WithLocation(11, 26),
+                // (12,26): error CS0452: The type 'int' must be a reference type in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var b = new Test<int>();            // value type
+                Diagnostic(ErrorCode.ERR_RefConstraintNotSatisfied, "int").WithArguments("Test<T>", "T", "int").WithLocation(12, 26),
+                // (13,26): error CS0311: The type 'string' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no implicit reference conversion from 'string' to 'System.Enum'.
+                //         var c = new Test<string>();         // reference type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "string").WithArguments("Test<T>", "System.Enum", "T", "string").WithLocation(13, 26));
+        }
+
+        [Fact]
+        public void EnumConstraint_Reference_ValueType()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test<T> where T : struct, System.Enum
+{
+}"
+                ).EmitToImageReference();
+
+            var code = @"
+public enum E1
+{
+    A
+}
+
+public class Test2
+{
+    public void M<U>() where U : struct, System.Enum
+    {
+        var a = new Test<E1>();             // enum
+        var b = new Test<int>();            // value type
+        var c = new Test<string>();         // reference type
+        var d = new Test<System.Enum>();    // Enum type
+        var e = new Test<U>();              // Generic type constrained to enum
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (12,26): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         var b = new Test<int>();            // value type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "int").WithArguments("Test<T>", "System.Enum", "T", "int").WithLocation(12, 26),
+                // (13,26): error CS0453: The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var c = new Test<string>();         // reference type
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "string").WithArguments("Test<T>", "T", "string").WithLocation(13, 26),
+                // (14,26): error CS0453: The type 'Enum' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var d = new Test<System.Enum>();    // Enum type
+                Diagnostic(ErrorCode.ERR_ValConstraintNotSatisfied, "System.Enum").WithArguments("Test<T>", "T", "System.Enum").WithLocation(14, 26));
+        }
+
+        [Fact]
+        public void EnumConstraint_Reference_Constructor()
+        {
+            var reference = CreateStandardCompilation(@"
+public class Test<T> where T : System.Enum, new()
+{
+}"
+                ).EmitToImageReference();
+
+            var code = @"
+public enum E1
+{
+    A
+}
+
+public class Test2
+{
+    public void M<U>() where U : System.Enum, new()
+    {
+        var a = new Test<E1>();             // enum
+        var b = new Test<int>();            // value type
+        var c = new Test<string>();         // reference type
+        var d = new Test<System.Enum>();    // Enum type
+        var e = new Test<U>();              // Generic type constrained to enum
+    }
+}";
+
+            CreateStandardCompilation(code, references: new[] { reference }).VerifyDiagnostics(
+                // (12,26): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         var b = new Test<int>();            // value type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "int").WithArguments("Test<T>", "System.Enum", "T", "int").WithLocation(12, 26),
+                // (13,26): error CS0311: The type 'string' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no implicit reference conversion from 'string' to 'System.Enum'.
+                //         var c = new Test<string>();         // reference type
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "string").WithArguments("Test<T>", "System.Enum", "T", "string").WithLocation(13, 26),
+                // (13,26): error CS0310: 'string' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var c = new Test<string>();         // reference type
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "string").WithArguments("Test<T>", "T", "string").WithLocation(13, 26),
+                // (14,26): error CS0310: 'Enum' must be a non-abstract type with a public parameterless constructor in order to use it as parameter 'T' in the generic type or method 'Test<T>'
+                //         var d = new Test<System.Enum>();    // Enum type
+                Diagnostic(ErrorCode.ERR_NewConstraintNotSatisfied, "System.Enum").WithArguments("Test<T>", "T", "System.Enum").WithLocation(14, 26));
+        }
+
+        [Fact]
+        public void EnumConstraint_Before_7_3()
+        {
+            var code = @"
+public class Test<T> where T : System.Enum
+{
+}";
+
+            CreateStandardCompilation(code, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp7_2)).VerifyDiagnostics(
+                // (2,32): error CS8320: Feature 'enum generic type constraints' is not available in C# 7.2. Please use language version 7.3 or greater.
+                // public class Test<T> where T : System.Enum
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_2, "System.Enum").WithArguments("enum generic type constraints", "7.3").WithLocation(2, 32));
+        }
+
+        [Theory]
+        [InlineData("byte")]
+        [InlineData("sbyte")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        public void EnumConstraint_DifferentBaseTypes(string type)
+        {
+            CreateStandardCompilation($@"
+public class Test<T> where T : System.Enum
+{{
+}}
+public enum E1 : {type}
+{{
+    A
+}}
+public class Test2
+{{
+    public void M()
+    {{
+        var a = new Test<E1>();     // Valid
+        var b = new Test<int>();    // Invalid
+    }}
+}}
+").VerifyDiagnostics(
+                // (14,26): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'Test<T>'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         var b = new Test<int>();    // Invalid
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "int").WithArguments("Test<T>", "System.Enum", "T", "int").WithLocation(14, 26));
+        }
+
+        [Fact]
+        public void EnumConstraint_InheritanceChain()
+        {
+            CreateStandardCompilation(@"
+public enum E
+{
+    A
+}
+public class Test<T, U> where U : System.Enum, T
+{
+}
+public class Test2
+{
+    public void M()
+    {
+        var a = new Test<Test2, E>();
+
+        var b = new Test<E, E>();
+        var c = new Test<System.Enum, System.Enum>();
+
+        var d = new Test<E, System.Enum>();
+        var e = new Test<System.Enum, E>();
+    }
+}").VerifyDiagnostics(
+                // (13,33): error CS0315: The type 'E' cannot be used as type parameter 'U' in the generic type or method 'Test<T, U>'. There is no boxing conversion from 'E' to 'Test2'.
+                //         var a = new Test<Test2, E>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "E").WithArguments("Test<T, U>", "Test2", "U", "E").WithLocation(13, 33),
+                // (18,29): error CS0311: The type 'System.Enum' cannot be used as type parameter 'U' in the generic type or method 'Test<T, U>'. There is no implicit reference conversion from 'System.Enum' to 'E'.
+                //         var d = new Test<E, System.Enum>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "System.Enum").WithArguments("Test<T, U>", "E", "U", "System.Enum").WithLocation(18, 29));
+        }
+
+        [Fact]
+        public void EnumConstraint_IsReflectedinSymbols_Alone()
+        {
+            var code = "public class Test<T> where T : System.Enum { }";
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var typeParameter = module.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
+                Assert.False(typeParameter.HasValueTypeConstraint);
+                Assert.False(typeParameter.HasReferenceTypeConstraint);
+                Assert.Equal(SpecialType.System_Enum, typeParameter.ConstraintTypes().Single().SpecialType);
+            };
+
+            CompileAndVerify(code, sourceSymbolValidator: validator, symbolValidator: validator);
+        }
+
+        [Fact]
+        public void EnumConstraint_IsReflectedinSymbols_ValueType()
+        {
+            var code = "public class Test<T> where T : struct, System.Enum { }";
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var typeParameter = module.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
+                Assert.True(typeParameter.HasValueTypeConstraint);
+                Assert.False(typeParameter.HasReferenceTypeConstraint);
+                Assert.False(typeParameter.HasConstructorConstraint);
+                Assert.Equal(SpecialType.System_Enum, typeParameter.ConstraintTypes().Single().SpecialType);
+            };
+
+            CompileAndVerify(code, sourceSymbolValidator: validator, symbolValidator: validator);
+        }
+
+        [Fact]
+        public void EnumConstraint_IsReflectedinSymbols_ReferenceType()
+        {
+            var code = "public class Test<T> where T : class, System.Enum { }";
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var typeParameter = module.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
+                Assert.False(typeParameter.HasValueTypeConstraint);
+                Assert.True(typeParameter.HasReferenceTypeConstraint);
+                Assert.False(typeParameter.HasConstructorConstraint);
+                Assert.Equal(SpecialType.System_Enum, typeParameter.ConstraintTypes().Single().SpecialType);
+            };
+
+            CompileAndVerify(code, sourceSymbolValidator: validator, symbolValidator: validator);
+        }
+
+        [Fact]
+        public void EnumConstraint_IsReflectedinSymbols_Constructor()
+        {
+            var code = "public class Test<T> where T : System.Enum, new() { }";
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var typeParameter = module.GlobalNamespace.GetTypeMember("Test").TypeParameters.Single();
+                Assert.False(typeParameter.HasValueTypeConstraint);
+                Assert.False(typeParameter.HasReferenceTypeConstraint);
+                Assert.True(typeParameter.HasConstructorConstraint);
+                Assert.Equal(SpecialType.System_Enum, typeParameter.ConstraintTypes().Single().SpecialType);
+            };
+
+            CompileAndVerify(code, sourceSymbolValidator: validator, symbolValidator: validator);
+        }
+
+        [Fact]
+        public void EnumConstraint_EnforcedInInheritanceChain_Downwards_Source()
+        {
+            CreateStandardCompilation(@"
+public abstract class A
+{
+    public abstract void M<T>() where T : System.Enum;
+}
+public class B : A
+{
+    public override void M<T>() { }
+
+    public void Test()
+    {
+        this.M<int>();
+        this.M<E>();
+    }
+}
+public enum E
+{
+}").VerifyDiagnostics(
+                // (12,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'B.M<T>()'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         this.M<int>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "this.M<int>").WithArguments("B.M<T>()", "System.Enum", "T", "int").WithLocation(12, 9));
+        }
+
+        [Fact]
+        public void EnumConstraint_EnforcedInInheritanceChain_Downwards_Reference()
+        {
+            var reference = CreateStandardCompilation(@"
+public abstract class A
+{
+    public abstract void M<T>() where T : System.Enum;
+}").EmitToImageReference();
+
+            CreateStandardCompilation(@"
+public class B : A
+{
+    public override void M<T>() { }
+
+    public void Test()
+    {
+        this.M<int>();
+        this.M<E>();
+    }
+}
+public enum E
+{
+}", references: new[] { reference }).VerifyDiagnostics(
+                // (8,9): error CS0315: The type 'int' cannot be used as type parameter 'T' in the generic type or method 'B.M<T>()'. There is no boxing conversion from 'int' to 'System.Enum'.
+                //         this.M<int>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedValType, "this.M<int>").WithArguments("B.M<T>()", "System.Enum", "T", "int").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void EnumConstraint_EnforcedInInheritanceChain_Upwards_Source()
+        {
+            CreateStandardCompilation(@"
+public abstract class A
+{
+    public abstract void M<T>();
+}
+public class B : A
+{
+    public override void M<T>() where T : System.Enum { }
+}").VerifyDiagnostics(
+                // (8,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                //     public override void M<T>() where T : System.Enum { }
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(8, 33));
+        }
+
+        [Fact]
+        public void EnumConstraint_EnforcedInInheritanceChain_Upwards_Reference()
+        {
+            var reference = CreateStandardCompilation(@"
+public abstract class A
+{
+    public abstract void M<T>();
+}").EmitToImageReference();
+
+            CreateStandardCompilation(@"
+public class B : A
+{
+    public override void M<T>() where T : System.Enum { }
+}", references: new[] { reference }).VerifyDiagnostics(
+                // (4,33): error CS0460: Constraints for override and explicit interface implementation methods are inherited from the base method, so they cannot be specified directly
+                //     public override void M<T>() where T : System.Enum { }
+                Diagnostic(ErrorCode.ERR_OverrideWithConstraints, "where").WithLocation(4, 33));
+        }
+
+        [Fact]
+        public void EnumConstraint_ResolveParentConstraints()
+        {
+            var comp = CreateStandardCompilation(@"
+public enum MyEnum
+{
+}
+public abstract class A<T>
+{
+    public abstract void F<U>() where U : System.Enum, T;
+}
+public class B : A<MyEnum>
+{
+    public override void F<U>() { }
+}");
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var method = module.GlobalNamespace.GetTypeMember("B").GetMethod("F");
+                var constraintTypeNames = method.TypeParameters.Single().ConstraintTypes().Select(type => type.ToTestDisplayString());
+
+                AssertEx.SetEqual(new[] { "System.Enum", "MyEnum" }, constraintTypeNames);
+            };
+
+            CompileAndVerify(comp, sourceSymbolValidator: validator, symbolValidator: validator);
+        }
+
+        [Fact]
+        public void EnumConstraint_TypeNotAvailable()
+        {
+            CreateCompilation(@"
+namespace System
+{
+    public class Object {}
+    public class Void {}
+}
+public class Test<T> where T : System.Enum
+{
+}").VerifyDiagnostics(
+                // (7,39): error CS0234: The type or namespace name 'Enum' does not exist in the namespace 'System' (are you missing an assembly reference?)
+                // public class Test<T> where T : System.Enum
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "Enum").WithArguments("Enum", "System").WithLocation(7, 39));
+        }
+
+        [Fact]
+        public void EnumConstraint_BindingToMethods()
+        {
+            var code = @"
+enum A : short { a }
+enum B : uint { b }
+class Test
+{
+    public static void Main()
+    {
+        Print(A.a);
+        Print(B.b);
+    }
+    static void Print<T>(T obj) where T : System.Enum
+    {
+        System.Console.WriteLine(obj.GetTypeCode());
+    }
+}";
+
+            CompileAndVerify(code, expectedOutput: @"
+Int16
+UInt32");
+        }
+    */
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -642,6 +642,11 @@ public class Test
         public void MissingIDisposable()
         {
             var source = @"
+namespace System
+{
+    public class Object { }
+    public class Void { }
+}
 class C
 {
     void M()
@@ -651,30 +656,12 @@ class C
 }";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // Related to the using statement:
-
-                // (6,30): warning CS0642: Possible mistaken empty statement
+                // (11,20): error CS0815: Cannot assign <null> to an implicitly-typed variable
                 //         using (var v = null) ;
-                Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";"),
-
-                // Cascading from the lack of mscorlib:
-
-                // (2,7): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // class C
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "C").WithArguments("System.Object"),
-                // (4,5): error CS0518: Predefined type 'System.Void' is not defined or imported
-                //     void M()
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "void").WithArguments("System.Void"),
-                // (6,16): error CS0518: Predefined type 'System.Object' is not defined or imported
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "v = null").WithArguments("<null>").WithLocation(11, 20),
+                // (11,30): warning CS0642: Possible mistaken empty statement
                 //         using (var v = null) ;
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "var").WithArguments("System.Object"),
-                // (6,20): error CS0815: Cannot assign <null> to an implicitly-typed variable
-                //         using (var v = null) ;
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, "v = null").WithArguments("<null>"),
-                // (2,7): error CS1729: 'object' does not contain a constructor that takes 0 arguments
-                // class C
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "C").WithArguments("object", "0")
-                );
+                Diagnostic(ErrorCode.WRN_PossibleMistakenNullStatement, ";").WithLocation(11, 30));
         }
 
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -562,6 +562,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute:
                     case WellKnownType.System_Span_T:
                     case WellKnownType.System_ReadOnlySpan_T:
+                    case WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute:
                     // Not yet in the platform.
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
                         // Not always available.
@@ -871,6 +872,7 @@ namespace System
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles:
                     case WellKnownMember.System_Runtime_CompilerServices_IsReadOnlyAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor:
                         // Not always available.
                         continue;
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -853,24 +853,26 @@ interface IB<T>
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (2,15): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //     where U : T*
                 Diagnostic(ErrorCode.ERR_BadConstraintType, "T*").WithLocation(2, 15),
                 // (3,15): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //     where V : T[]
                 Diagnostic(ErrorCode.ERR_BadConstraintType, "T[]").WithLocation(3, 15),
                 // (9,19): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //         where U : T*
                 Diagnostic(ErrorCode.ERR_BadConstraintType, "T*").WithLocation(9, 19),
                 // (10,19): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                //         where V : T[];
                 Diagnostic(ErrorCode.ERR_BadConstraintType, "T[]").WithLocation(10, 19),
 
                 // CONSIDER: Dev10 doesn't report these cascading errors.
 
                 // (2,15): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "T*"),
-                // (2,15): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('T')
-                Diagnostic(ErrorCode.ERR_ManagedAddr, "T*").WithArguments("T"),
+                //     where U : T*
+                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "T*").WithLocation(2, 15),
                 // (9,19): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "T*"),
-                // (9,19): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('T')
-                Diagnostic(ErrorCode.ERR_ManagedAddr, "T*").WithArguments("T"));
+                //         where U : T*
+                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "T*").WithLocation(9, 19));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -889,7 +888,7 @@ namespace Microsoft.CodeAnalysis
                         try
                         {
                             var memoryReader = this.Module.GetTypeSpecificationSignatureReaderOrThrow((TypeSpecificationHandle)token);
-                            DecodeModifiersOrThrow(ref memoryReader, AllowedRequiredModifierType.System_Runtime_InteropServices_UnmanagedType, out var typeCode, out var modReqFound);
+                            var modifiers = DecodeModifiersOrThrow(ref memoryReader, AllowedRequiredModifierType.System_Runtime_InteropServices_UnmanagedType, out var typeCode, out var modReqFound);
                             var type = DecodeTypeOrThrow(ref memoryReader, typeCode, out _);
 
                             if (modReqFound)
@@ -902,6 +901,12 @@ namespace Microsoft.CodeAnalysis
                                 {
                                     return GetUnsupportedMetadataTypeSymbol();
                                 }
+                            }
+                            else if (!modifiers.IsDefaultOrEmpty)
+                            {
+                                // Optional modifiers (also, other required parameters) not allowed on generic parameters
+                                // http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528856
+                                return GetUnsupportedMetadataTypeSymbol();
                             }
 
                             return type;

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -889,10 +889,10 @@ namespace Microsoft.CodeAnalysis
                         try
                         {
                             var memoryReader = this.Module.GetTypeSpecificationSignatureReaderOrThrow((TypeSpecificationHandle)token);
-                            DecodeModifiersOrThrow(ref memoryReader, AllowedRequiredModifierType.System_Runtime_InteropServices_UnmanagedType, out var typeCode, out var requiredModifierFound);
+                            DecodeModifiersOrThrow(ref memoryReader, AllowedRequiredModifierType.System_Runtime_InteropServices_UnmanagedType, out var typeCode, out var modReqFound);
                             var type = DecodeTypeOrThrow(ref memoryReader, typeCode, out _);
 
-                            if (requiredModifierFound)
+                            if (modReqFound)
                             {
                                 if (type.SpecialType == SpecialType.System_ValueType)
                                 {

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -944,6 +944,11 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, AttributeDescription.IsReadOnlyAttribute).HasValue;
         }
 
+        internal bool HasIsUnmanagedAttribute(EntityHandle token)
+        {
+            return FindTargetAttribute(token, AttributeDescription.IsUnmanagedAttribute).HasValue;
+        }
+
         internal bool HasExtensionAttribute(EntityHandle token, bool ignoreCase)
         {
             return FindTargetAttribute(token, ignoreCase ? AttributeDescription.CaseInsensitiveExtensionAttribute : AttributeDescription.CaseSensitiveExtensionAttribute).HasValue;

--- a/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract bool IsAcceptedVolatileModifierType(ModuleSymbol moduleSymbol, TypeSymbol type);
         internal abstract bool IsAcceptedInAttributeModifierType(TypeSymbol type);
+        internal abstract bool IsAcceptedUnmanagedTypeModifierType(TypeSymbol type);
+        
         internal abstract Cci.PrimitiveTypeCode GetPrimitiveTypeCode(ModuleSymbol moduleSymbol, TypeSymbol type);
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -98,6 +98,11 @@ namespace Microsoft.CodeAnalysis
             return _factory.IsAcceptedInAttributeModifierType(type);
         }
 
+        protected bool IsAcceptedUnmanagedTypeModifierType(TypeSymbol type)
+        {
+            return _factory.IsAcceptedUnmanagedTypeModifierType(type);
+        }
+
         protected Microsoft.Cci.PrimitiveTypeCode GetPrimitiveTypeCode(TypeSymbol type)
         {
             return _factory.GetPrimitiveTypeCode(this.moduleSymbol, type);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -257,6 +257,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfInAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfOutAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfIsReadOnlyAttribute = { s_signature_HasThis_Void };
+        private static readonly byte[][] s_signaturesOfIsUnmanagedAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfFixedBufferAttribute = { s_signature_HasThis_Void_Type_Int32 };
         private static readonly byte[][] s_signaturesOfSuppressUnmanagedCodeSecurityAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfPrincipalPermissionAttribute = { s_signature_HasThis_Void_SecurityAction };
@@ -453,6 +454,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription InAttribute = new AttributeDescription("System.Runtime.InteropServices", "InAttribute", s_signaturesOfInAttribute);
         internal static readonly AttributeDescription OutAttribute = new AttributeDescription("System.Runtime.InteropServices", "OutAttribute", s_signaturesOfOutAttribute);
         internal static readonly AttributeDescription IsReadOnlyAttribute = new AttributeDescription("System.Runtime.CompilerServices", "IsReadOnlyAttribute", s_signaturesOfIsReadOnlyAttribute);
+        internal static readonly AttributeDescription IsUnmanagedAttribute = new AttributeDescription("System.Runtime.CompilerServices", "IsUnmanagedAttribute", s_signaturesOfIsUnmanagedAttribute);
         internal static readonly AttributeDescription CoClassAttribute = new AttributeDescription("System.Runtime.InteropServices", "CoClassAttribute", s_signaturesOfCoClassAttribute);
         internal static readonly AttributeDescription GuidAttribute = new AttributeDescription("System.Runtime.InteropServices", "GuidAttribute", s_signaturesOfGuidAttribute);
         internal static readonly AttributeDescription CLSCompliantAttribute = new AttributeDescription("System", "CLSCompliantAttribute", s_signaturesOfCLSCompliantAttribute);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -430,6 +430,8 @@ namespace Microsoft.CodeAnalysis
         System_ReadOnlySpan_T__get_Item,
         System_ReadOnlySpan_T__get_Length,
 
+        System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor,
+
         Count
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2959,6 +2959,14 @@ namespace Microsoft.CodeAnalysis
                  0,                                                                                                                                             // Arity
                     0,                                                                                                                                          // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    
+                 // System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor
+                 (byte)(MemberFlags.Constructor),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute - WellKnownType.ExtSentinel),       // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     0,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3328,6 +3336,7 @@ namespace Microsoft.CodeAnalysis
                 "get_Length",                               // System_Span__get_Length
                 "get_Item",                                 // System_ReadOnlySpan__get_Item
                 "get_Length",                               // System_ReadOnlySpan__get_Length
+                ".ctor",                                    // System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -272,6 +272,7 @@ namespace Microsoft.CodeAnalysis
         System_Span_T,
         System_ReadOnlySpan_T,
         System_Runtime_InteropServices_UnmanagedType,
+        System_Runtime_CompilerServices_IsUnmanagedAttribute,
 
         NextAvailable,
     }
@@ -539,6 +540,7 @@ namespace Microsoft.CodeAnalysis
             "System.Span`1",
             "System.ReadOnlySpan`1",
             "System.Runtime.InteropServices.UnmanagedType",
+            "System.Runtime.CompilerServices.IsUnmanagedAttribute",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -271,6 +271,7 @@ namespace Microsoft.CodeAnalysis
         System_ObsoleteAttribute,
         System_Span_T,
         System_ReadOnlySpan_T,
+        System_Runtime_InteropServices_UnmanagedType,
 
         NextAvailable,
     }
@@ -537,6 +538,7 @@ namespace Microsoft.CodeAnalysis
             "System.ObsoleteAttribute",
             "System.Span`1",
             "System.ReadOnlySpan`1",
+            "System.Runtime.InteropServices.UnmanagedType",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
@@ -54,6 +54,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return False
         End Function
 
+        Friend Overrides Function IsAcceptedUnmanagedTypeModifierType(type As TypeSymbol) As Boolean
+            ' VB doesn't deal with unmanaged generic type constraints
+            Return False
+        End Function
+
         Friend Overrides Function GetSZArrayTypeSymbol(moduleSymbol As PEModuleSymbol, elementType As TypeSymbol, customModifiers As ImmutableArray(Of ModifierInfo(Of TypeSymbol))) As TypeSymbol
             If TypeOf elementType Is UnsupportedMetadataTypeSymbol Then
                 Return elementType

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
@@ -5,8 +5,6 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
 
-    ' PROTOTYPE: check tests here
-
     Public Class InAttributeModifierTests
         Inherits BasicTestBase
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/InAttributeModifierTests.vb
@@ -5,6 +5,8 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata
 
+    ' PROTOTYPE: check tests here
+
     Public Class InAttributeModifierTests
         Inherits BasicTestBase
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
@@ -167,6 +167,37 @@ BC30649: '' is an unsupported type.
                                                 </expected>)
         End Sub
 
+        <Fact>
+        Public Sub UnmanagedConstraint_RejectedSymbol_OnDelegate()
+            Dim reference = CreateCSharpCompilation("
+public delegate T D<T>() where T : unmanaged;
+", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Test
+    Shared Sub Main(del As D(Of String)) 
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30649: '' is an unsupported type.
+    Shared Sub Main(del As D(Of String)) 
+                    ~~~
+BC32044: Type argument 'String' does not inherit from or implement the constraint type '?'.
+    Shared Sub Main(del As D(Of String)) 
+                    ~~~
+BC32105: Type argument 'String' does not satisfy the 'Structure' constraint for type parameter 'T'.
+    Shared Sub Main(del As D(Of String)) 
+                    ~~~
+                                                </expected>)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
-
+Imports Microsoft.CodeAnalysis.CSharp
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
 
@@ -101,6 +101,70 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.Metadata.PE
             Dim m7Mod = m7.ReturnTypeCustomModifiers(0)
             Assert.True(m7Mod.IsOptional)
             Assert.Equal("System.Runtime.CompilerServices.IsConst", m7Mod.Modifier.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub UnmanagedConstraint_RejectedSymbol_OnClass()
+            Dim reference = CreateCSharpCompilation("
+public class TestRef<T> where T : unmanaged
+{
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Test
+    Shared Sub Main() 
+        Dim x = New TestRef(Of String)()
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30649: '' is an unsupported type.
+        Dim x = New TestRef(Of String)()
+                               ~~~~~~
+BC32044: Type argument 'String' does not inherit from or implement the constraint type '?'.
+        Dim x = New TestRef(Of String)()
+                               ~~~~~~
+BC32105: Type argument 'String' does not satisfy the 'Structure' constraint for type parameter 'T'.
+        Dim x = New TestRef(Of String)()
+                               ~~~~~~
+                                                </expected>)
+        End Sub
+
+        <Fact>
+        Public Sub UnmanagedConstraint_RejectedSymbol_OnMethod()
+            Dim reference = CreateCSharpCompilation("
+public class TestRef
+{
+    public void M<T>() where T : unmanaged
+    {
+    }
+}", parseOptions:=New CSharpParseOptions(CSharp.LanguageVersion.Latest)).EmitToImageReference()
+
+            Dim source =
+                <compilation>
+                    <file>
+Class Test
+    Shared Sub Main() 
+        Dim x = New TestRef()
+        x.M(Of String)()
+    End Sub
+End Class
+    </file>
+                </compilation>
+
+            Dim compilation = CreateCompilationWithMscorlib(source, references:={reference})
+
+            AssertTheseDiagnostics(compilation, <expected>
+BC30649: '' is an unsupported type.
+        x.M(Of String)()
+        ~~~~~~~~~~~~~~~~
+                                                </expected>)
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -511,7 +511,8 @@ End Namespace
                         Continue For
                     Case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation,
                          WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute
+                         WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute
                         ' Not always available.
                         Continue For
                 End Select
@@ -550,7 +551,8 @@ End Namespace
                         Continue For
                     Case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation,
                          WellKnownType.System_Runtime_CompilerServices_IsReadOnlyAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute
+                         WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_IsUnmanagedAttribute
                         ' Not always available.
                         Continue For
                 End Select
@@ -596,7 +598,8 @@ End Namespace
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
                          WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
                          WellKnownMember.System_Runtime_CompilerServices_IsReadOnlyAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor
                         ' Not always available.
                         Continue For
                 End Select
@@ -684,7 +687,8 @@ End Namespace
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
                          WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
                          WellKnownMember.System_Runtime_CompilerServices_IsReadOnlyAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor
                         ' Not always available.
                         Continue For
                 End Select

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -8678,7 +8678,7 @@ public class C
         #region Type Parameter Constraints
 
         [Fact]
-        public void TypeConstraintInsert()
+        public void TypeConstraintInsert_Class()
         {
             var src1 = "class C<T> { }";
             var src2 = "class C<T> where T : class { }";
@@ -8693,7 +8693,22 @@ public class C
         }
 
         [Fact]
-        public void TypeConstraintInsert2()
+        public void TypeConstraintInsert_Unmanaged()
+        {
+            var src1 = "class C<T> { }";
+            var src2 = "class C<T> where T : unmanaged { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [where T : unmanaged]@11");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "where T : unmanaged", FeaturesResources.type_constraint));
+        }
+
+        [Fact]
+        public void TypeConstraintInsert_DoubleStatement_New()
         {
             var src1 = "class C<S,T> where T : class { }";
             var src2 = "class C<S,T> where S : new() where T : class { }";
@@ -8708,7 +8723,22 @@ public class C
         }
 
         [Fact]
-        public void TypeConstraintDelete1()
+        public void TypeConstraintInsert_DoubleStatement_Unmanaged()
+        {
+            var src1 = "class C<S,T> where T : class { }";
+            var src2 = "class C<S,T> where S : unmanaged where T : class { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Insert [where S : unmanaged]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "where S : unmanaged", FeaturesResources.type_constraint));
+        }
+
+        [Fact]
+        public void TypeConstraintDelete_Class()
         {
             var src1 = "class C<S,T> where T : class { }";
             var src2 = "class C<S,T> { }";
@@ -8723,7 +8753,22 @@ public class C
         }
 
         [Fact]
-        public void TypeConstraintDelete2()
+        public void TypeConstraintDelete_Unmanaged()
+        {
+            var src1 = "class C<S,T> where T : unmanaged { }";
+            var src2 = "class C<S,T> { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Delete [where T : unmanaged]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C<S,T>", FeaturesResources.type_constraint));
+        }
+
+        [Fact]
+        public void TypeConstraintDelete_DoubleStatement_New()
         {
             var src1 = "class C<S,T> where S : new() where T : class  { }";
             var src2 = "class C<S,T> where T : class { }";
@@ -8738,7 +8783,22 @@ public class C
         }
 
         [Fact]
-        public void TypeConstraintReorder()
+        public void TypeConstraintDelete_DoubleStatement_Unmanaged()
+        {
+            var src1 = "class C<S,T> where S : unmanaged where T : class  { }";
+            var src2 = "class C<S,T> where T : class { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Delete [where S : unmanaged]@13");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "class C<S,T>", FeaturesResources.type_constraint));
+        }
+
+        [Fact]
+        public void TypeConstraintReorder_Class()
         {
             var src1 = "class C<S,T> where S : struct where T : class  { }";
             var src2 = "class C<S,T> where T : class where S : struct { }";
@@ -8747,6 +8807,20 @@ public class C
 
             edits.VerifyEdits(
                 "Reorder [where T : class]@30 -> @13");
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void TypeConstraintReorder_Unmanaged()
+        {
+            var src1 = "class C<S,T> where S : struct where T : unmanaged  { }";
+            var src2 = "class C<S,T> where T : unmanaged where S : struct { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [where T : unmanaged]@30 -> @13");
 
             edits.VerifyRudeDiagnostics();
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return _sourceTypeParameter.HasValueTypeConstraint; }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get { return _sourceTypeParameter.HasUnmanagedTypeConstraint; }
+        }
+
         public override ImmutableArray<Location> Locations
         {
             get { throw ExceptionUtilities.Unreachable; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
@@ -53,6 +53,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return false; }
         }
 
+        public override bool HasUnmanagedTypeConstraint
+        {
+            get { return false; }
+        }
+
         public override VarianceKind Variance
         {
             get { return VarianceKind.None; }


### PR DESCRIPTION
Adds support for the unmanaged constraint in C#.
- generating modreqs on the constraint, and an attribute on the type parameter.
- disabled EnC for constraints.
- VB treats them as bad symbols.
- a following PR will handle IDE support.