### PR TITLE
[WIP] Run integration tests in Visual Studio 2017 version 15.6

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/App.config
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/App.config
@@ -10,7 +10,7 @@
   <userSettings>
     <Microsoft.VisualStudio.IntegrationTest.Utilities.Settings>
       <setting name="VsProductVersion" serializeAs="String">
-        <value>15</value>
+        <value>15.6</value>
       </setting>
       <setting name="VsRootSuffix" serializeAs="String">
         <value>RoslynDev</value>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("15")]
+        [global::System.Configuration.DefaultSettingValueAttribute("15.6")]
         public string VsProductVersion {
             get {
                 return ((string)(this["VsProductVersion"]));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="VsProductVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)">15</Value>
+      <Value Profile="(Default)">15.6</Value>
     </Setting>
     <Setting Name="VsRootSuffix" Type="System.String" Scope="User">
       <Value Profile="(Default)">RoslynDev</Value>


### PR DESCRIPTION
@dotnet/roslyn-infrastructure I'm having trouble running integration tests locally because the harness keeps finding my 15.5 instance. This change updates the default version requirement to state 15.6. This fixes the problem locally, but has a downside of required maintenance. I'm open to ideas for alternate approaches.