### PR TITLE
Enable VerifyCodeRefactoringOffered tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
@@ -21,14 +21,13 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17393"),
-         Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public void VerifyCodeRefactoringOffered()
         {
             SetUpEditor(@"
 class C
 {
-    public void Method(int a, string b) { }
+    public void Method$$(int a, string b) { }
 }");
 
             VisualStudio.Editor.InvokeCodeActionList();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicChangeSignatureDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicChangeSignatureDialog.cs
@@ -22,8 +22,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17393"),
-         Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public void VerifyCodeRefactoringOffered()
         {
             SetUpEditor(@"


### PR DESCRIPTION
The underlying requirement that diagnostics be waitable through `FeatureAttribute.DiagnosticService` was recently implemented (#24783), so these tests should be reliable again.

Fixes #17393
