### PR TITLE
Self-reference const via lambda should not overflow

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -201,9 +201,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             builder.Add(CreatePart(SymbolDisplayPartKind.LocalName, symbol, symbol.Name));
 
-            if (symbol.IsConst &&
+            if (format.LocalOptions.IncludesOption(SymbolDisplayLocalOptions.IncludeConstantValue) &&
+                symbol.IsConst &&
                 symbol.HasConstantValue &&
-                format.LocalOptions.IncludesOption(SymbolDisplayLocalOptions.IncludeConstantValue) &&
                 CanAddConstant(symbol.Type, symbol.ConstantValue))
             {
                 AddSpace();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -535,7 +535,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsConst && _constantTuple == null)
                 {
-                    var value = Microsoft.CodeAnalysis.ConstantValue.Bad;
                     var initValueNodeLocation = _initializer.Value.Location;
                     var diagnostics = DiagnosticBag.GetInstance();
                     Debug.Assert(inProgress != this);
@@ -546,7 +545,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         boundInitValue = inProgressBinder.BindVariableOrAutoPropInitializer(_initializer, this.RefKind, type, diagnostics);
                     }
 
-                    value = ConstantValueUtils.GetAndValidateConstantValue(boundInitValue, this, type, initValueNodeLocation, diagnostics);
+                    ConstantValue value = ConstantValueUtils.GetAndValidateConstantValue(boundInitValue, this, type, initValueNodeLocation, diagnostics);
                     Interlocked.CompareExchange(ref _constantTuple, new EvaluatedConstant(value, diagnostics.ToReadOnlyAndFree()), null);
                 }
             }
@@ -555,12 +554,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (this.IsConst && inProgress == this)
                 {
-                    if (diagnostics != null)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_CircConstValue, node.GetLocation(), this);
-                    }
+                    var diag = new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_CircConstValue, this), node.GetLocation());
+                    diagnostics?.Add(diag);
 
-                    return Microsoft.CodeAnalysis.ConstantValue.Bad;
+                    Interlocked.CompareExchange(ref _constantTuple, new EvaluatedConstant(CodeAnalysis.ConstantValue.Bad, ImmutableArray.Create<Diagnostic>(diag)), null);
+                    return CodeAnalysis.ConstantValue.Bad;
                 }
 
                 MakeConstantTuple(inProgress, boundInitValue: null);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2977,8 +2977,30 @@ void f() { if () const int i = 0; }
                 //             case (object)"b":
                 Diagnostic(ErrorCode.ERR_ConstantExpected, @"(object)""b""").WithLocation(23, 18));
         }
-    }
 
+        [Fact]
+        [WorkItem(24869, "https://github.com/dotnet/roslyn/issues/24869")]
+        public void TestSelfReferencingViaLambda()
+        {
+            string source = @"
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    static void F(IEnumerable<C> c)
+    {
+        const int F =
+        c.Select(o => new { E = F });
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { LinqAssemblyRef });
+            comp.VerifyDiagnostics(
+                // (9,9): error CS0029: Cannot implicitly convert type 'System.Collections.Generic.IEnumerable<<anonymous type: int E>>' to 'int'
+                //         c.Select(o => new { E = F });
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "c.Select(o => new { E = F })").WithArguments("System.Collections.Generic.IEnumerable<<anonymous type: int E>>", "int").WithLocation(9, 9)
+                );
+        }
+    }
 
     internal sealed class BoundTreeSequencer : BoundTreeWalkerWithStackGuard
     {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3000,6 +3000,28 @@ class C
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "c.Select(o => new { E = F })").WithArguments("System.Collections.Generic.IEnumerable<<anonymous type: int E>>", "int").WithLocation(9, 9)
                 );
         }
+
+        [Fact]
+        [WorkItem(24869, "https://github.com/dotnet/roslyn/issues/24869")]
+        public void TestSelfReferencingViaLambda2()
+        {
+            string source = @"
+using System.Collections.Generic;
+using System.Linq;
+class C
+{
+    static void F(IEnumerable<C> c)
+    {
+        const int F = c.Sum(o => F);
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { LinqAssemblyRef });
+            comp.VerifyDiagnostics(
+                // (8,34): error CS0110: The evaluation of the constant value for 'F' involves a circular definition
+                //         const int F = c.Sum(o => F);
+                Diagnostic(ErrorCode.ERR_CircConstValue, "F").WithArguments("F").WithLocation(8, 34)
+                );
+        }
     }
 
     internal sealed class BoundTreeSequencer : BoundTreeWalkerWithStackGuard


### PR DESCRIPTION

### Customer scenario
Type a `const` local with a lambda referencing that same local. The compiler will overflow when trying to produce diagnostics.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24869

### Workarounds, if any
N/A

### Risk
### Performance impact
Low. The fix is to remember that the constant value for that local symbol is bad, since that local is self-referencing.

### Is this a regression from a previous update?
No.

### Root cause analysis
What happened is that when we try to print the diagnostic for a self-referencing local, we try to display that symbol including its constant value. We then try to bind the initializer to get that constant value, but in the process we try to print diagnostics for the lambda. This causes an infinite loop.
This PR simply saves the bad constant value into the local symbol at the point we produce that diagnostic, so if we try to display that symbol we won't need to try and bind the initializer.

### How was the bug found?
Internally