### PR TITLE
SubstituteNoPiaLocalType - use comparison of SpecialTypes to match bases across distinct core libraries.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -407,7 +407,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                         // Let's use a trick. To make sure the kind is the same, make sure
                         // base type is the same.
-                        if (!ReferenceEquals(baseType, candidate.BaseTypeNoUseSiteDiagnostics))
+                        SpecialType baseSpecialType = (candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType).GetValueOrDefault();
+                        if (baseSpecialType == SpecialType.None || baseSpecialType != (baseType?.SpecialType).GetValueOrDefault())
                         {
                             continue;
                         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -2611,5 +2611,65 @@ public class Consumer
 
             CompileAndVerify(consumer);
         }
+
+        [Fact]
+        [WorkItem(24964, "https://github.com/dotnet/roslyn/issues/24964")]
+        public void UnificationAcrossDistincCoreLibs()
+        {
+            string pia = @"
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+[assembly: ImportedFromTypeLib(""GeneralPIA.dll"")]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+public struct Test
+{
+}
+";
+
+            var piaCompilation = CreateCompilationWithMscorlib45(pia, options: TestOptions.DebugDll, assemblyName: "Pia");
+
+            string consumer1 = @"
+public class UsePia1 
+{
+    public static Test M1()
+    {
+        return default;
+    }
+} 
+";
+
+            string consumer2 = @"
+class UsePia2 
+{
+    public static void Main()
+    {
+        UsePia1.M1();
+    }
+} 
+";
+
+            foreach (MetadataReference piaRef in new[] { piaCompilation.EmitToImageReference(), piaCompilation.ToMetadataReference() })
+            {
+                var compilation1 = CreateCompilationWithMscorlib45(consumer1, references: new[] { piaRef.WithEmbedInteropTypes(true) });
+
+                foreach (MetadataReference consumer1Ref in new[] { compilation1.EmitToImageReference(), compilation1.ToMetadataReference() })
+                {
+                    var compilation2 = CreateCompilationWithMscorlib46(consumer2, references: new[] { piaRef, consumer1Ref });
+
+                    compilation2.VerifyDiagnostics();
+
+                    Assert.NotSame(compilation1.SourceAssembly.CorLibrary, compilation2.SourceAssembly.CorLibrary);
+
+                    var test = compilation2.GetTypeByMetadataName("Test");
+                    Assert.Equal("Pia.dll", test.ContainingModule.Name);
+
+                    var usePia1 = compilation2.GetTypeByMetadataName("UsePia1");
+                    Assert.Same(test, usePia1.GetMember<MethodSymbol>("M1").ReturnType);
+                }
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -2614,7 +2614,7 @@ public class Consumer
 
         [Fact]
         [WorkItem(24964, "https://github.com/dotnet/roslyn/issues/24964")]
-        public void UnificationAcrossDistincCoreLibs()
+        public void UnificationAcrossDistinctCoreLibs()
         {
             string pia = @"
 using System;

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -359,7 +359,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
                         ' Let's use a trick. To make sure the kind is the same, make sure
                         ' base type is the same.
-                        If baseType IsNot candidate.BaseTypeNoUseSiteDiagnostics Then
+                        Dim baseSpecialType As SpecialType = (candidate.BaseTypeNoUseSiteDiagnostics?.SpecialType).GetValueOrDefault()
+                        If baseSpecialType = SpecialType.None OrElse baseSpecialType <> (baseType?.SpecialType).GetValueOrDefault() Then
                             Continue For
                         End If
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
@@ -1687,7 +1687,7 @@ End Module
 
         <Fact>
         <WorkItem(24964, "https://github.com/dotnet/roslyn/issues/24964")>
-        Public Sub UnificationAcrossDistincCoreLibs()
+        Public Sub UnificationAcrossDistinctCoreLibs()
             Dim pia = "
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
@@ -1685,6 +1685,55 @@ End Module
             CompileAndVerify(comp3, expectedOutput:="Y").Diagnostics.Verify()
         End Sub
 
+        <Fact>
+        <WorkItem(24964, "https://github.com/dotnet/roslyn/issues/24964")>
+        Public Sub UnificationAcrossDistincCoreLibs()
+            Dim pia = "
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+<Assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")>
+<Assembly: ImportedFromTypeLib(""Pia.dll"")>
+
+Public Structure Test
+End Structure
+"
+            Dim piaCompilation = CreateCompilationWithMscorlib45(pia, options:=TestOptions.ReleaseDll, assemblyName:="Pia")
+
+            Dim consumer1 = "
+Public Class UsePia1 
+    Public Shared Function M1() As Test
+        Return Nothing
+    End Function
+End Class
+"
+
+            Dim consumer2 = "
+Public Class Program
+    Public Sub Main()
+        UsePia1.M1()
+    End Sub
+End Class
+"
+            For Each piaRef As MetadataReference In {piaCompilation.EmitToImageReference(), piaCompilation.ToMetadataReference()}
+                Dim compilation1 = CreateCompilationWithMscorlib45(consumer1, references:={piaRef.WithEmbedInteropTypes(True)}, options:=TestOptions.ReleaseDll)
+
+                For Each consumer1Ref As MetadataReference In {compilation1.EmitToImageReference(), compilation1.ToMetadataReference()}
+                    Dim compilation2 = CreateCompilation(consumer2, references:={MscorlibRef_v46, piaRef, consumer1Ref})
+
+                    compilation2.VerifyDiagnostics()
+
+                    Assert.NotSame(compilation1.SourceAssembly.CorLibrary, compilation2.SourceAssembly.CorLibrary)
+
+                    Dim test = compilation2.GetTypeByMetadataName("Test")
+                    Assert.Equal("Pia.dll", test.ContainingModule.Name)
+
+                    Dim usePia1 = compilation2.GetTypeByMetadataName("UsePia1")
+                    Assert.Same(test, usePia1.GetMember(Of MethodSymbol)("M1").ReturnType)
+                Next
+            Next
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #24964.

### Customer scenario

From https://github.com/dotnet/project-system/issues/2954:
1. git clone github.com/dotnet/projectsystem
2. git checkout 4d3123c
3. Open ProjectSystem.sln 

Observe massive amount of unexpected errors like:
```
Error	CS1748	Cannot find the interop type that matches the embedded interop type 'Microsoft.VisualStudio.Imaging.Interop.ImageMoniker'. Are you missing an assembly reference?	Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests	E:\project-system2\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Mocks\IDependencyModelFactory.cs	125	Active
```

### Bugs this fixes

#24964
https://github.com/dotnet/project-system/issues/2954

### Workarounds, if any

Target the same version of mscorlib in projects that depend on each other

### Risk

Low

### Performance impact

Low perf impact because no extra allocations/no complexity changes

### Is this a regression from a previous update?

No

### Root cause analysis

A test gap. A unit-test is added.

### How was the bug found?

Internal customer.

### Test documentation updated?

N/A