### PR TITLE
Fixed IDE services touching `unmanaged` constraint

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -690,6 +690,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 AddKeyword(SyntaxKind.ClassKeyword);
                                 needComma = true;
                             }
+                            else if (typeParam.HasUnmanagedTypeConstraint)
+                            {
+                                builder.Add(new SymbolDisplayPart(SymbolDisplayPartKind.Keyword, null, "unmanaged"));
+                                needComma = true;
+                            }
                             else if (typeParam.HasValueTypeConstraint)
                             {
                                 AddKeyword(SyntaxKind.StructKeyword);

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -6415,5 +6415,80 @@ End Structure";
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.ClassName);
         }
+
+        [Fact]
+        public void UnmanagedConstraint_Type()
+        {
+            TestSymbolDescription(
+                "class X<T> where T : unmanaged { }",
+                global => global.GetTypeMember("X"),
+                SymbolDisplayFormat.TestFormat.AddGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeConstraints),
+                "X<T> where T : unmanaged",
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword);
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Method()
+        {
+            TestSymbolDescription(@"
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                global => global.GetTypeMember("X").GetMethod("M"),
+                SymbolDisplayFormat.TestFormat.AddGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeConstraints),
+                "void X.M<T>() where T : unmanaged",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword);
+        }
+
+        [Fact]
+        public void UnmanagedConstraint_Delegate()
+        {
+            TestSymbolDescription(
+                "delegate void D<T>() where T : unmanaged;",
+                global => global.GetTypeMember("D"),
+                SymbolDisplayFormat.TestFormat.AddGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeConstraints),
+                "D<T> where T : unmanaged",
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.TypeParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -52,6 +52,7 @@ Microsoft.CodeAnalysis.IOperation.Syntax.get -> Microsoft.CodeAnalysis.SyntaxNod
 Microsoft.CodeAnalysis.IOperation.Type.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.IPropertySymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.IPropertySymbol.ReturnsByRefReadonly.get -> bool
+Microsoft.CodeAnalysis.ITypeParameterSymbol.HasUnmanagedTypeConstraint.get -> bool
 Microsoft.CodeAnalysis.ModuleMetadata.IsDisposed.get -> bool
 Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.AddressOf = 64 -> Microsoft.CodeAnalysis.OperationKind

--- a/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
@@ -46,9 +46,14 @@ namespace Microsoft.CodeAnalysis
         bool HasReferenceTypeConstraint { get; }
 
         /// <summary>
-        /// True if the value type constraint (<c>struct</c>)was specified for the type parameter.
+        /// True if the value type constraint (<c>struct</c>) was specified for the type parameter.
         /// </summary>
         bool HasValueTypeConstraint { get; }
+
+        /// <summary>
+        /// True if the value type constraint (<c>unmanaged</c>) was specified for the type parameter.
+        /// </summary>
+        bool HasUnmanagedTypeConstraint { get; }
 
         /// <summary>
         /// True if the parameterless constructor constraint (<c>new()</c>) was specified for the type parameter.

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
@@ -314,6 +314,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public MustOverride ReadOnly Property HasValueTypeConstraint As Boolean Implements ITypeParameterSymbol.HasValueTypeConstraint
 
+        Private ReadOnly Property HasUnmanagedTypeConstraint As Boolean Implements ITypeParameterSymbol.HasUnmanagedTypeConstraint
+            Get
+                Return False
+            End Get
+        End Property
+
         Public MustOverride ReadOnly Property Variance As VarianceKind Implements ITypeParameterSymbol.Variance
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/PE/LoadCustomModifiers.vb
@@ -134,6 +134,9 @@ BC32105: Type argument 'String' does not satisfy the 'Structure' constraint for 
         Dim x = New TestRef(Of String)()
                                ~~~~~~
                                                 </expected>)
+
+            Dim badTypeParameter = compilation.GetTypeByMetadataName("TestRef`1").TypeParameters.Single()
+            Assert.True(badTypeParameter.HasValueTypeConstraint)
         End Sub
 
         <Fact>
@@ -165,6 +168,9 @@ BC30649: '' is an unsupported type.
         x.M(Of String)()
         ~~~~~~~~~~~~~~~~
                                                 </expected>)
+
+            Dim badTypeParameter = compilation.GetTypeByMetadataName("TestRef").GetMethod("M").TypeParameters.Single()
+            Assert.True(badTypeParameter.HasValueTypeConstraint)
         End Sub
 
         <Fact>
