### PR TITLE
Minor bug fix: adding missing case for ConversionOperatorDeclaration in IsReturnableConstruct

### DIFF
--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/ReturnStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/ReturnStatementHighlighterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_1()
+        public async Task TestInLambda()
         {
             await TestAsync(
 @"static double CalculateArea(double radius)
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_2()
+        public async Task TestInLambda_NotOnReturnValue()
         {
             await TestAsync(
 @"class C
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_3()
+        public async Task TestInLambda_OnSemicolon()
         {
             await TestAsync(
 @"class C
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_4()
+        public async Task TestInLambda_SecondOccurence()
         {
             await TestAsync(
 @"class C
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_5()
+        public async Task TestInLambda_SecondOccurence_NotOnReturnValue()
         {
             await TestAsync(
 @"class C
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_6()
+        public async Task TestInLambda_SecondOccurence_OnSemicolon()
         {
             await TestAsync(
 @"class C
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_7()
+        public async Task TestInMethodWithLambda()
         {
             await TestAsync(
 @"class C
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_8()
+        public async Task TestInMethodWithLambda_NotOnReturnValue()
         {
             await TestAsync(
 @"class C
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
-        public async Task TestExample1_9()
+        public async Task TestInMethodWithLambda_OnSemicolon()
         {
             await TestAsync(
 @"class C
@@ -214,6 +214,226 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
             }
         };
         [|return|] calcArea(radius);{|Cursor:|}
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInConstructor()
+        {
+            await TestAsync(
+@"class C
+{
+    C()
+    {
+        {|Cursor:[|return|]|};
+        [|return|];
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInDestructor()
+        {
+            await TestAsync(
+@"class C
+{
+    ~C()
+    {
+        {|Cursor:[|return|]|};
+        [|return|];
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    public static string operator +(C a)
+    {
+        {|Cursor:[|return|]|} null;
+        [|return|] null;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInConversionOperator()
+        {
+            await TestAsync(
+@"class C
+{
+    public static explicit operator string(C a)
+    {
+        {|Cursor:[|return|]|} null;
+        [|return|] null;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInGetter()
+        {
+            await TestAsync(
+@"class C
+{
+    int P
+    {
+        get
+        {
+            {|Cursor:[|return|]|} 0;
+            [|return|] 0;
+        }
+        set
+        {
+            return;
+            return;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInSetter()
+        {
+            await TestAsync(
+@"class C
+{
+    int P
+    {
+        get
+        {
+            return 0;
+            return 0;
+        }
+        set
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInAdder()
+        {
+            await TestAsync(
+@"class C
+{
+    event EventHandler E
+    {
+        add
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        }
+        remove
+        {
+            return;
+            return;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInRemover()
+        {
+            await TestAsync(
+@"class C
+{
+    event EventHandler E
+    {
+        add
+        {
+            return;
+            return;
+        }
+        remove
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInLocalFunction()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        void F()
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        }
+
+        return;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInSimpleLambda()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        Action<string> f = s =>
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        };
+
+        return;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInParenthesizedLambda()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        Action<string> f = (s) =>
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        };
+
+        return;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
+        public async Task TestInAnonymousMethod()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        Action<string> f = delegate
+        {
+            {|Cursor:[|return|]|};
+            [|return|];
+        };
+
+        return;
     }
 }");
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -273,6 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                 case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                     return true;


### PR DESCRIPTION
`SyntaxNodeExtensions.IsReturnableConstruct` is missing a case for `ConversionOperatorDeclaration`.

This causes the following bug: highlighting return statements does not work inside conversion operators.
Repro:
```c#
class C
{
    public static explicit operator string(C a)
    {
        return null;
        return null;
    }
}
```
click on any `return` - nothing is highlighted.

This PR fixes that and adds a lot more tests into ReturnStatementHighlighterTests to cover cases for all constructs (it currently only covers methods & simple lambda expressions). I also renamed existing tests to give them better names as opposed to Test1, Test2, etc...