### PR TITLE
Allow default literal in comparisons

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -425,10 +425,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (result.Kind == BoundKind.BadExpression)
                 {
-                    var parenthesizedExpression = (ParenthesizedExpressionSyntax) current;
+                    var parenthesizedExpression = (ParenthesizedExpressionSyntax)current;
 
                     if (parenthesizedExpression.Expression.IsKind(SyntaxKind.IdentifierName)
-                        && ((IdentifierNameSyntax) parenthesizedExpression.Expression).Identifier.ValueText == "dynamic")
+                        && ((IdentifierNameSyntax)parenthesizedExpression.Expression).Identifier.ValueText == "dynamic")
                     {
                         Error(diagnostics, ErrorCode.ERR_PossibleBadNegCast, node);
                     }
@@ -553,7 +553,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultRight = CreateConversion(right, best.RightConversion, signature.RightType, diagnostics);
                     resultConstant = FoldBinaryOperator(node, resultOperatorKind, resultLeft, resultRight, resultType.SpecialType, diagnostics, ref compoundStringLength);
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    hasErrors = isObjectEquality && !BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
+
+                    bool leftDefault = left.IsLiteralDefault();
+                    bool rightDefault = right.IsLiteralDefault();
+                    hasErrors = isObjectEquality && !BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull || leftDefault, rightType, rightNull || rightDefault, ref useSiteDiagnostics);
+
                     diagnostics.Add(node, useSiteDiagnostics);
                 }
             }
