### PR TITLE
Point Mono build to apt snapshots directory

### DIFF
--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y  libunwind8 \
 
 # Install Mono
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial main" | \
+    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial snapshots" | \
     tee /etc/apt/sources.list.d/mono-official.list) && \
     apt-get update && \
     apt-get install -y mono-devel=5.8.0.108-0xamarin1+ubuntu1604b1 && \

--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y  libunwind8 \
 
 # Install Mono
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial snapshots/5.8.0" | \
+    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial/snapshots/5.8.0 main" | \
     tee /etc/apt/sources.list.d/mono-official.list) && \
     apt-get update && \
     apt-get install -y mono-devel=5.8.0.108-0xamarin1+ubuntu1604b1 && \

--- a/build/scripts/docker/Dockerfile
+++ b/build/scripts/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y  libunwind8 \
 
 # Install Mono
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial snapshots" | \
+    (echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial snapshots/5.8.0" | \
     tee /etc/apt/sources.list.d/mono-official.list) && \
     apt-get update && \
     apt-get install -y mono-devel=5.8.0.108-0xamarin1+ubuntu1604b1 && \


### PR DESCRIPTION
The mono build is failing because the apt repository listed in the docker file is the rolling stable repository. This changes it to track a specific version, which we've locked to to prevent test churn.