### PR TITLE
Prevent accidental passing by reference of reduced expressions when it was not valid originally.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -236,7 +236,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion ExplicitDynamic => new Conversion(ConversionKind.ExplicitDynamic);
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
-        internal static Conversion IdentityValue => new Conversion(ConversionKind.IdentityValue);
         internal static Conversion PinnedObjectToPointer => new Conversion(ConversionKind.PinnedObjectToPointer);
 
         // trivial conversions that could be underlying in nullable conversion

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -46,6 +46,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         StackAllocToPointerType,
         StackAllocToSpanType,
 
+        // TODO: VS remove this
+        // TODO: VS in emitaddress, if underlying is homeless, just emit that
+
         // IdentityValue is not a part of the language. 
         // It is used by lowering to ensure that trivially reduced expressions 
         // do not become exposed to mutations if used as receivers of struct methods.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -46,14 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         StackAllocToPointerType,
         StackAllocToSpanType,
 
-        // TODO: VS remove this
-        // TODO: VS in emitaddress, if underlying is homeless, just emit that
-
-        // IdentityValue is not a part of the language. 
-        // It is used by lowering to ensure that trivially reduced expressions 
-        // do not become exposed to mutations if used as receivers of struct methods.
-        IdentityValue,
-
         // PinnedObjectToPointer is not directly a part of the language
         // It is used by lowering of "fixed" statements to represent conversion of an object reference (O) to an unmanaged pointer (*)
         // The conversion is unsafe and makes sense only if (O) is pinned.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -50,6 +50,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal partial class BoundPassByCopy
+    {
+        public override ConstantValue ConstantValue
+        {
+            get
+            {
+                Debug.Assert(Expression.ConstantValue == null);
+                return null;
+            }
+        }
+
+        public override Symbol ExpressionSymbol
+        {
+            get
+            {
+                return Expression.ExpressionSymbol;
+            }
+        }
+    }
+
     internal partial class BoundCall
     {
         public override Symbol ExpressionSymbol

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -425,7 +425,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (this.ConversionKind)
             {
                 case ConversionKind.Identity:
-                case ConversionKind.IdentityValue:
                 // NOTE: even explicit float/double identity conversion does not have side
                 // effects since it does not throw
                 case ConversionKind.ImplicitNumeric:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -405,6 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (this.ConversionKind)
             {
                 case ConversionKind.Identity:
+                case ConversionKind.IdentityValue:
                 // NOTE: even explicit float/double identity conversion does not have side
                 // effects since it does not throw
                 case ConversionKind.ImplicitNumeric:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -96,6 +96,11 @@
     <Field Name="RefKind" Type="RefKind" Null="NotApplicable"/>
   </Node>
 
+  <!-- Wrapper node used to prevent passing the underlying expression by direct reference -->
+  <Node Name="BoundPassByCopy" Base="BoundExpression">
+    <Field Name="Expression" Type="BoundExpression"/>
+  </Node>
+  
   <!-- 
   An expression is classified as one of the following:
   A value. Every value has an associated type.

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -144,4 +144,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<BoundNode> Children => 
             (this.Kind == BoundKind.StatementList || this.Kind == BoundKind.Scope) ? StaticCast<BoundNode>.From(this.Statements) : ImmutableArray<BoundNode>.Empty;
     }
+
+    internal partial class BoundPassByCopy
+    {
+        protected override ImmutableArray<BoundNode> Children => ImmutableArray.Create<BoundNode>(this.Expression);
+    }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -152,4 +152,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return string.Format(MessageID.IDS_StackAllocExpression.Localize().ToString(), ElementType, Count.Syntax); }
         }
     }
+
+    internal partial class BoundPassByCopy
+    {
+        public override object Display => Expression.Display;
+    }
 }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -42,9 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case ConversionKind.Identity:
                     EmitIdentityConversion(conversion);
                     break;
-                case ConversionKind.IdentityValue:
-                    // noop
-                    return;
                 case ConversionKind.ImplicitNumeric:
                 case ConversionKind.ExplicitNumeric:
                     EmitNumericConversion(conversion);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -21,9 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     _builder.EmitOpCode(ILOpCode.Conv_u);
                     EmitPopIfUnused(used);
                     return;
-                case ConversionKind.IdentityValue:
-                    EmitExpressionCore(conversion.Operand, used);
-                    return;
             }
 
             if (!used && !conversion.ConversionHasSideEffects())
@@ -45,6 +42,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case ConversionKind.Identity:
                     EmitIdentityConversion(conversion);
                     break;
+                case ConversionKind.IdentityValue:
+                    // noop
+                    return;
                 case ConversionKind.ImplicitNumeric:
                 case ConversionKind.ExplicitNumeric:
                     EmitNumericConversion(conversion);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -122,6 +122,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitDupExpression((BoundDup)expression, used);
                     break;
 
+                case BoundKind.PassByCopy:
+                    EmitExpression(((BoundPassByCopy)expression).Expression, used);
+                    break;
+
                 case BoundKind.Parameter:
                     if (used)  // unused parameter has no side-effects
                     {

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -603,6 +603,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 node.Type);
         }
 
+        public override BoundNode VisitPassByCopy(BoundPassByCopy node)
+        {
+            var context = _context == ExprContext.Sideeffects ?
+                            ExprContext.Sideeffects :
+                            ExprContext.Value;
+
+            return node.Update(
+                this.VisitExpression(node.Expression, context),
+                node.Type);
+        }
+
         public override BoundNode VisitBlock(BoundBlock node)
         {
             Debug.Assert(EvalStackIsEmpty(), "entering blocks when evaluation stack is not empty?");

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -587,6 +587,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             return result;
         }
 
