### PR TITLE
Revert "Enable multicore JIT in the compilers (#23173)"

### DIFF
--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -86,11 +86,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 return RunCompilationResult.Failed;
             }
 
-            if (!TryEnableMulticoreJitting(out errorMessageOpt))
-            {
-                textWriter.WriteLine(errorMessageOpt);
-            }
-
             if (hasShared)
             {
                 sessionKeyOpt = sessionKeyOpt ?? GetSessionKey(buildPaths);


### PR DESCRIPTION
This reverts commit eed147d330e92a55cb2daa26acb28fcde1776f04.

We've seen crashes that appear to be involved with multicore JIT that
only started soon after multicore JIT was enabled for the compiler
(tracked in #23846). This change disables multicore JIT until we can fix
the root cause of the crashes.

<details><summary>Ask Mode template not completed</summary>
