### PR TITLE
Fix SyntacticClassificationTagger's handling of workspace changes

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -430,7 +430,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             {
                 if (_workspace != null && _workspace == args.Solution.Workspace)
                 {
-                    ParseIfThisDocument(null, args.Solution, args.NewActiveContextDocumentId);
+                    ParseIfThisDocument(args.Solution, args.NewActiveContextDocumentId);
                 }
             }
 
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             {
                 if (_workspace != null)
                 {
-                    ParseIfThisDocument(null, args.Document.Project.Solution, args.Document.Id);
+                    ParseIfThisDocument(args.Document.Project.Solution, args.Document.Id);
                 }
             }
 
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
                     case WorkspaceChangeKind.DocumentChanged:
                         {
-                            ParseIfThisDocument(args.OldSolution, args.NewSolution, args.DocumentId);
+                            ParseIfThisDocument(args.NewSolution, args.DocumentId);
                             break;
                         }
                 }
@@ -523,22 +523,29 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 }
 
 #if DEBUG
-                // do some sanity check
-                Contract.ThrowIfFalse(object.Equals(lastDocument.Project.ParseOptions, document.Project.ParseOptions));
-
                 // this must exist since we are holding it in the field.
                 Contract.ThrowIfNull(lastParsedSnapshot);
-                Contract.ThrowIfFalse(lastParsedSnapshot == newSnapshot || lastParsedText == newText || lastParsedText.ContentEquals(newText));
 #endif
-
-                // update document to new snapshot with same content
-                lock (_gate)
+                if (lastParsedSnapshot == newSnapshot)
                 {
-                    _lastParsedDocument = document;
+                    // update document to new snapshot with same content
+                    lock (_gate)
+                    {
+                        _lastParsedDocument = document;
+                    }
+                }
+                else
+                {
+                    // This workspace change must have also implicitly changed the text of our file. This can happen
+                    // if it's a linked file (and we are observing the non-active linked file changing before our own active file)
+                    // or some other workspace change (say a SolutionChanged) caused a text edit to happen and we didn't process
+                    // it directly. In that case, requeue a parse. This might be a redundant parse in the linked file case
+                    // since we might also get a DocumentChanged event for our ID. It's fine.
+                    ParseIfThisDocument(newSolution, document.Id);
                 }
             }
 
-            private void ParseIfThisDocument(Solution oldSolution, Solution newSolution, DocumentId documentId)
+            private void ParseIfThisDocument(Solution newSolution, DocumentId documentId)
             {
                 if (_workspace != null)
                 {


### PR DESCRIPTION
The SyntacticClassificationTagger builds a queue of work items. When it sees a workspace change of ProjectChanged, it sees if it needs to enqueue a new parse due to options changing. If it sees a DocumentChange it also enqueues a new parse if it's the document (note: in active context) we are tracking. In all cases (and after these two) it also enqueues a task to ensure the _lastParsedDocument field is brought forward to the current version. That had asserts (and assumptions) that in that case the contents of the text editor would never change.

That assumption is not correct for two reasons:

1. If a linked file is changing, we raise two DocumentChanged; both present the same OldSolution and NewSolution. If the non-active context gets its event raised first, then we would try to migrate the _lastParsedDocument forward, but that also is bringing forward a content change too.
2. If a SolutionChanged event was raised (say for a refactoring) that also changed a document, we could get a document changing as well.

The code that migrated _lastParsedDocument, since it presumed the content didn't change, would then only set _lastParsedDocument but wouldn't set _lastParsedSnapshot. This meant things were out of sync,
at least until the next parse that would reset them. I suspect this might be the cause of #23074.

As a fairly tactical fix, if the snapshots are different, I don't set _lastParsedDocument but rather enqueue a new parse operation. That way the two _lastParsed fields don't get out of sync and we still
will have a parse going that wil (eventually) refresh everything.

<details><summary>Ask Mode template</summary>

### Customer scenario

The user is editing a linked file. Sometimes, you get an error message saying an extension caused an exception. Syntax classification may stop working after that.

### Bugs this fixes

#23074 

### Workarounds, if any

Don't use linked files.

### Risk

Fairly low.

### Performance impact

No changes expected. Code change fits into the existing structure to maintain perf.

### Is this a regression from a previous update?

No, this bug has likely existed for quite awhile.

### Root cause analysis

This bug happens because in linked file cases we raise events slightly differently, which would cause some data tracking to be temporarily out of sync. You only will observe the exception dialog if a request for tags happened in the window where that was out of sync.

### How was the bug found?

Customer reports.

</details>