+        public override BoundNode VisitConversion(BoundConversion node)
+        {
+            var context = _context == ExprContext.Sideeffects && !node.ConversionHasSideEffects() ?
+                            ExprContext.Sideeffects :
+                            ExprContext.Value;
+
+            return node.Update(
+                this.VisitExpression(node.Operand, context),
+                node.Conversion,
+                node.IsBaseConversion,
+                node.Checked,
+                node.ExplicitCastInCode,
+                node.ConstantValue,
+                node.Type);
+        }
+
         public override BoundNode VisitBlock(BoundBlock node)
         {
             Debug.Assert(EvalStackIsEmpty(), "entering blocks when evaluation stack is not empty?");

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -937,6 +937,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node;
         }
 
+        public override BoundNode VisitPassByCopy(BoundPassByCopy node)
+        {
+            VisitRvalue(node.Expression);
+            return node;
+        }
+
         public override BoundNode VisitIsPatternExpression(BoundIsPatternExpression node)
         {
             VisitRvalue(node.Expression);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -838,9 +838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = RefKind.None;
             if (!receiver.Type.IsReferenceType && LocalRewriter.CanBePassedByReference(receiver))
             {
-                result = receiver.Type.IsReadOnly ?
-                                                RefKind.In :
-                                                RefKind.Ref;
+                result = receiver.Type.IsReadOnly ? RefKind.In : RefKind.Ref;
             }
 
             return result;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -823,9 +823,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var receiverBuilder = new BoundSpillSequenceBuilder();
 
                 receiver = node.ReceiverOpt;
-                var refKind = node.Method.ContainingType.IsReadOnly?
-                                                    RefKind.In:
-                                                    ReceiverSpillRefKind(receiver);
+                RefKind refKind = ReceiverSpillRefKind(receiver);
 
                 receiver = Spill(receiverBuilder, VisitExpression(ref receiverBuilder, receiver), refKind: refKind);
                 receiverBuilder.Include(builder);
@@ -837,9 +835,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static RefKind ReceiverSpillRefKind(BoundExpression receiver)
         {
-            return LocalRewriter.WouldBeAssignableIfUsedAsMethodReceiver(receiver) ?
-                RefKind.Ref :
-                RefKind.None;
+            var result = RefKind.None;
+            if (!receiver.Type.IsReferenceType && LocalRewriter.CanBePassedByReference(receiver))
+            {
+                result = receiver.Type.IsReadOnly ?
+                                                RefKind.In :
+                                                RefKind.Ref;
+            }
+
+            return result;
         }
 
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -906,6 +906,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     type: node.Type));
         }
 
+        public override BoundNode VisitPassByCopy(BoundPassByCopy node)
+        {
+            BoundSpillSequenceBuilder builder = null;
+            var expression = VisitExpression(ref builder, node.Expression);
+            return UpdateExpression(
+                builder,
+                node.Update(
+                    expression,
+                    type: node.Type));
+        }
+
         public override BoundNode VisitMethodGroup(BoundMethodGroup node)
         {
             throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -200,6 +200,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitConditionalOperator((BoundConditionalOperator)node);
                 case BoundKind.Conversion:
                     return VisitConversion((BoundConversion)node);
+                case BoundKind.PassByCopy:
+                    return Visit(((BoundPassByCopy)node).Expression);
                 case BoundKind.DelegateCreationExpression:
                     return VisitDelegateCreationExpression((BoundDelegateCreationExpression)node);
                 case BoundKind.FieldAccess:

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -633,10 +633,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var operand = Visit(node.Operand);
                         return node.ExplicitCastInCode ? Convert(operand, node.Type, false) : operand;
                     }
-                case ConversionKind.IdentityValue:
-                    {
-                        return Visit(node.Operand);
-                    }
                 case ConversionKind.ImplicitNullable:
                     if (node.Operand.Type.IsNullableType())
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -199,15 +199,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static BoundExpression RefAccessMustMakeCopy(BoundExpression visited)
         {
-            visited = new BoundConversion(
+            visited = new BoundPassByCopy(
                         visited.Syntax,
                         visited,
-                        Conversion.IdentityValue,
-                        @checked: false,
-                        explicitCastInCode: true,
-                        constantValueOpt: null,
-                        type: visited.Type)
-            { WasCompilerGenerated = true };
+                        type: visited.Type);
 
             return visited;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     visited.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamicAndTupleNames) ||
                     IsUnusedDeconstruction(node));
 