@@ -627,15 +631,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void ReportBinaryOperatorError(ExpressionSyntax node, DiagnosticBag diagnostics, SyntaxToken operatorToken, BoundExpression left, BoundExpression right, LookupResultKind resultKind)
         {
-            if ((operatorToken.Kind() == SyntaxKind.EqualsEqualsToken || operatorToken.Kind() == SyntaxKind.ExclamationEqualsToken) &&
-                (left.IsLiteralDefault() && right.IsLiteralDefault()))
+            bool leftDefault = left.IsLiteralDefault();
+            bool rightDefault = right.IsLiteralDefault();
+            if ((operatorToken.Kind() == SyntaxKind.EqualsEqualsToken || operatorToken.Kind() == SyntaxKind.ExclamationEqualsToken))
             {
-                Error(diagnostics, ErrorCode.ERR_AmbigBinaryOpsOnDefault, node, operatorToken.Text);
-                return;
+                if (leftDefault && rightDefault)
+                {
+                    Error(diagnostics, ErrorCode.ERR_AmbigBinaryOpsOnDefault, node, operatorToken.Text);
+                    return;
+                }
             }
-
-            if (left.IsLiteralDefault() || right.IsLiteralDefault())
+            else if (leftDefault || rightDefault)
             {
+                // other than == and !=, binary operators are disallowed on `default` literal
                 Error(diagnostics, ErrorCode.ERR_BadOpOnNullOrDefault, node, operatorToken.Text, "default");
                 return;
             }
@@ -3507,7 +3515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var whenTrue = node.WhenTrue.CheckAndUnwrapRefExpression(diagnostics, out var whenTrueRefKind);
             var whenFalse = node.WhenFalse.CheckAndUnwrapRefExpression(diagnostics, out var whenFalseRefKind);
 
-            var isRef = whenTrueRefKind == RefKind.Ref  && whenFalseRefKind == RefKind.Ref;
+            var isRef = whenTrueRefKind == RefKind.Ref && whenFalseRefKind == RefKind.Ref;
 
             if (!isRef)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -508,6 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool UseOnlyReferenceEquality(BoundExpression left, BoundExpression right, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
+            // We consider the `null` literal, but not the `default` literal, since the latter does not require a reference equality
             return
                 BuiltInOperators.IsValidObjectEquality(Conversions, left.Type, left.IsLiteralNull(), right.Type, right.IsLiteralNull(), ref useSiteDiagnostics) &&
                 ((object)left.Type == null || (!left.Type.IsDelegateType() && left.Type.SpecialType != SpecialType.System_String && left.Type.SpecialType != SpecialType.System_Delegate)) &&

--- a/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
@@ -715,7 +715,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal static bool IsValidObjectEquality(Conversions Conversions, TypeSymbol leftType, bool leftIsNull, TypeSymbol rightType, bool rightIsNull, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        internal static bool IsValidObjectEquality(Conversions Conversions, TypeSymbol leftType, bool leftIsNullOrDefault, TypeSymbol rightType, bool rightIsNullOrDefault, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // SPEC: The predefined reference type equality operators require one of the following:
 
@@ -739,7 +739,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (((object)leftType != null) && leftType.IsTypeParameter())
             {
-                if (leftType.IsValueType || (!leftType.IsReferenceType && !rightIsNull))
+                if (leftType.IsValueType || (!leftType.IsReferenceType && !rightIsNullOrDefault))
                 {
                     return false;
                 }
@@ -750,7 +750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (((object)rightType != null) && rightType.IsTypeParameter())
             {
-                if (rightType.IsValueType || (!rightType.IsReferenceType && !leftIsNull))
+                if (rightType.IsValueType || (!rightType.IsReferenceType && !leftIsNullOrDefault))
                 {
                     return false;
                 }
@@ -760,19 +760,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var leftIsReferenceType = ((object)leftType != null) && leftType.IsReferenceType;
-            if (!leftIsReferenceType && !leftIsNull)
+            if (!leftIsReferenceType && !leftIsNullOrDefault)
             {
                 return false;
             }
 
             var rightIsReferenceType = ((object)rightType != null) && rightType.IsReferenceType;
-            if (!rightIsReferenceType && !rightIsNull)
+            if (!rightIsReferenceType && !rightIsNullOrDefault)
             {
                 return false;
             }
 
             // If at least one side is null then clearly a conversion exists.
-            if (leftIsNull || rightIsNull)
+            if (leftIsNullOrDefault || rightIsNullOrDefault)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1314,7 +1314,7 @@ MODIFIER MyType
             void validateLangVer(string modifier, string type, string value, string equal, string semanticType, CSharpParseOptions parseOptions, params DiagnosticDescription[] diagnostics)
             {
                 var source = template.Replace("MODIFIER", modifier).Replace("TYPE", type).Replace("VALUE", value).Replace("EQUAL", equal);
-                var comp = CreateCompilation(source, parseOptions: parseOptions, options: TestOptions.DebugExe, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef } );
+                var comp = CreateCompilation(source, parseOptions: parseOptions, options: TestOptions.DebugExe);
                 if (diagnostics.Length == 0)
                 {
                     comp.VerifyDiagnostics();
@@ -1385,7 +1385,7 @@ struct MyType
             void validate(string type, string value, string equal, string semanticType, params DiagnosticDescription[] diagnostics)
             {
                 var source = template.Replace("TYPE", type).Replace("VALUE", value).Replace("EQUAL", equal);
-                var comp = CreateCompilation(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+                var comp = CreateCompilation(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe);
                 if (diagnostics.Length == 0)
                 {
                     comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -45,7 +45,7 @@ class C
     async Task M(CancellationToken t = default) { await Task.Delay(0); }
 }
 ";
-            var comp = CreateCompilationWithMscorlib46(source,parseOptions: TestOptions.Regular7 );
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: TestOptions.Regular7);
             comp.VerifyDiagnostics(
                 // (7,40): error CS8107: Feature 'default literal' is not available in C# 7.0. Please use language version 7.1 or greater.
                 //     async Task M(CancellationToken t = default) { await Task.Delay(0); }
@@ -835,8 +835,8 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
-            comp.VerifyDiagnostics(
+            var expected = new[]
+            {
                 // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
                 //         var a = default + default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + default").WithArguments("+", "default").WithLocation(6, 17),
@@ -894,7 +894,13 @@ class C
                 // (24,17): error CS8310: Operator '??' cannot be applied to operand 'default'
                 //         var s = default ?? default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default ?? default").WithArguments("??", "default").WithLocation(24, 17)
-                );
+            };
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(expected);
+
+            var comp2 = CreateCompilation(source, parseOptions: TestOptions.Regular7_3);
+            comp2.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -928,8 +934,8 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
-            comp.VerifyDiagnostics(
+            var expected = new[]
+            {
                 // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
                 //         var a = default + 1;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 1").WithArguments("+", "default").WithLocation(6, 17),
@@ -990,7 +996,13 @@ class C
                 // (21,13): warning CS0219: The variable 'p' is assigned but its value is never used
                 //         var p = default != 1; // ok
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(21, 13)
-                );
+            };
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(expected);
+
+            var comp2 = CreateCompilation(source, parseOptions: TestOptions.Regular7_3);
+            comp2.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -1024,8 +1036,8 @@ class C
     }
 }
 ";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
-            comp.VerifyDiagnostics(
+            var expected = new[]
+            {
                 // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
                 //         var a = 1 + default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 + default").WithArguments("+", "default").WithLocation(6, 17),
@@ -1083,7 +1095,13 @@ class C
                 // (21,13): warning CS0219: The variable 'p' is assigned but its value is never used
                 //         var p = 1 != default; // ok
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(21, 13)
-                );
+            };
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(expected);
+
+            var comp2 = CreateCompilation(source, parseOptions: TestOptions.Regular7_3);
+            comp2.VerifyDiagnostics(expected);
         }
 
         [Fact]
@@ -1122,12 +1140,18 @@ struct S
     public static S operator +(S left, S right) => new S(left.field + right.field);
 }
 ";
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics(
+            var expected = new[]
+            {
                 // (8,9): error CS8310: Operator '+=' cannot be applied to operand 'default'
                 //         s += default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "s += default").WithArguments("+=", "default").WithLocation(8, 9)
-                );
+            };
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(expected);
+
+            var comp2 = CreateCompilation(source, parseOptions: TestOptions.Regular7_3, options: TestOptions.DebugExe);
+            comp2.VerifyDiagnostics(expected);
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -1139,7 +1163,256 @@ struct S
         }
 
         [Fact]
-        public void WithUserDefinedEqualityOperator()
+        public void EqualityComparison()
+        {
+            string template = @"
+MODIFIER MyType
+{
+    static void Main()
+    {
+        TYPE x = VALUE;
+
+        if ((x == default) != EQUAL) throw null;
+        if ((default == x) != EQUAL) throw null;
+
+        if ((x != default) == EQUAL) throw null;
+        if ((default != x) == EQUAL) throw null;
+
+        if ((x == default(TYPE)) != EQUAL) throw null;
+        if ((x != default(TYPE)) == EQUAL) throw null;
+
+        System.Console.Write(""Done"");
+    }
+}
+";
+            validate("class", "int", "0", "true", "System.Int32");
+            validate("class", "int", "1", "false", "System.Int32");
+            validate("class", "int?", "null", "true", "System.Int32?");
+
+            validate("class", "string", "null", "true", "System.String");
+            validate("class", "string", "\"\"", "false", "System.String");
+
+            validate("class", "MyType", "null", "true", "System.Object");
+            validate("class", "MyType", "new MyType()", "false", "System.Object");
+
+            // struct MyType doesn't have an == operator
+            validate("struct", "MyType", "new MyType()", "false", "System.Object",
+                // (8,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType' and 'default'
+                //         if ((x == default) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "MyType", "default").WithLocation(8, 14),
+                // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and 'MyType'
+                //         if ((default == x) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "MyType").WithLocation(9, 14),
+                // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type 'MyType' and 'default'
+                //         if ((x != default) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "MyType", "default").WithLocation(11, 14),
+                // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and 'MyType'
+                //         if ((default != x) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "MyType").WithLocation(12, 14),
+                // (14,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType' and 'MyType'
+                //         if ((x == default(MyType)) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default(MyType)").WithArguments("==", "MyType", "MyType").WithLocation(14, 14),
+                // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type 'MyType' and 'MyType'
+                //         if ((x != default(MyType)) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default(MyType)").WithArguments("!=", "MyType", "MyType").WithLocation(15, 14)
+                );
+
+            // struct MyType doesn't have an == operator, so no lifted == operator on MyType?
+            validate("struct", "MyType?", "null", "true", "System.Object",
+                // (8,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType?' and 'default'
+                //         if ((x == default) != true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "MyType?", "default").WithLocation(8, 14),
+                // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and 'MyType?'
+                //         if ((default == x) != true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "MyType?").WithLocation(9, 14),
+                // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type 'MyType?' and 'default'
+                //         if ((x != default) == true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "MyType?", "default").WithLocation(11, 14),
+                // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and 'MyType?'
+                //         if ((default != x) == true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "MyType?").WithLocation(12, 14),
+                // (14,14): error CS0019: Operator '==' cannot be applied to operands of type 'MyType?' and 'MyType?'
+                //         if ((x == default(MyType?)) != true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default(MyType?)").WithArguments("==", "MyType?", "MyType?").WithLocation(14, 14),
+                // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type 'MyType?' and 'MyType?'
+                //         if ((x != default(MyType?)) == true) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default(MyType?)").WithArguments("!=", "MyType?", "MyType?").WithLocation(15, 14)
+                );
+
+            // struct ValueTuple doesn't have an == operator
+            validate("class", "(int, int)", "(1, 2)", "false", "System.Object",
+                // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'default'
+                //         if ((x == default) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)", "default").WithLocation(8, 14),
+                // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)'
+                //         if ((default == x) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)").WithLocation(9, 14),
+                // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and 'default'
+                //         if ((x != default) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)", "default").WithLocation(11, 14),
+                // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)'
+                //         if ((default != x) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)").WithLocation(12, 14),
+                // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         if ((x == default((int, int))) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int))").WithArguments("==", "(int, int)", "(int, int)").WithLocation(14, 14),
+                // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         if ((x != default((int, int))) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int))").WithArguments("!=", "(int, int)", "(int, int)").WithLocation(15, 14)
+                );
+
+            // struct ValueTuple doesn't have an == operator
+            validate("class", "(int, int)", "(0, 0)", "false", "System.Object",
+                // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and 'default'
+                //         if ((x == default) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)", "default").WithLocation(8, 14),
+                // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)'
+                //         if ((default == x) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)").WithLocation(9, 14),
+                // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and 'default'
+                //         if ((x != default) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)", "default").WithLocation(11, 14),
+                // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)'
+                //         if ((default != x) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)").WithLocation(12, 14),
+                // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         if ((x == default((int, int))) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int))").WithArguments("==", "(int, int)", "(int, int)").WithLocation(14, 14),
+                // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)' and '(int, int)'
+                //         if ((x != default((int, int))) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int))").WithArguments("!=", "(int, int)", "(int, int)").WithLocation(15, 14)
+                );
+
+            // struct ValueTuple doesn't have an == operator, so no lifted == on ValueTuple?
+            validate("class", "(int, int)?", "(0, 0)", "false", "System.Object",
+                // (8,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)?' and 'default'
+                //         if ((x == default) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default").WithArguments("==", "(int, int)?", "default").WithLocation(8, 14),
+                // (9,14): error CS0019: Operator '==' cannot be applied to operands of type 'default' and '(int, int)?'
+                //         if ((default == x) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default == x").WithArguments("==", "default", "(int, int)?").WithLocation(9, 14),
+                // (11,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)?' and 'default'
+                //         if ((x != default) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default").WithArguments("!=", "(int, int)?", "default").WithLocation(11, 14),
+                // (12,14): error CS0019: Operator '!=' cannot be applied to operands of type 'default' and '(int, int)?'
+                //         if ((default != x) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default != x").WithArguments("!=", "default", "(int, int)?").WithLocation(12, 14),
+                // (14,14): error CS0019: Operator '==' cannot be applied to operands of type '(int, int)?' and '(int, int)?'
+                //         if ((x == default((int, int)?)) != false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x == default((int, int)?)").WithArguments("==", "(int, int)?", "(int, int)?").WithLocation(14, 14),
+                // (15,14): error CS0019: Operator '!=' cannot be applied to operands of type '(int, int)?' and '(int, int)?'
+                //         if ((x != default((int, int)?)) == false) throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "x != default((int, int)?)").WithArguments("!=", "(int, int)?", "(int, int)?").WithLocation(15, 14)
+                );
+
+            void validate(string modifier, string type, string value, string equal, string semanticType, params DiagnosticDescription[] diagnostics)
+            {
+                validateLangVer(modifier, type, value, equal, semanticType, TestOptions.Regular7_2, diagnostics);
+                validateLangVer(modifier, type, value, equal, semanticType, TestOptions.Regular, diagnostics);
+            }
+
+            void validateLangVer(string modifier, string type, string value, string equal, string semanticType, CSharpParseOptions parseOptions, params DiagnosticDescription[] diagnostics)
+            {
+                var source = template.Replace("MODIFIER", modifier).Replace("TYPE", type).Replace("VALUE", value).Replace("EQUAL", equal);
+                var comp = CreateCompilation(source, parseOptions: parseOptions, options: TestOptions.DebugExe, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef } );
+                if (diagnostics.Length == 0)
+                {
+                    comp.VerifyDiagnostics();
+                    CompileAndVerify(comp, expectedOutput: "Done");
+                }
+                else
+                {
+                    comp.VerifyDiagnostics(diagnostics);
+                }
+
+                var tree = comp.SyntaxTrees.First();
+                var model = comp.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var defaults = nodes.OfType<LiteralExpressionSyntax>().Where(l => l.ToString() == "default");
+                Assert.True(defaults.Count() == 4);
+                foreach (var @default in defaults)
+                {
+                    Assert.Equal("default", @default.ToString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).Type.ToTestDisplayString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).ConvertedType.ToTestDisplayString());
+                }
+            }
+        }
+
+        [Fact]
+        public void EqualityComparison_StructWithComparison()
+        {
+            string template = @"
+struct MyType
+{
+    int i;
+    public MyType(int value)
+    {
+        i = value;
+    }
+    static void Main()
+    {
+        TYPE x = VALUE;
+
+        if ((x == default) != EQUAL) throw null;
+        if ((default == x) != EQUAL) throw null;
+
+        if ((x != default) == EQUAL) throw null;
+        if ((default != x) == EQUAL) throw null;
+
+        if ((x == default(TYPE)) != EQUAL) throw null;
+        if ((x != default(TYPE)) == EQUAL) throw null;
+
+        System.Console.Write(""Done"");
+    }
+    public static bool operator==(MyType x, MyType y)
+        => x.i == y.i;
+    public static bool operator!=(MyType x, MyType y)
+        => !(x == y);
+    public override bool Equals(object o) => throw null;
+    public override int GetHashCode() => throw null;
+}
+";
+
+            validate("MyType", "new MyType(0)", "true", "MyType");
+            validate("MyType", "new MyType(1)", "false", "MyType");
+
+            validate("MyType?", "new MyType(0)", "false", "MyType?");
+            validate("MyType?", "new MyType(1)", "false", "MyType?");
+            validate("MyType?", "null", "true", "MyType?");
+
+            void validate(string type, string value, string equal, string semanticType, params DiagnosticDescription[] diagnostics)
+            {
+                var source = template.Replace("TYPE", type).Replace("VALUE", value).Replace("EQUAL", equal);
+                var comp = CreateCompilation(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+                if (diagnostics.Length == 0)
+                {
+                    comp.VerifyDiagnostics();
+                    CompileAndVerify(comp, expectedOutput: "Done");
+                }
+                else
+                {
+                    comp.VerifyDiagnostics(diagnostics);
+                }
+
+                var tree = comp.SyntaxTrees.First();
+                var model = comp.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var defaults = nodes.OfType<LiteralExpressionSyntax>().Where(l => l.ToString() == "default");
+                Assert.True(defaults.Count() == 4);
+                foreach (var @default in defaults)
+                {
+                    Assert.Equal("default", @default.ToString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).Type.ToTestDisplayString());
+                    Assert.Equal(semanticType, model.GetTypeInfo(@default).ConvertedType.ToTestDisplayString());
+                }
+            }
+        }
+
+        [Fact]
+        public void EqualityComparisonWithUserDefinedEqualityOperator()
         {
             string source = @"
 struct S
@@ -1168,6 +1441,7 @@ struct S
             var first = nodes.OfType<LiteralExpressionSyntax>().ElementAt(0);
             Assert.Equal("default", first.ToString());
             Assert.Equal("S", model.GetTypeInfo(first).Type.ToTestDisplayString());
+            Assert.Equal("S", model.GetTypeInfo(first).ConvertedType.ToTestDisplayString());
         }
 
         [Fact]
@@ -1920,6 +2194,31 @@ class C
 ";
 
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,33): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write($"{default == default} {default != default}");
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default == default").WithArguments("==").WithLocation(6, 33),
+                // (6,54): error CS8315: Operator '!=' is ambiguous on operands 'default' and 'default'
+                //         System.Console.Write($"{default == default} {default != default}");
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default != default").WithArguments("!=").WithLocation(6, 54)
+                );
+        }
+
+        [Fact]
+        public void DefaultEqualsDefault_InCSharp7_3()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write($""{default == default} {default != default}"");
+    }
+}
+";
+
+            // default == default is still disallowed in 7.3
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_3, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
                 // (6,33): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
                 //         System.Console.Write($"{default == default} {default != default}");
