### PR TITLE
Use LHS of ref-assignment for ref-readonly

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1280,7 +1280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (op1.Type.IsByRefLikeType)
                 {
                     var leftEscape = GetValEscape(op1, LocalScopeDepth);
-                    op2 = ValidateEscape(op2, leftEscape, isByRef: false, diagnostics: diagnostics);
+                    op2 = ValidateEscape(op2, leftEscape, isByRef: false, diagnostics);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -129,6 +129,39 @@ class C
         }
 
         [Fact]
+        public void RefReassignRefExpressions()
+        {
+            var comp = CompileAndVerify(@"
+using System;
+class C
+{
+    static readonly int _ro = 42;
+    static int _rw = 42;
+
+    static void Main()
+    {
+        ref readonly var rro = ref _ro;
+        ref var rrw = ref _rw;
+
+        Console.WriteLine(rro);
+        Console.WriteLine(rrw);
+
+        rrw++;
+        rro = ref (rro = ref rrw);
+        rrw = ref (rrw = ref rrw);
+
+        Console.WriteLine(rro);
+        Console.WriteLine(rrw);
+        Console.WriteLine(_ro);
+    }
+}", verify: Verification.Fails, expectedOutput: @"42
+42
+43
+43
+42");
+        }
+
+        [Fact]
         public void RefReassignParamByVal()
         {
             var comp = CompileAndVerify(@"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -28,6 +28,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void RefReturnRefAssignment()
+        {
+            CompileAndVerify(@"
+using System;
+class C
+{
+    static readonly int _ro = 42;
+    static int _rw = 42;
+
+    static void Main()
+    {
+        Console.WriteLine(M1(ref _rw));
+        Console.WriteLine(M2(in _ro));
+        Console.WriteLine(M3(in _ro));;
+
+        M1(ref _rw)++;
+
+        Console.WriteLine(M1(ref _rw));
+        Console.WriteLine(M2(in _ro));
+        Console.WriteLine(M3(in _ro));;
+    }
+
+    static ref int M1(ref int rrw) => ref (rrw = ref _rw);
+
+    static ref readonly int M2(in int rro) => ref (rro = ref _ro);
+
+    static ref readonly int M3(in int rro) => ref (rro = ref _rw);
+}", verify: Verification.Fails, expectedOutput: @"42
+42
+42
+43
+42
+43");
+        }
+
+        [Fact]
         public void RefReturnArrayAccess()
         {
             var text = @"


### PR DESCRIPTION
The spec for ref-reassignment is that the LHS of the ref-reassignment
expression is the ref-readonlyness of the LValue produced by the
expression. That is, if the LHS of a ref assignment is readonly, the
resulting LValue is as well.

This PR also fixes a related issue for ref-like assignments, where the
resulting lifetime of the assignment was decided based on the RHS,
instead of the LHS.

Fixes #24874