### PR TITLE
Add ref for and foreach variables

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -477,7 +477,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.WRN_AssignmentToLockOrDispose, local.Syntax.Location, localSymbol);
                 }
 
-                if (!localSymbol.IsWritable)
+                // IsWritable means the variable is writable. If this is a ref variable, IsWritable
+                // does not imply anything about the storage location
+                if (localSymbol.RefKind == RefKind.RefReadOnly ||
+                    (localSymbol.RefKind == RefKind.None && !localSymbol.IsWritable))
                 {
                     ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
                     return false;
@@ -485,10 +488,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (RequiresRefAssignableVariable(valueKind))
             {
-                if (!(localSymbol.RefKind == RefKind.Ref ||
-                      localSymbol.RefKind == RefKind.RefReadOnly))
+                if (localSymbol.RefKind == RefKind.None)
                 {
                     diagnostics.Add(ErrorCode.ERR_RefLocalOrParamExpected, node.Location, localSymbol);
+                    return false;
+                }
+                else if (!localSymbol.IsWritable)
+                {
+                    ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
                     return false;
                 }
             }
@@ -795,21 +802,28 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private bool CheckCallValueKind(BoundCall call, SyntaxNode node, BindValueKind valueKind, bool checkingReceiver, DiagnosticBag diagnostics)
+            => CheckMethodReturnValueKind(call.Method, call.Syntax, node, valueKind, checkingReceiver, diagnostics);
+
+        protected bool CheckMethodReturnValueKind(
+            MethodSymbol methodSymbol,
+            SyntaxNode callSyntaxOpt,
+            SyntaxNode node,
+            BindValueKind valueKind,
+            bool checkingReceiver,
+            DiagnosticBag diagnostics)
         {
             // A call can only be a variable if it returns by reference. If this is the case,
             // whether or not it is a valid variable depends on whether or not the call is the
             // RHS of a return or an assign by reference:
             // - If call is used in a context demanding ref-returnable reference all of its ref
             //   inputs must be ref-returnable
-            var methodSymbol = call.Method;
-            var callSyntax = call.Syntax;
 
             if (RequiresVariable(valueKind) && methodSymbol.RefKind == RefKind.None)
             {
                 if (checkingReceiver)
                 {
                     // Error is associated with expression, not node which may be distinct.
-                    Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, callSyntax, methodSymbol);
+                    Error(diagnostics, ErrorCode.ERR_ReturnNotLValue, callSyntaxOpt, methodSymbol);
                 }
                 else
                 {
@@ -832,6 +846,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return true;
+
         }
 
         private bool CheckPropertyValueKind(SyntaxNode node, BoundExpression expr, BindValueKind valueKind, bool checkingReceiver, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -480,7 +480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // IsWritable means the variable is writable. If this is a ref variable, IsWritable
                 // does not imply anything about the storage location
                 if (localSymbol.RefKind == RefKind.RefReadOnly ||
-                    (localSymbol.RefKind == RefKind.None && !localSymbol.IsWritable))
+                    (localSymbol.RefKind == RefKind.None && !localSymbol.IsWritableVariable))
                 {
                     ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
                     return false;
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.ERR_RefLocalOrParamExpected, node.Location, localSymbol);
                     return false;
                 }
-                else if (!localSymbol.IsWritable)
+                else if (!localSymbol.IsWritableVariable)
                 {
                     ReportReadonlyLocalError(node, localSymbol, valueKind, checkingReceiver, diagnostics);
                     return false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -592,7 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindDeclarationStatementParts(LocalDeclarationStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var typeSyntax = node.Declaration.Type.SkipRef(out RefKind _);
+            var typeSyntax = node.Declaration.Type.SkipRef(out _);
             bool isConst = node.IsConst;
 
             bool isVar;
@@ -640,8 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or it might not; if it is not then we do not want to report an error. If it is, then
             // we want to treat the declaration as an explicitly typed declaration.
 
-            RefKind refKind;
-            TypeSymbol declType = BindType(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
+            TypeSymbol declType = BindType(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
             Debug.Assert((object)declType != null || isVar);
 
             if (isVar)
@@ -754,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return expression;
         }
 
-        protected static bool IsInitializerRefKindValid(
+        private static bool IsInitializerRefKindValid(
             EqualsValueClauseSyntax initializer,
             CSharpSyntaxNode node,
             RefKind variableRefKind,
@@ -2202,6 +2201,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var typeSyntax = nodeOpt.Type;
+            // Fixed and using variables are not allowed to be ref-like, but regular variables are
+            if (localKind == LocalDeclarationKind.RegularVariable)
+            {
+                typeSyntax = typeSyntax.SkipRef(out _);
+            }
 
             AliasSymbol alias;
             bool isVar;

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         // If the type in syntax is "var", then the type should be set explicitly so that the
                         // Type property doesn't fail.
-                        TypeSyntax typeSyntax = node.Type;
+                        TypeSyntax typeSyntax = node.Type.SkipRef(out _);
 
                         bool isVar;
                         AliasSymbol alias;
@@ -238,6 +238,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                         SourceLocalSymbol local = this.IterationVariable;
                         local.SetType(iterationVariableType);
                         local.SetValEscape(collectionEscape);
+
+                        BindValueKind requiredCurrentKind;
+                        switch (local.RefKind)
+                        {
+                            case RefKind.None:
+                                requiredCurrentKind = BindValueKind.RValue;
+                                break;
+                            case RefKind.Ref:
+                                requiredCurrentKind = BindValueKind.Assignable | BindValueKind.RefersToLocation;
+                                break;
+                            case RefKind.RefReadOnly:
+                                requiredCurrentKind = BindValueKind.RefersToLocation;
+                                break;
+                            default:
+                                throw ExceptionUtilities.UnexpectedValue(local.RefKind);
+                        }
+
+                        hasErrors |= !CheckMethodReturnValueKind(
+                            builder.CurrentPropertyGetter,
+                            callSyntaxOpt: null,
+                            collectionExpr.Syntax,
+                            requiredCurrentKind,
+                            checkingReceiver: false,
+                            diagnostics);
 
                         break;
                     }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -239,29 +239,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                         local.SetType(iterationVariableType);
                         local.SetValEscape(collectionEscape);
 
-                        BindValueKind requiredCurrentKind;
-                        switch (local.RefKind)
+                        if (!hasErrors)
                         {
-                            case RefKind.None:
-                                requiredCurrentKind = BindValueKind.RValue;
-                                break;
-                            case RefKind.Ref:
-                                requiredCurrentKind = BindValueKind.Assignable | BindValueKind.RefersToLocation;
-                                break;
-                            case RefKind.RefReadOnly:
-                                requiredCurrentKind = BindValueKind.RefersToLocation;
-                                break;
-                            default:
-                                throw ExceptionUtilities.UnexpectedValue(local.RefKind);
-                        }
+                            BindValueKind requiredCurrentKind;
+                            switch (local.RefKind)
+                            {
+                                case RefKind.None:
+                                    requiredCurrentKind = BindValueKind.RValue;
+                                    break;
+                                case RefKind.Ref:
+                                    requiredCurrentKind = BindValueKind.Assignable | BindValueKind.RefersToLocation;
+                                    break;
+                                case RefKind.RefReadOnly:
+                                    requiredCurrentKind = BindValueKind.RefersToLocation;
+                                    break;
+                                default:
+                                    throw ExceptionUtilities.UnexpectedValue(local.RefKind);
+                            }
 
-                        hasErrors |= !CheckMethodReturnValueKind(
-                            builder.CurrentPropertyGetter,
-                            callSyntaxOpt: null,
-                            collectionExpr.Syntax,
-                            requiredCurrentKind,
-                            checkingReceiver: false,
-                            diagnostics);
+                            hasErrors |= !CheckMethodReturnValueKind(
+                                builder.CurrentPropertyGetter,
+                                callSyntaxOpt: null,
+                                collectionExpr.Syntax,
+                                requiredCurrentKind,
+                                checkingReceiver: false,
+                                diagnostics);
+                        }
 
                         break;
                     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return ((BoundFieldAccess)receiver).IsByValue;
 
                 case BoundKind.Local:
-                    return !((BoundLocal)receiver).LocalSymbol.IsWritable;
+                    return !((BoundLocal)receiver).LocalSymbol.IsWritableVariable;
 
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7740,6 +7740,7 @@ tryAgain:
             }
 
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
+
             var variable = ParseExpressionOrDeclaration(ParseTypeMode.Normal, feature: MessageID.IDS_FeatureTuples, permitTupleDesignation: true);
             var @in = this.EatToken(SyntaxKind.InKeyword, ErrorCode.ERR_InExpected);
             if (!IsValidForeachVariable(variable))

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case LocalDeclarationKind.UsingVariable:
                         return false;
                     default:
-                        return RefKind != RefKind.RefReadOnly;
+                        return true;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -253,7 +253,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract SyntaxNode GetDeclaratorSyntax();
 
-        internal virtual bool IsWritable
+        /// <summary>
+        /// Describes whether this represents a modifiable variable. Note that
+        /// this refers to the variable, not the underlying value, so if this
+        /// variable is a ref-local, the writability refers to ref-assignment,
+        /// not assignment to the underlying storage.
+        /// </summary>
+        internal virtual bool IsWritableVariable
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -602,7 +602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SyntaxToken identifierToken,
                 ExpressionSyntax collection,
                 LocalDeclarationKind declarationKind) :
-                    base(containingSymbol, scopeBinder, false, typeSyntax, identifierToken, declarationKind)
+                    base(containingSymbol, scopeBinder, allowRefKind: true, typeSyntax, identifierToken, declarationKind)
             {
                 Debug.Assert(declarationKind == LocalDeclarationKind.ForEachIterationVariable);
                 _collection = collection;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -13,6 +13,100 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     public class RefLocalsAndReturnsTests : CompilingTestBase
     {
         [Fact]
+        public void RefForToReadonly()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    void M(in int x)
+    {
+        for (ref int i = ref x; i < 0; i++) {}
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,30): error CS8329: Cannot use variable 'in int' as a ref or out value because it is a readonly variable
+                //         for (ref int i = ref x; i < 0; i++) {}
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "x").WithArguments("variable", "in int").WithLocation(6, 30));
+        }
+
+        [Fact]
+        public void RefForOutOfScope()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    ref int M()
+    {
+        int x = 0;
+        for (ref int i = ref x; i < 0; i++)
+        {
+            if (i == 0)
+            {
+                return ref i;
+            }
+        }
+        return ref (new int[1])[0];
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (11,28): error CS8157: Cannot return 'i' by reference because it was initialized to a value that cannot be returned by reference
+                //                 return ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "i").WithArguments("i").WithLocation(11, 28));
+        }
+
+        [Fact]
+        public void RefForeachReadonly()
+        {
+            var comp = CreateStandardCompilation(@"
+using System;
+class C
+{
+    void M()
+    {
+        foreach (ref var v in new int[0])
+        {
+        }
+        foreach (ref readonly var v in new int[0])
+        {
+        }
+        foreach (ref var v in new RefEnumerable())
+        {
+            Console.WriteLine(v);
+        }
+    }
+}
+
+class RefEnumerable
+{
+    private readonly int[] _arr = new int[5];
+    public StructEnum GetEnumerator() => new StructEnum(_arr);
+
+    public struct StructEnum
+    {
+        private readonly int[] _arr;
+        private int _current;
+        public StructEnum(int[] arr)
+        {
+            _arr = arr;
+            _current = -1;
+        }
+        public ref readonly int Current => ref _arr[_current];
+        public bool MoveNext() => ++_current != _arr.Length;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (7,31): error CS1510: A ref or out value must be an assignable variable
+                //         foreach (ref var v in new int[0])
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new int[0]").WithLocation(7, 31),
+                // (10,40): error CS1510: A ref or out value must be an assignable variable
+                //         foreach (ref readonly var v in new int[0])
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "new int[0]").WithLocation(10, 40),
+                // (13,31): error CS8331: Cannot assign to method 'RefEnumerable.StructEnum.Current.get' because it is a readonly variable
+                //         foreach (ref var v in new RefEnumerable())
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "new RefEnumerable()").WithArguments("method", "RefEnumerable.StructEnum.Current.get").WithLocation(13, 31));
+        }
+
+        [Fact]
         public void RefReassignIdentityConversion()
         {
             var comp = CreateStandardCompilation(@"
@@ -193,12 +287,9 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (18,18): error CS1073: Unexpected token 'ref'
-                //         foreach (ref int x in new E())
-                Diagnostic(ErrorCode.ERR_UnexpectedToken, "ref").WithArguments("ref").WithLocation(18, 18),
-                // (21,13): error CS8355: The left-hand side of a ref assignment must be a ref local or parameter.
+                // (21,13): error CS1656: Cannot assign to 'x' because it is a 'foreach iteration variable'
                 //             x = ref y;
-                Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "x").WithArguments("x").WithLocation(21, 13));
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocalCause, "x").WithArguments("x", "foreach iteration variable").WithLocation(21, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -13,6 +13,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
     public class RefLocalsAndReturnsTests : CompilingTestBase
     {
         [Fact]
+        public void RefForeachErrorRecovery()
+        {
+            var comp = CreateStandardCompilation(@"
+class C
+{
+    void M()
+    {
+        foreach (ref var x in )
+        {
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,31): error CS1525: Invalid expression term ')'
+                //         foreach (ref var x in )
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 31));
+        }
+
+        [Fact]
         public void RefForToReadonly()
         {
             var comp = CreateStandardCompilation(@"

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                         properties = default(ResultProperties);
                                         return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
                                     });
-                                var flags = local.IsWritable ? DkmClrCompilationResultFlags.None : DkmClrCompilationResultFlags.ReadOnlyResult;
+                                var flags = local.IsWritableVariable ? DkmClrCompilationResultFlags.None : DkmClrCompilationResultFlags.ReadOnlyResult;
                                 localBuilder.Add(MakeLocalAndMethod(local, aliasMethod, flags));
                                 methodBuilder.Add(aliasMethod);
                             }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ExceptionLocalSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _getExceptionMethodName = getExceptionMethodName;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return false; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectAddressLocalSymbol.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _address = address;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             // Return true?
             get { return false; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ObjectIdLocalSymbol.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _isWritable = isWritable;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return _isWritable; }
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return ImmutableArray<SyntaxReference>.Empty; }
         }
 
-        internal abstract override bool IsWritable { get; }
+        internal abstract override bool IsWritableVariable { get; }
 
         internal override EELocalSymbolBase ToOtherMethod(MethodSymbol method, TypeMap typeMap)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/ReturnValueLocalSymbol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             _index = index;
         }
 
-        internal override bool IsWritable
+        internal override bool IsWritableVariable
         {
             get { return false; }
         }


### PR DESCRIPTION
It was previously disallowed for a local variable in a for statement or
the iteration variable in a foreach statement to be a ref or ref
readonly local. This is now allowed. Like other foreach iteration
variables, a ref foreach variable is read-only, meaning it can't be
ref-reassigned.