### PR TITLE
Improve error reporting for editor unhandled exceptions

### DIFF
--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                         .ToArray();
         }
 
-        public static IEnumerable<Assembly> GetVisualStudioAssemblies()
+        public static IEnumerable<Assembly> GetEditorAssemblies()
         {
             var assemblies = new[]
             {

--- a/src/EditorFeatures/TestUtilities/ServiceTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/ServiceTestExportProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         public static ComposableCatalog CreateAssemblyCatalog()
         {
             return MinimalTestExportProvider.CreateAssemblyCatalog(
-                GetLanguageNeutralTypes().Select(t => t.Assembly).Distinct().Concat(MinimalTestExportProvider.GetVisualStudioAssemblies()), MinimalTestExportProvider.CreateResolver());
+                GetLanguageNeutralTypes().Select(t => t.Assembly).Distinct().Concat(MinimalTestExportProvider.GetEditorAssemblies()), MinimalTestExportProvider.CreateResolver());
         }
 
         public static Type[] GetLanguageNeutralTypes()

--- a/src/EditorFeatures/TestUtilities/TestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         private static Lazy<ComposableCatalog> s_lazyMinimumCatalogWithCSharpAndVisualBasic =
             new Lazy<ComposableCatalog>(() => MinimalTestExportProvider.CreateTypeCatalog(GetNeutralAndCSharpAndVisualBasicTypes())
-                        .WithParts(MinimalTestExportProvider.CreateAssemblyCatalog(MinimalTestExportProvider.GetVisualStudioAssemblies())));
+                        .WithParts(MinimalTestExportProvider.CreateAssemblyCatalog(MinimalTestExportProvider.GetEditorAssemblies())));
 
         public static ComposableCatalog MinimumCatalogWithCSharpAndVisualBasic
             => s_lazyMinimumCatalogWithCSharpAndVisualBasic.Value;
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         public static IEnumerable<Assembly> GetCSharpAndVisualBasicAssemblies()
         {
-            return GetNeutralAndCSharpAndVisualBasicTypes().Select(t => t.Assembly).Distinct().Concat(MinimalTestExportProvider.GetVisualStudioAssemblies());
+            return GetNeutralAndCSharpAndVisualBasicTypes().Select(t => t.Assembly).Distinct().Concat(MinimalTestExportProvider.GetEditorAssemblies());
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
+++ b/src/EditorFeatures/TestUtilities/TestExtensionErrorHandler.cs
@@ -5,11 +5,11 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests
 {
-    [Export(typeof(TestExtensionErrorHandler))]
     [Export(typeof(IExtensionErrorHandler))]
     internal class TestExtensionErrorHandler : IExtensionErrorHandler
     {
@@ -17,36 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
 
         public void HandleError(object sender, Exception exception)
         {
-            if (exception == null)
-            {
-                // Log an exception saying we didn't get an exception. I'd consider throwing here, but double-faults are just caught and consumed by
-                // the editor so that won't give a good debugging experience either.
-                try
-                {
-                    ThrowExceptionToGetStackTrace();
-                }
-                catch (Exception e)
-                {
-                    exception = e;
-                }
-            }
-
-            ImmutableInterlocked.Update(
-                ref _exceptions,
-                (list, item) => list.Add(item),
-                exception);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowExceptionToGetStackTrace()
-        {
-            throw new Exception($"{nameof(TestExtensionErrorHandler)}.{nameof(HandleError)} called with null exception");
-        }
-
-        public ImmutableList<Exception> GetExceptions()
-        {
-            // We'll clear off our list, so that way we don't report this for other tests
-            return Interlocked.Exchange(ref _exceptions, ImmutableList<Exception>.Empty);
+            ExceptionUtilities.FailFast(exception);
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -144,38 +144,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 document.CloseTextView();
             }
 
-            var exceptions = Flatten(ExportProvider.GetExportedValue<TestExtensionErrorHandler>().GetExceptions());
-
-            if (exceptions.Count > 0)
-            {
-                var messageBuilder = new StringBuilder();
-                messageBuilder.AppendLine(
-$@"{exceptions.Count} exception(s) were thrown during test.
-Note: exceptions may have been thrown by another test running concurrently with
-this test.  This can happen with any tests that share the same ExportProvider.
-Examining individual exception stacks may help reveal the original test and source 
-of the problem.");
-
-                messageBuilder.AppendLine();
-                for (int i = 0; i < exceptions.Count; i++)
-                {
-                    var exception = exceptions[i];
-                    messageBuilder.AppendLine($"Exception {i}:");
-                    messageBuilder.AppendLine(exception.ToString());
-                    messageBuilder.AppendLine();
-                }
-
-                var message = messageBuilder.ToString();
-                if (exceptions.Count == 1)
-                {
-                    throw new Exception(message, exceptions[0]);
-                }
-                else
-                {
-                    throw new AggregateException(message, exceptions);
-                }
-            }
-
             if (SynchronizationContext.Current != null)
             {
                 Dispatcher.CurrentDispatcher.DoEvents();

--- a/src/Tools/Source/RunTests/ProcDumpUtil.cs
+++ b/src/Tools/Source/RunTests/ProcDumpUtil.cs
@@ -63,8 +63,7 @@ namespace RunTests
             // /accepteula command line option to automatically accept the Sysinternals license agreement.
             // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
             // -e	Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
-            // -t	Write a dump when the process terminates.
-            const string procDumpSwitches = "/accepteula -ma -e -t";
+            const string procDumpSwitches = "/accepteula -ma -e";
             Directory.CreateDirectory(dumpDirectory);
             dumpDirectory = dumpDirectory.TrimEnd('\\');
 

--- a/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/InteractiveWindowTestHost.cs
@@ -1,12 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
 using System.Linq;
-using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.InteractiveWindow;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
+using Microsoft.VisualStudio.InteractiveWindow;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.Text.Utilities;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
 {
@@ -27,6 +32,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Interactive
             }.Concat(MinimalTestExportProvider.GetEditorAssemblies());
             return new AggregateCatalog(assemblies.Select(a => new AssemblyCatalog(a)));
         });
+
+        // Provide an export of ILoggingServiceInternal to work around https://devdiv.visualstudio.com/DevDiv/_workitems/edit/570290
+        [Export(typeof(ILoggingServiceInternal))]
+        private sealed class HACK_LoggingProvider : ILoggingServiceInternal
+        {
+            public void AdjustCounter(string key, string name, int delta = 1)
+            {
+            }
+
+            public void PostCounters()
+            {
+            }
+
+            public void PostEvent(string key, params object[] namesAndProperties)
+            {
+            }
+
+            public void PostEvent(string key, IReadOnlyList<object> namesAndProperties)
+            {
+            }
+
+            public void PostEvent(DataModelEventType eventType, string eventName, TelemetryResult result = TelemetryResult.Success, params (string name, object property)[] namesAndProperties)
+            {
+            }
+
+            public void PostEvent(DataModelEventType eventType, string eventName, TelemetryResult result, IReadOnlyList<(string name, object property)> namesAndProperties)
+            {
+            }
+
+            public void PostFault(string eventName, string description, Exception exceptionObject, string additionalErrorInfo, bool? isIncludedInWatsonSample)
+            {
+            }
+        }
 
         internal InteractiveWindowTestHost()
         {


### PR DESCRIPTION
Two infrastructure changes:

1. Don't create crash dumps when xunit exits. These are usually (always?) clean exits and thus creates noise. This is dumps from the mechanism that was broken for months and months 
2. FailFast when some exceptions are happening vs. logging an exception that isn't necessarily useful.