@@ -196,6 +202,9 @@ BC32105: Type argument 'String' does not satisfy the 'Structure' constraint for 
     Shared Sub Main(del As D(Of String)) 
                     ~~~
                                                 </expected>)
+
+            Dim badTypeParameter = compilation.GetTypeByMetadataName("D`1").TypeParameters.Single()
+            Assert.True(badTypeParameter.HasValueTypeConstraint)
         End Sub
 
     End Class

--- a/src/EditorFeatures/CSharpTest/Classification/AbstractCSharpClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/AbstractCSharpClassifierTests.cs
@@ -79,11 +79,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                         switch (_text)
                         {
                             case "(":
-                                return "Punctation.OpenParen";
+                                return "Punctuation.OpenParen";
                             case ")":
-                                return "Punctation.CloseParen";
+                                return "Punctuation.CloseParen";
                             case ";":
-                                return "Punctation.Semicolon";
+                                return "Punctuation.Semicolon";
                             case ":":
                                 return "Punctuation.Colon";
                             case ",":
@@ -96,6 +96,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
                         {
                             case "=":
                                 return "Operators.Equals";
+                            case "++":
+                                return "Operators.DoublePlus";
                         }
                         goto default;
 

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2325,5 +2325,118 @@ class Program
     }
 }", Keyword("var"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_InsideMethod()
