### PR TITLE
[SQLite] Bump and use byte[] variants added to blob_open for performance

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -229,7 +229,7 @@
     <SystemXmlXmlDocumentVersion>4.3.0</SystemXmlXmlDocumentVersion>
     <SystemXmlXmlSerializerVersion>4.3.0</SystemXmlXmlSerializerVersion>
     <SystemXmlXPathXDocumentVersion>4.3.0</SystemXmlXPathXDocumentVersion>
-    <SQLitePCLRawbundle_greenVersion>1.1.10-pre20180223200113</SQLitePCLRawbundle_greenVersion>
+    <SQLitePCLRawbundle_greenVersion>1.1.11</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
     <VSExternalAPIsCodingConventionsVersion>1.0.60704.2</VSExternalAPIsCodingConventionsVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -229,7 +229,7 @@
     <SystemXmlXmlDocumentVersion>4.3.0</SystemXmlXmlDocumentVersion>
     <SystemXmlXmlSerializerVersion>4.3.0</SystemXmlXmlSerializerVersion>
     <SystemXmlXPathXDocumentVersion>4.3.0</SystemXmlXPathXDocumentVersion>
-    <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
+    <SQLitePCLRawbundle_greenVersion>1.1.10-pre20180223200113</SQLitePCLRawbundle_greenVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
     <VSExternalAPIsCodingConventionsVersion>1.0.60704.2</VSExternalAPIsCodingConventionsVersion>

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -80,11 +80,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x86\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win-x86\native\e_sqlite3.dll">
       <Link>x86\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x64\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win-x64\native\e_sqlite3.dll">
       <Link>x64\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -80,11 +80,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\1.1.2\runtimes\win7-x86\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x86\native\e_sqlite3.dll">
       <Link>x86\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\1.1.2\runtimes\win7-x64\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x64\native\e_sqlite3.dll">
       <Link>x64\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -245,12 +245,12 @@
     <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.batteries_v2.dll" />
     <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.provider.e_sqlite3.net45\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll" />
     <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.core\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.core.dll" />
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x86\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win-x86\native\e_sqlite3.dll">
       <Link>x86\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x64\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win-x64\native\e_sqlite3.dll">
       <Link>x64\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -241,16 +241,16 @@
     <NuGetPackageToIncludeInVsix Include="Mono.Cecil" />
   </ItemGroup>
   <ItemGroup>
-    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\1.1.2\lib\net45\SQLitePCLRaw.batteries_green.dll" />
-    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\1.1.2\lib\net45\SQLitePCLRaw.batteries_v2.dll" />
-    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.provider.e_sqlite3.net45\1.1.2\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll" />
-    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.core\1.1.2\lib\net45\SQLitePCLRaw.core.dll" />
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\1.1.2\runtimes\win7-x86\native\e_sqlite3.dll">
+    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.batteries_green.dll" />
+    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.batteries_v2.dll" />
+    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.provider.e_sqlite3.net45\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll" />
+    <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.core\$(SQLitePCLRawbundle_greenVersion)\lib\net45\SQLitePCLRaw.core.dll" />
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x86\native\e_sqlite3.dll">
       <Link>x86\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\1.1.2\runtimes\win7-x64\native\e_sqlite3.dll">
+    <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3.v110_xp\$(SQLitePCLRawbundle_greenVersion)\runtimes\win7-x64\native\e_sqlite3.dll">
       <Link>x64\e_sqlite3.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         public int LastInsertRowId()
             => (int)raw.sqlite3_last_insert_rowid(_handle);
 
-        public Stream ReadBlob(string dataTableName, string dataColumnName, long rowId)
+        public Stream ReadBlob(byte[] dataTableName, byte[] dataColumnName, long rowId)
         {
             // NOTE: we do need to do the blob reading in a transaction because of the
             // following: https://www.sqlite.org/c3ref/blob_open.html
@@ -204,10 +204,12 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
             return stream;
         }
 