@@ -2821,7 +3120,7 @@ class C
         {
             string source = @"
 public struct S { }
-public class A : System.Attribute 
+public class A : System.Attribute
 {
     public A(
         int? x1 = default,

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);
         public static readonly CSharpParseOptions Regular7_1 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_1);
         public static readonly CSharpParseOptions Regular7_2 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_2);
+        public static readonly CSharpParseOptions Regular7_3 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_3);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = Regular.WithDocumentationMode(DocumentationMode.Diagnose);
         public static readonly CSharpParseOptions WithoutImprovedOverloadCandidates = Regular.WithLanguageVersion(MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion() - 1);
 


### PR DESCRIPTION
### Customer scenario
Currently, the compiler rejects `x == default` when the overload resolution comes back with object equality. This means the comparison works if `x` is a built-in type (with built-in `==` operator) or a type with a user-defined `==` operator.
This PR fixes this inconsistency. The `object` comparison will be allowed and `default` will be `default(object)`. That means `x == default` is allowed for reference types, and still fails for value types.

Note that  `nullable == default` is disallowed, since nullable types are structs and don't have `==` operator defined.
The same applies to `tuple == default`, although I intend to fix that in the branch implementing tuple equality.

### Bugs this fixes
Fixes https://github.com/dotnet/roslyn/issues/24725

### Workarounds, if any
You can always use explicit type `default(object)` or simply `null`.

### Risk
### Performance impact


### Is this a regression from a previous update?
No

### Root cause analysis


### How was the bug found?
Internally. Noticed while working on Roslyn.