### PR TITLE
Skipping PasteCommandWithOutInteractiveFormat test

### DIFF
--- a/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/InteractivePaste/InteractivePasteCommandHandlerTests.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InteractivePaste
             End Using
         End Sub
 
-        <WpfFact>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/24850")>
         <Trait(Traits.Feature, Traits.Features.Interactive)>
         Public Sub PasteCommandWithOutInteractiveFormat()
             Using workspace = TestWorkspace.Create(


### PR DESCRIPTION
Skipping PasteCommandWithOutInteractiveFormat test

Here is the issue: https://github.com/dotnet/roslyn/issues/24850