### PR TITLE
Switch some .ConfigureAwait(true) to .ConfigureAwait(false)

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/SendToInteractiveSubmissionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/SendToInteractiveSubmissionProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
             CancellationToken cancellationToken)
         {
             Document doc = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-            var semanticDocument = await SemanticDocument.CreateAsync(doc, cancellationToken).ConfigureAwait(true);
+            var semanticDocument = await SemanticDocument.CreateAsync(doc, cancellationToken).ConfigureAwait(false);
             var root = semanticDocument.Root;
 
             return GetExecutableSyntaxTreeNodeSelection(selectionSpan, root)
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 TextSpan.FromBounds(selectedSpansStart, selectedSpansEnd),
                 args,
                 snapshot,
-                cancellationToken).ConfigureAwait(true);
+                cancellationToken).ConfigureAwait(false);
 
             return newSpans.Any()
                 ? newSpans.Select(n => new SnapshotSpan(snapshot, n.Span.Start, n.Span.Length))


### PR DESCRIPTION
These tasks are being waited for with a .WaitAndGetResult(); using .ConfigureAwait(true) means if they don't run synchronously then we will schedule something to the UI thread while simultaneously
blocking the thread. That will deadlock the product, and also tests. Turns out the latter happens on a semi-regular basis.

Fixes dotnet/roslyn#21563.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

Using "send to interactive" might hang. This might rarely happen in the product, but often happens in our tests that test that feature.

### Bugs this fixes

dotnet/roslyn#21563

### Workarounds, if any

Alternative is to disable our tests.

### Risk

Low. This changes where we are scheduling async continuations too, but the code involved is just looking at syntax trees and is quite safe.

### Performance impact

None.

### Is this a regression from a previous update?

Nope, existed for a very long time.

### Root cause analysis

This was caught by unit testing, and the tests will now reliably pass.

### How was the bug found?

Unit test automation.

</details>