+        {
+            await TestInMethodAsync(
+                "var unmanaged = 0;",
+                Keyword("var"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_Keyword()
+        {
+            await TestAsync(
+                "class X<T> where T : unmanaged { }",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X<T> where T : unmanaged { }",
+                TypeParameter("T"),
+                Interface("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X<T> where T : unmanaged { }",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_Keyword()
+        {
+            await TestAsync(@"
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                TypeParameter("T"),
+                Interface("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_Keyword()
+        {
+            await TestAsync(
+                "delegate void D<T>() where T : unmanaged;",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+delegate void D<T>() where T : unmanaged;",
+                TypeParameter("T"),
+                Interface("unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+delegate void D<T>() where T : unmanaged;",
+                TypeParameter("T"),
+                Keyword("unmanaged"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2329,8 +2329,10 @@ class Program
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task TestUnmanagedConstraint_InsideMethod()
         {
-            await TestInMethodAsync(
-                "var unmanaged = 0;",
+            // Asserts no Keyword("unmanaged") because it is an identifier.
+            await TestInMethodAsync(@"
+var unmanaged = 0;
+unmanaged++;",
                 Keyword("var"));
         }
 

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -4011,5 +4011,263 @@ void M()
                 Comment(">>>>>>> End"),
                 Punctuation.CloseCurly);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_InsideMethod()
+        {
+            await TestInMethodAsync(
+                "var unmanaged = 0;",
+                Keyword("var"),
+                Identifier("unmanaged"),
+                Operators.Equals,
+                Number("0"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_Keyword()
+        {
+            await TestAsync(
+                "class X<T> where T : unmanaged { }",
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X<T> where T : unmanaged { }",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X<T> where T : unmanaged { }",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_Keyword()
+        {
+            await TestAsync(@"
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_Keyword()
+        {
+            await TestAsync(
+                "delegate void D<T>() where T : unmanaged;",
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+delegate void D<T>() where T : unmanaged;",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+delegate void D<T>() where T : unmanaged;",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                Identifier("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.Semicolon);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -4015,12 +4015,16 @@ void M()
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task TestUnmanagedConstraint_InsideMethod()
         {
-            await TestInMethodAsync(
-                "var unmanaged = 0;",
+            await TestInMethodAsync(@"
+var unmanaged = 0;
+unmanaged++;",
                 Keyword("var"),
                 Identifier("unmanaged"),
                 Operators.Equals,
                 Number("0"),
+                Punctuation.Semicolon,
+                Identifier("unmanaged"),
+                Operators.DoublePlus,
                 Punctuation.Semicolon);
         }
 

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -849,5 +849,263 @@ class Program : IReadOnlyCollection<int,string>
                 Punctuation.OpenCurly,
                 Punctuation.CloseCurly);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_InsideMethod()
+        {
+            await TestInMethodAsync(
+                "var unmanaged = 0;",
+                Keyword("var"),
+                Identifier("unmanaged"),
+                Operators.Equals,
+                Number("0"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_Keyword()
+        {
+            await TestAsync(
+                "class X<T> where T : unmanaged { }",
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X<T> where T : unmanaged { }",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Type_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X<T> where T : unmanaged { }",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_Keyword()
+        {
+            await TestAsync(@"
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Method_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+class X
+{
+    void M<T>() where T : unmanaged { }
+}",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("class"),
+                Class("X"),
+                Punctuation.OpenCurly,
+                Keyword("void"),
+                Identifier("M"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_Keyword()
+        {
+            await TestAsync(
+                "delegate void D<T>() where T : unmanaged;",
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterface()
+        {
+            await TestAsync(@"
+interface unmanaged {}
+delegate void D<T>() where T : unmanaged;",
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Interface("unmanaged"),
+                Punctuation.Semicolon);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestUnmanagedConstraint_Delegate_ExistingInterfaceButOutOfScope()
+        {
+            await TestAsync(@"
+namespace OtherScope
+{
+    interface unmanaged {}
+}
+delegate void D<T>() where T : unmanaged;",
+                Keyword("namespace"),
+                Identifier("OtherScope"),
+                Punctuation.OpenCurly,
+                Keyword("interface"),
+                Interface("unmanaged"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly,
+                Keyword("delegate"),
+                Keyword("void"),
+                Delegate("D"),
+                Punctuation.OpenAngle,
+                TypeParameter("T"),
+                Punctuation.CloseAngle,
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Keyword("where"),
+                TypeParameter("T"),
+                Punctuation.Colon,
+                Keyword("unmanaged"),
+                Punctuation.Semicolon);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -853,12 +853,16 @@ class Program : IReadOnlyCollection<int,string>
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task TestUnmanagedConstraint_InsideMethod()
         {
-            await TestInMethodAsync(
-                "var unmanaged = 0;",
+            await TestInMethodAsync(@"
+var unmanaged = 0;
+unmanaged++;",
                 Keyword("var"),
                 Identifier("unmanaged"),
                 Operators.Equals,
                 Number("0"),
+                Punctuation.Semicolon,
+                Identifier("unmanaged"),
+                Operators.DoublePlus,
                 Punctuation.Semicolon);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -4095,42 +4095,47 @@ class A
 new TestParameters(Options.Regular));
         }
 
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("new()")]
+        [InlineData("unmanaged")]
         [WorkItem(542529, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542529")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-        public async Task TestTypeParameterConstraints1()
+        [Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestTypeParameterConstraints(string constraint)
         {
             await TestInRegularAndScriptAsync(
-@"using System;
+$@"using System;
 
-class A<T> where T : class
-{
-}
+class A<T> where T : {constraint}
+{{
+}}
 
 class Program
-{
-    static void Goo<T>(A<T> x) where T : class
-    {
+{{
+    static void Goo<T>(A<T> x) where T : {constraint}
+    {{
         [|Bar|](x);
-    }
-}",
-@"using System;
+    }}
+}}",
+$@"using System;
 
-class A<T> where T : class
-{
-}
+class A<T> where T : {constraint}
+{{
+}}
 
 class Program
-{
-    static void Goo<T>(A<T> x) where T : class
-    {
+{{
+    static void Goo<T>(A<T> x) where T : {constraint}
+    {{
         Bar(x);
-    }
+    }}
 
-    private static void Bar<T>(A<T> x) where T : class
-    {
+    private static void Bar<T>(A<T> x) where T : {constraint}
+    {{
         throw new NotImplementedException();
-    }
-}");
+    }}
+}}");
         }
 
         [WorkItem(542622, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542622")]
@@ -4165,42 +4170,47 @@ class Program
 }");
         }
 
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("new()")]
+        [InlineData("unmanaged")]
         [WorkItem(542626, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542626")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-        public async Task TestMethodConstraints1()
+        [Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestMethodConstraints(string constraint)
         {
             await TestInRegularAndScriptAsync(
-@"using System;
+$@"using System;
 
-class A<T> where T : class
-{
-}
+class A<T> where T : {constraint}
+{{
+}}
 
 class Program
-{
-    static void Goo<T>(A<T> x) where T : class
-    {
+{{
+    static void Goo<T>(A<T> x) where T : {constraint}
+    {{
         [|Bar<T>|](x);
-    }
-}",
-@"using System;
+    }}
+}}",
+$@"using System;
 
-class A<T> where T : class
-{
-}
+class A<T> where T : {constraint}
+{{
+}}
 
 class Program
-{
-    static void Goo<T>(A<T> x) where T : class
-    {
+{{
+    static void Goo<T>(A<T> x) where T : {constraint}
+    {{
         Bar<T>(x);
-    }
+    }}
 
-    private static void Bar<T>(A<T> x) where T : class
-    {
+    private static void Bar<T>(A<T> x) where T : {constraint}
+    {{
         throw new NotImplementedException();
-    }
-}");
+    }}
+}}");
         }
 
         [WorkItem(542627, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542627")]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -566,5 +566,17 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
+        public async Task TestUnmanagedConstraint()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C<T> where T : [|umanaged|]
+{
+}",
+@"class C<T> where T : unmanaged
+{
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -487,6 +487,23 @@ class Test<T> where T : [|unmanaged|]
         }
 
         [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Type_AlreadyDefined()
+        {
+            await TestExactActionSetOfferedAsync(
+@"<Workspace>
+    <Project Language=""C#"" LanguageVersion=""7"">
+        <Document>
+interface unmanaged { }
+class Test&lt;T&gt; where T : [|unmanaged|]
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                expectedActionSet: Enumerable.Empty<string>());
+        }
+
+        [Fact]
         public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Method()
         {
             await TestLanguageVersionUpgradedAsync(
@@ -501,6 +518,24 @@ class Test
         }
 
         [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Method_AlreadyDefined()
+        {
+            await TestExactActionSetOfferedAsync(
+@"<Workspace>
+    <Project Language=""C#"" LanguageVersion=""7"">
+        <Document>
+interface unmanaged { }
+class Test
+{
+    public void M&lt;T&gt;() where T : [|unmanaged|] { }
+}
+        </Document>
+    </Project>
+</Workspace>",
+                expectedActionSet: Enumerable.Empty<string>());
+        }
+
+        [Fact]
         public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Delegate()
         {
             await TestLanguageVersionUpgradedAsync(
@@ -508,6 +543,21 @@ class Test
                 LanguageVersion.CSharp7_3,
                 new CSharpParseOptions(LanguageVersion.CSharp7),
                 index: 1);
+        }
+
+        [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Delegate_AlreadyDefined()
+        {
+            await TestExactActionSetOfferedAsync(
+@"<Workspace>
+    <Project Language=""C#"" LanguageVersion=""7"">
+        <Document>
+interface unmanaged { }
+delegate void D&lt;T&gt;() where T : [| unmanaged |];
+        </Document>
+    </Project>
+</Workspace>",
+                expectedActionSet: Enumerable.Empty<string>());
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -472,5 +472,42 @@ class C
                     string.Format(CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0, "7.0")
                     });
         }
+
+        [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Type()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Test<T> where T : [|unmanaged|]
+{
+}",
+                LanguageVersion.CSharp7_3,
+                new CSharpParseOptions(LanguageVersion.CSharp7),
+                index: 1);
+        }
+
+        [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Method()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Test
+{
+    public void M<T>() where T : [|unmanaged|] { }
+}",
+                LanguageVersion.CSharp7_3,
+                new CSharpParseOptions(LanguageVersion.CSharp7),
+                index: 1);
+        }
+
+        [Fact]
+        public async Task UpgradeProjectWithUnmanagedConstraintTo7_3_Delegate()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"delegate void D<T>() where T : [|unmanaged|];",
+                LanguageVersion.CSharp7_3,
+                new CSharpParseOptions(LanguageVersion.CSharp7),
+                index: 1);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -1179,5 +1179,37 @@ class $$TestClass
     ref readonly int this[int p1] { get; }
 }");
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task TestUnmanagedConstraint_Type()
+        {
+            var markup = @"
+class $$TestClass<T> where T : unmanaged
+{
+    public void M(T arg) => throw null;
+}";
+
+            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true, expectedInterfaceCode:
+@"interface ITestClass<T> where T : unmanaged
+{
+    void M(T arg);
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task TestUnmanagedConstraint_Method()
+        {
+            var markup = @"
+class $$TestClass
+{
+    public void M<T>() where T : unmanaged => throw null;
+}";
+
+            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true, expectedInterfaceCode:
+@"interface ITestClass
+{
+    void M<T>() where T : unmanaged;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1683,5 +1683,29 @@ public class Test : TestParent
     public override ref readonly int this[int p] => throw new System.NotImplementedException();
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TestUnmanagedConstraint()
+        {
+            await TestInRegularAndScriptAsync(
+@"public abstract class ParentTest
+{
+    public abstract void M<T>() where T : unmanaged;
+}
+public class [|Test|] : ParentTest
+{
+}",
+@"public abstract class ParentTest
+{
+    public abstract void M<T>() where T : unmanaged;
+}
+public class Test : ParentTest
+{
+    public override void M<T>()
+    {
+        throw new System.NotImplementedException();
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -6943,5 +6943,29 @@ public class Test : ITest
     public ref readonly int this[int p] => throw new System.NotImplementedException();
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TestUnmanagedConstraint()
+        {
+            await TestInRegularAndScriptAsync(
+@"public interface ITest
+{
+    void M<T>() where T : unmanaged;
+}
+public class Test : [|ITest|]
+{
+}",
+@"public interface ITest
+{
+    void M<T>() where T : unmanaged;
+}
+public class Test : ITest
+{
+    public void M<T>() where T : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -5188,5 +5188,36 @@ class X<T> where T : System.MulticastDelegate
 }",
                 MainDescription($"T {FeaturesResources.in_} X<T> where T : MulticastDelegate"));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task UnmanagedConstraint_Type()
+        {
+            await TestAsync(
+@"
+class $$X<T> where T : unmanaged
+{
+}",
+                MainDescription("class X<T> where T : unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task UnmanagedConstraint_Method()
+        {
+            await TestAsync(
+@"
+class X
+{
+    void $$M<T>() where T : unmanaged { }
+}",
+                MainDescription("void X.M<T>() where T : unmanaged"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task UnmanagedConstraint_Delegate()
+        {
+            await TestAsync(
+                "delegate void $$D<T>() where T : unmanaged;",
+                MainDescription("delegate void D<T>() where T : unmanaged"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNameSignatureHelpProviderTests.cs
@@ -624,6 +624,33 @@ class C
             await TestAsync(markup, expectedOrderedItems);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TestUnmanagedConstraint()
+        {
+            var markup = @"
+
+class C
+{
+    /// <summary>
+    /// summary headline
+    /// </summary>
+    /// <typeparam name=""T"">T documentation</typeparam>
+    void M<T>(T arg) where T : unmanaged
+    {
+    }
+
+    void Bar()
+    {
+        [|M<$$|]>
+    }
+}";
+
+            await TestAsync(markup, new List<SignatureHelpTestItem>
+            {
+                new SignatureHelpTestItem("void C.M<T>(T arg) where T : unmanaged", "summary headline", "T documentation", currentParameterIndex: 0)
+            });
+        }
+
         #endregion
 
         #region "Trigger tests"

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UnmanagedKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UnmanagedKeywordRecommenderTests.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
+{
+    public class UnmanagedKeywordRecommenderTests : RecommenderTests
+    {
+        private readonly UnmanagedKeywordRecommender _recommender = new UnmanagedKeywordRecommender();
+
+        public UnmanagedKeywordRecommenderTests()
+        {
+            this.keywordText = "unmanaged";
+            this.RecommendKeywordsAsync = (position, context) => _recommender.RecommendKeywordsAsync(position, context, CancellationToken.None);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAtRoot_Interactive()
+        {
+            await VerifyAbsenceAsync(SourceCodeKind.Script,
+@"$$");
+        }
+        
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInUsingAlias()
+        {
+            await VerifyAbsenceAsync(
+@"using Goo = $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterName_Type()
+        {
+            await VerifyAbsenceAsync(
+@"class Test $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClause_Type()
+        {
+            await VerifyAbsenceAsync(
+@"class Test<T> where $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClauseType_Type()
+        {
+            await VerifyAbsenceAsync(
+@"class Test<T> where T $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterWhereClauseColon_Type()
+        {
+            await VerifyKeywordAsync(
+@"class Test<T> where T : $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterTypeConstraint_Type()
+        {
+            await VerifyAbsenceAsync(
+@"class Test<T> where T : I $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTypeConstraintComma_Type()
+        {
+            await VerifyKeywordAsync(
+@"class Test<T> where T : I, $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterName_Method()
+        {
+            await VerifyAbsenceAsync(
+@"class Test {
+    void M $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClause_Method()
+        {
+            await VerifyAbsenceAsync(
+@"class Test {
+    void M<T> where $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClauseType_Method()
+        {
+            await VerifyAbsenceAsync(
+@"class Test {
+    void M<T> where T $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterWhereClauseColon_Method()
+        {
+            await VerifyKeywordAsync(
+@"class Test {
+    void M<T> where T : $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterTypeConstraint_Method()
+        {
+            await VerifyAbsenceAsync(
+@"class Test {
+    void M<T> where T : I $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTypeConstraintComma_Method()
+        {
+            await VerifyKeywordAsync(
+@"class Test {
+    void M<T> where T : I, $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterName_Delegate()
+        {
+            await VerifyAbsenceAsync(
+@"delegate void D $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClause_Delegate()
+        {
+            await VerifyAbsenceAsync(
+@"delegate void D<T>() where $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterWhereClauseType_Delegate()
+        {
+            await VerifyAbsenceAsync(
+@"delegate void D<T>() where T $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterWhereClauseColon_Delegate()
+        {
+            await VerifyKeywordAsync(
+@"delegate void D<T>() where T : $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterTypeConstraint_Delegate()
+        {
+            await VerifyAbsenceAsync(
+@"delegate void D<T>() where T : I $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterTypeConstraintComma_Delegate()
+        {
+            await VerifyKeywordAsync(
+@"delegate void D<T>() where T : I, $$");
+        }
+    }
+}

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -216,14 +216,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 bool includeXmlDocComments, string sourceWithSymbolReference,
                 string languageVersion)
             {
+                string languageVersionAttribute = languageVersion is null ? "" : $@" LanguageVersion=""{languageVersion}""";
+
                 var xmlString = string.Concat(@"
 <Workspace>
-    <Project Language=""", projectLanguage, @""" CommonReferences=""true""");
-
-                if (languageVersion != null)
-                {
-                    xmlString += $@" LanguageVersion=""{languageVersion}""";
-                }
+    <Project Language=""", projectLanguage, @""" CommonReferences=""true""", languageVersionAttribute);
 
                 xmlString += ">";
 
@@ -234,14 +231,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                     var metadataLanguage = DeduceLanguageString(source);
 
                     xmlString = string.Concat(xmlString, string.Format(@"
-        <MetadataReferenceFromSource Language=""{0}"" CommonReferences=""true"" IncludeXmlDocComments=""{2}"">
+        <MetadataReferenceFromSource Language=""{0}"" CommonReferences=""true"" IncludeXmlDocComments=""{2}""{3}>
             <Document FilePath=""MetadataDocument"">
 {1}
             </Document>
         </MetadataReferenceFromSource>",
                         metadataLanguage,
                         SecurityElement.Escape(source),
-                        includeXmlDocComments.ToString()));
+                        includeXmlDocComments.ToString(),
+                        languageVersionAttribute));
                 }
 
                 if (sourceWithSymbolReference != null)

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1503,5 +1503,48 @@ class C
             }
         }
 
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameTracking_UnmanagedConstraint_Keyword()
+        {
+            var code = @"
+class C&lt;T&gt; where T : $$unmanaged
+{
+}";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
+            {
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameTracking_UnmanagedConstraint_Type()
+        {
+            var code = @"
+interface unmanaged
+{
+}
+class C&lt;T&gt; where T : $$unmanaged
+{
+}";
+            using (var state = RenameTrackingTestState.Create(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("my");
+
+                await state.AssertTag("unmanaged", "myunmanaged", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+interface myunmanaged
+{
+}
+class C<T> where T : myunmanaged
+{
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
     }
 }

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -813,6 +813,41 @@ class C
             Test(workspace)
         End Sub
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub TestCSharpGoToUnmanaged_Keyword()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            class C&lt;T&gt; where T : un$$managed
+            {
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace, expectedResult:=False)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        Public Sub TestCSharpGoToUnmanaged_Type()
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+            interface [|unmanaged|]
+            {
+            }
+            class C&lt;T&gt; where T : un$$managed
+            {
+            }
+        </Document>
+    </Project>
+</Workspace>
+
+            Test(workspace)
+        End Sub
+
 #End Region
 
 #Region "CSharp TupleTests"

--- a/src/EditorFeatures/TestUtilities/Classification/ClassificationBuilder.OperatorClassificationTypes.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/ClassificationBuilder.OperatorClassificationTypes.cs
@@ -42,6 +42,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 }
             }
 
+            public Tuple<string, string> DoublePlus
+            {
+                [DebuggerStepThrough]
+                get
+                {
+                    return New("++");
+                }
+            }
+
             public Tuple<string, string> DoublePipe
             {
                 [DebuggerStepThrough]

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -140,6 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new ULongKeywordRecommender(),
                 new UncheckedKeywordRecommender(),
                 new UndefKeywordRecommender(),
+                new UnmanagedKeywordRecommender(),
                 new UnsafeKeywordRecommender(),
                 new UShortKeywordRecommender(),
                 new UsingKeywordRecommender(),

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnmanagedKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UnmanagedKeywordRecommender.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
+{
+    internal class UnmanagedKeywordRecommender : IKeywordRecommender<CSharpSyntaxContext>
+    {
+        public Task<IEnumerable<RecommendedKeyword>> RecommendKeywordsAsync(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            if (context.SyntaxTree.IsTypeParameterConstraintContext(position, context.LeftToken, cancellationToken))
+            {
+                return Task.FromResult(SpecializedCollections.SingletonEnumerable(new RecommendedKeyword("unmanaged")));
+            }
+
+            return Task.FromResult<IEnumerable<RecommendedKeyword>>(null);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/GenericNameSignatureHelpProvider.cs
@@ -247,6 +247,11 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                     parts.Add(Keyword(SyntaxKind.ClassKeyword));
                     needComma = true;
                 }
+                else if (typeParam.HasUnmanagedTypeConstraint)
+                {
+                    parts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.Keyword, null, "unmanaged"));
+                    needComma = true;
+                }
                 else if (typeParam.HasValueTypeConstraint)
                 {
                     parts.Add(Keyword(SyntaxKind.StructKeyword));

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -289,7 +289,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
                     typeParameters.Add(CodeGenerationSymbolFactory.CreateTypeParameter(
                         parameter.GetAttributes(), parameter.Variance, parameter.Name, ImmutableArray.Create<ITypeSymbol>(),
-                        parameter.HasConstructorConstraint, parameter.HasReferenceTypeConstraint, parameter.HasValueTypeConstraint, parameter.Ordinal));
+                        parameter.HasConstructorConstraint, parameter.HasReferenceTypeConstraint, parameter.HasValueTypeConstraint,
+                        parameter.HasUnmanagedTypeConstraint, parameter.Ordinal));
                 }
 
                 return typeParameters.ToImmutableAndFree();

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
@@ -72,7 +72,8 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     constraintTypes: constraints.AsImmutable<ITypeSymbol>(),
                     hasConstructorConstraint: typeParameter.HasConstructorConstraint,
                     hasReferenceConstraint: typeParameter.HasReferenceTypeConstraint,
-                    hasValueConstraint: typeParameter.HasValueTypeConstraint);
+                    hasValueConstraint: typeParameter.HasValueTypeConstraint,
+                    hasUnmanagedConstraint: typeParameter.HasUnmanagedTypeConstraint);
             }
 
             private List<ITypeSymbol> MergeClassTypes(List<ITypeSymbol> classTypes, CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -297,12 +297,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
 
         private bool IsSymbolWithName(ISymbol symbol, string name)
         {
-            if (symbol is INamedTypeSymbol namedType)
+            if (symbol is null || symbol.Name != name)
             {
-                return namedType.Arity == 0 && symbol.Name == name;
+                return false;
             }
 
-            return symbol != null && symbol.Name == name;
+            if (symbol is INamedTypeSymbol namedType)
+            {
+                return namedType.Arity == 0;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/NameSyntaxClassifier.cs
@@ -135,9 +135,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                 var alias = semanticModel.GetAliasInfo(name, cancellationToken);
                 if (alias == null || alias.Name != "var")
                 {
-                    if (!IsSymbolCalledVar(symbol))
+                    if (!IsSymbolWithName(symbol, "var"))
                     {
                         // We bound to a symbol.  If we bound to a symbol called "var" then we want to
+                        // classify this appropriately as a type.  Otherwise, we want to classify this as
+                        // a keyword.
+                        classifiedSpan = new ClassifiedSpan(name.Span, ClassificationTypeNames.Keyword);
+                        return true;
+                    }
+                }
+            }
+
+            if (name.IsUnmanaged && name.Parent.IsKind(SyntaxKind.TypeConstraint))
+            {
+                var alias = semanticModel.GetAliasInfo(name, cancellationToken);
+                if (alias == null || alias.Name != "unmanaged")
+                {
+                    if (!IsSymbolWithName(symbol, "unmanaged"))
+                    {
+                        // We bound to a symbol.  If we bound to a symbol called "unmanaged" then we want to
                         // classify this appropriately as a type.  Otherwise, we want to classify this as
                         // a keyword.
                         classifiedSpan = new ClassifiedSpan(name.Span, ClassificationTypeNames.Keyword);
@@ -279,14 +295,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
             return false;
         }
 
-        private bool IsSymbolCalledVar(ISymbol symbol)
+        private bool IsSymbolWithName(ISymbol symbol, string name)
         {
             if (symbol is INamedTypeSymbol namedType)
             {
-                return namedType.Arity == 0 && symbol.Name == "var";
+                return namedType.Arity == 0 && symbol.Name == name;
             }
 
-            return symbol != null && symbol.Name == "var";
+            return symbol != null && symbol.Name == name;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeParameterSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeParameterSymbolExtensions.cs
@@ -42,6 +42,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 constraints.Add(SyntaxFactory.ClassOrStructConstraint(SyntaxKind.ClassConstraint));
             }
+            else if (typeParameter.HasUnmanagedTypeConstraint)
+            {
+                constraints.Add(SyntaxFactory.TypeConstraint(SyntaxFactory.IdentifierName("unmanaged")));
+            }
             else if (typeParameter.HasValueTypeConstraint)
             {
                 constraints.Add(SyntaxFactory.ClassOrStructConstraint(SyntaxKind.StructConstraint));

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 attributes: default, varianceKind: VarianceKind.None,
                 name: name, constraintTypes: ImmutableArray.Create<ITypeSymbol>(),
                 hasConstructorConstraint: false, hasReferenceConstraint: false, hasValueConstraint: false,
-                ordinal: ordinal);
+                hasUnmanagedConstraint: false, ordinal: ordinal);
         }
 
         /// <summary>
@@ -264,9 +264,10 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<ITypeSymbol> constraintTypes,
             bool hasConstructorConstraint = false,
             bool hasReferenceConstraint = false,
+            bool hasUnmanagedConstraint = false,
             bool hasValueConstraint = false, int ordinal = 0)
         {
-            return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, ordinal);
+            return new CodeGenerationTypeParameterSymbol(null, attributes, varianceKind, name, constraintTypes, hasConstructorConstraint, hasReferenceConstraint, hasValueConstraint, hasUnmanagedConstraint, ordinal);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public bool HasConstructorConstraint { get; }
         public bool HasReferenceTypeConstraint { get; }
         public bool HasValueTypeConstraint { get; }
+        public bool HasUnmanagedTypeConstraint { get; }
         public int Ordinal { get; }
 
         public CodeGenerationTypeParameterSymbol(
@@ -24,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             bool hasConstructorConstraint,
             bool hasReferenceConstraint,
             bool hasValueConstraint,
+            bool hasUnmanagedConstraint,
             int ordinal)
             : base(containingType, attributes, Accessibility.NotApplicable, default, name, SpecialType.None)
         {
@@ -33,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             this.HasConstructorConstraint = hasConstructorConstraint;
             this.HasReferenceTypeConstraint = hasReferenceConstraint;
             this.HasValueTypeConstraint = hasValueConstraint;
+            this.HasUnmanagedTypeConstraint = hasUnmanagedConstraint;
         }
 
         protected override CodeGenerationSymbol Clone()
@@ -40,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return new CodeGenerationTypeParameterSymbol(
                 this.ContainingType, this.GetAttributes(), this.Variance, this.Name,
                 this.ConstraintTypes, this.HasConstructorConstraint, this.HasReferenceTypeConstraint,
-                this.HasValueTypeConstraint, this.Ordinal);
+                this.HasValueTypeConstraint, this.HasUnmanagedTypeConstraint, this.Ordinal);
         }
 
         public new ITypeParameterSymbol OriginalDefinition => this;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     typeParameter.HasConstructorConstraint,
                     typeParameter.HasReferenceTypeConstraint,
                     typeParameter.HasValueTypeConstraint,
+                    typeParameter.HasUnmanagedTypeConstraint,
                     typeParameter.Ordinal);
 
                 newTypeParameters.Add(newTypeParameter);

--- a/src/Workspaces/CoreTest/FindReferencesTests.cs
+++ b/src/Workspaces/CoreTest/FindReferencesTests.cs
@@ -320,6 +320,26 @@ namespace M
             Assert.Equal(refsFromVirtualSorted, refsFromOverrideSorted);
         }
 
+        [Fact]
+        public async Task FindRefereceToUnmanagedConstraint_Type()
+        {
+            var text = @"
+interface unmanaged                             // Line 1
+{
+}
+abstract class C<T> where T : unmanaged         // Line 4
+{
+}";
+            var solution = GetSingleDocumentSolution(text);
+            var project = solution.Projects.First();
+            var comp = await project.GetCompilationAsync();
+
+            var constraint = comp.GetTypeByMetadataName("C`1").TypeParameters.Single().ConstraintTypes.Single();
+            var result = (await SymbolFinder.FindReferencesAsync(constraint, solution)).Single();
+
+            Verify(result, new HashSet<int> { 1, 4 });
+        }
+
         private static void Verify(ReferencedSymbol reference, HashSet<int> expectedMatchedLines)
         {
             void verifier(Location location)


### PR DESCRIPTION
In this PR:

* Completion Service
* Extract Interface Service
* Implement interface service
* Metadata As Source Service
* Upgrade Project Service
* Quick Info and Symbol Display
* Classification Service

Each service has the corresponding tests

Document: https://github.com/dotnet/csharplang/blob/master/proposals/blittable.md