### PR TITLE
Use TLS1.2 for GitHub references

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -23,6 +23,7 @@ Param(
 )
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 function Get-PublishKey([string]$uploadUrl) {
     $url = New-Object Uri $uploadUrl


### PR DESCRIPTION
Change our publish script to use TLS1.2 as it downloads assets directly
from GitHub using an https connection

**Infrastructure Only**
