### PR TITLE
Set ChecksumAlgorithm to SHA256

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -138,6 +138,9 @@
     <DeterministicSourceRoot Condition="'$(DeveloperBuild)' != 'true'">/_/</DeterministicSourceRoot>
 
     <EnableSourceLink Condition="'$(DeveloperBuild)' != 'true'">true</EnableSourceLink>
+
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
+
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
 
     <!-- 


### PR DESCRIPTION
### Customer scenario

Change checksum algorithm of source files in PDBs built for Roslyn binaries.
Enabling this in our build allows us to dogfood more and increase confidence in making SHA256 the default.

### Bugs this fixes


### Workarounds, if any


### Risk

Small.

### Performance impact

Small.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

### Test documentation updated?