-        private Stream ReadBlob_InTransaction(string tableName, string columnName, long rowId)
+
+        private static byte[] mainPtr = Util.ToUtf8("main");
+        private Stream ReadBlob_InTransaction(byte[] tableName, byte[] columnName, long rowId)
         {
             const int ReadOnlyFlags = 0;
-            var result = raw.sqlite3_blob_open(_handle, "main", tableName, columnName, rowId, ReadOnlyFlags, out var blob);
+            var result = raw.sqlite3_blob_open(_handle, mainPtr, tableName, columnName, rowId, ReadOnlyFlags, out var blob);
             if (result == raw.SQLITE_ERROR)
             {
                 // can happen when rowId points to a row that hasn't been written to yet.

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/SqlConnection.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.SQLite.Interop
         }
 
 
-        private static byte[] mainPtr = Util.ToUtf8("main");
+        private static readonly byte[] mainPtr = Util.ToUtf8WithNullTerminator("main");
         private Stream ReadBlob_InTransaction(byte[] tableName, byte[] columnName, long rowId)
         {
             const int ReadOnlyFlags = 0;

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Util.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Util.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.SQLite
 {
     internal static class Util
     {
-        internal static byte[] ToUtf8(string text)
+        internal static byte[] ToUtf8WithNullTerminator(string text)
         {
             if (text == null)
             {
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             // SQLite expects null terminated UTF8, so append an extra null terminator
-            return Encoding.UTF8.GetBytes (text + "\0");
+            return Encoding.UTF8.GetBytes(text + "\0");
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Util.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/Interop/Util.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.SQLite
+{
+    internal static class Util
+    {
+        internal static byte[] ToUtf8(string text)
+        {
+            if (text == null)
+            {
+                return null;
+            }
+
+            // SQLite expects null terminated UTF8, so append an extra null terminator
+            return Encoding.UTF8.GetBytes (text + "\0");
+        }
+    }
+}

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.Accessor.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             protected abstract string DataTableName { get; }
+            protected abstract byte[] DataTableNamePtr { get; }
 
             protected abstract bool TryGetDatabaseId(SqlConnection connection, TKey key, out TDatabaseId dataId);
             protected abstract void BindFirstParameter(SqlStatement statement, TDatabaseId dataId);
@@ -146,7 +147,7 @@ namespace Microsoft.CodeAnalysis.SQLite
                     // data for a row in our system can change, the ID will always stay the
                     // same, and the data will always be valid for our ID.  So there is no
                     // safety issue here.
-                    return connection.ReadBlob(DataTableName, DataColumnName, rowId);
+                    return connection.ReadBlob(DataTableNamePtr, DataColumnNamePtr, rowId);
                 }
 
                 return null;

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  -----------------------------------------------
         /// </summary>
         private const string SolutionDataTableName = "SolutionData" + Version;
+        private static byte[] SolutionDataTableNamePtr = Util.ToUtf8(SolutionDataTableName);
 
         /// <summary>
         /// Inside the DB we have a table for data that we want associated with a <see cref="Project"/>.
@@ -71,6 +72,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  -----------------------------------------------
         /// </summary>
         private const string ProjectDataTableName = "ProjectData" + Version;
+        private static byte[] ProjectDataTableNamePtr = Util.ToUtf8(ProjectDataTableName);
 
         /// <summary>
         /// Inside the DB we have a table for data that we want associated with a <see cref="Document"/>.
@@ -88,9 +90,11 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  ----------------------------------------------
         /// </summary>
         private const string DocumentDataTableName = "DocumentData" + Version;
+        private static byte[] DocumentDataTableNamePtr = Util.ToUtf8(DocumentDataTableName);
 
         private const string DataIdColumnName = "DataId";
         private const string DataColumnName = "Data";
+        private static byte[] DataColumnNamePtr = Util.ToUtf8(DataColumnName);
 
         private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  -----------------------------------------------
         /// </summary>
         private const string SolutionDataTableName = "SolutionData" + Version;
-        private static byte[] SolutionDataTableNamePtr = Util.ToUtf8(SolutionDataTableName);
+        private static readonly byte[] SolutionDataTableNamePtr = Util.ToUtf8WithNullTerminator(SolutionDataTableName);
 
         /// <summary>
         /// Inside the DB we have a table for data that we want associated with a <see cref="Project"/>.
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  -----------------------------------------------
         /// </summary>
         private const string ProjectDataTableName = "ProjectData" + Version;
-        private static byte[] ProjectDataTableNamePtr = Util.ToUtf8(ProjectDataTableName);
+        private static readonly byte[] ProjectDataTableNamePtr = Util.ToUtf8WithNullTerminator(ProjectDataTableName);
 
         /// <summary>
         /// Inside the DB we have a table for data that we want associated with a <see cref="Document"/>.
@@ -90,11 +90,11 @@ namespace Microsoft.CodeAnalysis.SQLite
         ///  ----------------------------------------------
         /// </summary>
         private const string DocumentDataTableName = "DocumentData" + Version;
-        private static byte[] DocumentDataTableNamePtr = Util.ToUtf8(DocumentDataTableName);
+        private static readonly byte[] DocumentDataTableNamePtr = Util.ToUtf8WithNullTerminator(DocumentDataTableName);
 
         private const string DataIdColumnName = "DataId";
         private const string DataColumnName = "Data";
-        private static byte[] DataColumnNamePtr = Util.ToUtf8(DataColumnName);
+        private static readonly byte[] DataColumnNamePtr = Util.ToUtf8WithNullTerminator(DataColumnName);
 
         private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_DocumentSerialization.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_DocumentSerialization.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             protected override string DataTableName => DocumentDataTableName;
+            protected override byte[] DataTableNamePtr => DocumentDataTableNamePtr;
 
             protected override (DocumentId, string) GetWriteQueueKey((Document document, string name) key)
                 => (key.document.Id, key.name);

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_ProjectSerialization.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_ProjectSerialization.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             protected override string DataTableName => ProjectDataTableName;
+            protected override byte[] DataTableNamePtr => ProjectDataTableNamePtr;
 
             protected override (ProjectId projectId, string name) GetWriteQueueKey((Project project, string name) key)
                 => (key.project.Id, key.name);

--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_SolutionSerialization.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage_SolutionSerialization.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             protected override string DataTableName => SolutionDataTableName;
+            protected override byte[] DataTableNamePtr => SolutionDataTableNamePtr;
 
             protected override string GetWriteQueueKey(string key)
                 => key;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/23424

NOTE: Currently using CI as a build bot, roslyn builds take too much time on my machine.

<details><summary>Ask Mode template not completed</summary>

<!-- This template is not always required. If you aren't sure about whether it's needed or want help filling out the sections,
submit the pull request and then ask us for help. :) -->

### Customer scenario

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

### Bugs this fixes

(either VSO or GitHub links)

### Workarounds, if any

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

### Risk

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

### Performance impact

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

### Is this a regression from a previous update?

### Root cause analysis

How did we miss it?  What tests are we adding to guard against it in the future?

### How was the bug found?

(E.g. customer reported it vs. ad hoc testing)

### Test documentation updated?

If this is a new non-compiler feature or a significant improvement to an existing feature, update https://github.com/dotnet/roslyn/wiki/Manual-Testing once you know which release it is targeting.

</details>