-            if (visited != null & visited != node)
+            if (visited != null && visited != node)
             {
                 if (!CanBePassedByReference(node) && CanBePassedByReference(visited))
                 {
@@ -625,7 +625,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.DeconstructValuePlaceholder:
-                    // is this always a proxy for a temp local?
+                    // we will consider that placeholder always represents a temp local
+                    // the assumption should be confirmed or changed when https://github.com/dotnet/roslyn/issues/24160 is fixed 
                     return true;
 
                 case BoundKind.EventAccess:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.DiscardExpression:
                     {
-                        return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenRight);
+                        return rewrittenRight;
                     }
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -317,7 +317,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConversionKind.ExplicitNumeric:
                                 case ConversionKind.ExplicitReference:
                                 case ConversionKind.Identity:
-                                case ConversionKind.IdentityValue:
                                 case ConversionKind.ImplicitEnumeration:
                                 case ConversionKind.ImplicitNullable:
                                 case ConversionKind.ImplicitNumeric:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -296,6 +296,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // A ref to a local variable or formal parameter is safe to reorder; it
                         // never has a side effect or consumes one.
                         return kind != RefKind.None;
+                    case BoundKind.PassByCopy:
+                        return IsSafeForReordering(((BoundPassByCopy)current).Expression, kind);
                     case BoundKind.Conversion:
                         {
                             BoundConversion conv = (BoundConversion)current;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -315,6 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConversionKind.ExplicitNumeric:
                                 case ConversionKind.ExplicitReference:
                                 case ConversionKind.Identity:
+                                case ConversionKind.IdentityValue:
                                 case ConversionKind.ImplicitEnumeration:
                                 case ConversionKind.ImplicitNullable:
                                 case ConversionKind.ImplicitNumeric:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -728,6 +728,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return conv.ConversionHasSideEffects() ||
                         ReadIsSideeffecting(conv.Operand);
 
+                case BoundKind.PassByCopy:
+                    return ReadIsSideeffecting(((BoundPassByCopy)expression).Expression);
+
                 case BoundKind.ObjectCreationExpression:
                     // common production of lowered conversions to nullable
                     // new S?(arg)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -49,20 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConstantValue conditionConstantValue = rewrittenCondition.ConstantValue;
             if (conditionConstantValue == ConstantValue.True)
             {
-                if (!isRef)
-                {
-                    rewrittenConsequence = EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenConsequence);
-                }
-
                 return rewrittenConsequence;
             }
             else if (conditionConstantValue == ConstantValue.False)
             {
-                if (!isRef)
-                {
-                    rewrittenAlternative = EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenAlternative);
-                }
-
                 return rewrittenAlternative;
             }
             else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If this is not an identity conversion of a float with unknown precision, strip away the identity conversion.
                     if (!IsFloatingPointExpressionOfUnknownPrecision(rewrittenOperand))
                     {
-                        return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenOperand);
+                        return rewrittenOperand;
                     }
 
                     break;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (rewrittenLeft.IsDefaultValue())
             {
-                return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenRight);
+                return rewrittenRight;
             }
 
             if (rewrittenLeft.ConstantValue != null)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1330,9 +1330,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal ImmutableArray<BoundExpression> MakeTempsForDiscardArguments(ImmutableArray<BoundExpression> arguments, ArrayBuilder<LocalSymbol> builder)
         {
-            var discardsCount = arguments.Count(a => a.Kind == BoundKind.DiscardExpression);
+            var discardsPresent = arguments.Any(a => a.Kind == BoundKind.DiscardExpression);
 
-            if (discardsCount != 0)
+            if (discardsPresent)
             {
                 arguments = arguments.SelectAsArray(
                     (arg, t) => arg.Kind == BoundKind.DiscardExpression ? t.factory.MakeTempForDiscard((BoundDiscardExpression)arg, t.builder) : arg,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -5056,5 +5056,44 @@ public class C {
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             base.CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
+
+        [Fact, WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        public void CaptureStructReceiver()
+        {
+            var source = @"
+
+    using System;
+    using System.Threading.Tasks;
+
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            System.Console.WriteLine(Test1().Result);
+        }
+
+        static int x = 123;
+        async static Task<string> Test1()
+        {
+            // cannot capture 'x' by value, since write in M1 is observable
+            return x.ToString(await M1());
+        }
+
+        async static Task<string> M1()
+        {
+            x = 42;
+            await Task.Yield();
+            return """";
+        }
+    }
+";
+            var expectedOutput = @"42";
+
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe);
+            base.CompileAndVerify(compilation, expectedOutput: expectedOutput);
+
+            compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
+            base.CompileAndVerify(compilation, expectedOutput: expectedOutput);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -15421,7 +15421,7 @@ class C
         public int Length = 123;
     }
 ";
-            var comp = CompileAndVerify(source, expectedOutput: "321 123", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            var comp = CompileAndVerify(source, expectedOutput: "321 123", references: new[] { SystemCoreRef, CSharpRef });
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -15386,5 +15386,44 @@ class C
         }
 
         #endregion
+
+        #region Regression Tests
+
+        [Fact]
+        public void ByRefDynamic()
+        {
+            string source = @"
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            System.Console.Write(Test1());
+            System.Console.Write("" "");
+            System.Console.Write(x.Length);
+        }
+
+        static dynamic x = new C1();
+
+        static int Test1()
+        {
+            return M1(ref x.Length);
+        }
+
+        static dynamic M1(ref dynamic d)
+        {
+            d = 321;
+            return d;
+        }
+    }
+
+    class C1
+    {
+        public int Length = 123;
+    }
+";
+            var comp = CompileAndVerify(source, expectedOutput: "321 123", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -2896,5 +2896,677 @@ class Program
 }
 ");
         }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_Local()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        int x = 50;
+        Moo(x + 0, () => x = 60);
+    }
+    
+    static void Moo(in int y, Action change)
+    {
+        Console.Write(y);
+        change();
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
+
+            verifier.VerifyIL("Test.Main(string[])", @"
+{
+  // Code size       41 (0x29)
+  .maxstack  3
+  .locals init (Test.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                int V_1)
+  IL_0000:  newobj     ""Test.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.s   50
+  IL_0009:  stfld      ""int Test.<>c__DisplayClass0_0.x""
+  IL_000e:  ldloc.0
+  IL_000f:  ldfld      ""int Test.<>c__DisplayClass0_0.x""
+  IL_0014:  stloc.1
+  IL_0015:  ldloca.s   V_1
+  IL_0017:  ldloc.0
+  IL_0018:  ldftn      ""void Test.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_001e:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0023:  call       ""void Test.Moo(in int, System.Action)""
+  IL_0028:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_ArrayAccess()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        int[] x = new int[] { 50 };
+        Moo(x[0] + 0, () => x[0] = 60);
+    }
+
+    static void Moo(in int y, Action change)
+    {
+        Console.Write(y);
+        change();
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
+
+            verifier.VerifyIL("Test.Main(string[])", @"
+{
+  // Code size       52 (0x34)
+  .maxstack  5
+  .locals init (Test.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                int V_1)
+  IL_0000:  newobj     ""Test.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.1
+  IL_0008:  newarr     ""int""
+  IL_000d:  dup
+  IL_000e:  ldc.i4.0
+  IL_000f:  ldc.i4.s   50
+  IL_0011:  stelem.i4
+  IL_0012:  stfld      ""int[] Test.<>c__DisplayClass0_0.x""
+  IL_0017:  ldloc.0
+  IL_0018:  ldfld      ""int[] Test.<>c__DisplayClass0_0.x""
+  IL_001d:  ldc.i4.0
+  IL_001e:  ldelem.i4
+  IL_001f:  stloc.1
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  ldloc.0
+  IL_0023:  ldftn      ""void Test.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_0029:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_002e:  call       ""void Test.Moo(in int, System.Action)""
+  IL_0033:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_ArrayAccessReordered()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        int[] x = new int[] { 50 };
+        Moo(change: () => x[0] = 60, y: x[0] + 0);
+    }
+
+    static void Moo(in int y, Action change)
+    {
+        Console.Write(y);
+        change();
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
+
+            verifier.VerifyIL("Test.Main(string[])", @"
+{
+  // Code size       52 (0x34)
+  .maxstack  5
+  .locals init (Test.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                int V_1)
+  IL_0000:  newobj     ""Test.<>c__DisplayClass0_0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.1
+  IL_0008:  newarr     ""int""
+  IL_000d:  dup
+  IL_000e:  ldc.i4.0
+  IL_000f:  ldc.i4.s   50
+  IL_0011:  stelem.i4
+  IL_0012:  stfld      ""int[] Test.<>c__DisplayClass0_0.x""
+  IL_0017:  ldloc.0
+  IL_0018:  ldfld      ""int[] Test.<>c__DisplayClass0_0.x""
+  IL_001d:  ldc.i4.0
+  IL_001e:  ldelem.i4
+  IL_001f:  stloc.1
+  IL_0020:  ldloca.s   V_1
+  IL_0022:  ldloc.0
+  IL_0023:  ldftn      ""void Test.<>c__DisplayClass0_0.<Main>b__0()""
+  IL_0029:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_002e:  call       ""void Test.Moo(in int, System.Action)""
+  IL_0033:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_FieldAcces()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    struct S1
+    {
+        public int x;
+    }
+
+    static S1 s = new S1 { x = 555 };
+
+    static void Main(string[] args)
+    {
+        Moo(s.x + 0);
+    }
+
+    static void Moo(in int y)
+    {
+        Console.Write(y);
+        s.x = 123;
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "555555");
+
+            verifier.VerifyIL("Test.Main(string[])", @"
+{
+  // Code size       19 (0x13)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldsflda    ""Test.S1 Test.s""
+  IL_0005:  ldfld      ""int Test.S1.x""
+  IL_000a:  stloc.0
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  call       ""void Test.Moo(in int)""
+  IL_0012:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_RoFieldAcces()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    struct S1
+    {
+        public int x;
+    }
+
+    readonly S1 s;
+
+    static void Main(string[] args)
+    {
+        var x = new Test();
+    }
+
+    public Test()
+    {
+        Test1(s.x + 0, ref s.x);
+    }
+
+    private void Test1(in int y, ref int f)
+    {
+        Console.Write(y);
+        f = 1;
+        Console.Write(y);
+
+        Test2(s.x + 0, ref f);
+    }
+
+    private void Test2(in int y, ref int f)
+    {
+        Console.Write(y);
+        f = 2;
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "0011", verify: Verification.Fails);
+
+            verifier.VerifyIL("Test..ctor()", @"
+{
+  // Code size       38 (0x26)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ldarg.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldflda     ""Test.S1 Test.s""
+  IL_000d:  ldfld      ""int Test.S1.x""
+  IL_0012:  stloc.0
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  ldarg.0
+  IL_0016:  ldflda     ""Test.S1 Test.s""
+  IL_001b:  ldflda     ""int Test.S1.x""
+  IL_0020:  call       ""void Test.Test1(in int, ref int)""
+  IL_0025:  ret
+}
+");
+
+            verifier.VerifyIL("Test.Test1(in int, ref int)", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldind.i4
+  IL_0002:  call       ""void System.Console.Write(int)""
+  IL_0007:  ldarg.2
+  IL_0008:  ldc.i4.1
+  IL_0009:  stind.i4
+  IL_000a:  ldarg.1
+  IL_000b:  ldind.i4
+  IL_000c:  call       ""void System.Console.Write(int)""
+  IL_0011:  ldarg.0
+  IL_0012:  ldarg.0
+  IL_0013:  ldflda     ""Test.S1 Test.s""
+  IL_0018:  ldfld      ""int Test.S1.x""
+  IL_001d:  stloc.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  ldarg.2
+  IL_0021:  call       ""void Test.Test2(in int, ref int)""
+  IL_0026:  ret
+}
+");
+
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_ThisAcces()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        var x = new Test();
+    }
+
+    public Test()
+    {
+        Test3(null ?? this);
+    }
+
+    private void Test3(in Test y)
+    {
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "");
+
+            verifier.VerifyIL("Test..ctor()", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  2
+  .locals init (Test V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ldarg.0
+  IL_0007:  ldarg.0
+  IL_0008:  stloc.0
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  call       ""void Test.Test3(in Test)""
+  IL_0010:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_RefMethod()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        var x = new Test();
+    }
+
+    private string s = ""hi"";
+
+    private ref string M1()
+    {
+        return ref s;
+    }
+
+    public Test()
+    {
+        Test3(null ?? M1());
+    }
+
+    private void Test3(in string y)
+    {
+        Console.Write(y);
+        s = ""bye"";
+        Console.Write(y);
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "hihi");
+
+            verifier.VerifyIL("Test..ctor()", @"
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  .locals init (string V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""hi""
+  IL_0006:  stfld      ""string Test.s""
+  IL_000b:  ldarg.0
+  IL_000c:  call       ""object..ctor()""
+  IL_0011:  ldarg.0
+  IL_0012:  ldarg.0
+  IL_0013:  call       ""ref string Test.M1()""
+  IL_0018:  ldind.ref
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  call       ""void Test.Test3(in string)""
+  IL_0021:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_InOperator()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        var x = new Test();
+    }
+
+    private static string s = ""hi"";
+
+    public Test()
+    {
+        var dummy = (null ?? s) + this;
+    }
+
+    public static string operator +(in string y, in Test t)
+    {
+        Console.Write(y);
+        s = ""bye"";
+        Console.Write(y);
+
+        return y;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "hihi");
+
+            verifier.VerifyIL("Test..ctor()", @"
+{
+  // Code size       23 (0x17)
+  .maxstack  2
+  .locals init (string V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  call       ""object..ctor()""
+  IL_0006:  ldsfld     ""string Test.s""
+  IL_000b:  stloc.0
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldarga.s   V_0
+  IL_0010:  call       ""string Test.op_Addition(in string, in Test)""
+  IL_0015:  pop
+  IL_0016:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_InOperatorLifted()
+        {
+            var code = @"
+using System;
+
+public struct Test
+{
+    static void Main(string[] args)
+    {
+        var x = new Test();
+        x.Test1();
+    }
+
+    private Action change;
+    public Test(Action change)
+    {
+        this.change = change;
+    }
+
+
+    public void Test1()
+    {
+        int s = 1;
+        Test? t = new Test(() => s = 42);
+
+        var dummy = s + t;
+    }
+
+    public static int operator +(in int y, in Test t)
+    {
+        Console.Write(y);
+        t.change();
+        Console.Write(y);
+
+        return 88;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "11");
+
+            verifier.VerifyIL("Test.Test1()", @"
+{
+  // Code size       71 (0x47)
+  .maxstack  2
+  .locals init (Test.<>c__DisplayClass3_0 V_0, //CS$<>8__locals0
+                int V_1,
+                Test? V_2,
+                Test V_3)
+  IL_0000:  newobj     ""Test.<>c__DisplayClass3_0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldc.i4.1
+  IL_0008:  stfld      ""int Test.<>c__DisplayClass3_0.s""
+  IL_000d:  ldloc.0
+  IL_000e:  ldftn      ""void Test.<>c__DisplayClass3_0.<Test1>b__0()""
+  IL_0014:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0019:  newobj     ""Test..ctor(System.Action)""
+  IL_001e:  newobj     ""Test?..ctor(Test)""
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      ""int Test.<>c__DisplayClass3_0.s""
+  IL_0029:  stloc.1
+  IL_002a:  stloc.2
+  IL_002b:  ldloca.s   V_2
+  IL_002d:  call       ""bool Test?.HasValue.get""
+  IL_0032:  brfalse.s  IL_0046
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  ldloca.s   V_2
+  IL_0038:  call       ""Test Test?.GetValueOrDefault()""
+  IL_003d:  stloc.3
+  IL_003e:  ldloca.s   V_3
+  IL_0040:  call       ""int Test.op_Addition(in int, in Test)""
+  IL_0045:  pop
+  IL_0046:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_InOperatorUnary()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        Test1();
+    }
+
+    private static Test s = new Test();
+
+    public static void Test1()
+    {
+        var dummy = +(null ?? s);
+    }
+
+    public static Test operator +(in Test y)
+    {
+        Console.Write(y);
+        s = default;
+        Console.Write(y);
+
+        return y;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "TestTest");
+
+            verifier.VerifyIL("Test.Test1()", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  1
+  .locals init (Test V_0)
+  IL_0000:  ldsfld     ""Test Test.s""
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       ""Test Test.op_UnaryPlus(in Test)""
+  IL_000d:  pop
+  IL_000e:  ret
+}
+");
+        }
+
+        [WorkItem(24806, "https://github.com/dotnet/roslyn/issues/24806")]
+        [Fact]
+        public void OptimizedRValueToIn_InConversion()
+        {
+            var code = @"
+using System;
+
+public class Test
+{
+    static void Main(string[] args)
+    {
+        Test1();
+    }
+
+    private static Test s = new Test();
+
+    public static void Test1()
+    {
+        int dummyI = (null ?? s);
+
+        s = new Derived();
+
+        long dummyL = (null ?? s);
+    }
+
+    public static implicit operator int(in Test y)
+    {
+        Console.Write(y.ToString());
+        s = default;
+        Console.Write(y.ToString());
+
+        return 1;
+    }
+}
+
+class Derived : Test { }
+";
+
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(compilation, expectedOutput: "TestTestDerivedDerived");
+
+            verifier.VerifyIL("Test.Test1()", @"
+{
+  // Code size       39 (0x27)
+  .maxstack  1
+  .locals init (Test V_0)
+  IL_0000:  ldsfld     ""Test Test.s""
+  IL_0005:  stloc.0
+  IL_0006:  ldloca.s   V_0
+  IL_0008:  call       ""int Test.op_Implicit(in Test)""
+  IL_000d:  pop
+  IL_000e:  newobj     ""Derived..ctor()""
+  IL_0013:  stsfld     ""Test Test.s""
+  IL_0018:  ldsfld     ""Test Test.s""
+  IL_001d:  stloc.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  call       ""int Test.op_Implicit(in Test)""
+  IL_0025:  pop
+  IL_0026:  ret
+}
+");
+        }
+
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -2921,7 +2921,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
 
             verifier.VerifyIL("Test.Main(string[])", @"
@@ -2972,7 +2972,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
 
             verifier.VerifyIL("Test.Main(string[])", @"
@@ -3030,7 +3030,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "5050");
 
             verifier.VerifyIL("Test.Main(string[])", @"
@@ -3094,7 +3094,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
             var verifier = CompileAndVerify(compilation, expectedOutput: "555555");
 
             verifier.VerifyIL("Test.Main(string[])", @"
@@ -3156,7 +3156,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "0011", verify: Verification.Fails);
 
@@ -3234,7 +3234,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "");
 
@@ -3290,7 +3290,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "hihi");
 
@@ -3348,7 +3348,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "hihi");
 
@@ -3411,7 +3411,7 @@ public struct Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "11");
 
@@ -3484,7 +3484,7 @@ public class Test
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "TestTest");
 
@@ -3541,7 +3541,7 @@ public class Test
 class Derived : Test { }
 ";
 
-            var compilation = CreateCompilationWithMscorlibAndSystemCore(code, options: TestOptions.ReleaseExe);
+            var compilation = CreateCompilation(code, options: TestOptions.ReleaseExe);
 
             var verifier = CompileAndVerify(compilation, expectedOutput: "TestTestDerivedDerived");
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -3566,7 +3566,5 @@ class Derived : Test { }
 }
 ");
         }
-
-
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1800,29 +1800,27 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size       59 (0x3b)
+  // Code size       57 (0x39)
   .maxstack  3
   .locals init (S V_0,
-                S V_1)
+  S V_1)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.0
   IL_000b:  stfld      ""int S.x""
-  IL_0010:  ldloc.0
-  IL_0011:  stloc.0
-  IL_0012:  ldloca.s   V_0
-  IL_0014:  ldloca.s   V_1
-  IL_0016:  initobj    ""S""
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  ldc.i4.1
-  IL_001f:  stfld      ""int S.x""
-  IL_0024:  ldloc.1
-  IL_0025:  box        ""S""
-  IL_002a:  constrained. ""S""
-  IL_0030:  callvirt   ""bool object.Equals(object)""
-  IL_0035:  call       ""void System.Console.WriteLine(bool)""
-  IL_003a:  ret
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  initobj    ""S""
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  ldc.i4.1
+  IL_001d:  stfld      ""int S.x""
+  IL_0022:  ldloc.1
+  IL_0023:  box        ""S""
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""bool object.Equals(object)""
+  IL_0033:  call       ""void System.Console.WriteLine(bool)""
+  IL_0038:  ret
 }
 ");
         }
@@ -1858,7 +1856,7 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size       96 (0x60)
+  // Code size       94 (0x5e)
   .maxstack  4
   .locals init (S V_0,
                 S1 V_1,
@@ -1873,27 +1871,26 @@ struct S
   IL_0015:  stfld      ""int S1.x""
   IL_001a:  ldloc.1
   IL_001b:  stfld      ""S1 S.x""
-  IL_0020:  ldloc.0
-  IL_0021:  stloc.0
-  IL_0022:  ldloca.s   V_0
-  IL_0024:  ldflda     ""S1 S.x""
-  IL_0029:  ldloca.s   V_2
-  IL_002b:  initobj    ""S""
-  IL_0031:  ldloca.s   V_2
-  IL_0033:  ldloca.s   V_1
-  IL_0035:  initobj    ""S1""
-  IL_003b:  ldloca.s   V_1
-  IL_003d:  ldc.i4.1
-  IL_003e:  stfld      ""int S1.x""
-  IL_0043:  ldloc.1
-  IL_0044:  stfld      ""S1 S.x""
-  IL_0049:  ldloc.2
-  IL_004a:  box        ""S""
-  IL_004f:  constrained. ""S1""
-  IL_0055:  callvirt   ""bool object.Equals(object)""
-  IL_005a:  call       ""void System.Console.WriteLine(bool)""
-  IL_005f:  ret
-}");
+  IL_0020:  ldloca.s   V_0
+  IL_0022:  ldflda     ""S1 S.x""
+  IL_0027:  ldloca.s   V_2
+  IL_0029:  initobj    ""S""
+  IL_002f:  ldloca.s   V_2
+  IL_0031:  ldloca.s   V_1
+  IL_0033:  initobj    ""S1""
+  IL_0039:  ldloca.s   V_1
+  IL_003b:  ldc.i4.1
+  IL_003c:  stfld      ""int S1.x""
+  IL_0041:  ldloc.1
+  IL_0042:  stfld      ""S1 S.x""
+  IL_0047:  ldloc.2
+  IL_0048:  box        ""S""
+  IL_004d:  constrained. ""S1""
+  IL_0053:  callvirt   ""bool object.Equals(object)""
+  IL_0058:  call       ""void System.Console.WriteLine(bool)""
+  IL_005d:  ret
+}
+");
         }
 
         [Fact]
@@ -1981,50 +1978,47 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size      120 (0x78)
+  // Code size      116 (0x74)
   .maxstack  4
   .locals init (S V_0,
                 S V_1,
-                bool V_2)
+                bool V_2,
+                S V_3)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.0
   IL_000b:  stfld      ""int S.x""
-  IL_0010:  ldloc.0
-  IL_0011:  stloc.0
-  IL_0012:  ldloca.s   V_0
-  IL_0014:  ldloca.s   V_1
-  IL_0016:  initobj    ""S""
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  ldc.i4.1
-  IL_001f:  stfld      ""int S.x""
-  IL_0024:  ldloc.1
-  IL_0025:  box        ""S""
-  IL_002a:  constrained. ""S""
-  IL_0030:  callvirt   ""bool object.Equals(object)""
-  IL_0035:  stloc.2
-  IL_0036:  ldloca.s   V_2
-  IL_0038:  ldloca.s   V_0
-  IL_003a:  initobj    ""S""
-  IL_0040:  ldloca.s   V_0
-  IL_0042:  ldc.i4.1
-  IL_0043:  stfld      ""int S.x""
-  IL_0048:  ldloc.0
-  IL_0049:  stloc.0
-  IL_004a:  ldloca.s   V_0
-  IL_004c:  ldloca.s   V_1
-  IL_004e:  initobj    ""S""
-  IL_0054:  ldloca.s   V_1
-  IL_0056:  ldc.i4.1
-  IL_0057:  stfld      ""int S.x""
-  IL_005c:  ldloc.1
-  IL_005d:  box        ""S""
-  IL_0062:  constrained. ""S""
-  IL_0068:  callvirt   ""bool object.Equals(object)""
-  IL_006d:  call       ""bool bool.Equals(bool)""
-  IL_0072:  call       ""void System.Console.WriteLine(bool)""
-  IL_0077:  ret
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  ldloca.s   V_1
+  IL_0014:  initobj    ""S""
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  ldc.i4.1
+  IL_001d:  stfld      ""int S.x""
+  IL_0022:  ldloc.1
+  IL_0023:  box        ""S""
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""bool object.Equals(object)""
+  IL_0033:  stloc.2
+  IL_0034:  ldloca.s   V_2
+  IL_0036:  ldloca.s   V_1
+  IL_0038:  initobj    ""S""
+  IL_003e:  ldloca.s   V_1
+  IL_0040:  ldc.i4.1
+  IL_0041:  stfld      ""int S.x""
+  IL_0046:  ldloca.s   V_1
+  IL_0048:  ldloca.s   V_3
+  IL_004a:  initobj    ""S""
+  IL_0050:  ldloca.s   V_3
+  IL_0052:  ldc.i4.1
+  IL_0053:  stfld      ""int S.x""
+  IL_0058:  ldloc.3
+  IL_0059:  box        ""S""
+  IL_005e:  constrained. ""S""
+  IL_0064:  callvirt   ""bool object.Equals(object)""
+  IL_0069:  call       ""bool bool.Equals(bool)""
+  IL_006e:  call       ""void System.Console.WriteLine(bool)""
+  IL_0073:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1800,27 +1800,29 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size       57 (0x39)
+  // Code size       59 (0x3b)
   .maxstack  3
   .locals init (S V_0,
-  S V_1)
+                S V_1)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.0
   IL_000b:  stfld      ""int S.x""
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  ldloca.s   V_1
-  IL_0014:  initobj    ""S""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldc.i4.1
-  IL_001d:  stfld      ""int S.x""
-  IL_0022:  ldloc.1
-  IL_0023:  box        ""S""
-  IL_0028:  constrained. ""S""
-  IL_002e:  callvirt   ""bool object.Equals(object)""
-  IL_0033:  call       ""void System.Console.WriteLine(bool)""
-  IL_0038:  ret
+  IL_0010:  ldloc.0
+  IL_0011:  stloc.0
+  IL_0012:  ldloca.s   V_0
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  initobj    ""S""
+  IL_001c:  ldloca.s   V_1
+  IL_001e:  ldc.i4.1
+  IL_001f:  stfld      ""int S.x""
+  IL_0024:  ldloc.1
+  IL_0025:  box        ""S""
+  IL_002a:  constrained. ""S""
+  IL_0030:  callvirt   ""bool object.Equals(object)""
+  IL_0035:  call       ""void System.Console.WriteLine(bool)""
+  IL_003a:  ret
 }
 ");
         }
@@ -1856,7 +1858,7 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size       94 (0x5e)
+  // Code size       96 (0x60)
   .maxstack  4
   .locals init (S V_0,
                 S1 V_1,
@@ -1871,26 +1873,27 @@ struct S
   IL_0015:  stfld      ""int S1.x""
   IL_001a:  ldloc.1
   IL_001b:  stfld      ""S1 S.x""
-  IL_0020:  ldloca.s   V_0
-  IL_0022:  ldflda     ""S1 S.x""
-  IL_0027:  ldloca.s   V_2
-  IL_0029:  initobj    ""S""
-  IL_002f:  ldloca.s   V_2
-  IL_0031:  ldloca.s   V_1
-  IL_0033:  initobj    ""S1""
-  IL_0039:  ldloca.s   V_1
-  IL_003b:  ldc.i4.1
-  IL_003c:  stfld      ""int S1.x""
-  IL_0041:  ldloc.1
-  IL_0042:  stfld      ""S1 S.x""
-  IL_0047:  ldloc.2
-  IL_0048:  box        ""S""
-  IL_004d:  constrained. ""S1""
-  IL_0053:  callvirt   ""bool object.Equals(object)""
-  IL_0058:  call       ""void System.Console.WriteLine(bool)""
-  IL_005d:  ret
-}
-");
+  IL_0020:  ldloc.0
+  IL_0021:  stloc.0
+  IL_0022:  ldloca.s   V_0
+  IL_0024:  ldflda     ""S1 S.x""
+  IL_0029:  ldloca.s   V_2
+  IL_002b:  initobj    ""S""
+  IL_0031:  ldloca.s   V_2
+  IL_0033:  ldloca.s   V_1
+  IL_0035:  initobj    ""S1""
+  IL_003b:  ldloca.s   V_1
+  IL_003d:  ldc.i4.1
+  IL_003e:  stfld      ""int S1.x""
+  IL_0043:  ldloc.1
+  IL_0044:  stfld      ""S1 S.x""
+  IL_0049:  ldloc.2
+  IL_004a:  box        ""S""
+  IL_004f:  constrained. ""S1""
+  IL_0055:  callvirt   ""bool object.Equals(object)""
+  IL_005a:  call       ""void System.Console.WriteLine(bool)""
+  IL_005f:  ret
+}");
         }
 
         [Fact]
@@ -1978,47 +1981,50 @@ struct S
             compilation.VerifyIL("S.Main",
 @"
 {
-  // Code size      116 (0x74)
+  // Code size      120 (0x78)
   .maxstack  4
   .locals init (S V_0,
                 S V_1,
-                bool V_2,
-                S V_3)
+                bool V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
   IL_000a:  ldc.i4.0
   IL_000b:  stfld      ""int S.x""
-  IL_0010:  ldloca.s   V_0
-  IL_0012:  ldloca.s   V_1
-  IL_0014:  initobj    ""S""
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldc.i4.1
-  IL_001d:  stfld      ""int S.x""
-  IL_0022:  ldloc.1
-  IL_0023:  box        ""S""
-  IL_0028:  constrained. ""S""
-  IL_002e:  callvirt   ""bool object.Equals(object)""
-  IL_0033:  stloc.2
-  IL_0034:  ldloca.s   V_2
-  IL_0036:  ldloca.s   V_1
-  IL_0038:  initobj    ""S""
-  IL_003e:  ldloca.s   V_1
-  IL_0040:  ldc.i4.1
-  IL_0041:  stfld      ""int S.x""
-  IL_0046:  ldloca.s   V_1
-  IL_0048:  ldloca.s   V_3
-  IL_004a:  initobj    ""S""
-  IL_0050:  ldloca.s   V_3
-  IL_0052:  ldc.i4.1
-  IL_0053:  stfld      ""int S.x""
-  IL_0058:  ldloc.3
-  IL_0059:  box        ""S""
-  IL_005e:  constrained. ""S""
-  IL_0064:  callvirt   ""bool object.Equals(object)""
-  IL_0069:  call       ""bool bool.Equals(bool)""
-  IL_006e:  call       ""void System.Console.WriteLine(bool)""
-  IL_0073:  ret
+  IL_0010:  ldloc.0
+  IL_0011:  stloc.0
+  IL_0012:  ldloca.s   V_0
+  IL_0014:  ldloca.s   V_1
+  IL_0016:  initobj    ""S""
+  IL_001c:  ldloca.s   V_1
+  IL_001e:  ldc.i4.1
+  IL_001f:  stfld      ""int S.x""
+  IL_0024:  ldloc.1
+  IL_0025:  box        ""S""
+  IL_002a:  constrained. ""S""
+  IL_0030:  callvirt   ""bool object.Equals(object)""
+  IL_0035:  stloc.2
+  IL_0036:  ldloca.s   V_2
+  IL_0038:  ldloca.s   V_0
+  IL_003a:  initobj    ""S""
+  IL_0040:  ldloca.s   V_0
+  IL_0042:  ldc.i4.1
+  IL_0043:  stfld      ""int S.x""
+  IL_0048:  ldloc.0
+  IL_0049:  stloc.0
+  IL_004a:  ldloca.s   V_0
+  IL_004c:  ldloca.s   V_1
+  IL_004e:  initobj    ""S""
+  IL_0054:  ldloca.s   V_1
+  IL_0056:  ldc.i4.1
+  IL_0057:  stfld      ""int S.x""
+  IL_005c:  ldloc.1
+  IL_005d:  box        ""S""
+  IL_0062:  constrained. ""S""
+  IL_0068:  callvirt   ""bool object.Equals(object)""
+  IL_006d:  call       ""bool bool.Equals(bool)""
+  IL_0072:  call       ""void System.Console.WriteLine(bool)""
+  IL_0077:  ret
 }
 ");
         }


### PR DESCRIPTION
Fixes:#https://github.com/dotnet/roslyn/issues/24806

### Customer scenario

Customer writes some code where compiler is able to reduce complex expressions into simpler ones. That makes the resulting code smaller and possibly faster.
However if while doing so a reduction replaced an expression that could not be passed by reference - like `(x + 0)` into one that can - like `x`, the code may subtly change its semantics by passing the `x` by reference. 

Generally C# is very explicit about passing variables by reference and `(x + 1)` would be an error in such contexts.
There are two situations where it is not an error
- receiver of a struct/generic, method calls
- ordinary byval argument that is matched to an `in` parameter of a method/operator/conversion

In the above cases the expressions in the source are required to only be `readable`, but also can pass the variable by reference if it is possible. 
As a result we must be careful to not make passing by reference _possible_ in the process of reduction.

### Bugs this fixes

#https://github.com/dotnet/roslyn/issues/24806

### Workarounds, if any

No workaround. User must be very careful to not use the code as described or not take dependency on "no-aliasing" behavior.

### Risk

Ultimately this is a bit of a corner case. Accidental aliasing is relatively hard to achieve and hard to observe. It is unlikely to be breaking in the majority of cases. 

We are fixing this to have a rational specified behavior that we can comfortably preserve in the future.

### Performance impact

Low perf impact. 
The new checks are relatively cheap. 
A new node will be allocated in very rare cases and is typically just a node for a node swap. (something needs to be reduced in order  for the new node even be needed) - the bound tree cannot get bigger because of this.

### Is this a regression from a previous update?

N/A. 

### Root cause analysis

The problem we are fixing is not new. In some cases the bug was present for more than a decade. 
We are adding more contexts now where the bug is observable and therefore we are fixing it here.

### How was the bug found?

Customer reported. More scenarios from internal testing.

### Test documentation updated?

N/A