### PR TITLE
Fix code that violated the (!Alive || !Reported) control-flow-analysis invariant.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -323,7 +323,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var boundLabel = node.SwitchLabels.Last();
                 Diagnostics.Add(lastSection ? ErrorCode.ERR_SwitchFallOut : ErrorCode.ERR_SwitchFallThrough,
                                 new SourceLocation(boundLabel.Syntax), boundLabel.Label.Name);
-                this.State.Reported = true;
             }
 
             return null;
@@ -344,7 +343,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var syntax = node.SwitchLabels.Last().Pattern.Syntax;
                 Diagnostics.Add(isLastSection ? ErrorCode.ERR_SwitchFallOut : ErrorCode.ERR_SwitchFallThrough,
                                 new SourceLocation(syntax), syntax.ToString());
-                this.State.Reported = true;
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -5577,6 +5577,50 @@ class C
             Assert.Equal("x, y", GetSymbolNamesJoined(results.AlwaysAssigned));
         }
 
+        [Fact, WorkItem(25043, "https://github.com/dotnet/roslyn/issues/25043")]
+        public void FallThroughInSwitch_01()
+        {
+            var analysis = CompileAndAnalyzeControlFlowStatements(@"
+class C
+{
+    void M()
+    {
+/*<bind>*/
+        switch (true)
+        {
+            case true:
+                void f()
+                {
+                }
+        }
+/*</bind>*/
+    }
+}");
+            Assert.Equal(0, analysis.EntryPoints.Count());
+        }
+
+        [Fact, WorkItem(25043, "https://github.com/dotnet/roslyn/issues/25043")]
+        public void FallThroughInSwitch_02()
+        {
+            var analysis = CompileAndAnalyzeControlFlowStatements(@"
+class C
+{
+    void M()
+    {
+/*<bind>*/
+        switch (true)
+        {
+            case true when true:
+                void f()
+                {
+                }
+        }
+/*</bind>*/
+    }
+}");
+            Assert.Equal(0, analysis.EntryPoints.Count());
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
### Customer scenario

An assertion error in the compiler arises when using a debug build of Roslyn and analyzing control-flow in code in which there is a "fall through" error in a switch statement.

### Bugs this fixes

Fixes #25043

### Workarounds, if any

None needed (customers do not usually use a Debug build).

### Risk

Tiny. The fix is the deletion of code that simply violates asserted invariants.

### Performance impact

Deletion of code could, if anything, speed up the compiler.

### Is this a regression from a previous update?

No; longstanding bug not previously detected.

### Root cause analysis

Unusual combination of conditions not hit in existing tests.

### How was the bug found?

Customer reported.

### Test documentation updated?

N/A

@dotnet/roslyn-compiler May I please have a couple of reviews of this ultra-tiny bug fix?
