### PR TITLE
When a text buffer does not represent a document from a workspace Get…

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -897,6 +897,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 using (var asyncToken = _owner.OperationListener.BeginAsyncOperation(nameof(GetSuggestedActionCategoriesAsync)))
                 {
                     var document = range.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
+                    if (document == null)
+                    {
+                        return null;
+                    }
+
                     using (var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
                     {
                         var linkedToken = linkedTokenSource.Token;


### PR DESCRIPTION
…OpenDocumentInCurrentContextWithChanges() will return null. Allow for that without a NullReferenceException.

Fixes #24625.

<details><summary>Ask Mode template</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

In cases where the editor is hosting text with C# content type, but it's not added to any workspace, there is a null reference exception thrown because document is null. It may or may not be fatal depending on the circumstances (i.e. how the editor is hosted).

### Bugs this fixes

https://github.com/dotnet/roslyn/issues/24625

### Workarounds, if any

Don't host C# files without adding them to a workspace

### Risk

Very low risk, just a null check.

### Performance impact

A null check - no discernible perf impact.

### Is this a regression from a previous update?

### Root cause analysis

Need the new "Nullable Reference Types" to catch nullrefs early.

### How was the bug found?

Hosting Roslyn outside of Visual Studio (VSMac, etc).

### Test documentation updated?


</details>
