### PR TITLE
Enable xUnit xml output generation on microbuild

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -469,7 +469,7 @@ function Test-XUnit() {
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*\\ref\\.*") }
     $dlls = $dlls | ?{ -not ($_.FullName -match ".*/ref/.*") }
 
-    if ($cibuild) {
+    if ($cibuild -or $official) {
         # Use a 50 minute timeout on CI
         $args += " -xml -timeout:50"
 


### PR DESCRIPTION
We need xml files to report results to MicroBuild. This is what our build queue expects but must have been broken semi-recently.
