### PR TITLE
Restrict overload stress tests to release

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionPerfTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class OverloadResolutionPerfTests : CSharpTestBase
     {
         [WorkItem(13685, "https://github.com/dotnet/roslyn/issues/13685")]
-        [NoIOperationValidationFact]
+        [ConditionalFactAttribute(typeof(IsRelease), typeof(NoIOperationValidation))]
         public void Overloads()
         {
             const int n = 3000;
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [WorkItem(13685, "https://github.com/dotnet/roslyn/issues/13685")]
-        [NoIOperationValidationFact]
+        [ConditionalFactAttribute(typeof(IsRelease), typeof(NoIOperationValidation))]
         public void BinaryOperatorOverloads()
         {
             const int n = 3000;
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "x + null").WithArguments("+", "C", "<null>").WithLocation(3, 29));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease))]
         public void StaticMethodsWithLambda()
         {
             const int n = 100;
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease))]
         public void ConstructorsWithLambdaAndParams()
         {
             const int n = 100;
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease))]
         public void ExtensionMethodsWithLambda()
         {
             const int n = 100;
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease))]
         public void ExtensionMethodsWithLambdaAndParams()
         {
             const int n = 100;
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics();
         }
 
-        [NoIOperationValidationFact]
+        [ConditionalFactAttribute(typeof(IsRelease), typeof(NoIOperationValidation))]
         public void ExtensionMethodsWithLambdaAndErrors()
         {
             const int n = 200;

--- a/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Portable/Assert/ConditionalFactAttribute.cs
@@ -71,7 +71,7 @@ namespace Roslyn.Test.Utilities
         public override bool ShouldSkip => false;
 #endif
 
-        public override string SkipReason => "Not in release mode.";
+        public override string SkipReason => "Test not supported in DEBUG";
     }
 
     public class WindowsOnly : ExecutionCondition
@@ -96,5 +96,17 @@ namespace Roslyn.Test.Utilities
     {
         public override bool ShouldSkip => CoreClrShim.AssemblyLoadContext.Type != null;
         public override string SkipReason => "Test not supported on CoreCLR";
+    }
+
+    public class NoIOperationValidation : ExecutionCondition
+    {
+
+#if TEST_IOPERATION_INTERFACE
+        public override bool ShouldSkip => true;
+#else
+        public override bool ShouldSkip => false;
+#endif
+
+        public override string SkipReason => "Test not supported in TEST_IOPERATION_INTERFACE";
     }
 }


### PR DESCRIPTION
Only run our overload performance stress suites in Release. The suites guard against
overload bugs which previously caused the compiler to virtually hang.

The situation we're guarding against is algorithm flaws in the compiler that would
easily reproduce even in release code. This is evidenced by the fact that customers
found this code on released compilers :)

This stress though causes an unacceptable increase in time to run the suites in
DEBUG mode. The semantic tests jump from 3-4 minutes of execution to 12-13. There is
no extra value gained by running these in DEBUG hence we're disabling them
in that context.

closes #25004
